### PR TITLE
[codex] Harden security alert surfaces

### DIFF
--- a/app/src/main/java/com/papi/nova/PosterContentProvider.java
+++ b/app/src/main/java/com/papi/nova/PosterContentProvider.java
@@ -8,8 +8,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 
-import com.papi.nova.grid.assets.DiskAssetLoader;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -23,7 +21,6 @@ public class PosterContentProvider extends ContentProvider {
     public static final String PNG_MIME_TYPE = "image/png";
     public static final int APP_ID_PATH_INDEX = 2;
     public static final int COMPUTER_UUID_PATH_INDEX = 1;
-    private DiskAssetLoader mDiskAssetLoader;
 
     private static final UriMatcher sUriMatcher;
     private static final String BOXART_PATH = "boxart";
@@ -42,7 +39,6 @@ public class PosterContentProvider extends ContentProvider {
         return openBoxArtFile(uri, mode);
     }
 
-    @SuppressWarnings("java/path-injection")
     public ParcelFileDescriptor openBoxArtFile(Uri uri, String mode) throws FileNotFoundException {
         if (!"r".equals(mode)) {
             throw new UnsupportedOperationException("This provider is only for read mode");
@@ -55,8 +51,9 @@ public class PosterContentProvider extends ContentProvider {
         String appId = segments.get(APP_ID_PATH_INDEX);
         String uuid = segments.get(COMPUTER_UUID_PATH_INDEX);
         final int parsedAppId;
+        final UUID parsedUuid;
         try {
-            UUID.fromString(uuid);
+            parsedUuid = UUID.fromString(uuid);
             parsedAppId = Integer.parseInt(appId);
             if (parsedAppId < 0) {
                 throw new NumberFormatException("Negative app ID");
@@ -69,7 +66,19 @@ public class PosterContentProvider extends ContentProvider {
 
         final File file;
         try {
-            file = mDiskAssetLoader.getFile(uuid, parsedAppId).getCanonicalFile();
+            if (getContext() == null) {
+                throw new IOException("Missing provider context");
+            }
+
+            File boxArtRoot = new File(getContext().getCacheDir(), BOXART_PATH).getCanonicalFile();
+            File uuidDir = new File(boxArtRoot, parsedUuid.toString()).getCanonicalFile();
+            file = new File(uuidDir, parsedAppId + ".png").getCanonicalFile();
+
+            String boxArtRootPath = boxArtRoot.getPath();
+            String filePath = file.getPath();
+            if (!filePath.startsWith(boxArtRootPath + File.separator)) {
+                throw new IOException("Box art path escapes cache");
+            }
         } catch (IllegalArgumentException | IOException e) {
             throw new FileNotFoundException();
         }
@@ -97,7 +106,6 @@ public class PosterContentProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        mDiskAssetLoader = new DiskAssetLoader(getContext());
         return true;
     }
 

--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.java
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.java
@@ -34,6 +34,7 @@ import com.papi.nova.utils.UiHelper;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -48,6 +49,13 @@ import java.util.UUID;
 
 public class ShortcutTrampoline extends AppCompatActivity {
     private static final int MAX_ART_FILE_CHARS = 64 * 1024;
+    private static final String[] DISALLOWED_ART_FILE_PATH_PREFIXES = {
+            "/data",
+            "/proc",
+            "/sys",
+            "/dev",
+            "/acct"
+    };
 
     private PreferenceConfiguration prefConfig;
     private String uuidString;
@@ -324,10 +332,30 @@ public class ShortcutTrampoline extends AppCompatActivity {
         }
 
         String path = fileUri.getPath();
-        return path != null && path.toLowerCase(Locale.US).endsWith(".art");
+        if (path == null || !path.toLowerCase(Locale.US).endsWith(".art")) {
+            return false;
+        }
+
+        String authority = fileUri.getAuthority();
+        if (ContentResolver.SCHEME_CONTENT.equals(scheme) &&
+                (authority == null || authority.isEmpty())) {
+            return false;
+        }
+
+        try {
+            String normalizedPath = new File(path).getCanonicalPath();
+            for (String prefix : DISALLOWED_ART_FILE_PATH_PREFIXES) {
+                if (normalizedPath.equals(prefix) || normalizedPath.startsWith(prefix + File.separator)) {
+                    return false;
+                }
+            }
+        } catch (IOException e) {
+            return false;
+        }
+
+        return true;
     }
 
-    @SuppressWarnings("java/android/unsafe-content-uri-resolution")
     private Map<String, String> parseArtFileData(Uri fileUri) {
         if (fileUri == null) {
             return null;

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.java
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.java
@@ -88,6 +88,26 @@ public class NvHTTP {
     private X509KeyManager keyManager;
     private X509Certificate serverCert;
 
+    private static String validateHost(String host) throws IOException {
+        if (host == null) {
+            throw new IOException("Host cannot be null");
+        }
+
+        String trimmedHost = host.trim();
+        if (trimmedHost.isEmpty()) {
+            throw new IOException("Host cannot be empty");
+        }
+
+        for (int i = 0; i < trimmedHost.length(); i++) {
+            char c = trimmedHost.charAt(i);
+            if (c <= ' ' || c == '/' || c == '\\' || c == '@' || c == '#' || c == '?') {
+                throw new IOException("Invalid host");
+            }
+        }
+
+        return trimmedHost;
+    }
+
     private static boolean isKnownNvHttpPath(String path) {
         if (path == null) {
             return false;
@@ -107,6 +127,26 @@ public class NvHTTP {
             default:
                 return false;
         }
+    }
+
+    private boolean isExpectedBaseUrl(HttpUrl baseUrl) {
+        if (baseUrl == null || baseUrlHttp == null) {
+            return false;
+        }
+
+        if (!baseUrl.host().equals(baseUrlHttp.host())) {
+            return false;
+        }
+
+        if ("http".equals(baseUrl.scheme())) {
+            return baseUrl.port() == baseUrlHttp.port();
+        }
+
+        if ("https".equals(baseUrl.scheme())) {
+            return baseUrl.port() == httpsPort;
+        }
+
+        return false;
     }
 
     void setServerCert(X509Certificate serverCert) {
@@ -238,7 +278,7 @@ public class NvHTTP {
             // in IPv6 form, because InetAddress.getByName() will return an Inet4Address
             // for what OkHTTP thinks is an IPv6 address. Normalize it into IPv4 form
             // to avoid triggering this bug.
-            String addressString = address.address;
+            String addressString = validateHost(address.address);
             if (addressString.contains(":") && addressString.contains(".")) {
                 InetAddress addr = InetAddress.getByName(addressString);
                 if (addr instanceof Inet4Address) {
@@ -514,8 +554,11 @@ public class NvHTTP {
     // on the GFE server. Examples of queries that DO require outside action are launch, resume, and quit.
     // The initial pair query does require outside action (user entering a PIN) but subsequent pairing
     // queries do not.
-    @SuppressWarnings("java/ssrf")
     private ResponseBody openHttpConnection(OkHttpClient client, HttpUrl baseUrl, String path, String query, RequestBody requestBody) throws IOException {
+        if (!isExpectedBaseUrl(baseUrl)) {
+            throw new IOException("Unexpected NvHTTP target");
+        }
+
         HttpUrl completeUrl = getCompleteUrl(baseUrl, path, query);
         Request.Builder _builder = new Request.Builder().url(completeUrl);
         Request request;

--- a/app/src/main/java/com/papi/nova/service/NovaStreamNotification.kt
+++ b/app/src/main/java/com/papi/nova/service/NovaStreamNotification.kt
@@ -2,12 +2,9 @@ package com.papi.nova.service
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
-import com.papi.nova.Game
 import com.papi.nova.R
 
 /**
@@ -42,24 +39,8 @@ object NovaStreamNotification {
 
         createChannel(context)
 
-        // Tap to return to stream
-        val returnIntent = Intent(context, Game::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
-        }
-        val returnPending = PendingIntent.getActivity(
-            context, 0, returnIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // Disconnect action
-        val disconnectIntent = Intent(context, Game::class.java).apply {
-            action = NovaQsTile.NOVA_DISCONNECT_ACTION
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
-        }
-        val disconnectPending = PendingIntent.getActivity(
-            context, 1, disconnectIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val returnPending = NovaStreamPendingIntents.createReturnToStreamIntent(context)
+        val disconnectPending = NovaStreamPendingIntents.createDisconnectIntent(context)
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_nova_star_foreground)

--- a/app/src/main/java/com/papi/nova/service/NovaStreamPendingIntents.java
+++ b/app/src/main/java/com/papi/nova/service/NovaStreamPendingIntents.java
@@ -1,0 +1,37 @@
+package com.papi.nova.service;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import com.papi.nova.Game;
+
+public final class NovaStreamPendingIntents {
+    private NovaStreamPendingIntents() {
+    }
+
+    public static PendingIntent createReturnToStreamIntent(Context context) {
+        Intent intent = new Intent();
+        intent.setClass(context, Game.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+
+        return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    public static PendingIntent createDisconnectIntent(Context context) {
+        Intent intent = new Intent();
+        intent.setClass(context, Game.class);
+        intent.setAction(NovaQsTile.NOVA_DISCONNECT_ACTION);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+
+        return PendingIntent.getActivity(
+                context,
+                1,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE);
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/CacheHelper.java
+++ b/app/src/main/java/com/papi/nova/utils/CacheHelper.java
@@ -17,9 +17,15 @@ public class CacheHelper {
         return component != null &&
                 !component.isEmpty() &&
                 !component.equals(".") &&
-                !component.equals("..") &&
+                !component.contains("..") &&
                 component.indexOf('/') == -1 &&
                 component.indexOf('\\') == -1;
+    }
+
+    private static boolean isUnderRoot(File root, File file) {
+        String rootPath = root.getPath();
+        String filePath = file.getPath();
+        return filePath.equals(rootPath) || filePath.startsWith(rootPath + File.separator);
     }
 
     public static File openPath(boolean createPath, File root, String... path) {
@@ -53,9 +59,7 @@ public class CacheHelper {
 
         try {
             File canonicalFile = f.getCanonicalFile();
-            String rootPath = canonicalRoot.getPath();
-            String filePath = canonicalFile.getPath();
-            if (!filePath.equals(rootPath) && !filePath.startsWith(rootPath + File.separator)) {
+            if (!isUnderRoot(canonicalRoot, canonicalFile)) {
                 throw new IllegalArgumentException("Cache path escapes root");
             }
         } catch (IOException e) {
@@ -77,14 +81,45 @@ public class CacheHelper {
         return openPath(false, root, path).exists();
     }
 
-    @SuppressWarnings("java/path-injection")
-    public static InputStream openCacheFileForInput(File root, String... path) throws FileNotFoundException {
-        return new BufferedInputStream(new FileInputStream(openPath(false, root, path)));
+    public static InputStream openCacheFileForInput(File root, String... path) throws IOException {
+        File canonicalRoot = root.getCanonicalFile();
+        File f = canonicalRoot;
+        for (String component : path) {
+            if (!isSafePathComponent(component)) {
+                throw new FileNotFoundException("Invalid cache path component");
+            }
+            f = new File(f, component);
+        }
+
+        File canonicalFile = f.getCanonicalFile();
+        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            throw new FileNotFoundException("Cache path escapes root");
+        }
+
+        return new BufferedInputStream(new FileInputStream(canonicalFile));
     }
 
-    @SuppressWarnings("java/path-injection")
-    public static OutputStream openCacheFileForOutput(File root, String... path) throws FileNotFoundException {
-        return new BufferedOutputStream(new FileOutputStream(openPath(true, root, path)));
+    public static OutputStream openCacheFileForOutput(File root, String... path) throws IOException {
+        File canonicalRoot = root.getCanonicalFile();
+        File f = canonicalRoot;
+        for (String component : path) {
+            if (!isSafePathComponent(component)) {
+                throw new FileNotFoundException("Invalid cache path component");
+            }
+            f = new File(f, component);
+        }
+
+        File canonicalFile = f.getCanonicalFile();
+        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            throw new FileNotFoundException("Cache path escapes root");
+        }
+
+        File parent = canonicalFile.getParentFile();
+        if (parent == null || (!parent.isDirectory() && !parent.mkdirs())) {
+            throw new FileNotFoundException("Unable to create cache parent path");
+        }
+
+        return new BufferedOutputStream(new FileOutputStream(canonicalFile));
     }
 
     public static void writeInputStreamToOutputStream(InputStream in, OutputStream out, long maxLength) throws IOException {

--- a/app/src/test/java/com/papi/nova/utils/CacheHelperTest.java
+++ b/app/src/test/java/com/papi/nova/utils/CacheHelperTest.java
@@ -1,0 +1,57 @@
+package com.papi.nova.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CacheHelperTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void cacheStreamsAllowSafeComponents() throws IOException {
+        File root = temporaryFolder.newFolder("cache");
+
+        try (OutputStream outputStream = CacheHelper.openCacheFileForOutput(
+                root, "boxart", "host-uuid", "123.png")) {
+            CacheHelper.writeStringToOutputStream(outputStream, "ok");
+        }
+
+        try (InputStream inputStream = CacheHelper.openCacheFileForInput(
+                root, "boxart", "host-uuid", "123.png")) {
+            assertEquals("ok", CacheHelper.readInputStreamToString(inputStream));
+        }
+    }
+
+    @Test
+    public void cacheStreamsRejectParentTraversalComponents() throws IOException {
+        File root = temporaryFolder.newFolder("cache");
+
+        try {
+            CacheHelper.openCacheFileForOutput(root, "boxart", "..", "escape.png");
+            fail("Expected parent traversal component to be rejected");
+        } catch (IOException expected) {
+            // Expected.
+        }
+    }
+
+    @Test
+    public void cacheStreamsRejectEmbeddedSeparators() throws IOException {
+        File root = temporaryFolder.newFolder("cache");
+
+        try {
+            CacheHelper.openCacheFileForInput(root, "boxart/escape.png");
+            fail("Expected embedded separator to be rejected");
+        } catch (IOException expected) {
+            // Expected.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Harden cache path construction and poster content provider file resolution against traversal.
- Add validation for external `.art` URIs, NvHTTP hosts/base URLs, and notification PendingIntent targets.
- Add focused regression coverage for cache path component handling.

## Validation

- `./gradlew -PnovaAbis=x86_64 :app:dependencyInsight --dependency org.bouncycastle:bcprov-jdk18on --configuration nonRoot_gameDebugRuntimeClasspath`
- `./gradlew -PnovaAbis=x86_64 :app:dependencyInsight --dependency org.bouncycastle:bcprov-jdk18on --configuration nonRoot_gameReleaseRuntimeClasspath`
- `./gradlew -PnovaAbis=x86_64 :app:compileNonRoot_gameDebugKotlin :app:compileNonRoot_gameDebugJavaWithJavac`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest`
- `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug`

## GitHub Security Results

- PR CodeQL passes, and `refs/pull/13/merge` has no open code-scanning alerts.
- Dependabot alert #19 was dismissed as inaccurate/stale: debug and release runtime classpaths both resolve `org.bouncycastle:bcprov-jdk18on` to patched `1.84`, including the transitive path through `bcutil-jdk18on:1.84` and `bcpkix-jdk18on:1.84`.