### PR TITLE
Add manual Wake-on-LAN MAC entry for Nova 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.3 - 2026-05-09
+
+- Added manual Wake-on-LAN MAC entry for hosts that do not report a MAC address.
+- Normalized common MAC address formats before sending Wake-on-LAN packets.
+- Updated public README guidance for Wake-on-LAN, VPN, and remote-host setup.
+
 ## 1.0.2 - 2026-04-28
 
 - Hardened externally supplied host, URI, and cache path handling found during CodeQL/security review.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sha256sum -c Nova-Android-arm64-v8a.apk.sha256
 > If you distribute Nova from a private GitHub fork, Obtainium needs a Personal Access Token with `repo` scope. Public release repos do not.
 
 > [!NOTE]
-> `v1.0.0` is the first public Nova release line, `v1.0.1` adds the first store-packaging pass, and `v1.0.2` hardens the security surfaces found during public scanner review. Nova is already usable, but this is still an early public release and you should expect bugs, regressions, and rough edges while the Android client and Polaris integration continue to harden. `app/` is the only shipping client today.
+> `v1.0.0` is the first public Nova release line, `v1.0.1` adds the first store-packaging pass, `v1.0.2` hardens the security surfaces found during public scanner review, and `v1.0.3` adds manual Wake-on-LAN MAC entry for hosts that do not report a MAC address. Nova is already usable, but this is still an early public release and you should expect bugs, regressions, and rough edges while the Android client and Polaris integration continue to harden. `app/` is the only shipping client today.
 
 **Built and tested most heavily on:** Retroid Pocket 6, Retroid Pocket Flip 2, Pixel 10 Pro.
 
@@ -82,6 +82,8 @@ sha256sum -c Nova-Android-arm64-v8a.apk.sha256
    - **Manual PIN** pairing for standard Moonlight servers
 4. **Launch a game** from the game grid or the Polaris library.
 5. **Use the quick menu** for stream tuning, overlays, controller actions, and quit/disconnect controls.
+
+Wake-on-LAN uses UDP magic packets sent directly from Nova. If a host does not report its MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address for the server and reuses it when sending future wake requests, which helps remote setups such as WireGuard where discovery metadata may be incomplete.
 
 ### If you use Polaris
 
@@ -108,6 +110,7 @@ Nova still works as a standard Moonlight client. Pair normally, launch normally,
 | Android phones and tablets | Supported | Works well, but the UX is tuned most heavily for handhelds |
 | Polaris | Best experience | Full launch-mode, watch-mode, tuning, library, and live-session integration |
 | Other Moonlight-compatible hosts | Compatible | Standard Moonlight-compatible client flow |
+| Wake-on-LAN | Supported | Sends UDP magic packets directly from Android and supports manual MAC entry when the host does not report one |
 | High refresh devices | Supported | Nova can request 90/120 Hz when the device display and host both support it |
 | Official release assets | `arm64-v8a`, `x86_64` | Public GitHub Releases ship separate APKs per Android ABI |
 
@@ -294,6 +297,13 @@ Trusted Pair is Nova’s TOFU flow. If Polaris trusts the subnet you are on, Nov
 <summary><b>What is the difference between Headless and Virtual Display?</b></summary>
 
 **Headless** launches against Polaris’ isolated compositor path without touching your physical desktop layout. **Virtual Display** asks the host for a virtual display-backed launch instead. Nova’s Polaris library now shows what the host recommends, what the app prefers, and which modes are currently allowed.
+
+</details>
+
+<details>
+<summary><b>Does Wake-on-LAN work over WireGuard or another VPN?</b></summary>
+
+It can, as long as the network path forwards the UDP wake packet to a host or subnet that can reach the sleeping PC. Nova sends Wake-on-LAN packets directly from Android. If the server did not provide a MAC address during discovery or pairing, use **Edit Wake-on-LAN MAC** in the host menu and enter the PC network adapter MAC address manually.
 
 </details>
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.0.2"
-        versionCode = 17
+        versionName "1.0.3"
+        versionCode = 18
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/PcView.java
+++ b/app/src/main/java/com/papi/nova/PcView.java
@@ -1045,6 +1045,10 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
             sheet.dismiss();
             Dialog.displayDialog(this, getString(R.string.title_details), computer.details.toString(), false);
         });
+        addPcSheetAction(actions, getString(R.string.pcview_menu_edit_wol_mac), () -> {
+            sheet.dismiss();
+            showWakeMacDialog(computer.details, false);
+        });
 
         // Delete at the bottom — dangerous action
         android.widget.TextView deleteItem = new android.widget.TextView(this);
@@ -1346,9 +1350,13 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
             return;
         }
 
-        if (computer.macAddress == null) {
-            com.papi.nova.ui.NovaSnackbar.INSTANCE.showError(PcView.this, getResources().getString(R.string.wol_no_mac));
+        String normalizedMacAddress = WakeOnLanSender.normalizeMacAddress(computer.macAddress);
+        if (normalizedMacAddress == null) {
+            showWakeMacDialog(computer, true);
             return;
+        }
+        if (!normalizedMacAddress.equals(computer.macAddress)) {
+            saveWakeMacAddress(computer, normalizedMacAddress);
         }
 
         new Thread(() -> {
@@ -1363,6 +1371,76 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
                 final String snackMessage = message;
                 runOnUiThread(() -> com.papi.nova.ui.NovaSnackbar.INSTANCE.show(PcView.this, snackMessage));
         }).start();
+    }
+
+    private void showWakeMacDialog(final ComputerDetails computer, boolean wakeAfterSave) {
+        if (managerBinder == null) {
+            Toast.makeText(this, R.string.error_manager_not_running, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        EditText macInput = new EditText(this);
+        macInput.setSingleLine(true);
+        macInput.setHint(R.string.wol_mac_hint);
+        macInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
+        macInput.setFilters(new InputFilter[] { new InputFilter.LengthFilter(17) });
+
+        String normalizedMacAddress = WakeOnLanSender.normalizeMacAddress(computer.macAddress);
+        if (normalizedMacAddress != null) {
+            macInput.setText(normalizedMacAddress);
+            macInput.setSelection(macInput.getText().length());
+        }
+
+        int padding = (int) UiHelper.dpToPx(this, 24);
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(padding, padding / 2, padding, 0);
+        layout.addView(macInput);
+
+        AlertDialog dialog = new AlertDialog.Builder(this)
+                .setTitle(R.string.wol_mac_title)
+                .setMessage(R.string.wol_mac_message)
+                .setView(layout)
+                .setPositiveButton(wakeAfterSave ? R.string.wol_mac_save_and_wake : R.string.save, null)
+                .setNegativeButton(R.string.cancel, (d, which) -> d.dismiss())
+                .create();
+
+        dialog.setOnShowListener(d -> dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            String normalized = WakeOnLanSender.normalizeMacAddress(macInput.getText().toString());
+            if (normalized == null) {
+                macInput.setError(getString(R.string.wol_mac_invalid));
+                return;
+            }
+
+            saveWakeMacAddress(computer, normalized);
+            dialog.dismiss();
+
+            if (wakeAfterSave) {
+                doWakeOnLan(computer);
+            }
+            else {
+                com.papi.nova.ui.NovaSnackbar.INSTANCE.showSuccess(PcView.this, getString(R.string.wol_mac_saved));
+            }
+        }));
+
+        dialog.show();
+    }
+
+    private void saveWakeMacAddress(final ComputerDetails computer, String normalizedMacAddress) {
+        computer.macAddress = normalizedMacAddress;
+
+        if (managerBinder == null) {
+            return;
+        }
+
+        ComputerDetails managedComputer = managerBinder.getComputer(computer.uuid);
+        if (managedComputer != null) {
+            managedComputer.macAddress = normalizedMacAddress;
+            managerBinder.persistComputer(managedComputer);
+        }
+        else {
+            managerBinder.persistComputer(computer);
+        }
     }
 
 

--- a/app/src/main/java/com/papi/nova/nvstream/wol/WakeOnLanSender.java
+++ b/app/src/main/java/com/papi/nova/nvstream/wol/WakeOnLanSender.java
@@ -4,9 +4,8 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
-import java.util.Scanner;
+import java.util.Locale;
 
-import com.papi.nova.LimeLog;
 import com.papi.nova.nvstream.http.ComputerDetails;
 
 public class WakeOnLanSender {
@@ -110,25 +109,49 @@ public class WakeOnLanSender {
         }
     }
     
-    private static byte[] macStringToBytes(String macAddress) {
+    public static String normalizeMacAddress(String macAddress) {
+        if (macAddress == null) {
+            return null;
+        }
+
+        String compactMacAddress = macAddress.trim()
+                .replace(":", "")
+                .replace("-", "")
+                .replace(".", "");
+
+        if (!compactMacAddress.matches("(?i)[0-9a-f]{12}")) {
+            return null;
+        }
+
+        compactMacAddress = compactMacAddress.toUpperCase(Locale.US);
+        StringBuilder normalized = new StringBuilder(17);
+        for (int i = 0; i < compactMacAddress.length(); i += 2) {
+            if (i > 0) {
+                normalized.append(':');
+            }
+            normalized.append(compactMacAddress, i, i + 2);
+        }
+
+        return normalized.toString();
+    }
+
+    private static byte[] macStringToBytes(String macAddress) throws IOException {
+        String normalizedMacAddress = normalizeMacAddress(macAddress);
+        if (normalizedMacAddress == null) {
+            throw new IOException("Invalid Wake-on-LAN MAC address");
+        }
+
         byte[] macBytes = new byte[6];
 
-        try (@SuppressWarnings("resource")
-             final Scanner scan = new Scanner(macAddress).useDelimiter(":")
-        ) {
-            for (int i = 0; i < macBytes.length && scan.hasNext(); i++) {
-                try {
-                    macBytes[i] = (byte) Integer.parseInt(scan.next(), 16);
-                } catch (NumberFormatException e) {
-                    LimeLog.warning("Malformed MAC address: " + macAddress + " (index: " + i + ")");
-                    break;
-                }
-            }
-            return macBytes;
+        for (int i = 0; i < macBytes.length; i++) {
+            int segmentStart = i * 3;
+            macBytes[i] = (byte) Integer.parseInt(normalizedMacAddress.substring(segmentStart, segmentStart + 2), 16);
         }
+
+        return macBytes;
     }
-    
-    private static byte[] createWolPayload(ComputerDetails computer) {
+
+    private static byte[] createWolPayload(ComputerDetails computer) throws IOException {
         byte[] payload = new byte[102];
         byte[] macAddress = macStringToBytes(computer.macAddress);
         int i;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="pcview_sync_no_server">No paired online server available for Polaris Sync</string>
     <string name="pcview_menu_unpair_pc">Unpair</string>
     <string name="pcview_menu_send_wol">Send Wake-On-LAN request</string>
+    <string name="pcview_menu_edit_wol_mac">Edit Wake-on-LAN MAC</string>
     <string name="pcview_menu_delete_pc">Delete PC</string>
     <string name="pcview_menu_test_network">Test Network Connection</string>
     <string name="pcview_menu_details">View Details</string>
@@ -221,6 +222,12 @@
 	    If it doesn\'t, make sure it\'s configured properly for Wake-On-LAN.
     </string>
     <string name="wol_fail">Failed to send Wake-On-LAN packets</string>
+    <string name="wol_mac_title">Wake-on-LAN MAC address</string>
+    <string name="wol_mac_message">Enter the host network adapter MAC address. Nova stores it for this server and uses it to build Wake-on-LAN packets.</string>
+    <string name="wol_mac_hint">AA:BB:CC:DD:EE:FF</string>
+    <string name="wol_mac_invalid">Enter a valid MAC address</string>
+    <string name="wol_mac_saved">Wake-on-LAN MAC saved</string>
+    <string name="wol_mac_save_and_wake">Save and Wake</string>
 
     <!-- Unpair messages -->
     <string name="unpairing">Unpairing…</string>

--- a/app/src/test/java/com/papi/nova/nvstream/wol/WakeOnLanSenderTest.java
+++ b/app/src/test/java/com/papi/nova/nvstream/wol/WakeOnLanSenderTest.java
@@ -1,0 +1,24 @@
+package com.papi.nova.nvstream.wol;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class WakeOnLanSenderTest {
+    @Test
+    public void normalizeMacAddressAcceptsCommonFormats() {
+        assertEquals("AA:BB:CC:DD:EE:FF", WakeOnLanSender.normalizeMacAddress("aa:bb:cc:dd:ee:ff"));
+        assertEquals("AA:BB:CC:DD:EE:FF", WakeOnLanSender.normalizeMacAddress("AA-BB-CC-DD-EE-FF"));
+        assertEquals("AA:BB:CC:DD:EE:FF", WakeOnLanSender.normalizeMacAddress("aabbccddeeff"));
+        assertEquals("AA:BB:CC:DD:EE:FF", WakeOnLanSender.normalizeMacAddress("aabb.ccdd.eeff"));
+    }
+
+    @Test
+    public void normalizeMacAddressRejectsInvalidValues() {
+        assertNull(WakeOnLanSender.normalizeMacAddress(null));
+        assertNull(WakeOnLanSender.normalizeMacAddress(""));
+        assertNull(WakeOnLanSender.normalizeMacAddress("aa:bb:cc:dd:ee"));
+        assertNull(WakeOnLanSender.normalizeMacAddress("aa:bb:cc:dd:ee:xx"));
+    }
+}

--- a/docs/fdroid.md
+++ b/docs/fdroid.md
@@ -23,7 +23,7 @@ The metadata is intentionally written for public stores and app-index mirrors:
 - title and short description are store-sized
 - full description avoids marketing-only language and names the Polaris relationship clearly
 - screenshots are copied from `docs/screenshots/`
-- changelog `17.txt` matches Nova `versionCode = 17`
+- changelog `18.txt` matches Nova `versionCode = 18`
 
 ## APK Scan and Security Notes
 
@@ -88,9 +88,9 @@ RepoType: git
 Repo: https://github.com/papi-ux/nova.git
 
 Builds:
-  - versionName: 1.0.2
-    versionCode: 17
-    commit: v1.0.2
+  - versionName: 1.0.3
+    versionCode: 18
+    commit: v1.0.3
     subdir: .
     gradle:
       - nonRoot_gameRelease
@@ -100,11 +100,11 @@ Builds:
 
 AutoUpdateMode: Version v%v
 UpdateCheckMode: Tags
-CurrentVersion: 1.0.2
-CurrentVersionCode: 17
+CurrentVersion: 1.0.3
+CurrentVersionCode: 18
 ```
 
-`v1.0.2` contains the F-Droid build switch, store metadata, and public scanner hardening. Official F-Droid main still needs the source-built native dependency path described above; do not submit this sample against `v1.0.0` because that tag predates the packaging prep.
+`v1.0.3` contains the F-Droid build switch, store metadata, public scanner hardening, and the latest Wake-on-LAN setup fixes. Official F-Droid main still needs the source-built native dependency path described above; do not submit this sample against `v1.0.0` because that tag predates the packaging prep.
 
 ## Future IzzyOnDroid Checklist
 

--- a/fastlane/metadata/android/en-US/changelogs/18.txt
+++ b/fastlane/metadata/android/en-US/changelogs/18.txt
@@ -1,0 +1,5 @@
+Nova 1.0.3
+
+- Added manual Wake-on-LAN MAC entry for hosts that do not report a MAC address.
+- Improved Wake-on-LAN MAC validation and normalization.
+- Updated public setup guidance for Wake-on-LAN and VPN-based host access.


### PR DESCRIPTION
## Summary
- Add a host-sheet action to edit the saved Wake-on-LAN MAC address.
- Prompt for a MAC address when Wake is tapped and the server has no usable MAC saved.
- Normalize common MAC formats before sending WOL packets and reject malformed values instead of building a bad magic packet.
- Prepare Nova `1.0.3` release metadata, README guidance, changelog, and Fastlane changelog.

## Context
This addresses https://github.com/papi-ux/nova/discussions/14 for remote/WireGuard setups where the server XML does not provide a MAC address. Nova sends Wake-on-LAN magic packets directly over UDP from Android, so it does not use Linux tools like `etherwake` or `wol`.

## Validation
- `bash scripts/check-public-surface.sh`
- `bash scripts/check-public-docs.sh`
- `./gradlew :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.nvstream.wol.WakeOnLanSenderTest`
- GitHub Actions: public hygiene, CodeQL, lint/unit test, emulator smoke test, and release APK assembly all passed.