### PR TITLE
Polish Nova Android TV and Polaris sync UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Built for [Polaris](https://github.com/papi-ux/polaris), compatible with other M
 
 1. Download the latest release from GitHub Releases, add Nova to Obtainium, or open it in GitHub Store on Android.
 2. Install the APK that matches your Android device.
-   Most phones and handhelds use `Nova-Android-arm64-v8a.apk`; x86_64 Android devices and emulators use `Nova-Android-x86_64.apk`.
+   Most phones, handhelds, and Android TV devices use `Nova-Android-arm64-v8a.apk`; x86_64 Android devices and emulators use `Nova-Android-x86_64.apk`.
 3. Open Nova, add or discover your host, then pair it.
 
 | Public release asset | Use it for |
 |---|---|
-| `Nova-Android-arm64-v8a.apk` | Recommended Android install for phones and handhelds |
+| `Nova-Android-arm64-v8a.apk` | Recommended Android install for phones, handhelds, and Android TV devices such as NVIDIA Shield |
 | `Nova-Android-x86_64.apk` | Android x86_64 devices and emulators |
 | `*.apk.sha256` | Integrity checks for the public APKs |
 
@@ -69,6 +69,8 @@ sha256sum -c Nova-Android-arm64-v8a.apk.sha256
 > `v1.0.0` is the first public Nova release line, `v1.0.1` adds the first store-packaging pass, `v1.0.2` hardens the security surfaces found during public scanner review, and `v1.0.3` adds manual Wake-on-LAN MAC entry for hosts that do not report a MAC address. Nova is already usable, but this is still an early public release and you should expect bugs, regressions, and rough edges while the Android client and Polaris integration continue to harden. `app/` is the only shipping client today.
 
 **Built and tested most heavily on:** Retroid Pocket 6, Retroid Pocket Flip 2, Pixel 10 Pro.
+
+**Android TV:** Nova ships Android TV support in the same APK. On NVIDIA Shield and similar ARM64 Android TV devices, install `Nova-Android-arm64-v8a.apk`; Nova appears in the TV launcher and uses D-pad/controller-friendly focus behavior on the server browser, library, launch sheets, and Polaris Sync surfaces.
 
 ## Quick Start
 
@@ -109,6 +111,7 @@ Nova still works as a standard Moonlight client. Pair normally, launch normally,
 |---|---|---|
 | Android handhelds | Primary target | Designed first for landscape handheld use |
 | Android phones and tablets | Supported | Works well, but the UX is tuned most heavily for handhelds |
+| Android TV | Supported | Uses the normal ARM64 APK with Leanback launcher support and D-pad/controller-friendly browsing |
 | Polaris | Best experience | Full launch-mode, watch-mode, tuning, library, and live-session integration |
 | Other Moonlight-compatible hosts | Compatible | Standard Moonlight-compatible client flow |
 | Wake-on-LAN | Supported | Sends UDP magic packets directly from Android and supports manual MAC entry when the host does not report one |

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/backup_rules_s"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:banner="@drawable/nova_atv_banner"
+        android:banner="@drawable/nova_tv_banner"
         android:icon="@mipmap/ic_launcher"
         android:installLocation="auto"
         android:gwpAsanMode="always"

--- a/app/src/main/java/com/papi/nova/AppView.java
+++ b/app/src/main/java/com/papi/nova/AppView.java
@@ -2,11 +2,15 @@ package com.papi.nova;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
+import com.papi.nova.api.PolarisApiClient;
+import com.papi.nova.api.PolarisGame;
 import com.papi.nova.computers.ComputerManagerListener;
 import com.papi.nova.computers.ComputerManagerService;
 import com.papi.nova.grid.AppGridAdapter;
@@ -65,6 +69,10 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
     private boolean inForeground;
     private boolean showHiddenApps;
     private final HashSet<Integer> hiddenAppIds = new HashSet<>();
+    private final Object polarisMetadataLock = new Object();
+    private Map<String, PolarisGame> polarisGamesByUuid = new HashMap<>();
+    private Map<Integer, PolarisGame> polarisGamesByAppId = new HashMap<>();
+    private boolean polarisMetadataRefreshInFlight;
 
     private PreferenceConfiguration prefConfig;
 
@@ -299,6 +307,9 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
 
         androidx.swiperefreshlayout.widget.SwipeRefreshLayout swipeRefresh = findViewById(R.id.appSwipeRefresh);
         if (swipeRefresh != null) {
+            if (UiHelper.isTvDevice(this)) {
+                swipeRefresh.setEnabled(false);
+            }
             swipeRefresh.setColorSchemeColors(androidx.core.content.ContextCompat.getColor(this, R.color.nova_accent));
             swipeRefresh.setProgressBackgroundColorSchemeColor(androidx.core.content.ContextCompat.getColor(this, R.color.nova_bg_elevated));
             swipeRefresh.setOnRefreshListener(() -> {
@@ -566,6 +577,7 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
         }
 
         card.setVisibility(View.VISIBLE);
+        UiHelper.applyTvFocusStyle(this, card);
         TextView nameView = findViewById(R.id.recently_played_name);
         TextView kickerView = findViewById(R.id.recently_played_kicker);
         TextView metaView = findViewById(R.id.recently_played_meta);
@@ -584,9 +596,12 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
                     : (appIsRunning ? R.string.applist_hero_live : R.string.applist_hero_continue));
         }
         if (metaView != null) {
-            metaView.setText(appOwnedByAnotherClient
-                    ? R.string.applist_hero_summary_watch
-                    : (appIsRunning ? R.string.applist_hero_summary_resume : R.string.applist_hero_summary_continue));
+            String metadata = targetApp.app.getMetadataLabel();
+            metaView.setText(!metadata.isEmpty()
+                    ? metadata
+                    : getString(appOwnedByAnotherClient
+                            ? R.string.applist_hero_summary_watch
+                            : (appIsRunning ? R.string.applist_hero_summary_resume : R.string.applist_hero_summary_continue)));
         }
         if (actionView != null) {
             actionView.setText(appOwnedByAnotherClient
@@ -623,6 +638,7 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
             // Build a map of incoming apps by ID for O(1) lookup
             java.util.HashMap<Integer, NvApp> incomingMap = new java.util.HashMap<>(appList.size());
             for (NvApp app : appList) {
+                applyPolarisMetadata(app);
                 incomingMap.put(app.getAppId(), app);
             }
 
@@ -643,6 +659,9 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
                     // Update name if changed
                     if (!existing.app.getAppName().equals(app.getAppName())) {
                         existing.app.setAppName(app.getAppName());
+                        updated = true;
+                    }
+                    if (applyPolarisMetadata(existing.app)) {
                         updated = true;
                     }
                 } else {
@@ -672,6 +691,8 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
             if (searchView != null) {
                 searchView.setVisibility(appGridAdapter.getTotalAppCount() > 5 ? View.VISIBLE : View.GONE);
             }
+
+            refreshPolarisGameMetadataAsync();
         });
     }
 
@@ -838,6 +859,90 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
         return fallbackApp;
     }
 
+    private boolean applyPolarisMetadata(NvApp app) {
+        if (app == null) {
+            return false;
+        }
+
+        PolarisGame metadata = null;
+        if (app.getAppUUID() != null && !app.getAppUUID().isEmpty()) {
+            metadata = polarisGamesByUuid.get(app.getAppUUID().toLowerCase(java.util.Locale.US));
+        }
+        if (metadata == null && app.getAppId() != 0) {
+            metadata = polarisGamesByAppId.get(app.getAppId());
+        }
+        return metadata != null && app.applyPolarisMetadata(metadata);
+    }
+
+    private boolean applyPolarisMetadataToVisibleApps() {
+        if (appGridAdapter == null) {
+            return false;
+        }
+
+        boolean changed = false;
+        for (int i = 0; i < appGridAdapter.getItemCount(); i++) {
+            Object item = appGridAdapter.getItem(i);
+            if (item instanceof AppObject) {
+                changed |= applyPolarisMetadata(((AppObject) item).app);
+            }
+        }
+        return changed;
+    }
+
+    private void refreshPolarisGameMetadataAsync() {
+        ComputerDetails.AddressTuple address = computer == null ? null :
+                (computer.activeAddress != null ? computer.activeAddress : computer.localAddress);
+        if (address == null || computer.httpsPort <= 0) {
+            return;
+        }
+
+        synchronized (polarisMetadataLock) {
+            if (polarisMetadataRefreshInFlight) {
+                return;
+            }
+            polarisMetadataRefreshInFlight = true;
+        }
+
+        final String host = address.address;
+        final int httpsPort = computer.httpsPort;
+        final java.security.cert.X509Certificate serverCert = computer.serverCert;
+
+        new Thread(() -> {
+            try {
+                PolarisApiClient client = new PolarisApiClient(AppView.this, host, httpsPort, serverCert);
+                List<PolarisGame> games = client.getGames("", "", 500);
+                if (games.isEmpty()) {
+                    return;
+                }
+
+                HashMap<String, PolarisGame> byUuid = new HashMap<>();
+                HashMap<Integer, PolarisGame> byAppId = new HashMap<>();
+                for (PolarisGame game : games) {
+                    if (game.getId() != null && !game.getId().isEmpty()) {
+                        byUuid.put(game.getId().toLowerCase(java.util.Locale.US), game);
+                    }
+                    if (game.getAppId() != 0) {
+                        byAppId.put(game.getAppId(), game);
+                    }
+                }
+
+                runOnUiThread(() -> {
+                    polarisGamesByUuid = byUuid;
+                    polarisGamesByAppId = byAppId;
+                    if (applyPolarisMetadataToVisibleApps()) {
+                        appGridAdapter.notifyDataSetChanged();
+                        updateRecentlyPlayedCard();
+                    }
+                });
+            } catch (Exception e) {
+                LimeLog.warning("Nova: Polaris game metadata fetch failed: " + e.getMessage());
+            } finally {
+                synchronized (polarisMetadataLock) {
+                    polarisMetadataRefreshInFlight = false;
+                }
+            }
+        }, "PolarisGameMetadata").start();
+    }
     @Override
     public int getAdapterFragmentLayoutId() {
         return R.layout.app_grid_view;
@@ -846,6 +951,10 @@ public class AppView extends AppCompatActivity implements AdapterFragmentCallbac
     @Override
     public void receiveAbsListView(View gridView) {
         if (gridView instanceof androidx.recyclerview.widget.RecyclerView rv) {
+            if (appGridAdapter == null || prefConfig == null) {
+                LimeLog.warning("App grid view attached before AppView was ready; waiting for service binding");
+                return;
+            }
             int widthDp = prefConfig.smallIconMode ? 110 : 170;
             int spanCount = Math.max(1, getResources().getDisplayMetrics().widthPixels / (int)(widthDp * getResources().getDisplayMetrics().density));
             rv.setLayoutManager(new androidx.recyclerview.widget.GridLayoutManager(this, spanCount));

--- a/app/src/main/java/com/papi/nova/PcView.java
+++ b/app/src/main/java/com/papi/nova/PcView.java
@@ -348,6 +348,26 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
             }
         }
 
+        applyTvNavigationMode(
+                modeServers,
+                modeLibrary,
+                addServerAction,
+                scanPairAction,
+                themeAction,
+                polarisSyncAction,
+                settingsAction,
+                helpAction,
+                emptyRefresh,
+                emptyAddServer,
+                emptyScanPair,
+                emptyHelp,
+                filterAllServers,
+                filterOnlineServers,
+                filterStreamingServers,
+                filterNeedsPairingServers,
+                profilesButton
+        );
+
         applyThemeToServerBrowser();
         updateModeTabs();
         updateServerFilterTabs();
@@ -359,6 +379,38 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
 
         noPcFoundLayout = findViewById(R.id.no_pc_found_layout);
         updateEmptyState();
+    }
+
+    private void applyTvNavigationMode(View... focusTargets) {
+        if (!UiHelper.isTvDevice(this)) {
+            return;
+        }
+
+        androidx.swiperefreshlayout.widget.SwipeRefreshLayout swipeRefresh = findViewById(R.id.swipe_refresh);
+        if (swipeRefresh != null) {
+            swipeRefresh.setEnabled(false);
+        }
+
+        if (!UiHelper.hasCamera(this)) {
+            View scanPairAction = findViewById(R.id.actionScanPair);
+            if (scanPairAction != null) {
+                scanPairAction.setVisibility(View.GONE);
+            }
+            View emptyScanPair = findViewById(R.id.emptyScanPair);
+            if (emptyScanPair != null) {
+                emptyScanPair.setVisibility(View.GONE);
+            }
+        }
+
+        for (View target : focusTargets) {
+            UiHelper.applyTvFocusStyle(target);
+        }
+
+        View initialFocus = findViewById(R.id.modeServers);
+        if (initialFocus == null || initialFocus.getVisibility() != View.VISIBLE) {
+            initialFocus = findViewById(R.id.actionAddServer);
+        }
+        UiHelper.requestInitialTvFocus(this, initialFocus);
     }
 
     private void applyThemeToServerBrowser() {
@@ -785,6 +837,19 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
         // between binding to CMS and onResume()
         inForeground = true;
 
+        // On first launch, show onboarding before creating the temporary GL surface used
+        // for renderer detection. Some Android TV builds do not like that surface being
+        // backgrounded immediately by the welcome activity.
+        if (UiHelper.isTvDevice(this) && com.papi.nova.ui.NovaWelcomeActivity.Companion.shouldShow(this)) {
+            Intent welcomeIntent = new Intent(this, com.papi.nova.ui.NovaWelcomeActivity.class);
+            if (getIntent().getExtras() != null) {
+                welcomeIntent.putExtras(getIntent().getExtras());
+            }
+            startActivity(welcomeIntent);
+            finish();
+            return;
+        }
+
         // Create a GLSurfaceView to fetch GLRenderer unless we have
         // a cached result already.
         final GlPreferences glPrefs = GlPreferences.readPreferences(this);
@@ -813,11 +878,6 @@ public class PcView extends AppCompatActivity implements AdapterFragmentCallback
 
     private void completeOnCreate() {
         completeOnCreateCalled = true;
-
-        // Show welcome screen on first launch
-        if (com.papi.nova.ui.NovaWelcomeActivity.Companion.shouldShow(this)) {
-            startActivity(new Intent(this, com.papi.nova.ui.NovaWelcomeActivity.class));
-        }
 
         shortcutHelper = new ShortcutHelper(this);
 

--- a/app/src/main/java/com/papi/nova/api/PolarisGame.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisGame.kt
@@ -5,6 +5,12 @@ data class PolarisGame(
     val appId: Int = 0,
     val name: String,
     val source: String = "other",
+    val launcherSource: String = source,
+    val launcherDetail: String = "",
+    val platform: String = "unknown",
+    val runtime: String = "unknown",
+    val platformLabelFromServer: String = "",
+    val runtimeLabelFromServer: String = "",
     val steamAppid: String = "",
     val category: String = "",
     val installed: Boolean = true,
@@ -53,6 +59,12 @@ data class PolarisGame(
                 appId = json.optString("app_id", "").toIntOrNull() ?: json.optInt("app_id", 0),
                 name = json.optString("name", ""),
                 source = json.optString("source", "other"),
+                launcherSource = json.optString("launcher_source", json.optString("source", "other")),
+                launcherDetail = json.optString("launcher_detail", ""),
+                platform = json.optString("platform", "unknown").lowercase(),
+                runtime = json.optString("runtime", "unknown").lowercase(),
+                platformLabelFromServer = json.optString("platform_label", ""),
+                runtimeLabelFromServer = json.optString("runtime_label", ""),
                 steamAppid = json.optString("steam_appid", ""),
                 category = json.optString("category", ""),
                 installed = json.optBoolean("installed", true),
@@ -67,7 +79,7 @@ data class PolarisGame(
     }
 
     val isSteamBigPicture get() = name.equals("Steam Big Picture", ignoreCase = true)
-    val isProtonGame get() = source == "steam" && steamAppid.isNotEmpty()
+    val isProtonGame get() = runtime == "proton" || (runtime == "unknown" && source == "steam" && steamAppid.isNotEmpty())
     val hasMangoHudCompatibilityRisk get() = isSteamBigPicture || isProtonGame
     val categoryLabel get() = when (category) {
         "fast_action" -> "Action"
@@ -80,6 +92,34 @@ data class PolarisGame(
         "steam" -> "Steam"
         "lutris" -> "Lutris"
         "heroic" -> "Heroic"
+        "manual" -> "Manual"
         else -> ""
+    }
+    val platformLabel get() = platformLabelFromServer.ifBlank {
+        when (platform) {
+            "linux" -> "Linux"
+            "windows" -> "Windows"
+            "macos" -> "macOS"
+            else -> ""
+        }
+    }
+    val runtimeLabel get() = runtimeLabelFromServer.ifBlank {
+        when (runtime) {
+            "native" -> "Native"
+            "proton" -> "Proton"
+            "wine" -> "Wine"
+            "steam" -> "Steam"
+            "umu" -> "UMU"
+            else -> ""
+        }
+    }
+    val sourceRuntimeLabel: String get() {
+        val parts = mutableListOf<String>()
+        if (sourceLabel.isNotEmpty()) parts += sourceLabel
+        if (platformLabel.isNotEmpty()) parts += platformLabel
+        if (runtimeLabel.isNotEmpty() && !parts.any { it.equals(runtimeLabel, ignoreCase = true) }) {
+            parts += runtimeLabel
+        }
+        return parts.joinToString(" · ")
     }
 }

--- a/app/src/main/java/com/papi/nova/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/papi/nova/binding/input/ControllerHandler.java
@@ -3096,10 +3096,31 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             return options;
         }
 
+        @Override
+        public boolean supportsControllerMouseEmulation() {
+            return true;
+        }
+
+        @Override
+        public boolean isControllerMouseEmulationActive() {
+            return mouseEmulationActive;
+        }
+
+        @Override
+        public void setControllerMouseEmulationActive(boolean active) {
+            setMouseEmulationActive(active, false);
+        }
+
         public void toggleMouseEmulation() {
+            setMouseEmulationActive(!mouseEmulationActive, true);
+        }
+
+        private void setMouseEmulationActive(boolean active, boolean showToast) {
             mainThreadHandler.removeCallbacks(mouseEmulationRunnable);
-            mouseEmulationActive = !mouseEmulationActive;
-            Toast.makeText(activityContext, "Mouse emulation is: " + (mouseEmulationActive ? "ON" : "OFF"), Toast.LENGTH_SHORT).show();
+            mouseEmulationActive = active;
+            if (showToast) {
+                Toast.makeText(activityContext, "Mouse emulation is: " + (mouseEmulationActive ? "ON" : "OFF"), Toast.LENGTH_SHORT).show();
+            }
 
             if (mouseEmulationActive) {
                 mainThreadHandler.postDelayed(mouseEmulationRunnable, mouseEmulationReportPeriod);

--- a/app/src/main/java/com/papi/nova/binding/input/GameInputDevice.java
+++ b/app/src/main/java/com/papi/nova/binding/input/GameInputDevice.java
@@ -16,4 +16,24 @@ public interface GameInputDevice {
      * @return list of device specific game menu options, e.g. configure a controller's mouse mode
      */
     List<GameMenu.MenuOption> getGameMenuOptions();
+
+    /**
+     * @return true when this input device can temporarily behave like a host mouse
+     */
+    default boolean supportsControllerMouseEmulation() {
+        return false;
+    }
+
+    /**
+     * @return true when this input device is currently sending mouse input instead of gamepad input
+     */
+    default boolean isControllerMouseEmulationActive() {
+        return false;
+    }
+
+    /**
+     * Enables or disables controller-driven host mouse input.
+     */
+    default void setControllerMouseEmulationActive(boolean active) {
+    }
 }

--- a/app/src/main/java/com/papi/nova/discovery/DiscoveryService.java
+++ b/app/src/main/java/com/papi/nova/discovery/DiscoveryService.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import com.papi.nova.nvstream.mdns.MdnsComputer;
 import com.papi.nova.nvstream.mdns.JmDNSDiscoveryAgent;
+import com.papi.nova.nvstream.mdns.LegacyNsdManagerDiscoveryAgent;
 import com.papi.nova.nvstream.mdns.MdnsDiscoveryAgent;
 import com.papi.nova.nvstream.mdns.MdnsDiscoveryListener;
 import com.papi.nova.nvstream.mdns.NsdManagerDiscoveryAgent;
+import com.papi.nova.utils.UiHelper;
 
 import android.app.Service;
 import android.content.Intent;
@@ -63,8 +65,11 @@ public class DiscoveryService extends Service {
         //
         // As such, we use the jmDNS-based MdnsDiscoveryAgent prior to Android 14 and NsdManager
         // on Android 14 and above.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE && !UiHelper.isTvDevice(this)) {
             discoveryAgent = new JmDNSDiscoveryAgent(getApplicationContext(), listener);
+        }
+        else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            discoveryAgent = new LegacyNsdManagerDiscoveryAgent(getApplicationContext(), listener);
         }
         else {
             discoveryAgent = new NsdManagerDiscoveryAgent(getApplicationContext(), listener);

--- a/app/src/main/java/com/papi/nova/grid/AppGridAdapter.java
+++ b/app/src/main/java/com/papi/nova/grid/AppGridAdapter.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -70,8 +71,8 @@ public class AppGridAdapter extends GenericGridAdapter<AppView.AppObject> {
         for (AppView.AppObject app : allApps) {
             app.isHidden = hiddenAppIds.contains(app.app.getAppId());
             if (app.isHidden && !showHiddenApps) continue;
-            if (!searchFilter.isEmpty() &&
-                !app.app.getAppName().toLowerCase().contains(searchFilter)) continue;
+            String searchableText = (app.app.getAppName() + " " + app.app.getMetadataLabel()).toLowerCase();
+            if (!searchFilter.isEmpty() && !searchableText.contains(searchFilter)) continue;
             newList.add(app);
         }
         sortList(newList);
@@ -265,7 +266,8 @@ public class AppGridAdapter extends GenericGridAdapter<AppView.AppObject> {
                 && a.isRunning == b.isRunning
                 && a.isHidden == b.isHidden
                 && a.isPinned == b.isPinned
-                && a.app.getAppName().equals(b.app.getAppName());
+                && a.app.getAppName().equals(b.app.getAppName())
+                && a.app.getMetadataKey().equals(b.app.getMetadataKey());
         }
     }
 
@@ -276,11 +278,21 @@ public class AppGridAdapter extends GenericGridAdapter<AppView.AppObject> {
 
         // Running state indicators
         TextView hdrBadge = parentView.findViewById(R.id.hdr_badge);
+        TextView sourceBadge = parentView.findViewById(R.id.grid_source_badge);
+        TextView metaView = parentView.findViewById(R.id.grid_meta);
         View runningBadge = parentView.findViewById(R.id.running_badge);
         View runningBorder = parentView.findViewById(R.id.running_border);
 
         if (hdrBadge != null) {
             hdrBadge.setVisibility(showHdrBadges && obj.app.isHdrSupported() ? View.VISIBLE : View.GONE);
+        }
+
+        bindSourceBadge(sourceBadge, obj.app.getSourceLabel(), obj.app.getSource());
+
+        if (metaView != null) {
+            String metadata = obj.app.getMetadataLabel();
+            metaView.setText(metadata);
+            metaView.setVisibility(metadata.isEmpty() ? View.GONE : View.VISIBLE);
         }
 
         if (obj.isRunning) {
@@ -307,5 +319,45 @@ public class AppGridAdapter extends GenericGridAdapter<AppView.AppObject> {
 
     public void populateFeaturedArt(AppView.AppObject obj, ImageView imageView) {
         loader.populateImageView(obj.app, imageView);
+    }
+
+    private void bindSourceBadge(TextView badge, String label, String source) {
+        if (badge == null) {
+            return;
+        }
+        if (label == null || label.isEmpty()) {
+            badge.setVisibility(View.GONE);
+            return;
+        }
+
+        badge.setText(label);
+        badge.setVisibility(View.VISIBLE);
+
+        int bgColor;
+        int textColor;
+        switch (source) {
+            case "steam":
+                bgColor = 0x1A3B82F6;
+                textColor = 0xFF60A5FA;
+                break;
+            case "lutris":
+                bgColor = 0x1AF97316;
+                textColor = 0xFFFB923C;
+                break;
+            case "heroic":
+                bgColor = 0x1AA855F7;
+                textColor = 0xFFC084FC;
+                break;
+            default:
+                bgColor = 0x1A6B7280;
+                textColor = 0xFF9CA3AF;
+                break;
+        }
+
+        GradientDrawable bg = new GradientDrawable();
+        bg.setCornerRadius(context.getResources().getDisplayMetrics().density * 8f);
+        bg.setColor(bgColor);
+        badge.setTextColor(textColor);
+        badge.setBackground(bg);
     }
 }

--- a/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.java
+++ b/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.papi.nova.R;
+import com.papi.nova.utils.UiHelper;
 
 import java.util.ArrayList;
 
@@ -104,6 +105,7 @@ public abstract class GenericGridAdapter<T> extends RecyclerView.Adapter<Generic
     public void onBindViewHolder(ViewHolder holder, int position) {
         T item = itemList.get(position);
         populateView(holder.itemView, holder.imgView, holder.gridMask, holder.prgView, holder.txtView, holder.overlayView, item);
+        UiHelper.applyTvFocusStyle(context, holder.itemView);
         
         holder.itemView.setOnClickListener(v -> {
             if (clickListener != null) {

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvApp.java
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvApp.java
@@ -1,6 +1,11 @@
 package com.papi.nova.nvstream.http;
 
 import com.papi.nova.LimeLog;
+import com.papi.nova.api.PolarisGame;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 public class NvApp {
     public static final String REMOTE_INPUT_UUID = "8CB5C136-DA67-4F99-B4A1-F9CD35005CF4";
@@ -10,6 +15,13 @@ public class NvApp {
     private int appIndex;
     private boolean initialized;
     private boolean hdrSupported;
+    private String source = "";
+    private String launcherSource = "";
+    private String launcherDetail = "";
+    private String platform = "";
+    private String runtime = "";
+    private String steamAppid = "";
+    private String category = "";
     
     public NvApp() {}
     
@@ -63,6 +75,37 @@ public class NvApp {
     public void setHdrSupported(boolean hdrSupported) {
         this.hdrSupported = hdrSupported;
     }
+
+    public boolean applyPolarisMetadata(PolarisGame game) {
+        if (game == null) {
+            return false;
+        }
+
+        String nextSource = normalizeToken(game.getSource());
+        String nextLauncherSource = normalizeToken(game.getLauncherSource());
+        String nextLauncherDetail = normalizeToken(game.getLauncherDetail());
+        String nextPlatform = normalizeToken(game.getPlatform());
+        String nextRuntime = normalizeToken(game.getRuntime());
+        String nextSteamAppid = safeString(game.getSteamAppid());
+        String nextCategory = normalizeToken(game.getCategory());
+
+        boolean changed = !source.equals(nextSource)
+                || !launcherSource.equals(nextLauncherSource)
+                || !launcherDetail.equals(nextLauncherDetail)
+                || !platform.equals(nextPlatform)
+                || !runtime.equals(nextRuntime)
+                || !steamAppid.equals(nextSteamAppid)
+                || !category.equals(nextCategory);
+
+        source = nextSource;
+        launcherSource = nextLauncherSource;
+        launcherDetail = nextLauncherDetail;
+        platform = nextPlatform;
+        runtime = nextRuntime;
+        steamAppid = nextSteamAppid;
+        category = nextCategory;
+        return changed;
+    }
     
     public String getAppName() {
         return this.appName;
@@ -83,6 +126,90 @@ public class NvApp {
     public boolean isHdrSupported() {
         return this.hdrSupported;
     }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getLauncherSource() {
+        return launcherSource;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public String getRuntime() {
+        return runtime;
+    }
+
+    public String getSteamAppid() {
+        return steamAppid;
+    }
+
+    public String getSourceLabel() {
+        switch (!launcherSource.isEmpty() ? launcherSource : source) {
+            case "steam":
+                return "Steam";
+            case "lutris":
+                return "Lutris";
+            case "heroic":
+                return "Heroic";
+            case "manual":
+                return "Manual";
+            default:
+                return "";
+        }
+    }
+
+    public String getPlatformLabel() {
+        switch (platform) {
+            case "linux":
+                return "Linux";
+            case "windows":
+                return "Windows";
+            case "macos":
+                return "macOS";
+            default:
+                return "";
+        }
+    }
+
+    public String getRuntimeLabel() {
+        switch (runtime) {
+            case "native":
+                return "Native";
+            case "proton":
+                return "Proton";
+            case "wine":
+                return "Wine";
+            case "steam":
+                return "Steam";
+            case "umu":
+                return "UMU";
+            default:
+                return "";
+        }
+    }
+
+    public String getMetadataLabel() {
+        List<String> parts = new ArrayList<>();
+        addDistinct(parts, getSourceLabel());
+        addDistinct(parts, getPlatformLabel());
+        addDistinct(parts, getRuntimeLabel());
+        StringBuilder label = new StringBuilder();
+        for (String part : parts) {
+            if (label.length() > 0) {
+                label.append(" · ");
+            }
+            label.append(part);
+        }
+        return label.toString();
+    }
+
+    public String getMetadataKey() {
+        return source + "|" + launcherSource + "|" + launcherDetail + "|" + platform + "|" + runtime + "|" + steamAppid + "|" + category;
+    }
     
     public boolean isInitialized() {
         return this.initialized;
@@ -95,6 +222,30 @@ public class NvApp {
         str.append("UUID: ").append(appUUID).append("\n");
         str.append("ID: ").append(appId).append("\n");
         str.append("HDR Supported: ").append(hdrSupported ? "Yes" : "Unknown").append("\n");
+        String metadata = getMetadataLabel();
+        if (!metadata.isEmpty()) {
+            str.append("Source: ").append(metadata).append("\n");
+        }
         return str.toString();
+    }
+
+    private static String safeString(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static String normalizeToken(String value) {
+        return safeString(value).toLowerCase(Locale.US);
+    }
+
+    private static void addDistinct(List<String> parts, String value) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        for (String part : parts) {
+            if (part.equalsIgnoreCase(value)) {
+                return;
+            }
+        }
+        parts.add(value);
     }
 }

--- a/app/src/main/java/com/papi/nova/nvstream/mdns/LegacyNsdManagerDiscoveryAgent.java
+++ b/app/src/main/java/com/papi/nova/nvstream/mdns/LegacyNsdManagerDiscoveryAgent.java
@@ -1,0 +1,190 @@
+package com.papi.nova.nvstream.mdns;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+
+import com.papi.nova.LimeLog;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class LegacyNsdManagerDiscoveryAgent extends MdnsDiscoveryAgent {
+    private static final String SERVICE_TYPE = "_nvstream._tcp";
+
+    private final NsdManager nsdManager;
+    private final Object lock = new Object();
+    private final Queue<NsdServiceInfo> pendingResolutions = new LinkedList<>();
+    private final HashSet<String> queuedServiceNames = new HashSet<>();
+
+    private NsdManager.DiscoveryListener pendingListener;
+    private NsdManager.DiscoveryListener activeListener;
+    private boolean resolving;
+
+    public LegacyNsdManagerDiscoveryAgent(Context context, MdnsDiscoveryListener listener) {
+        super(listener);
+        this.nsdManager = (NsdManager) context.getSystemService(Context.NSD_SERVICE);
+    }
+
+    @Override
+    public void startDiscovery(int discoveryIntervalMs) {
+        synchronized (lock) {
+            if (pendingListener != null || activeListener != null || nsdManager == null) {
+                return;
+            }
+
+            pendingListener = createDiscoveryListener();
+            nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, pendingListener);
+        }
+    }
+
+    @Override
+    public void stopDiscovery() {
+        synchronized (lock) {
+            pendingListener = null;
+
+            if (activeListener != null && nsdManager != null) {
+                try {
+                    nsdManager.stopServiceDiscovery(activeListener);
+                } catch (IllegalArgumentException ignored) {
+                    // Android can throw if the listener has already been stopped asynchronously.
+                }
+                activeListener = null;
+            }
+
+            pendingResolutions.clear();
+            queuedServiceNames.clear();
+            resolving = false;
+        }
+    }
+
+    private NsdManager.DiscoveryListener createDiscoveryListener() {
+        return new NsdManager.DiscoveryListener() {
+            @Override
+            public void onStartDiscoveryFailed(String serviceType, int errorCode) {
+                LimeLog.severe("NSD legacy: Service discovery start failed: " + errorCode);
+                synchronized (lock) {
+                    if (pendingListener == this) {
+                        pendingListener = null;
+                    }
+                }
+                listener.notifyDiscoveryFailure(new RuntimeException("onStartDiscoveryFailed(): " + errorCode));
+            }
+
+            @Override
+            public void onStopDiscoveryFailed(String serviceType, int errorCode) {
+                LimeLog.severe("NSD legacy: Service discovery stop failed: " + errorCode);
+                synchronized (lock) {
+                    if (activeListener == this) {
+                        activeListener = null;
+                    }
+                }
+            }
+
+            @Override
+            public void onDiscoveryStarted(String serviceType) {
+                LimeLog.info("NSD legacy: Service discovery started");
+                synchronized (lock) {
+                    if (pendingListener != this) {
+                        nsdManager.stopServiceDiscovery(this);
+                        return;
+                    }
+
+                    pendingListener = null;
+                    activeListener = this;
+                }
+            }
+
+            @Override
+            public void onDiscoveryStopped(String serviceType) {
+                LimeLog.info("NSD legacy: Service discovery stopped");
+                synchronized (lock) {
+                    if (activeListener == this) {
+                        activeListener = null;
+                    }
+                }
+            }
+
+            @Override
+            public void onServiceFound(NsdServiceInfo serviceInfo) {
+                synchronized (lock) {
+                    if (activeListener != this) {
+                        return;
+                    }
+                }
+
+                LimeLog.info("NSD legacy: Machine appeared: " + serviceInfo.getServiceName());
+                queueResolution(serviceInfo);
+            }
+
+            @Override
+            public void onServiceLost(NsdServiceInfo serviceInfo) {
+                LimeLog.info("NSD legacy: Machine lost: " + serviceInfo.getServiceName());
+            }
+        };
+    }
+
+    private void queueResolution(NsdServiceInfo serviceInfo) {
+        synchronized (lock) {
+            String serviceName = serviceInfo.getServiceName();
+            if (!queuedServiceNames.add(serviceName)) {
+                return;
+            }
+
+            pendingResolutions.add(serviceInfo);
+            if (resolving) {
+                return;
+            }
+
+            resolving = true;
+        }
+
+        resolveNext();
+    }
+
+    private void resolveNext() {
+        NsdServiceInfo next;
+        synchronized (lock) {
+            next = pendingResolutions.poll();
+            if (next == null || activeListener == null) {
+                resolving = false;
+                return;
+            }
+        }
+
+        nsdManager.resolveService(next, new NsdManager.ResolveListener() {
+            @Override
+            public void onResolveFailed(NsdServiceInfo serviceInfo, int errorCode) {
+                LimeLog.warning("NSD legacy: Service resolve failed for " +
+                        serviceInfo.getServiceName() + ": " + errorCode);
+                finishResolution(serviceInfo);
+            }
+
+            @Override
+            public void onServiceResolved(NsdServiceInfo serviceInfo) {
+                LimeLog.info("NSD legacy: Machine resolved: " + serviceInfo.getServiceName());
+                InetAddress host = serviceInfo.getHost();
+                if (host instanceof Inet4Address) {
+                    reportNewComputer(serviceInfo.getServiceName(), serviceInfo.getPort(),
+                            new Inet4Address[]{(Inet4Address) host}, new Inet6Address[0]);
+                } else if (host instanceof Inet6Address) {
+                    reportNewComputer(serviceInfo.getServiceName(), serviceInfo.getPort(),
+                            new Inet4Address[0], new Inet6Address[]{(Inet6Address) host});
+                }
+
+                finishResolution(serviceInfo);
+            }
+        });
+    }
+
+    private void finishResolution(NsdServiceInfo serviceInfo) {
+        synchronized (lock) {
+            queuedServiceNames.remove(serviceInfo.getServiceName());
+        }
+        resolveNext();
+    }
+}

--- a/app/src/main/java/com/papi/nova/preferences/NovaListPreferenceDialogFragment.java
+++ b/app/src/main/java/com/papi/nova/preferences/NovaListPreferenceDialogFragment.java
@@ -1,0 +1,95 @@
+package com.papi.nova.preferences;
+
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.ListPreference;
+import androidx.preference.PreferenceDialogFragmentCompat;
+
+import com.papi.nova.R;
+
+public class NovaListPreferenceDialogFragment extends PreferenceDialogFragmentCompat {
+    private static final String SAVE_STATE_INDEX =
+            "NovaListPreferenceDialogFragment.index";
+    private static final String SAVE_STATE_ENTRIES =
+            "NovaListPreferenceDialogFragment.entries";
+    private static final String SAVE_STATE_ENTRY_VALUES =
+            "NovaListPreferenceDialogFragment.entryValues";
+
+    private int clickedDialogEntryIndex;
+    private CharSequence[] entries;
+    private CharSequence[] entryValues;
+
+    public static NovaListPreferenceDialogFragment newInstance(String key) {
+        NovaListPreferenceDialogFragment fragment = new NovaListPreferenceDialogFragment();
+        Bundle args = new Bundle(1);
+        args.putString(ARG_KEY, key);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            ListPreference preference = getListPreference();
+            if (preference.getEntries() == null || preference.getEntryValues() == null) {
+                throw new IllegalStateException("ListPreference requires entries and entry values");
+            }
+            clickedDialogEntryIndex = preference.findIndexOfValue(preference.getValue());
+            entries = preference.getEntries();
+            entryValues = preference.getEntryValues();
+        } else {
+            clickedDialogEntryIndex = savedInstanceState.getInt(SAVE_STATE_INDEX, 0);
+            entries = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRIES);
+            entryValues = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRY_VALUES);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(SAVE_STATE_INDEX, clickedDialogEntryIndex);
+        outState.putCharSequenceArray(SAVE_STATE_ENTRIES, entries);
+        outState.putCharSequenceArray(SAVE_STATE_ENTRY_VALUES, entryValues);
+    }
+
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        super.onPrepareDialogBuilder(builder);
+
+        ListAdapter adapter = new ArrayAdapter<>(
+                requireContext(),
+                R.layout.nova_select_dialog_singlechoice,
+                android.R.id.text1,
+                entries);
+        builder.setSingleChoiceItems(adapter, clickedDialogEntryIndex, (dialog, which) -> {
+            clickedDialogEntryIndex = which;
+            onClick(dialog, DialogInterface.BUTTON_POSITIVE);
+            dialog.dismiss();
+        });
+        builder.setPositiveButton(null, null);
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        if (!positiveResult || clickedDialogEntryIndex < 0 || entryValues == null) {
+            return;
+        }
+
+        String value = entryValues[clickedDialogEntryIndex].toString();
+        ListPreference preference = getListPreference();
+        if (preference.callChangeListener(value)) {
+            preference.setValue(value);
+        }
+    }
+
+    private ListPreference getListPreference() {
+        return (ListPreference) getPreference();
+    }
+}

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.java
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.java
@@ -416,11 +416,25 @@ public class StreamSettings extends AppCompatActivity {
             }
 
             // All input, gamepad, and OSC settings are now in category_input and category_overlays.
-            // Hide touch-only overlay controls on non-touchscreen devices
+            // Hide touch-only overlay controls on non-touchscreen devices.
+            // Remove dependent preferences with their parent toggles or AndroidX
+            // Preference throws while binding the screen.
             if (!pm.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)) {
                 PreferenceCategory overlays = findPreference("category_overlays");
                 if (overlays != null) {
+                    removeIfExists(overlays, "list_onscreen_controls_layout_preset");
+                    removeIfExists(overlays, "checkbox_hide_osc_when_has_gamepad");
+                    removeIfExists(overlays, "checkbox_vibrate_osc");
+                    removeIfExists(overlays, "seekbar_osc_opacity");
+                    removeIfExists(overlays, "checkbox_only_show_L3R3");
+                    removeIfExists(overlays, "checkbox_show_guide_button");
+                    removeIfExists(overlays, "seekbar_osc_free_analog_stick_opacity");
+                    removeIfExists(overlays, "checkbox_enable_analog_stick_new");
+                    removeIfExists(overlays, "option_reset_osc_preference");
                     removeIfExists(overlays, "checkbox_show_onscreen_controls");
+                    removeIfExists(overlays, "keyboard_axi_list");
+                    removeIfExists(overlays, "import_keyboard_file");
+                    removeIfExists(overlays, "export_keyboard_file");
                     removeIfExists(overlays, "checkbox_enable_keyboard");
                 }
             }
@@ -1125,6 +1139,10 @@ public class StreamSettings extends AppCompatActivity {
                 dialogFragment.show(getFragmentManager(), null);
             } else if (preference instanceof ConfirmDeleteKeyboardPreference) {
                 DialogFragment dialogFragment = ConfirmDeleteKeyboardPreference.DialogFragmentCompat.newInstance(preference.getKey());
+                dialogFragment.setTargetFragment(this, 0);
+                dialogFragment.show(getFragmentManager(), null);
+            } else if (preference instanceof ListPreference) {
+                DialogFragment dialogFragment = NovaListPreferenceDialogFragment.newInstance(preference.getKey());
                 dialogFragment.setTargetFragment(this, 0);
                 dialogFragment.show(getFragmentManager(), null);
             } else super.onDisplayPreferenceDialog(preference);

--- a/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
@@ -85,6 +85,7 @@ class NovaGameAdapter(
         private val categoryBadge: TextView = itemView.findViewById(R.id.nova_category_badge)
         private val sourceBadge: TextView = itemView.findViewById(R.id.nova_source_badge)
         private val hdrBadge: TextView = itemView.findViewById(R.id.nova_hdr_badge)
+        private val focusRing: View = itemView.findViewById(R.id.nova_focus_ring)
 
         fun bind(game: PolarisGame) {
             gameName.text = game.name
@@ -183,13 +184,16 @@ class NovaGameAdapter(
             itemView.isFocusableInTouchMode = false
             itemView.setOnFocusChangeListener { v, hasFocus ->
                 val card = v as? androidx.cardview.widget.CardView ?: return@setOnFocusChangeListener
+                focusRing.visibility = if (hasFocus) View.VISIBLE else View.GONE
                 if (hasFocus) {
                     card.cardElevation = 8f
-                    card.setCardBackgroundColor(0xFF4c5265.toInt())
+                    card.setCardBackgroundColor(
+                        v.context.resources.getColor(R.color.nova_twilight, v.context.theme)
+                    )
                     v.scaleX = 1.03f
                     v.scaleY = 1.03f
                 } else {
-                    card.cardElevation = 2f
+                    card.cardElevation = 0f
                     card.setCardBackgroundColor(
                         v.context.resources.getColor(R.color.nova_bg_card, v.context.theme)
                     )
@@ -220,6 +224,12 @@ class NovaGameAdapter(
             } else {
                 if (game.sourceLabel.isNotEmpty()) parts += game.sourceLabel
                 if (game.categoryLabel.isNotEmpty()) parts += game.categoryLabel
+            }
+            if (game.platformLabel.isNotEmpty() && !parts.any { it.equals(game.platformLabel, ignoreCase = true) }) {
+                parts += game.platformLabel
+            }
+            if (game.runtimeLabel.isNotEmpty() && !parts.any { it.equals(game.runtimeLabel, ignoreCase = true) }) {
+                parts += game.runtimeLabel
             }
 
             return if (parts.isEmpty()) {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
@@ -12,6 +12,7 @@ import android.view.animation.DecelerateInterpolator
 import android.view.animation.OvershootInterpolator
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.papi.nova.R
@@ -188,14 +189,14 @@ class NovaGameAdapter(
                 if (hasFocus) {
                     card.cardElevation = 8f
                     card.setCardBackgroundColor(
-                        v.context.resources.getColor(R.color.nova_twilight, v.context.theme)
+                        ContextCompat.getColor(v.context, R.color.nova_twilight)
                     )
                     v.scaleX = 1.03f
                     v.scaleY = 1.03f
                 } else {
                     card.cardElevation = 0f
                     card.setCardBackgroundColor(
-                        v.context.resources.getColor(R.color.nova_bg_card, v.context.theme)
+                        ContextCompat.getColor(v.context, R.color.nova_bg_card)
                     )
                     v.scaleX = 1.0f
                     v.scaleY = 1.0f

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -28,6 +28,7 @@ import com.papi.nova.R
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.api.PolarisGame
+import com.papi.nova.utils.UiHelper
 
 /**
  * Bottom sheet showing game details, tuning, and explicit launch modes.
@@ -151,11 +152,17 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
             catBadge.visibility = View.GONE
         }
 
-        // Genre chips
+        // Genre and runtime chips
         val genreContainer = view.findViewById<LinearLayout>(R.id.detail_genres)
-        if (game.genres.isNotEmpty()) {
+        val detailChips = mutableListOf<String>()
+        detailChips += game.genres
+        if (game.platformLabel.isNotEmpty()) detailChips += game.platformLabel
+        if (game.runtimeLabel.isNotEmpty() && !detailChips.any { it.equals(game.runtimeLabel, ignoreCase = true) }) {
+            detailChips += game.runtimeLabel
+        }
+        if (detailChips.isNotEmpty()) {
             genreContainer.visibility = View.VISIBLE
-            for (genre in game.genres) {
+            for (genre in detailChips) {
                 val chip = TextView(requireContext()).apply {
                     text = genre
                     textSize = 11f
@@ -412,6 +419,22 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         }
         gpuButton.setOnClickListener {
             launchWithSyncedMode(game, PolarisClientSettings.MODE_GPU_NATIVE_TEST)
+        }
+
+        if (UiHelper.isTvDevice(requireContext())) {
+            val launchButtonsByMode = mapOf(
+                PolarisClientSettings.MODE_HEADLESS_STREAM to headlessButton,
+                PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY to virtualButton,
+                PolarisClientSettings.MODE_DESKTOP_DISPLAY to desktopButton,
+                PolarisClientSettings.MODE_GPU_NATIVE_TEST to gpuButton
+            )
+            launchButtonsByMode.values.forEach { UiHelper.applyTvFocusStyle(it) }
+            view.post {
+                val preferredButton = launchButtonsByMode[recommendedMode]
+                val focusTarget = preferredButton?.takeIf { it.isEnabled && it.visibility == View.VISIBLE }
+                    ?: launchButtonsByMode.values.firstOrNull { it.isEnabled && it.visibility == View.VISIBLE }
+                focusTarget?.requestFocus()
+            }
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -9,6 +9,7 @@ import android.text.TextWatcher
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import android.view.View
+import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -70,6 +71,7 @@ class NovaLibraryActivity : AppCompatActivity() {
     private var streamServerCert: ByteArray? = null
     private var settingsSync: PolarisSettingsSyncManager? = null
     private var currentClientSettings: PolarisClientSettings? = null
+    private var tvInitialFocusRequested = false
 
     companion object {
         const val EXTRA_HOST = "host"
@@ -86,6 +88,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         NovaThemeManager.applyTheme(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_nova_library)
+        UiHelper.notifyNewRootView(this)
         applyHeaderInsets()
         if (savedInstanceState != null) {
             dismissOpenGameDetail()
@@ -130,11 +133,15 @@ class NovaLibraryActivity : AppCompatActivity() {
             getString(R.string.nova_library_server_context, serverName)
         }
 
-        val columns = when (resources.configuration.screenWidthDp) {
-            in 960..Int.MAX_VALUE -> 5
-            in 720..959 -> 4
-            in 600..719 -> 3
-            else -> 2
+        val columns = if (UiHelper.isTvDevice(this)) {
+            (resources.configuration.screenWidthDp / 230).coerceIn(4, 6)
+        } else {
+            when (resources.configuration.screenWidthDp) {
+                in 960..Int.MAX_VALUE -> 5
+                in 720..959 -> 4
+                in 600..719 -> 3
+                else -> 2
+            }
         }
         gameGrid.layoutManager = GridLayoutManager(this, columns)
 
@@ -148,6 +155,9 @@ class NovaLibraryActivity : AppCompatActivity() {
         // Swipe to refresh
         swipeRefresh.setColorSchemeColors(ContextCompat.getColor(this, R.color.nova_accent))
         swipeRefresh.setProgressBackgroundColorSchemeColor(ContextCompat.getColor(this, R.color.nova_bg_elevated))
+        if (UiHelper.isTvDevice(this)) {
+            swipeRefresh.isEnabled = false
+        }
         swipeRefresh.setOnRefreshListener {
             swipeRefresh.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
             loadGames()
@@ -185,6 +195,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         setupFilterTab(R.id.filter_steam, "steam")
         setupFilterTab(R.id.filter_action, "fast_action")
         setupFilterTab(R.id.filter_cinematic, "cinematic")
+        setupTvNavigation()
 
         // Retry button
         findViewById<MaterialButton>(R.id.nova_empty_retry).setOnClickListener { loadGames() }
@@ -204,7 +215,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                 val child = tabContainer.getChildAt(i)
                 child.setBackgroundResource(
                     if (child.id == id) R.drawable.nova_chip_selected
-                    else 0 // transparent — style handles default
+                    else R.drawable.nova_chip_default
                 )
             }
             filterGames(searchBar.text.toString())
@@ -246,6 +257,29 @@ class NovaLibraryActivity : AppCompatActivity() {
         }
     }
 
+    private fun setupTvNavigation() {
+        if (!UiHelper.isTvDevice(this)) return
+
+        gameGrid.isFocusable = true
+        gameGrid.isFocusableInTouchMode = false
+        gameGrid.descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
+        searchBar.isFocusableInTouchMode = false
+
+        intArrayOf(
+            R.id.nova_library_back,
+            R.id.nova_library_refresh,
+            R.id.nova_library_polaris_sync,
+            R.id.filter_all,
+            R.id.filter_recent,
+            R.id.filter_steam,
+            R.id.filter_action,
+            R.id.filter_cinematic,
+            R.id.nova_empty_retry
+        ).forEach { id ->
+            findViewById<View>(id)?.let { UiHelper.applyTvFocusStyle(it) }
+        }
+    }
+
     private fun filterGames(search: String, forceCoverRefresh: Boolean = false) {
         var filtered = allGames
 
@@ -273,6 +307,26 @@ class NovaLibraryActivity : AppCompatActivity() {
         resultsSummary.text = getString(R.string.nova_library_results_format, filtered.size)
         updateEmptyState(search)
         emptyText.visibility = if (filtered.isEmpty()) View.VISIBLE else View.GONE
+        requestInitialTvLibraryFocus(filtered.isEmpty())
+    }
+
+    private fun requestInitialTvLibraryFocus(isEmpty: Boolean) {
+        if (!UiHelper.isTvDevice(this) || tvInitialFocusRequested) return
+
+        tvInitialFocusRequested = true
+        if (isEmpty) {
+            UiHelper.requestInitialTvFocus(this, findViewById(R.id.nova_empty_retry))
+            return
+        }
+
+        gameGrid.postDelayed({
+            val firstCard = gameGrid.findViewHolderForAdapterPosition(0)?.itemView
+            if (firstCard != null && firstCard.isShown) {
+                firstCard.requestFocus()
+            } else {
+                gameGrid.requestFocus()
+            }
+        }, 140L)
     }
 
     private fun updateLibraryStats() {

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
@@ -24,6 +24,7 @@ import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.manager.PolarisProfileSync
 import com.papi.nova.manager.PolarisSettingsSyncManager
 import com.papi.nova.preferences.PreferenceConfiguration
+import com.papi.nova.utils.UiHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -150,6 +151,15 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
             PolarisClientSettings.MODE_GPU_NATIVE_TEST to view.findViewById(R.id.polaris_sync_gpu)
         )
 
+        if (UiHelper.isTvDevice(requireContext())) {
+            (modeButtons.values + listOf(
+                matchNovaButton,
+                sendNovaButton,
+                usePolarisButton,
+                clearProfileButton
+            )).forEach { UiHelper.applyTvFocusStyle(it) }
+        }
+
         modeButtons.forEach { (mode, button) ->
             button.setOnClickListener { updatePolarisSettings(streamDisplayMode = mode) }
         }
@@ -168,6 +178,7 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
         })
         currentSettings = initialSettings
         render(initialSettings)
+        requestInitialTvFocus(view)
 
         settingsSync = PolarisSettingsSyncManager(client) { settings ->
             if (settings != null) {
@@ -181,6 +192,16 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
             render(renderedSettings)
             settings?.let { maybeAutoSync(it) }
         }.also { it.start(immediate = true) }
+    }
+
+    private fun requestInitialTvFocus(root: View) {
+        if (!UiHelper.isTvDevice(requireContext())) return
+
+        root.post {
+            val modeButton = modeButtons.values.firstOrNull { it.isEnabled && it.visibility == View.VISIBLE }
+            val focusTarget = modeButton ?: sendNovaButton.takeIf { it.isEnabled && it.visibility == View.VISIBLE }
+            focusTarget?.requestFocus()
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -108,6 +108,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         val perfState = sheet.findViewById<TextView>(R.id.perf_state)
         val oscState = sheet.findViewById<TextView>(R.id.osc_state)
         val keyboardState = sheet.findViewById<TextView>(R.id.keyboard_state)
+        val mouseModeTitle = sheet.findViewById<TextView>(R.id.mouse_mode_title)
         val mouseModeState = sheet.findViewById<TextView>(R.id.mouse_mode_label)
 
         val apiClient = game.novaApiClient ?: getServerAddress()?.let {
@@ -295,7 +296,18 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 if (game.isKeyboardLayoutVisible() == true) "Shown" else "Hidden",
                 if (game.isKeyboardLayoutVisible() == true) ChipTone.ACTIVE else ChipTone.INACTIVE
             )
-            updateStateChip(mouseModeState, game.currentMouseModeLabel, ChipTone.INACTIVE)
+            if (device?.supportsControllerMouseEmulation() == true) {
+                val active = device.isControllerMouseEmulationActive()
+                mouseModeTitle?.setText(R.string.nova_quick_menu_controller_mouse_title)
+                updateStateChip(
+                    mouseModeState,
+                    if (active) "On" else "Off",
+                    if (active) ChipTone.ACTIVE else ChipTone.INACTIVE
+                )
+            } else {
+                mouseModeTitle?.setText(R.string.nova_quick_menu_touch_mouse_title)
+                updateStateChip(mouseModeState, game.currentMouseModeLabel, ChipTone.INACTIVE)
+            }
         }
 
         fun refreshTuningStates() {
@@ -391,7 +403,8 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
 
         fun refreshInputAvailability() {
             val ownerInputAllowed = !viewerSession
-            setRowEnabled(mouseRow, ownerInputAllowed && game.allowChangeMouseMode)
+            val controllerMouseSupported = device?.supportsControllerMouseEmulation() == true
+            setRowEnabled(mouseRow, ownerInputAllowed && (controllerMouseSupported || game.allowChangeMouseMode))
             setRowEnabled(oscRow, ownerInputAllowed)
             setRowEnabled(keyboardRow, ownerInputAllowed)
             setRowEnabled(pasteRow, ownerInputAllowed)
@@ -446,12 +459,23 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             refreshOverlayStates()
         } }
 
-        if (game.allowChangeMouseMode) {
-            mouseRow?.let { hapticClick(it) {
+        mouseRow?.let { hapticClick(it) {
+            val controllerMouseDevice = device?.takeIf { it.supportsControllerMouseEmulation() }
+            if (controllerMouseDevice != null) {
+                val next = !controllerMouseDevice.isControllerMouseEmulationActive()
+                controllerMouseDevice.setControllerMouseEmulationActive(next)
+                refreshOverlayStates()
+                dismiss()
+                Toast.makeText(
+                    game,
+                    if (next) R.string.nova_controller_mouse_enabled else R.string.nova_controller_mouse_disabled,
+                    if (next) Toast.LENGTH_LONG else Toast.LENGTH_SHORT
+                ).show()
+            } else if (game.allowChangeMouseMode) {
                 dismiss()
                 game.selectMouseMode(game)
-            } }
-        }
+            }
+        } }
 
         oscRow?.let { hapticClick(it) {
             dismiss()

--- a/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
@@ -3,6 +3,7 @@ package com.papi.nova.ui
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.papi.nova.R
+import com.papi.nova.PcView
 
 /**
  * First-launch welcome screen. Shows once, then never again.
@@ -18,7 +19,10 @@ class NovaWelcomeActivity : AppCompatActivity() {
             // Mark as seen
             getSharedPreferences("nova_prefs", MODE_PRIVATE).edit()
                 .putBoolean("welcome_seen", true)
-                .apply()
+                .commit()
+            val next = android.content.Intent(this, PcView::class.java)
+            intent.extras?.let { next.putExtras(it) }
+            startActivity(next)
             finish()
         }
     }

--- a/app/src/main/java/com/papi/nova/utils/UiHelper.java
+++ b/app/src/main/java/com/papi/nova/utils/UiHelper.java
@@ -9,6 +9,7 @@ import android.app.UiModeManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Insets;
 import android.os.Build;
@@ -35,6 +36,8 @@ public class UiHelper {
 
     private static final int TV_VERTICAL_PADDING_DP = 15;
     private static final int TV_HORIZONTAL_PADDING_DP = 15;
+    private static final float TV_FOCUS_SCALE = 1.04f;
+    private static final long TV_FOCUS_ANIMATION_MS = 120L;
 
     private static void setGameModeStatus(Context context, boolean streaming, boolean interruptible) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -125,7 +128,6 @@ public class UiHelper {
     public static void notifyNewRootView(final Activity activity)
     {
         View rootView = activity.findViewById(android.R.id.content);
-        UiModeManager modeMgr = (UiModeManager) activity.getSystemService(Context.UI_MODE_SERVICE);
 
         // Set GameState.MODE_NONE initially for all activities
         setGameModeStatus(activity, false, false);
@@ -140,7 +142,7 @@ public class UiHelper {
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
         }
 
-        if (modeMgr.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+        if (isTvDevice(activity)) {
             // Increase view padding on TVs
             float scale = activity.getResources().getDisplayMetrics().density;
             int verticalPaddingPixels = (int) (TV_VERTICAL_PADDING_DP*scale + 0.5f);
@@ -177,6 +179,78 @@ public class UiHelper {
 
             activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
         }
+    }
+
+    public static boolean isTvDevice(Context context) {
+        if (context == null) {
+            return false;
+        }
+
+        UiModeManager modeMgr = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+        if (modeMgr != null && modeMgr.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true;
+        }
+
+        int uiMode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_TYPE_MASK;
+        if (uiMode == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true;
+        }
+
+        PackageManager packageManager = context.getPackageManager();
+        return packageManager != null && packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK);
+    }
+
+    public static boolean hasCamera(Context context) {
+        if (context == null || context.getPackageManager() == null) {
+            return false;
+        }
+
+        PackageManager packageManager = context.getPackageManager();
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
+    }
+
+    public static void applyTvFocusStyle(Context context, View view) {
+        if (isTvDevice(context)) {
+            applyTvFocusStyle(view);
+        }
+    }
+
+    public static void applyTvFocusStyle(View view) {
+        if (view == null) {
+            return;
+        }
+
+        view.setFocusable(true);
+        view.setFocusableInTouchMode(false);
+        view.setOnFocusChangeListener((v, hasFocus) -> {
+            View focusRing = v.findViewById(R.id.nova_focus_ring);
+            if (focusRing != null) {
+                focusRing.setVisibility(hasFocus ? View.VISIBLE : View.GONE);
+            }
+            float scale = hasFocus ? TV_FOCUS_SCALE : 1.0f;
+            v.animate()
+                    .scaleX(scale)
+                    .scaleY(scale)
+                    .setDuration(TV_FOCUS_ANIMATION_MS)
+                    .start();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                v.setTranslationZ(hasFocus ? dpToPx(v.getContext(), 8) : 0);
+            }
+        });
+    }
+
+    public static void requestInitialTvFocus(Context context, View preferredView) {
+        if (!isTvDevice(context) || preferredView == null) {
+            return;
+        }
+
+        preferredView.postDelayed(() -> {
+            if (preferredView.isShown() && preferredView.isFocusable()) {
+                preferredView.requestFocus();
+            }
+        }, TV_FOCUS_ANIMATION_MS);
     }
 
     public static void showDecoderCrashDialog(Activity activity) {

--- a/app/src/main/res/drawable/nova_card_bg_focusable.xml
+++ b/app/src/main/res/drawable/nova_card_bg_focusable.xml
@@ -2,17 +2,20 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
+            <solid android:color="#3Ac8d6e5" />
             <stroke
                 android:width="2dp"
-                android:color="@color/nova_ice" />
-            <corners android:radius="12dp" />
+                android:color="@color/nova_accent" />
+            <corners android:radius="16dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
-            <corners android:radius="12dp" />
+            <solid android:color="#30c8d6e5" />
+            <stroke
+                android:width="1dp"
+                android:color="#18c8d6e5" />
+            <corners android:radius="16dp" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/nova_card_focus_ring.xml
+++ b/app/src/main/res/drawable/nova_card_focus_ring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/nova_accent" />
+    <corners android:radius="18dp" />
+</shape>

--- a/app/src/main/res/drawable/nova_chip_default.xml
+++ b/app/src/main/res/drawable/nova_chip_default.xml
@@ -2,16 +2,19 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
+            <solid android:color="@color/nova_badge_bg" />
             <stroke
                 android:width="2dp"
-                android:color="@color/nova_ice" />
+                android:color="@color/nova_accent" />
             <corners android:radius="12dp" />
         </shape>
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
+            <solid android:color="@color/nova_badge_bg" />
+            <stroke
+                android:width="1dp"
+                android:color="#18c8d6e5" />
             <corners android:radius="12dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/nova_dialog_choice_bg.xml
+++ b/app/src/main/res/drawable/nova_dialog_choice_bg.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <solid android:color="#407C73FF" />
+            <stroke android:width="2dp" android:color="@color/nova_accent" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <solid android:color="#337C73FF" />
+            <stroke android:width="2dp" android:color="@color/nova_accent" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <solid android:color="#337C73FF" />
+            <stroke android:width="2dp" android:color="@color/nova_accent" />
+        </shape>
+    </item>
+    <item android:state_activated="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <solid android:color="#247C73FF" />
+        </shape>
+    </item>
+    <item android:drawable="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/drawable/nova_streaming_badge_bg.xml
+++ b/app/src/main/res/drawable/nova_streaming_badge_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/nova_success" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/nova_tv_banner.xml
+++ b/app/src/main/res/drawable/nova_tv_banner.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="320dp"
+    android:height="180dp"
+    android:viewportWidth="320"
+    android:viewportHeight="180">
+
+    <path
+        android:fillColor="#101827"
+        android:pathData="M0,0h320v180H0z" />
+
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M42,126 C84,102 120,92 160,90 C200,88 236,78 278,54"
+        android:strokeAlpha="0.45"
+        android:strokeColor="#3b4565"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M54,138 C96,116 128,106 160,104 C192,102 224,92 266,70"
+        android:strokeAlpha="0.3"
+        android:strokeColor="#7c73ff"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+
+    <group
+        android:translateX="100"
+        android:translateY="30">
+        <path
+            android:fillColor="#d4dde8"
+            android:pathData="M60,10 Q63,52 100,60 Q63,68 60,110 Q57,68 20,60 Q57,52 60,10 Z" />
+        <path
+            android:fillColor="#7c73ff"
+            android:pathData="M60,40 Q62,57 75,60 Q62,63 60,80 Q58,63 45,60 Q58,57 60,40 Z" />
+        <path
+            android:fillColor="#d4dde8"
+            android:pathData="M60,56 A4,4 0 1,1 60,64 A4,4 0 1,1 60,56 Z" />
+    </group>
+</vector>

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -24,26 +24,25 @@
             android:orientation="vertical"
             android:paddingStart="24dp"
             android:paddingEnd="20dp"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp">
+            android:paddingTop="14dp"
+            android:paddingBottom="12dp">
 
             <TextView
                 android:id="@+id/appListText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textSize="26sp"
+                android:textSize="@dimen/nova_text_header"
                 android:textColor="@color/nova_ice"
-                android:fontFamily="sans-serif-light"
-                android:letterSpacing="0.02" />
+                android:fontFamily="sans-serif-medium" />
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Games"
-                android:textSize="11sp"
+                android:text="@string/server_library_label"
+                android:textSize="@dimen/nova_text_badge"
                 android:textColor="@color/nova_text_muted"
                 android:fontFamily="sans-serif-medium"
-                android:letterSpacing="0.12"
+                android:letterSpacing="0.08"
                 android:textAllCaps="true"
                 android:paddingTop="4dp" />
 
@@ -53,17 +52,20 @@
         <EditText
             android:id="@+id/app_search"
             android:layout_width="match_parent"
-            android:layout_height="44dp"
+            android:layout_height="@dimen/nova_search_height"
             android:layout_marginStart="20dp"
             android:layout_marginEnd="20dp"
             android:layout_marginBottom="10dp"
-            android:hint="Search games\u2026"
+            android:background="@drawable/nova_search_bg"
+            android:drawableStart="@android:drawable/ic_menu_search"
+            android:drawablePadding="12dp"
+            android:drawableTint="@color/nova_text_muted"
+            android:hint="@string/server_library_search_hint"
             android:textColorHint="@color/nova_text_muted"
             android:textColor="@color/nova_text_primary"
             android:textSize="14sp"
-            android:background="@drawable/nova_search_bg"
-            android:paddingStart="18dp"
-            android:paddingEnd="18dp"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
             android:singleLine="true"
             android:imeOptions="actionSearch"
             android:inputType="text"
@@ -79,19 +81,19 @@
             android:gravity="center_vertical"
             android:layout_marginStart="20dp"
             android:layout_marginEnd="20dp"
-            android:layout_marginBottom="8dp"
-            android:background="@drawable/nova_card_bg"
-            android:paddingStart="12dp"
-            android:paddingTop="12dp"
-            android:paddingEnd="12dp"
-            android:paddingBottom="12dp"
+            android:layout_marginBottom="10dp"
+            android:background="@drawable/nova_card_bg_focusable"
+            android:paddingStart="14dp"
+            android:paddingTop="14dp"
+            android:paddingEnd="14dp"
+            android:paddingBottom="14dp"
             android:foreground="?attr/selectableItemBackground"
             android:focusable="true"
             android:visibility="gone">
 
             <androidx.cardview.widget.CardView
-                android:layout_width="74dp"
-                android:layout_height="96dp"
+                android:layout_width="86dp"
+                android:layout_height="112dp"
                 app:cardCornerRadius="14dp"
                 app:cardElevation="0dp"
                 app:cardBackgroundColor="@color/nova_deep">

--- a/app/src/main/res/layout/activity_nova_library.xml
+++ b/app/src/main/res/layout/activity_nova_library.xml
@@ -21,9 +21,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingStart="@dimen/nova_spacing_lg"
+            android:paddingStart="@dimen/nova_spacing_xxl"
             android:paddingTop="@dimen/nova_spacing_sm"
-            android:paddingEnd="@dimen/nova_spacing_lg">
+            android:paddingEnd="@dimen/nova_spacing_xxl">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -97,9 +97,9 @@
                 android:layout_marginTop="@dimen/nova_spacing_xs"
                 android:text="@string/nova_library_title"
                 android:textColor="@color/nova_ice"
-                android:textSize="22sp"
+                android:textSize="@dimen/nova_text_header"
                 android:fontFamily="sans-serif-medium"
-                android:letterSpacing="0.02" />
+                android:letterSpacing="0" />
 
             <TextView
                 android:id="@+id/nova_library_context"
@@ -124,7 +124,7 @@
                 android:id="@+id/nova_search"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/nova_search_height"
-                android:layout_marginTop="@dimen/nova_spacing_xs"
+                android:layout_marginTop="@dimen/nova_spacing_sm"
                 android:background="@drawable/nova_search_bg"
                 android:drawableStart="@android:drawable/ic_menu_search"
                 android:drawablePadding="12dp"
@@ -141,7 +141,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/nova_spacing_xs"
+                android:layout_marginTop="@dimen/nova_spacing_sm"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
@@ -173,7 +173,7 @@
             android:paddingStart="@dimen/nova_spacing_md"
             android:paddingTop="@dimen/nova_spacing_xs"
             android:paddingEnd="@dimen/nova_spacing_md"
-            android:paddingBottom="@dimen/nova_spacing_xs"
+            android:paddingBottom="@dimen/nova_spacing_sm"
             android:scrollbars="none">
 
             <LinearLayout
@@ -230,9 +230,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:clipToPadding="false"
-                    android:paddingStart="6dp"
-                    android:paddingTop="4dp"
-                    android:paddingEnd="6dp"
+                    android:paddingStart="@dimen/nova_spacing_md"
+                    android:paddingTop="@dimen/nova_spacing_sm"
+                    android:paddingEnd="@dimen/nova_spacing_md"
                     android:paddingBottom="@dimen/nova_spacing_huge" />
 
             </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/app_grid_item.xml
+++ b/app/src/main/res/layout/app_grid_item.xml
@@ -26,6 +26,11 @@
                 android:transitionName="game_cover_art"
                 android:contentDescription="@string/nova_a11y_game_cover" />
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/nova_cover_scrim" />
+
             <!-- Running overlay + play icon -->
             <RelativeLayout
                 android:id="@+id/grid_mask"
@@ -39,24 +44,45 @@
                     android:layout_centerInParent="true" />
             </RelativeLayout>
 
-            <!-- Running indicator badge (top-right) -->
-            <TextView
-                android:id="@+id/hdr_badge"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="top|start"
                 android:layout_margin="8dp"
-                android:text="@string/badge_hdr"
-                android:textSize="9sp"
-                android:textColor="@color/nova_ice"
-                android:fontFamily="sans-serif-medium"
-                android:letterSpacing="0.05"
-                android:background="@drawable/nova_badge_bg"
-                android:paddingStart="6dp"
-                android:paddingEnd="6dp"
-                android:paddingTop="2dp"
-                android:paddingBottom="2dp"
-                android:visibility="gone" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/grid_source_badge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/nova_badge_bg"
+                    android:fontFamily="sans-serif-medium"
+                    android:paddingStart="7dp"
+                    android:paddingTop="2dp"
+                    android:paddingEnd="7dp"
+                    android:paddingBottom="2dp"
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="9sp"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/hdr_badge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:text="@string/badge_hdr"
+                    android:textSize="9sp"
+                    android:textColor="@color/nova_ice"
+                    android:fontFamily="sans-serif-medium"
+                    android:letterSpacing="0.05"
+                    android:background="@drawable/nova_badge_bg"
+                    android:paddingStart="6dp"
+                    android:paddingEnd="6dp"
+                    android:paddingTop="2dp"
+                    android:paddingBottom="2dp"
+                    android:visibility="gone" />
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/running_badge"
@@ -64,12 +90,12 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="top|end"
                 android:layout_margin="8dp"
-                android:text="STREAMING"
+                android:text="@string/badge_streaming"
                 android:textSize="9sp"
                 android:textColor="@color/nova_bg_window"
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.05"
-                android:background="@color/nova_success"
+                android:background="@drawable/nova_streaming_badge_bg"
                 android:paddingStart="6dp"
                 android:paddingEnd="6dp"
                 android:paddingTop="2dp"
@@ -94,6 +120,17 @@
                     android:fontFamily="sans-serif-medium"
                     android:maxLines="2"
                     android:ellipsize="end" />
+
+                <TextView
+                    android:id="@+id/grid_meta"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="3dp"
+                    android:textColor="@color/nova_text_muted"
+                    android:textSize="10sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:visibility="gone" />
             </LinearLayout>
 
         </FrameLayout>
@@ -105,6 +142,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/nova_running_border"
+        android:visibility="gone" />
+
+    <View
+        android:id="@+id/nova_focus_ring"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/nova_card_focus_ring"
         android:visibility="gone" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/app_grid_item_small.xml
+++ b/app/src/main/res/layout/app_grid_item_small.xml
@@ -23,6 +23,11 @@
                 android:layout_height="match_parent"
                 android:scaleType="centerCrop" />
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/nova_cover_scrim" />
+
             <RelativeLayout
                 android:id="@+id/grid_mask"
                 android:layout_width="match_parent"
@@ -53,18 +58,42 @@
                 android:paddingBottom="2dp"
                 android:visibility="gone" />
 
-            <TextView
-                android:id="@+id/grid_text"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
                 android:background="@color/nova_bg_card"
-                android:padding="8dp"
-                android:textColor="@color/nova_ice"
-                android:fontFamily="sans-serif-medium"
-                android:textSize="11sp"
-                android:maxLines="2"
-                android:ellipsize="end" />
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <TextView
+                    android:id="@+id/grid_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/nova_ice"
+                    android:fontFamily="sans-serif-medium"
+                    android:textSize="11sp"
+                    android:maxLines="1"
+                    android:ellipsize="end" />
+
+                <TextView
+                    android:id="@+id/grid_meta"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:textColor="@color/nova_text_muted"
+                    android:textSize="8sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
+                    android:visibility="gone" />
+            </LinearLayout>
         </FrameLayout>
     </androidx.cardview.widget.CardView>
+
+    <View
+        android:id="@+id/nova_focus_ring"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/nova_card_focus_ring"
+        android:visibility="gone" />
 </FrameLayout>

--- a/app/src/main/res/layout/nova_game_card.xml
+++ b/app/src/main/res/layout/nova_game_card.xml
@@ -112,5 +112,12 @@
                     android:textSize="11sp" />
             </LinearLayout>
         </FrameLayout>
+
+        <View
+            android:id="@+id/nova_focus_ring"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/nova_game_card_cover_height"
+            android:background="@drawable/nova_card_focus_ring"
+            android:visibility="gone" />
     </FrameLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/nova_quick_menu.xml
+++ b/app/src/main/res/layout/nova_quick_menu.xml
@@ -451,10 +451,11 @@
                     android:paddingEnd="2dp">
 
                     <TextView
+                        android:id="@+id/mouse_mode_title"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Mouse"
+                        android:text="@string/nova_quick_menu_touch_mouse_title"
                         android:textColor="@color/nova_text_primary"
                         android:textSize="14sp" />
 

--- a/app/src/main/res/layout/nova_select_dialog_singlechoice.xml
+++ b/app/src/main/res/layout/nova_select_dialog_singlechoice.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="64dp"
+    android:background="@drawable/nova_dialog_choice_bg"
+    android:checkMark="?android:attr/listChoiceIndicatorSingle"
+    android:ellipsize="end"
+    android:focusable="false"
+    android:gravity="center_vertical"
+    android:maxLines="1"
+    android:paddingStart="32dp"
+    android:paddingEnd="32dp"
+    android:textColor="@color/nova_text_primary"
+    android:textSize="20sp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,9 @@
 
     <string name="menu_button">Menu</string>
     <string name="quick_menu_title">Quick Menu</string>
+    <string name="server_library_label">Server Library</string>
+    <string name="server_library_search_hint">Search games…</string>
+    <string name="badge_streaming">Streaming</string>
     <string name="configuration_mode_move_buttons">Move buttons mode</string>
     <string name="configuration_mode_resize_buttons">Resize buttons mode</string>
     <string name="configuration_mode_disable_enable_buttons">Enable/Disable buttons mode</string>
@@ -583,6 +586,10 @@
     <string name="nova_quick_menu_owner_only_caption">owner controls host tuning</string>
     <string name="nova_quick_menu_host_controls_unavailable_caption">host controls unavailable</string>
     <string name="nova_quick_menu_session_ending_caption">session ending</string>
+    <string name="nova_quick_menu_controller_mouse_title">Controller Mouse</string>
+    <string name="nova_quick_menu_touch_mouse_title">Touch Mouse</string>
+    <string name="nova_controller_mouse_enabled">Controller mouse enabled. Move with the sticks; A clicks and B right-clicks.</string>
+    <string name="nova_controller_mouse_disabled">Controller mouse disabled</string>
     <string name="nova_quick_menu_mode_unknown">Checking stream mode</string>
     <string name="nova_quick_menu_mode_format">%1$s session</string>
     <string name="nova_session_mode_headless">Headless Stream</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -126,6 +126,11 @@
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
         <item name="android:textColorSecondary">@color/nova_text_secondary</item>
         <item name="colorAccent">@color/nova_accent</item>
+        <item name="android:colorControlHighlight">@color/nova_accent_surface</item>
+        <item name="colorControlHighlight">@color/nova_accent_surface</item>
+        <item name="android:listChoiceBackgroundIndicator">@drawable/nova_dialog_choice_bg</item>
+        <item name="listChoiceBackgroundIndicator">@drawable/nova_dialog_choice_bg</item>
+        <item name="android:listSelector">@drawable/nova_dialog_choice_bg</item>
         <item name="buttonBarPositiveButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/NovaDialogButton</item>
@@ -160,7 +165,7 @@
         <item name="android:textColor">@color/nova_text_primary</item>
         <item name="android:textSize">13sp</item>
         <item name="android:fontFamily">sans-serif-medium</item>
-        <item name="android:background">@drawable/nova_badge_bg</item>
+        <item name="android:background">@drawable/nova_chip_default</item>
         <item name="android:clickable">true</item>
         <item name="android:focusable">true</item>
     </style>

--- a/app/src/test/java/com/papi/nova/LayoutInflationTest.java
+++ b/app/src/test/java/com/papi/nova/LayoutInflationTest.java
@@ -1,6 +1,7 @@
 package com.papi.nova;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.LayoutInflater;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -30,6 +31,22 @@ public class LayoutInflationTest {
         Context base = ApplicationProvider.getApplicationContext();
         Context context = new androidx.appcompat.view.ContextThemeWrapper(base,
                 com.google.android.material.R.style.Theme_MaterialComponents_NoActionBar);
+        inflateAllLayouts(context);
+    }
+
+    @Test
+    public void allLayoutsInflateInTelevisionMode() throws IllegalAccessException {
+        Context base = ApplicationProvider.getApplicationContext();
+        Configuration config = new Configuration(base.getResources().getConfiguration());
+        config.uiMode = (config.uiMode & ~Configuration.UI_MODE_TYPE_MASK) |
+                Configuration.UI_MODE_TYPE_TELEVISION;
+        Context tvBase = base.createConfigurationContext(config);
+        Context context = new androidx.appcompat.view.ContextThemeWrapper(tvBase,
+                com.google.android.material.R.style.Theme_MaterialComponents_NoActionBar);
+        inflateAllLayouts(context);
+    }
+
+    private static void inflateAllLayouts(Context context) throws IllegalAccessException {
         for (int layoutId : getAllLayoutResourceIds()) {
             try {
                 LayoutInflater.from(context).inflate(layoutId, null);

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.java
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.java
@@ -281,6 +281,8 @@ public class PolarisApiClientParsingTest {
     public void parseGameResponse_includesLaunchModeContract() throws Exception {
         JSONObject json = new JSONObject(
                 "{\"id\":\"game-uuid\",\"app_id\":42,\"name\":\"Steam Big Picture\"," +
+                        "\"source\":\"lutris\",\"launcher_source\":\"lutris\",\"launcher_detail\":\"wine\"," +
+                        "\"platform\":\"windows\",\"runtime\":\"wine\"," +
                         "\"launch_mode\":{\"preferred_mode\":\"host_virtual_display\",\"recommended_mode\":\"headless_stream\"," +
                         "\"allowed_modes\":[\"headless_stream\",\"host_virtual_display\"]," +
                         "\"mode_reason\":\"Headless is recommended because this Polaris host is already configured for headless streaming.\"}}"
@@ -289,6 +291,14 @@ public class PolarisApiClientParsingTest {
         PolarisGame game = PolarisGame.Companion.fromJson(json);
 
         assertEquals("game-uuid", game.getId());
+        assertEquals("lutris", game.getLauncherSource());
+        assertEquals("wine", game.getLauncherDetail());
+        assertEquals("windows", game.getPlatform());
+        assertEquals("wine", game.getRuntime());
+        assertEquals("Lutris", game.getSourceLabel());
+        assertEquals("Windows", game.getPlatformLabel());
+        assertEquals("Wine", game.getRuntimeLabel());
+        assertEquals("Lutris · Windows · Wine", game.getSourceRuntimeLabel());
         assertEquals("host_virtual_display", game.getLaunchMode().getPreferredMode());
         assertEquals("headless_stream", game.getLaunchMode().getRecommendedMode());
         assertTrue(game.getLaunchMode().getAllowedModes().contains("headless_stream"));

--- a/app/src/test/java/com/papi/nova/utils/UiHelperTvTest.java
+++ b/app/src/test/java/com/papi/nova/utils/UiHelperTvTest.java
@@ -1,0 +1,54 @@
+package com.papi.nova.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.view.View;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(sdk = {33})
+@RunWith(RobolectricTestRunner.class)
+public class UiHelperTvTest {
+    @Test
+    public void isTvDeviceHonorsTelevisionConfiguration() {
+        Context base = ApplicationProvider.getApplicationContext();
+        Configuration config = new Configuration(base.getResources().getConfiguration());
+        config.uiMode = (config.uiMode & ~Configuration.UI_MODE_TYPE_MASK) |
+                Configuration.UI_MODE_TYPE_TELEVISION;
+
+        Context tvContext = base.createConfigurationContext(config);
+
+        assertTrue(UiHelper.isTvDevice(tvContext));
+    }
+
+    @Test
+    public void isTvDeviceReturnsFalseForNormalConfiguration() {
+        Context base = ApplicationProvider.getApplicationContext();
+        Configuration config = new Configuration(base.getResources().getConfiguration());
+        config.uiMode = (config.uiMode & ~Configuration.UI_MODE_TYPE_MASK) |
+                Configuration.UI_MODE_TYPE_NORMAL;
+
+        Context normalContext = base.createConfigurationContext(config);
+
+        assertFalse(UiHelper.isTvDevice(normalContext));
+    }
+
+    @Test
+    public void applyTvFocusStyleMakesViewDpadFocusable() {
+        Context context = ApplicationProvider.getApplicationContext();
+        View view = new View(context);
+
+        UiHelper.applyTvFocusStyle(view);
+
+        assertTrue(view.isFocusable());
+        assertFalse(view.isFocusableInTouchMode());
+    }
+}


### PR DESCRIPTION
## Summary

This PR bundles the current Nova Android TV and Polaris sync UX work into a draft review branch.

## Changes

- Adds Android TV-oriented polish for Nova library and server library screens, including clearer focus states, card styling, source metadata, and streaming badges.
- Improves Polaris-aware app metadata and sync surfaces so Steam/Lutris/Heroic/manual sources and platform/runtime details are easier to distinguish.
- Adds TV-friendly settings/dialog handling and supporting UI assets for controller/remote navigation.
- Keeps the existing Polaris stream/session plumbing intact while refining the visible UX around it.

## Validation

- Built ARM64 debug APK with `./gradlew -PnovaAbis=arm64-v8a :app:assembleNonRoot_gameDebug`.
- Ran focused unit/layout checks with `./gradlew :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.LayoutInflationTest --tests com.papi.nova.utils.UiHelperTvTest`.
- Installed and smoke-launched the APK on NVIDIA Shield.
- Installed the APK on Pixel 10 Pro.

## Notes

Draft PR for CI and review. The branch is `docs/bidirectional-sync-release` at commit `8f53dd4`.