### PR TITLE
Add runtime filters to Nova library

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisGame.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisGame.kt
@@ -79,7 +79,8 @@ data class PolarisGame(
     }
 
     val isSteamBigPicture get() = name.equals("Steam Big Picture", ignoreCase = true)
-    val isProtonGame get() = runtime == "proton" || (runtime == "unknown" && source == "steam" && steamAppid.isNotEmpty())
+    val effectiveSource get() = launcherSource.ifBlank { source }
+    val isProtonGame get() = runtime == "proton" || (runtime == "unknown" && effectiveSource == "steam" && steamAppid.isNotEmpty())
     val hasMangoHudCompatibilityRisk get() = isSteamBigPicture || isProtonGame
     val categoryLabel get() = when (category) {
         "fast_action" -> "Action"
@@ -88,7 +89,7 @@ data class PolarisGame(
         "vr" -> "VR"
         else -> ""
     }
-    val sourceLabel get() = when (source) {
+    val sourceLabel get() = when (effectiveSource) {
         "steam" -> "Steam"
         "lutris" -> "Lutris"
         "heroic" -> "Heroic"

--- a/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameAdapter.kt
@@ -99,13 +99,13 @@ class NovaGameAdapter(
                 sourceBadge.text = srcLabel
                 sourceBadge.visibility = View.VISIBLE
                 // Color-code by source
-                val bgColor = when (game.source) {
+                val bgColor = when (game.effectiveSource) {
                     "steam" -> 0x1A3B82F6.toInt()  // blue/10
                     "lutris" -> 0x1AF97316.toInt()  // orange/10
                     "heroic" -> 0x1AA855F7.toInt()  // purple/10
                     else -> 0x1A6B7280.toInt()
                 }
-                val textColor = when (game.source) {
+                val textColor = when (game.effectiveSource) {
                     "steam" -> 0xFF60A5FA.toInt()    // blue-400
                     "lutris" -> 0xFFFB923C.toInt()   // orange-400
                     "heroic" -> 0xFFC084FC.toInt()   // purple-400

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -193,6 +193,12 @@ class NovaLibraryActivity : AppCompatActivity() {
         setupFilterTab(R.id.filter_all, "")
         setupFilterTab(R.id.filter_recent, "recent")
         setupFilterTab(R.id.filter_steam, "steam")
+        setupFilterTab(R.id.filter_lutris, "lutris")
+        setupFilterTab(R.id.filter_heroic, "heroic")
+        setupFilterTab(R.id.filter_linux, "linux")
+        setupFilterTab(R.id.filter_windows, "windows")
+        setupFilterTab(R.id.filter_proton, "proton")
+        setupFilterTab(R.id.filter_wine, "wine")
         setupFilterTab(R.id.filter_action, "fast_action")
         setupFilterTab(R.id.filter_cinematic, "cinematic")
         setupTvNavigation()
@@ -272,6 +278,12 @@ class NovaLibraryActivity : AppCompatActivity() {
             R.id.filter_all,
             R.id.filter_recent,
             R.id.filter_steam,
+            R.id.filter_lutris,
+            R.id.filter_heroic,
+            R.id.filter_linux,
+            R.id.filter_windows,
+            R.id.filter_proton,
+            R.id.filter_wine,
             R.id.filter_action,
             R.id.filter_cinematic,
             R.id.nova_empty_retry
@@ -285,7 +297,12 @@ class NovaLibraryActivity : AppCompatActivity() {
 
         // Text search
         if (search.isNotEmpty()) {
-            filtered = filtered.filter { it.name.contains(search, ignoreCase = true) }
+            filtered = filtered.filter { game ->
+                game.name.contains(search, ignoreCase = true) ||
+                    game.sourceRuntimeLabel.contains(search, ignoreCase = true) ||
+                    game.categoryLabel.contains(search, ignoreCase = true) ||
+                    game.genres.any { it.contains(search, ignoreCase = true) }
+            }
         }
 
         // "Recent" sort — show only played games, sorted by most recent
@@ -294,9 +311,12 @@ class NovaLibraryActivity : AppCompatActivity() {
                 .filter { it.lastLaunched > 0 }
                 .sortedByDescending { it.lastLaunched }
         } else if (currentFilter.isNotEmpty()) {
-            // Category/source filter
+            // Category/source/platform/runtime filter
             filtered = filtered.filter {
-                it.source == currentFilter || it.category == currentFilter
+                it.effectiveSource == currentFilter ||
+                    it.category == currentFilter ||
+                    it.platform == currentFilter ||
+                    it.runtime == currentFilter
             }
         }
 
@@ -362,6 +382,8 @@ class NovaLibraryActivity : AppCompatActivity() {
     // Filter tab IDs in order for bumper switching
     private val filterTabIds = listOf(
         R.id.filter_all, R.id.filter_recent, R.id.filter_steam,
+        R.id.filter_lutris, R.id.filter_heroic, R.id.filter_linux,
+        R.id.filter_windows, R.id.filter_proton, R.id.filter_wine,
         R.id.filter_action, R.id.filter_cinematic
     )
     private var activeTabIndex = 0

--- a/app/src/main/res/layout/activity_nova_library.xml
+++ b/app/src/main/res/layout/activity_nova_library.xml
@@ -199,6 +199,36 @@
                     android:text="@string/nova_library_filter_steam" />
 
                 <TextView
+                    android:id="@+id/filter_lutris"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_lutris" />
+
+                <TextView
+                    android:id="@+id/filter_heroic"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_heroic" />
+
+                <TextView
+                    android:id="@+id/filter_linux"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_linux" />
+
+                <TextView
+                    android:id="@+id/filter_windows"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_windows" />
+
+                <TextView
+                    android:id="@+id/filter_proton"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_proton" />
+
+                <TextView
+                    android:id="@+id/filter_wine"
+                    style="@style/NovaFilterChip"
+                    android:text="@string/nova_library_filter_wine" />
+
+                <TextView
                     android:id="@+id/filter_action"
                     style="@style/NovaFilterChip"
                     android:text="@string/nova_library_filter_action" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,12 @@
     <string name="nova_library_filter_all">All</string>
     <string name="nova_library_filter_recent">Recent</string>
     <string name="nova_library_filter_steam">Steam</string>
+    <string name="nova_library_filter_lutris">Lutris</string>
+    <string name="nova_library_filter_heroic">Heroic</string>
+    <string name="nova_library_filter_linux">Linux</string>
+    <string name="nova_library_filter_windows">Windows</string>
+    <string name="nova_library_filter_proton">Proton</string>
+    <string name="nova_library_filter_wine">Wine</string>
     <string name="nova_library_filter_action">Action</string>
     <string name="nova_library_filter_cinematic">Cinematic</string>
     <string name="nova_library_empty_title_default">No games found</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.java
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.java
@@ -293,6 +293,7 @@ public class PolarisApiClientParsingTest {
         assertEquals("game-uuid", game.getId());
         assertEquals("lutris", game.getLauncherSource());
         assertEquals("wine", game.getLauncherDetail());
+        assertEquals("lutris", game.getEffectiveSource());
         assertEquals("windows", game.getPlatform());
         assertEquals("wine", game.getRuntime());
         assertEquals("Lutris", game.getSourceLabel());
@@ -303,5 +304,26 @@ public class PolarisApiClientParsingTest {
         assertEquals("headless_stream", game.getLaunchMode().getRecommendedMode());
         assertTrue(game.getLaunchMode().getAllowedModes().contains("headless_stream"));
         assertTrue(game.getLaunchMode().getAllowedModes().contains("host_virtual_display"));
+    }
+
+    @Test
+    public void parseGameResponse_prefersLauncherSourceAndFallsBackForOlderHosts() throws Exception {
+        PolarisGame launcherGame = PolarisGame.Companion.fromJson(new JSONObject(
+                "{\"id\":\"game-uuid\",\"app_id\":43,\"name\":\"Wine Game\"," +
+                        "\"source\":\"manual\",\"launcher_source\":\"lutris\",\"launcher_detail\":\"wine\"," +
+                        "\"platform\":\"windows\",\"runtime\":\"wine\"}"
+        ));
+        assertEquals("lutris", launcherGame.getEffectiveSource());
+        assertEquals("Lutris", launcherGame.getSourceLabel());
+        assertEquals("Lutris · Windows · Wine", launcherGame.getSourceRuntimeLabel());
+
+        PolarisGame olderHostGame = PolarisGame.Companion.fromJson(new JSONObject(
+                "{\"id\":\"older-game\",\"app_id\":44,\"name\":\"Older Host Game\",\"source\":\"steam\"}"
+        ));
+        assertEquals("steam", olderHostGame.getEffectiveSource());
+        assertEquals("Steam", olderHostGame.getSourceLabel());
+        assertEquals("", olderHostGame.getPlatformLabel());
+        assertEquals("", olderHostGame.getRuntimeLabel());
+        assertEquals("Steam", olderHostGame.getSourceRuntimeLabel());
     }
 }


### PR DESCRIPTION
## Summary

- prefer Polaris `launcher_source` metadata when labeling games, while keeping older host fallback behavior
- add Nova Library filters for Lutris, Heroic, Linux, Windows, Proton, and Wine
- include source/runtime/category/genre metadata in library search
- cover launcher-source precedence and older-host fallback in API parsing tests

## Validation

- `./gradlew testDebugUnitTest --no-daemon`
- `./gradlew assembleDebug --no-daemon`
- `git diff --check`

Note: an initial parallel Gradle test/build run hit generated-resource cache contention; the serial reruns above passed.