### PR TITLE
Fix locked host overlay unlock action

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/LockScreenOverlay.kt
+++ b/app/src/main/java/com/papi/nova/ui/LockScreenOverlay.kt
@@ -21,16 +21,20 @@ class LockScreenOverlay(
     private val apiClient: PolarisApiClient
 ) {
     private var overlayView: View? = null
+    @Volatile private var unlockInProgress = false
 
     fun show() {
         if (overlayView != null) return
 
         activity.runOnUiThread {
+            unlockInProgress = false
             val container = LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL
                 gravity = Gravity.CENTER
                 setBackgroundColor(0xEE000000.toInt())
                 setPadding(80, 80, 80, 80)
+                isClickable = true
+                isFocusable = true
             }
 
             val title = TextView(activity).apply {
@@ -46,30 +50,13 @@ class LockScreenOverlay(
                 text = "Tap to Unlock"
                 textSize = 18f
                 setOnClickListener {
-                    isEnabled = false
-                    text = "Unlocking..."
-                    Thread {
-                        val unlocked = try {
-                            LimeLog.info("Nova: Requesting unlock...")
-                            apiClient.unlockScreen()
-                        } catch (e: Exception) {
-                            LimeLog.warning("Nova: Unlock failed: ${e.message}")
-                            false
-                        }
-
-                        activity.runOnUiThread {
-                            if (unlocked) {
-                                dismiss()
-                            } else {
-                                isEnabled = true
-                                text = "Tap to Unlock"
-                                Toast.makeText(activity, "Unlock request failed", Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                    }.start()
+                    requestUnlock(this)
                 }
             }
             container.addView(unlockBtn)
+            container.setOnClickListener {
+                requestUnlock(unlockBtn)
+            }
 
             val params = FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -78,14 +65,43 @@ class LockScreenOverlay(
 
             val rootView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
             rootView.addView(container, params)
+            container.bringToFront()
             overlayView = container
 
             LimeLog.info("Nova: Lock screen overlay shown")
         }
     }
 
+    private fun requestUnlock(unlockBtn: Button) {
+        if (unlockInProgress) return
+        unlockInProgress = true
+        unlockBtn.isEnabled = false
+        unlockBtn.text = "Unlocking..."
+        LimeLog.info("Nova: Requesting unlock...")
+        Thread {
+            val unlocked = try {
+                apiClient.unlockScreen()
+            } catch (e: Exception) {
+                LimeLog.warning("Nova: Unlock failed: ${e.message}")
+                false
+            }
+
+            activity.runOnUiThread {
+                if (unlocked) {
+                    dismiss()
+                } else {
+                    unlockInProgress = false
+                    unlockBtn.isEnabled = true
+                    unlockBtn.text = "Tap to Unlock"
+                    Toast.makeText(activity, "Unlock request failed", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }.start()
+    }
+
     fun dismiss() {
         activity.runOnUiThread {
+            unlockInProgress = false
             val view = overlayView
             overlayView = null
             view?.let {

--- a/app/src/test/java/com/papi/nova/ui/LockScreenOverlayTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/LockScreenOverlayTest.kt
@@ -1,0 +1,85 @@
+package com.papi.nova.ui
+
+import android.app.Activity
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import com.papi.nova.api.PolarisApiClient
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class LockScreenOverlayTest {
+
+    @Test
+    fun overlayTapRequestsUnlockAndPreventsDuplicateRequests() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val client = Mockito.mock(PolarisApiClient::class.java)
+        val unlockStarted = CountDownLatch(1)
+        val finishUnlock = CountDownLatch(1)
+
+        Mockito.doAnswer {
+            unlockStarted.countDown()
+            assertTrue(finishUnlock.await(1, TimeUnit.SECONDS))
+            false
+        }.`when`(client).unlockScreen()
+
+        val overlay = LockScreenOverlay(activity, client)
+        overlay.show()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val root = overlayRoot(activity)
+        val button = findButton(root)
+        assertNotNull(button)
+
+        root.performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(unlockStarted.await(1, TimeUnit.SECONDS))
+        assertFalse(button!!.isEnabled)
+        assertEquals("Unlocking...", button.text.toString())
+
+        root.performClick()
+        verify(client, timeout(1000).times(1)).unlockScreen()
+
+        finishUnlock.countDown()
+        repeat(20) {
+            shadowOf(Looper.getMainLooper()).idle()
+            if (button.isEnabled) return@repeat
+            Thread.sleep(50)
+        }
+
+        assertTrue(button.isEnabled)
+        assertEquals("Tap to Unlock", button.text.toString())
+    }
+
+    private fun overlayRoot(activity: Activity): ViewGroup {
+        val content = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
+        return content.getChildAt(content.childCount - 1) as ViewGroup
+    }
+
+    private fun findButton(view: View): Button? {
+        if (view is Button) return view
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                findButton(view.getChildAt(i))?.let { return it }
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
## Summary
- Make the locked-host overlay itself clickable/focusable so taps reach the unlock action on devices.
- Guard duplicate unlock requests while an unlock call is in progress.
- Add a Robolectric guard test for overlay tap dispatch and duplicate suppression.

## Verification
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.LockScreenOverlayTest --tests com.papi.nova.KotlinGameRuntimeMigrationTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain`
- `git diff --check`
- Flip2 smoke: launched Indiana Jones with host locked; overlay displayed; tapping overlay logged `Nova: Requesting unlock...` and Polaris logged `Attempting to dismiss lock screen`.

## Follow-up
- Polaris currently reports the unlock endpoint as successful after `org.freedesktop.ScreenSaver.SetActive false`, but this KDE/Linux host remained locked until `loginctl unlock-session "$XDG_SESSION_ID"` was run. That should be handled in Polaris as a host-side fallback.