### PR TITLE
Harden Nova runtime task lifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -240,6 +240,7 @@ dependencies {
     // Unit test dependencies
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.7.0'
+    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.8.7'
     testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'org.mockito:mockito-core:5.23.0'
 

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -36,6 +36,8 @@ import com.papi.nova.nvstream.jni.MoonBridge
 import com.papi.nova.preferences.GlPreferences
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.profiles.ProfilesManager
+import com.papi.nova.runtime.BackgroundResumePolicy
+import com.papi.nova.runtime.NovaRuntimeTasks
 import com.papi.nova.ui.ExternalControllerView
 import com.papi.nova.ui.GameGestures
 import com.papi.nova.ui.StreamContainer
@@ -138,6 +140,7 @@ import android.view.ViewGroup
 
  class Game:AppCompatActivity(), SurfaceHolder.Callback, OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener, OnSystemUiVisibilityChangeListener, GameGestures, StreamContainer.InputCallbacks, ExternalControllerView.InputCallbacks, PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener {
 
+private val runtimeTasks:NovaRuntimeTasks = NovaRuntimeTasks(this, "Nova runtime")
 private var novaHud:com.papi.nova.ui.NovaStreamHud? = null
  var configuredHudTargetFps:Float = 0f
 private var configuredStreamFrameRateFps:Float = 0f
@@ -2321,10 +2324,14 @@ super.onDestroy()
 
  // Nova: clean up Polaris integration
         stopPolarisLiveSessionStatusRefresh()
+runtimeTasks.cancelAll()
 stopCursorVisibilitySync()
 if (novaEventSource != null) novaEventSource!!.stop()
 if (novaProgressOverlay != null) novaProgressOverlay!!.dismiss()
-if (novaLockScreenOverlay != null) novaLockScreenOverlay!!.dismiss()
+if (novaLockScreenOverlay != null) {
+novaLockScreenOverlay!!.dismiss()
+novaLockScreenOverlay!!.destroy()
+}
 if (novaReconnectOverlay != null) novaReconnectOverlay!!.dismiss()
 com.papi.nova.jni.PolarisNativeHook.unregister()
 com.papi.nova.manager.FeatureFlagManager.reset()
@@ -5082,6 +5089,19 @@ cursorVisibilitySyncScheduled = false
 cursorVisibilitySyncExecutor!!.shutdownNow()
 }
 
+internal fun launchRuntimeIo(name:String, block:suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {
+runtimeTasks.launchIo(name, block)
+}
+
+internal suspend fun runOnMainIfRuntimeActive(block:() -> Unit) {
+runtimeTasks.runOnMainIfActive {
+if (!isFinishing && !isDestroyed)
+{
+block()
+}
+}
+}
+
 private fun startNovaFeatureProbe() {
 var client:com.papi.nova.api.PolarisApiClient? = novaApiClient
 if (client == null)
@@ -5089,17 +5109,21 @@ if (client == null)
 return
 }
 
-Thread({ com.papi.nova.manager.FeatureFlagManager.probe(client)
-runOnUiThread({ if (isFinishing() || isDestroyed())
+runtimeTasks.launchIo("NovaFeatureProbe") {
+com.papi.nova.manager.FeatureFlagManager.probe(client)
+runtimeTasks.runOnMainIfActive {
+if (isFinishing || isDestroyed)
 {
-return@runOnUiThread
+return@runOnMainIfActive
 }
 startNovaEventSourceIfSupported()
 if (com.papi.nova.manager.FeatureFlagManager.isPolarisServer)
 {
 queuePolarisClientSettingsSnapshot(null)
 schedulePolarisLiveSessionStatusRefresh(true)
-} }) }, "NovaFeatureProbe").start()
+}
+}
+}
 }
 
 private fun startNovaEventSourceIfSupported() {
@@ -5168,6 +5192,7 @@ if (timerHandler != null)
 timerHandler!!.removeCallbacks(polarisSessionStatusRefreshTick)
 }
 polarisSessionStatusRefreshInFlight.set(false)
+runtimeTasks.cancel("NovaSessionStatus")
 }
 
 private fun queuePolarisClientSettingsSnapshot(clientPresentation:JSONObject?) {
@@ -5175,7 +5200,9 @@ if ((novaApiClient == null || !com.papi.nova.manager.FeatureFlagManager.hasClien
 {
 return
 }
-Thread({ reportPolarisClientSettingsSnapshot(clientPresentation) }, "NovaClientSettingsSync").start()
+runtimeTasks.launchIo("NovaClientSettingsSync") {
+reportPolarisClientSettingsSnapshot(clientPresentation)
+}
 }
 
 private fun reportPolarisClientSettingsSnapshot(clientPresentation:JSONObject?):Boolean {
@@ -5377,7 +5404,7 @@ if (novaApiClient == null || !polarisSessionStatusRefreshInFlight.compareAndSet(
 return
 }
 
-Thread({ try
+runtimeTasks.launchIo("NovaSessionStatus") { try
 {
 var status:com.papi.nova.api.PolarisSessionStatus? = novaApiClient!!.getSessionStatus()
 if (status != null)
@@ -5385,10 +5412,19 @@ if (status != null)
 lastPolarisSessionStatus = status
 if (novaHud != null)
 {
+runtimeTasks.runOnMainIfActive {
+if (isFinishing || isDestroyed)
+{
+return@runOnMainIfActive
+}
 novaHud!!.applySessionStatus(status)
+}
 }
 reportClientPresentationIfNeeded(status)
 }
+}
+catch (e:kotlinx.coroutines.CancellationException) {
+throw e
 }
 catch (e:Exception) {
 com.papi.nova.LimeLog.warning("Nova: Live session status refresh failed: " + e!!.message)
@@ -5396,7 +5432,7 @@ com.papi.nova.LimeLog.warning("Nova: Live session status refresh failed: " + e!!
 finally
 {
 polarisSessionStatusRefreshInFlight.set(false)
-} }, "NovaSessionStatus").start()
+} }
 }
 
 private fun applyMouseMode(mode:Int) {
@@ -5476,14 +5512,21 @@ performanceOverlayView!!.setVisibility(View.GONE)
 prefConfig!!.enableTouchSensitivity = !prefConfig!!.enableTouchSensitivity
 }
 private fun syncDisconnectResumeTimeoutPolicy() {
-if (!::prefConfig.isInitialized || watchOnlyRequested || !prefConfig.keepStreamAlive || disconnectResumeTimeoutSynced)
+val preferencesReady:Boolean = ::prefConfig.isInitialized
+val keepAlive:Boolean = preferencesReady && prefConfig.keepStreamAlive
+if (!BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+preferencesReady,
+watchOnlyRequested,
+keepAlive,
+disconnectResumeTimeoutSynced
+))
 {
 return
 }
 val client:com.papi.nova.api.PolarisApiClient = novaApiClient ?: return
 val timeoutSeconds:Int = prefConfig.disconnectResumeTimeoutSeconds
 disconnectResumeTimeoutSynced = true
-Thread({ try
+runtimeTasks.launchIo("NovaResumePolicy") { try
 {
 client.updateClientSettings(disconnectResumeTimeoutSeconds = timeoutSeconds)
 LimeLog.info("Nova: Synced disconnect resume timeout: " + timeoutSeconds + "s")
@@ -5491,11 +5534,19 @@ LimeLog.info("Nova: Synced disconnect resume timeout: " + timeoutSeconds + "s")
 catch (e:Exception) {
 LimeLog.warning("Nova: Failed to sync disconnect resume timeout: " + e!!.message)
 }
-}, "NovaResumePolicy").start()
+}
 }
 
 private fun prepareBackgroundResumeWindow() {
-if (backgroundResumePrepared || !::prefConfig.isInitialized || quitOnStop || watchOnlyRequested || !prefConfig.keepStreamAlive)
+val preferencesReady:Boolean = ::prefConfig.isInitialized
+val keepAlive:Boolean = preferencesReady && prefConfig.keepStreamAlive
+if (!BackgroundResumePolicy.shouldPrepareResumeWindow(
+backgroundResumePrepared,
+preferencesReady,
+quitOnStop,
+watchOnlyRequested,
+keepAlive
+))
 {
 return
 }

--- a/app/src/main/java/com/papi/nova/runtime/BackgroundResumePolicy.kt
+++ b/app/src/main/java/com/papi/nova/runtime/BackgroundResumePolicy.kt
@@ -1,0 +1,27 @@
+package com.papi.nova.runtime
+
+internal object BackgroundResumePolicy {
+    fun shouldSyncDisconnectTimeout(
+        preferencesReady: Boolean,
+        watchOnlyRequested: Boolean,
+        keepStreamAlive: Boolean,
+        alreadySynced: Boolean
+    ): Boolean =
+        preferencesReady &&
+            !watchOnlyRequested &&
+            keepStreamAlive &&
+            !alreadySynced
+
+    fun shouldPrepareResumeWindow(
+        alreadyPrepared: Boolean,
+        preferencesReady: Boolean,
+        quitOnStop: Boolean,
+        watchOnlyRequested: Boolean,
+        keepStreamAlive: Boolean
+    ): Boolean =
+        !alreadyPrepared &&
+            preferencesReady &&
+            !quitOnStop &&
+            !watchOnlyRequested &&
+            keepStreamAlive
+}

--- a/app/src/main/java/com/papi/nova/runtime/NovaRuntimeTasks.kt
+++ b/app/src/main/java/com/papi/nova/runtime/NovaRuntimeTasks.kt
@@ -1,0 +1,93 @@
+package com.papi.nova.runtime
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.papi.nova.LimeLog
+import java.util.Collections
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class NovaRuntimeTasks(
+    private val owner: LifecycleOwner,
+    private val logPrefix: String = "Nova"
+) {
+    private val jobsByName = Collections.synchronizedMap(LinkedHashMap<String, MutableSet<Job>>())
+
+    fun launchIo(name: String, block: suspend CoroutineScope.() -> Unit): Job =
+        launch(name, Dispatchers.IO, block)
+
+    fun launchMain(name: String, block: suspend CoroutineScope.() -> Unit): Job =
+        launch(name, Dispatchers.Main.immediate, block)
+
+    suspend fun runOnMainIfActive(block: () -> Unit) {
+        withContext(Dispatchers.Main.immediate) {
+            if (isOwnerActive()) {
+                block()
+            }
+        }
+    }
+
+    fun cancel(name: String) {
+        val jobs = synchronized(jobsByName) {
+            jobsByName.remove(name)?.toList().orEmpty()
+        }
+        jobs.forEach { it.cancel() }
+    }
+
+    fun cancelAll() {
+        val jobs = synchronized(jobsByName) {
+            jobsByName.values.flatten().also { jobsByName.clear() }
+        }
+        jobs.forEach { it.cancel() }
+    }
+
+    fun activeJobCount(name: String? = null): Int {
+        return synchronized(jobsByName) {
+            if (name == null) jobsByName.values.sumOf { it.size } else jobsByName[name]?.size ?: 0
+        }
+    }
+
+    private fun launch(
+        name: String,
+        dispatcher: CoroutineDispatcher,
+        block: suspend CoroutineScope.() -> Unit
+    ): Job {
+        val handler = CoroutineExceptionHandler { _, throwable ->
+            if (throwable !is CancellationException) {
+                LimeLog.warning("$logPrefix: $name failed: ${throwable.message}")
+            }
+        }
+        val job = owner.lifecycleScope.launch(dispatcher + CoroutineName(name) + handler) {
+            if (!isOwnerActive()) return@launch
+            block()
+        }
+        track(name, job)
+        return job
+    }
+
+    private fun track(name: String, job: Job) {
+        synchronized(jobsByName) {
+            jobsByName.getOrPut(name) { LinkedHashSet() }.add(job)
+        }
+        job.invokeOnCompletion {
+            synchronized(jobsByName) {
+                val jobs = jobsByName[name] ?: return@synchronized
+                jobs.remove(job)
+                if (jobs.isEmpty()) {
+                    jobsByName.remove(name)
+                }
+            }
+        }
+    }
+
+    private fun isOwnerActive(): Boolean =
+        owner.lifecycle.currentState != Lifecycle.State.DESTROYED
+}

--- a/app/src/main/java/com/papi/nova/ui/ApertureViewGroup.kt
+++ b/app/src/main/java/com/papi/nova/ui/ApertureViewGroup.kt
@@ -10,6 +10,7 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Shader
 import android.util.AttributeSet
+import android.util.Property
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.widget.LinearLayout
@@ -69,7 +70,7 @@ class ApertureViewGroup @JvmOverloads constructor(
             typedArray.recycle()
         }
 
-        animator = ObjectAnimator.ofFloat(this, "currentSpeed", 0f, 360f).apply {
+        animator = ObjectAnimator.ofFloat(this, CURRENT_SPEED_PROPERTY, 0f, 360f).apply {
             repeatCount = ObjectAnimator.INFINITE
             repeatMode = ObjectAnimator.RESTART
             interpolator = null
@@ -138,5 +139,18 @@ class ApertureViewGroup @JvmOverloads constructor(
 
         canvas.restore()
         super.dispatchDraw(canvas)
+    }
+
+    private companion object {
+        val CURRENT_SPEED_PROPERTY = object : Property<ApertureViewGroup, Float>(
+            Float::class.java,
+            "currentSpeed"
+        ) {
+            override fun get(view: ApertureViewGroup): Float = view.currentSpeed
+
+            override fun set(view: ApertureViewGroup, value: Float?) {
+                view.currentSpeed = value ?: 0f
+            }
+        }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/LockScreenOverlay.kt
+++ b/app/src/main/java/com/papi/nova/ui/LockScreenOverlay.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui
 
 import android.app.Activity
+import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -9,8 +10,18 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.papi.nova.LimeLog
 import com.papi.nova.api.PolarisApiClient
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Overlay shown when the server's screen is locked.
@@ -22,6 +33,8 @@ class LockScreenOverlay(
 ) {
     private var overlayView: View? = null
     @Volatile private var unlockInProgress = false
+    private val fallbackScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var unlockJob: Job? = null
 
     fun show() {
         if (overlayView != null) return
@@ -78,7 +91,8 @@ class LockScreenOverlay(
         unlockBtn.isEnabled = false
         unlockBtn.text = "Unlocking..."
         LimeLog.info("Nova: Requesting unlock...")
-        Thread {
+        unlockJob?.cancel()
+        unlockJob = unlockScope().launch(Dispatchers.IO + CoroutineName("NovaUnlockScreen")) {
             val unlocked = try {
                 apiClient.unlockScreen()
             } catch (e: Exception) {
@@ -86,9 +100,12 @@ class LockScreenOverlay(
                 false
             }
 
-            activity.runOnUiThread {
+            withContext(Dispatchers.Main.immediate) {
+                if (!isActivityUsable() || overlayView == null) {
+                    return@withContext
+                }
                 if (unlocked) {
-                    dismiss()
+                    dismiss(cancelUnlock = false)
                 } else {
                     unlockInProgress = false
                     unlockBtn.isEnabled = true
@@ -96,10 +113,18 @@ class LockScreenOverlay(
                     Toast.makeText(activity, "Unlock request failed", Toast.LENGTH_SHORT).show()
                 }
             }
-        }.start()
+        }
     }
 
     fun dismiss() {
+        dismiss(cancelUnlock = true)
+    }
+
+    private fun dismiss(cancelUnlock: Boolean) {
+        if (cancelUnlock) {
+            unlockJob?.cancel()
+            unlockJob = null
+        }
         activity.runOnUiThread {
             unlockInProgress = false
             val view = overlayView
@@ -111,6 +136,12 @@ class LockScreenOverlay(
         }
     }
 
+    fun destroy() {
+        unlockJob?.cancel()
+        unlockJob = null
+        fallbackScope.cancel()
+    }
+
     private fun safeRemoveFromParent(view: View) {
         val parent = view.parent as? ViewGroup ?: return
         parent.post {
@@ -118,6 +149,12 @@ class LockScreenOverlay(
             currentParent?.removeView(view)
         }
     }
+
+    private fun unlockScope(): CoroutineScope =
+        (activity as? LifecycleOwner)?.lifecycleScope ?: fallbackScope
+
+    private fun isActivityUsable(): Boolean =
+        !activity.isFinishing && (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed)
 
     val isShowing get() = overlayView != null
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -202,7 +202,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                         return@haptic
                     }
 
-                    Thread {
+                    game.launchRuntimeIo("NovaQuickMenuStability") {
                         var success = true
                         if (shouldEnableAutoQuality) {
                             success = apiClient.setAiAutoQualityEnabled(true) && success
@@ -214,7 +214,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                             sessionStatus = apiClient.getSessionStatus() ?: sessionStatus
                             syncSessionDerivedState()
                         }
-                        game.runOnUiThread {
+                        game.runOnMainIfRuntimeActive {
                             if (!success) {
                                 stabilityApplied = false
                                 Toast.makeText(game, R.string.nova_quick_menu_stability_failed, Toast.LENGTH_SHORT).show()
@@ -232,7 +232,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                             }
                             refreshState()
                         }
-                    }.start()
+                    }
                 }
             },
             onSyncStatus = {
@@ -244,14 +244,14 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                         game.relaunchStream()
                         return@haptic
                     }
-                    Thread {
+                    game.launchRuntimeIo("NovaQuickMenuSyncStatus") {
                         sessionStatus = apiClient.getSessionStatus() ?: sessionStatus
-                        game.runOnUiThread {
+                        game.runOnMainIfRuntimeActive {
                             syncSessionDerivedState()
                             hostStateUnavailable = false
                             refreshState()
                         }
-                    }.start()
+                    }
                 }
             },
             onToggleAdvanced = {
@@ -269,20 +269,20 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     val next = !aiEnabled
                     aiEnabled = next
                     refreshState()
-                    Thread {
+                    game.launchRuntimeIo("NovaQuickMenuAiAutoQuality") {
                         val success = apiClient.setAiAutoQualityEnabled(next)
                         if (success) {
                             sessionStatus = apiClient.getSessionStatus() ?: sessionStatus
                             syncSessionDerivedState()
                         }
-                        game.runOnUiThread {
+                        game.runOnMainIfRuntimeActive {
                             if (!success) {
                                 aiEnabled = !next
                                 Toast.makeText(game, R.string.nova_quick_menu_ai_toggle_failed, Toast.LENGTH_SHORT).show()
                             }
                             refreshState()
                         }
-                    }.start()
+                    }
                 }
             },
             onClearGameProfile = {
@@ -294,13 +294,13 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     }
                     profileClearInProgress = true
                     refreshState()
-                    Thread {
+                    game.launchRuntimeIo("NovaQuickMenuClearProfile") {
                         val cleared = apiClient.clearOptimizerProfile(DeviceUtils.getModel(), gameName)
                         if (cleared == true) {
                             sessionStatus = apiClient.getSessionStatus() ?: sessionStatus
                             syncSessionDerivedState()
                         }
-                        game.runOnUiThread {
+                        game.runOnMainIfRuntimeActive {
                             profileClearInProgress = false
                             val message = when (cleared) {
                                 true -> R.string.nova_library_reset_game_profile_cleared
@@ -310,7 +310,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                             Toast.makeText(game, message, Toast.LENGTH_SHORT).show()
                             refreshState()
                         }
-                    }.start()
+                    }
                 }
             },
             onMangoHud = {
@@ -326,20 +326,20 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     if (next && status.game.equals("Steam Big Picture", ignoreCase = true)) {
                         Toast.makeText(game, R.string.nova_mangohud_warning_big_picture, Toast.LENGTH_LONG).show()
                     }
-                    Thread {
+                    game.launchRuntimeIo("NovaQuickMenuMangoHud") {
                         val success = apiClient.setMangoHud(gameUuid, next)
                         if (success) {
                             sessionStatus = apiClient.getSessionStatus() ?: sessionStatus
                             syncSessionDerivedState()
                         }
-                        game.runOnUiThread {
+                        game.runOnMainIfRuntimeActive {
                             if (!success) {
                                 mangoHudEnabled = !next
                                 Toast.makeText(game, R.string.nova_quick_menu_mangohud_failed, Toast.LENGTH_SHORT).show()
                             }
                             refreshState()
                         }
-                    }.start()
+                    }
                 }
             },
             onProfilePreference = { preference ->
@@ -440,7 +440,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         }
 
         if (apiClient != null) {
-            Thread {
+            game.launchRuntimeIo("NovaQuickMenuStateRefresh") {
                 try {
                     capabilities = apiClient.getCapabilities()
                     sessionStatus = apiClient.getSessionStatus()
@@ -453,13 +453,15 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     hostStateUnavailable = false
                     syncSessionDerivedState()
 
-                    game.runOnUiThread { refreshState() }
+                    game.runOnMainIfRuntimeActive { refreshState() }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     LimeLog.warning("Nova: Quick menu state refresh failed: ${e.message}")
                     hostStateUnavailable = true
-                    game.runOnUiThread { refreshState() }
+                    game.runOnMainIfRuntimeActive { refreshState() }
                 }
-            }.start()
+            }
         } else {
             refreshState()
         }

--- a/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
@@ -24,7 +24,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class KotlinLaunchHelpersMigrationTest {
     @Test

--- a/app/src/test/java/com/papi/nova/binding/input/KotlinControllerHandlerMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/input/KotlinControllerHandlerMigrationTest.kt
@@ -17,7 +17,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class KotlinControllerHandlerMigrationTest {
     @Test

--- a/app/src/test/java/com/papi/nova/binding/video/KotlinVideoRuntimeMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/KotlinVideoRuntimeMigrationTest.kt
@@ -18,7 +18,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class KotlinVideoRuntimeMigrationTest {
 

--- a/app/src/test/java/com/papi/nova/computers/KotlinComputerServiceMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/computers/KotlinComputerServiceMigrationTest.kt
@@ -16,7 +16,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class KotlinComputerServiceMigrationTest {
     @Test

--- a/app/src/test/java/com/papi/nova/runtime/BackgroundResumePolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/runtime/BackgroundResumePolicyTest.kt
@@ -1,0 +1,111 @@
+package com.papi.nova.runtime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackgroundResumePolicyTest {
+    @Test
+    fun syncDisconnectTimeoutRequiresReadyResumableStream() {
+        assertTrue(
+            BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+                preferencesReady = true,
+                watchOnlyRequested = false,
+                keepStreamAlive = true,
+                alreadySynced = false
+            )
+        )
+
+        assertFalse(
+            BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+                preferencesReady = false,
+                watchOnlyRequested = false,
+                keepStreamAlive = true,
+                alreadySynced = false
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+                preferencesReady = true,
+                watchOnlyRequested = true,
+                keepStreamAlive = true,
+                alreadySynced = false
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+                preferencesReady = true,
+                watchOnlyRequested = false,
+                keepStreamAlive = false,
+                alreadySynced = false
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldSyncDisconnectTimeout(
+                preferencesReady = true,
+                watchOnlyRequested = false,
+                keepStreamAlive = true,
+                alreadySynced = true
+            )
+        )
+    }
+
+    @Test
+    fun prepareResumeWindowSkipsQuitWatchAndAlreadyPreparedSessions() {
+        assertTrue(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = false,
+                preferencesReady = true,
+                quitOnStop = false,
+                watchOnlyRequested = false,
+                keepStreamAlive = true
+            )
+        )
+
+        assertFalse(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = true,
+                preferencesReady = true,
+                quitOnStop = false,
+                watchOnlyRequested = false,
+                keepStreamAlive = true
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = false,
+                preferencesReady = false,
+                quitOnStop = false,
+                watchOnlyRequested = false,
+                keepStreamAlive = true
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = false,
+                preferencesReady = true,
+                quitOnStop = true,
+                watchOnlyRequested = false,
+                keepStreamAlive = true
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = false,
+                preferencesReady = true,
+                quitOnStop = false,
+                watchOnlyRequested = true,
+                keepStreamAlive = true
+            )
+        )
+        assertFalse(
+            BackgroundResumePolicy.shouldPrepareResumeWindow(
+                alreadyPrepared = false,
+                preferencesReady = true,
+                quitOnStop = false,
+                watchOnlyRequested = false,
+                keepStreamAlive = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/runtime/GameRuntimeTaskLifecycleTest.kt
+++ b/app/src/test/java/com/papi/nova/runtime/GameRuntimeTaskLifecycleTest.kt
@@ -1,0 +1,76 @@
+package com.papi.nova.runtime
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.awaitCancellation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class GameRuntimeTaskLifecycleTest {
+    @Test
+    fun runtimeTasksCancelWhenLifecycleIsDestroyed() {
+        val owner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        val tasks = NovaRuntimeTasks(owner)
+        val started = CountDownLatch(1)
+        val cancelled = CountDownLatch(1)
+
+        tasks.launchIo("blocked") {
+            started.countDown()
+            try {
+                awaitCancellation()
+            } finally {
+                cancelled.countDown()
+            }
+        }
+
+        assertTrue(started.await(1, TimeUnit.SECONDS))
+
+        owner.currentState = Lifecycle.State.DESTROYED
+
+        assertTrue(cancelled.await(1, TimeUnit.SECONDS))
+        assertNoActiveJobs(tasks, "blocked")
+    }
+
+    @Test
+    fun explicitCancelRemovesNamedRuntimeTasks() {
+        val owner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        val tasks = NovaRuntimeTasks(owner)
+        val started = CountDownLatch(1)
+        val cancelled = CountDownLatch(1)
+
+        tasks.launchIo("session") {
+            started.countDown()
+            try {
+                awaitCancellation()
+            } finally {
+                cancelled.countDown()
+            }
+        }
+
+        assertTrue(started.await(1, TimeUnit.SECONDS))
+
+        tasks.cancel("session")
+
+        assertTrue(cancelled.await(1, TimeUnit.SECONDS))
+        assertNoActiveJobs(tasks, "session")
+    }
+
+    private fun assertNoActiveJobs(tasks: NovaRuntimeTasks, name: String) {
+        repeat(20) {
+            if (tasks.activeJobCount(name) == 0) {
+                assertEquals(0, tasks.activeJobCount(name))
+                return
+            }
+            Thread.sleep(25)
+        }
+        assertEquals(0, tasks.activeJobCount(name))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/LockScreenOverlayTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/LockScreenOverlayTest.kt
@@ -68,6 +68,59 @@ class LockScreenOverlayTest {
         assertEquals("Tap to Unlock", button.text.toString())
     }
 
+    @Test
+    fun successfulUnlockDismissesOverlay() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val client = Mockito.mock(PolarisApiClient::class.java)
+        Mockito.`when`(client.unlockScreen()).thenReturn(true)
+
+        val overlay = LockScreenOverlay(activity, client)
+        overlay.show()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        overlayRoot(activity).performClick()
+
+        verify(client, timeout(1000)).unlockScreen()
+        repeat(20) {
+            shadowOf(Looper.getMainLooper()).idle()
+            if (!overlay.isShowing) return@repeat
+            Thread.sleep(50)
+        }
+
+        assertFalse(overlay.isShowing)
+    }
+
+    @Test
+    fun dismissedOverlayIgnoresLateUnlockFailure() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val client = Mockito.mock(PolarisApiClient::class.java)
+        val unlockStarted = CountDownLatch(1)
+        val finishUnlock = CountDownLatch(1)
+
+        Mockito.doAnswer {
+            unlockStarted.countDown()
+            assertTrue(finishUnlock.await(1, TimeUnit.SECONDS))
+            false
+        }.`when`(client).unlockScreen()
+
+        val overlay = LockScreenOverlay(activity, client)
+        overlay.show()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        overlayRoot(activity).performClick()
+        assertTrue(unlockStarted.await(1, TimeUnit.SECONDS))
+
+        overlay.dismiss()
+        shadowOf(Looper.getMainLooper()).idle()
+        finishUnlock.countDown()
+        repeat(10) {
+            shadowOf(Looper.getMainLooper()).idle()
+            Thread.sleep(25)
+        }
+
+        assertFalse(overlay.isShowing)
+    }
+
     private fun overlayRoot(activity: Activity): ViewGroup {
         val content = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
         return content.getChildAt(content.childCount - 1) as ViewGroup


### PR DESCRIPTION
## Summary
- Add lifecycle-tracked runtime tasks for Nova stream runtime work
- Move Polaris probes, session polling, client settings sync, resume policy sync, and quick-menu Polaris actions off raw threads
- Harden lock-screen unlock overlay against duplicate taps and late callbacks after dismiss
- Add a testable background resume policy and runtime task lifecycle tests
- Use a typed ObjectAnimator property for ApertureViewGroup to avoid a lint detector crash while preserving behavior

## Verification
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain`
- `git diff --check`