### PR TITLE
Fix Polaris disconnect resume

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -296,6 +296,7 @@ private var watchStreamWidth:Int = 0
 private var watchStreamHeight:Int = 0
 private var watchStreamFps:Float = 0f
 private var backgroundResumePrepared:Boolean = false
+@Volatile private var disconnectResumeTimeoutSyncInFlight:Boolean = false
 private var disconnectResumeTimeoutSynced:Boolean = false
  var serverCmds:ArrayList<String> = ArrayList()
 
@@ -5523,17 +5524,36 @@ disconnectResumeTimeoutSynced
 {
 return
 }
+if (disconnectResumeTimeoutSyncInFlight)
+{
+return
+}
 val client:com.papi.nova.api.PolarisApiClient = novaApiClient ?: return
 val timeoutSeconds:Int = prefConfig.disconnectResumeTimeoutSeconds
-disconnectResumeTimeoutSynced = true
+disconnectResumeTimeoutSyncInFlight = true
 runtimeTasks.launchIo("NovaResumePolicy") { try
 {
 client.updateClientSettings(disconnectResumeTimeoutSeconds = timeoutSeconds)
+disconnectResumeTimeoutSynced = true
 LimeLog.info("Nova: Synced disconnect resume timeout: " + timeoutSeconds + "s")
 }
 catch (e:Exception) {
 LimeLog.warning("Nova: Failed to sync disconnect resume timeout: " + e!!.message)
 }
+finally {
+disconnectResumeTimeoutSyncInFlight = false
+}
+}
+}
+
+private fun encodedServerCertificateForResume():ByteArray? {
+return try
+{
+serverCert?.encoded
+}
+catch (e:Exception) {
+LimeLog.warning("Nova: Failed to encode server cert for resume notification: " + e.message)
+null
 }
 }
 
@@ -5559,7 +5579,14 @@ com.papi.nova.service.NovaStreamKeepAlive.start(
 this,
 timeoutSeconds,
 appName,
-pcName
+pcName,
+host,
+port,
+httpsPort,
+uniqueId,
+this@Game.getIntent().getStringExtra(EXTRA_PC_UUID),
+serverCmds,
+encodedServerCertificateForResume()
 )
 LimeLog.info("Nova: Background resume window prepared for " + timeoutSeconds + "s")
 }

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -257,9 +257,12 @@ data class PolarisSessionStatus(
         val relaunchRecommended: Boolean = false
     )
 
-    val isStreaming get() = state == "streaming" || streamingActive
-    val isSessionAlive get() = state in listOf("initializing", "cage_starting", "game_launching", "streaming")
-    val isShuttingDown get() = shutdownRequested || state == "tearing_down"
+    private val normalizedState get() = state.lowercase()
+    val isStreaming get() = normalizedState == "streaming" || streamingActive
+    val isPausedForResume get() = normalizedState == "paused"
+    val isSessionAlive get() = normalizedState in listOf("initializing", "cage_starting", "game_launching", "streaming", "paused")
+    val isShuttingDown get() = shutdownRequested || normalizedState == "tearing_down"
+    val isResumable get() = !isShuttingDown && gameId > 0 && (isSessionAlive || isPausedForResume)
     val isTenBitActive get() = dynamicRange > 0 || encoder.targetFormat.equals("p010", ignoreCase = true)
     val isGpuPath get() = encoder.targetResidency.equals("gpu", ignoreCase = true)
     val isHeadlessMode get() = displayMode.effectiveHeadless

--- a/app/src/main/java/com/papi/nova/service/NovaStreamKeepAlive.kt
+++ b/app/src/main/java/com/papi/nova/service/NovaStreamKeepAlive.kt
@@ -10,7 +10,15 @@ import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import com.papi.nova.LimeLog
 import com.papi.nova.R
+import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.ui.NovaLibraryActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class NovaStreamKeepAlive : Service() {
 
@@ -21,18 +29,44 @@ class NovaStreamKeepAlive : Service() {
         private const val EXTRA_TIMEOUT_SECONDS = "timeout_seconds"
         private const val EXTRA_GAME_NAME = "game_name"
         private const val EXTRA_SERVER_NAME = "server_name"
+        private const val EXTRA_HOST = "host"
+        private const val EXTRA_HTTP_PORT = "http_port"
+        private const val EXTRA_HTTPS_PORT = "https_port"
+        private const val EXTRA_UNIQUE_ID = "unique_id"
+        private const val EXTRA_PC_UUID = "pc_uuid"
+        private const val EXTRA_SERVER_COMMANDS = "server_commands"
+        private const val EXTRA_SERVER_CERT = "server_cert"
 
         @JvmStatic
+        @JvmOverloads
         fun start(
             context: Context,
             timeoutSeconds: Int = 300,
             gameName: String? = null,
-            serverName: String? = null
+            serverName: String? = null,
+            host: String? = null,
+            httpPort: Int = 47989,
+            httpsPort: Int = 47984,
+            uniqueId: String? = null,
+            pcUuid: String? = null,
+            serverCommands: ArrayList<String>? = null,
+            serverCert: ByteArray? = null
         ) {
             val intent = Intent(context, NovaStreamKeepAlive::class.java)
                 .putExtra(EXTRA_TIMEOUT_SECONDS, timeoutSeconds)
                 .putExtra(EXTRA_GAME_NAME, gameName.orEmpty())
                 .putExtra(EXTRA_SERVER_NAME, serverName.orEmpty())
+                .putExtra(EXTRA_HOST, host.orEmpty())
+                .putExtra(EXTRA_HTTP_PORT, httpPort)
+                .putExtra(EXTRA_HTTPS_PORT, httpsPort)
+                .putExtra(EXTRA_UNIQUE_ID, uniqueId.orEmpty())
+                .putExtra(EXTRA_PC_UUID, pcUuid.orEmpty())
+            if (serverCommands != null) {
+                intent.putStringArrayListExtra(EXTRA_SERVER_COMMANDS, serverCommands)
+            }
+            if (serverCert != null) {
+                intent.putExtra(EXTRA_SERVER_CERT, serverCert)
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
             } else {
@@ -48,6 +82,7 @@ class NovaStreamKeepAlive : Service() {
 
     private val autoStopRunnable = Runnable { stopSelf() }
     private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
@@ -66,7 +101,8 @@ class NovaStreamKeepAlive : Service() {
         val gameName = intent?.getStringExtra(EXTRA_GAME_NAME).orEmpty()
         val serverName = intent?.getStringExtra(EXTRA_SERVER_NAME).orEmpty()
 
-        startForeground(NOTIFICATION_ID, buildNotification(gameName, serverName, timeoutSeconds))
+        startForeground(NOTIFICATION_ID, buildNotification(intent, gameName, serverName, timeoutSeconds))
+        syncDisconnectResumeTimeout(intent, timeoutSeconds)
         handler.removeCallbacks(autoStopRunnable)
         if (timeoutMs > 0) {
             handler.postDelayed(autoStopRunnable, timeoutMs)
@@ -76,6 +112,7 @@ class NovaStreamKeepAlive : Service() {
 
     override fun onDestroy() {
         handler.removeCallbacks(autoStopRunnable)
+        serviceScope.cancel()
         super.onDestroy()
     }
 
@@ -96,10 +133,8 @@ class NovaStreamKeepAlive : Service() {
         }
     }
 
-    private fun buildNotification(gameName: String, serverName: String, timeoutSeconds: Int): Notification {
-        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
-            ?: Intent(this, com.papi.nova.PcView::class.java)
-        launchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    private fun buildNotification(intent: Intent?, gameName: String, serverName: String, timeoutSeconds: Int): Notification {
+        val launchIntent = buildResumeIntent(intent)
         val pendingIntent = PendingIntent.getActivity(
             this,
             0,
@@ -124,6 +159,61 @@ class NovaStreamKeepAlive : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .build()
+    }
+
+    private fun buildResumeIntent(intent: Intent?): Intent {
+        val host = intent?.getStringExtra(EXTRA_HOST).orEmpty()
+        val uniqueId = intent?.getStringExtra(EXTRA_UNIQUE_ID).orEmpty()
+        val pcUuid = intent?.getStringExtra(EXTRA_PC_UUID).orEmpty()
+        val serverCert = intent?.getByteArrayExtra(EXTRA_SERVER_CERT)
+        val serverName = intent?.getStringExtra(EXTRA_SERVER_NAME).orEmpty()
+        val httpPort = intent?.getIntExtra(EXTRA_HTTP_PORT, 47989) ?: 47989
+        val httpsPort = intent?.getIntExtra(EXTRA_HTTPS_PORT, 47984) ?: 47984
+        val serverCommands = intent?.getStringArrayListExtra(EXTRA_SERVER_COMMANDS)
+        val launchIntent = if (host.isNotBlank() && uniqueId.isNotBlank() && pcUuid.isNotBlank() && serverCert != null) {
+            Intent(this, NovaLibraryActivity::class.java)
+                .putExtra(NovaLibraryActivity.EXTRA_HOST, host)
+                .putExtra(NovaLibraryActivity.EXTRA_SERVER_NAME, serverName)
+                .putExtra(NovaLibraryActivity.EXTRA_HTTP_PORT, httpPort)
+                .putExtra(NovaLibraryActivity.EXTRA_HTTPS_PORT, httpsPort)
+                .putExtra(NovaLibraryActivity.EXTRA_UNIQUE_ID, uniqueId)
+                .putExtra(NovaLibraryActivity.EXTRA_PC_UUID, pcUuid)
+                .putExtra(NovaLibraryActivity.EXTRA_SERVER_CERT, serverCert)
+                .apply {
+                    if (serverCommands != null) {
+                        putStringArrayListExtra(NovaLibraryActivity.EXTRA_SERVER_COMMANDS, serverCommands)
+                    }
+                }
+        } else {
+            packageManager.getLaunchIntentForPackage(packageName)
+                ?: Intent(this, com.papi.nova.PcView::class.java)
+        }
+        return launchIntent.apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+    }
+
+    private fun syncDisconnectResumeTimeout(intent: Intent?, timeoutSeconds: Int) {
+        val host = intent?.getStringExtra(EXTRA_HOST).orEmpty()
+        if (host.isBlank()) {
+            return
+        }
+
+        val httpsPort = intent?.getIntExtra(EXTRA_HTTPS_PORT, 47984) ?: 47984
+        val serverCert = intent?.getByteArrayExtra(EXTRA_SERVER_CERT)
+        serviceScope.launch {
+            try {
+                PolarisApiClient(
+                    this@NovaStreamKeepAlive,
+                    host,
+                    httpsPort,
+                    serverCert
+                ).updateClientSettings(disconnectResumeTimeoutSeconds = timeoutSeconds)
+                LimeLog.info("Nova: Keep-alive synced disconnect resume timeout: ${timeoutSeconds}s")
+            } catch (e: Exception) {
+                LimeLog.warning("Nova: Keep-alive failed to sync disconnect resume timeout: ${e.message}")
+            }
+        }
     }
 
     private fun formatResumeWindow(timeoutSeconds: Int): String {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -65,7 +65,7 @@ data class NovaLibraryActiveSessionUiState(
             if (status == null || status.isShuttingDown || status.gameId <= 0) {
                 return null
             }
-            if (!status.isSessionAlive && !status.isStreaming) {
+            if (!status.isResumable) {
                 return null
             }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -159,6 +159,28 @@ class NovaLibraryUiStateTest {
     }
 
     @Test
+    fun activeSessionUsesPausedPolarisStatusForResume() {
+        val session = NovaLibraryActiveSessionUiState.from(
+            PolarisSessionStatus(
+                state = "paused",
+                streamingActive = false,
+                game = "Indiana Jones and the Great Circle",
+                gameId = 777,
+                gameUuid = "indy-uuid",
+                ownerDeviceName = "Retroid Pocket",
+                ownedByClient = true
+            )
+        )
+
+        requireNotNull(session)
+        assertEquals(777, session.gameId)
+        assertEquals("indy-uuid", session.gameUuid)
+        assertEquals("Indiana Jones and the Great Circle", session.gameName)
+        assertTrue(session.ownedByClient)
+        assertFalse(session.watchOnly)
+    }
+
+    @Test
     fun activeSessionUsesWatchPolicyForOtherClientOwner() {
         val session = NovaLibraryActiveSessionUiState.from(
             PolarisSessionStatus(


### PR DESCRIPTION
## Summary
- Treat Polaris `paused` session status as resumable in Nova library active-session state.
- Preserve stream host/session extras in the background keep-alive notification so tapping it can reopen the Nova library resume surface.
- Move disconnect resume timeout sync into a retry-safe path and mirror it from the foreground keep-alive service so it is less likely to be cancelled during activity teardown.

## Verification
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain`
- `git diff --check`