### PR TITLE
Polish Kotlin runtime hardening

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,9 @@
             android:enabled="true"
             android:exported="true">
         </provider>
-        <receiver android:name=".StartExternalDisplayControlReceiver" />
+        <receiver
+            android:name=".StartExternalDisplayControlReceiver"
+            android:exported="false" />
         <!-- Samsung multi-window support -->
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -312,22 +312,40 @@ class ShortcutTrampoline : AppCompatActivity() {
         }
 
         val authority = fileUri.authority
-        if (ContentResolver.SCHEME_CONTENT == scheme && authority.isNullOrEmpty()) {
-            return false
+        if (ContentResolver.SCHEME_CONTENT == scheme) {
+            if (authority.isNullOrEmpty() || isNovaInternalContentAuthority(authority)) {
+                return false
+            }
         }
 
-        try {
-            val normalizedPath = File(path).canonicalPath
-            for (prefix in DISALLOWED_ART_FILE_PATH_PREFIXES) {
-                if (normalizedPath == prefix || normalizedPath.startsWith(prefix + File.separator)) {
-                    return false
-                }
-            }
+        val canonicalPath = try {
+            File(path).canonicalPath
         } catch (_: IOException) {
             return false
         }
 
+        if (canonicalPath == "/data" || canonicalPath.startsWith("/data/")) {
+            return false
+        }
+        if (canonicalPath == "/proc" || canonicalPath.startsWith("/proc/")) {
+            return false
+        }
+        if (canonicalPath == "/sys" || canonicalPath.startsWith("/sys/")) {
+            return false
+        }
+        if (canonicalPath == "/dev" || canonicalPath.startsWith("/dev/")) {
+            return false
+        }
+        if (canonicalPath == "/acct" || canonicalPath.startsWith("/acct/")) {
+            return false
+        }
+
         return true
+    }
+
+    private fun isNovaInternalContentAuthority(authority: String): Boolean {
+        return authority == BuildConfig.APPLICATION_ID + ".fileprovider" ||
+            authority == PosterContentProvider.AUTHORITY
     }
 
     private fun parseArtFileData(fileUri: Uri?): Map<String, String>? {
@@ -641,13 +659,6 @@ class ShortcutTrampoline : AppCompatActivity() {
 
     companion object {
         private const val MAX_ART_FILE_CHARS = 64 * 1024
-        private val DISALLOWED_ART_FILE_PATH_PREFIXES = arrayOf(
-            "/data",
-            "/proc",
-            "/sys",
-            "/dev",
-            "/acct",
-        )
         private const val TAG = "ShortcutTrampoline"
     }
 }

--- a/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
+++ b/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
@@ -16,10 +16,17 @@ import com.papi.nova.utils.ExternalDisplayControlActivity
 class StartExternalDisplayControlReceiver : BroadcastReceiver() {
     @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_START_EXTERNAL_DISPLAY_CONTROL) {
+            return
+        }
+
         requestFocusToGameActivity(true)
     }
 
     companion object {
+        const val ACTION_START_EXTERNAL_DISPLAY_CONTROL =
+            "com.papi.nova.action.START_EXTERNAL_DISPLAY_CONTROL"
+
         private const val TIMEOUT_MS = 300L
         private val handler = Handler(Looper.getMainLooper())
         private var isTimeoutActive = false

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -17,7 +17,6 @@ import android.os.HandlerThread
 import android.os.Process
 import android.os.SystemClock
 import android.util.LongSparseArray
-import android.util.Range
 import android.view.Choreographer
 import android.view.Surface
 import android.view.WindowManager
@@ -167,6 +166,7 @@ class MediaCodecDecoderRenderer(
     private var foreground = true
 
     private val codecRecoveryType = AtomicInteger(CR_RECOVERY_TYPE_NONE)
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     private val codecRecoveryMonitor = Object()
     private var codecRecoveryThreadQuiescedFlags = 0
     private var codecRecoveryAttempts = 0
@@ -288,9 +288,13 @@ class MediaCodecDecoderRenderer(
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private fun decoderCanMeetPerformancePoint(
-        caps: MediaCodecInfo.VideoCapabilities,
+        caps: MediaCodecInfo.VideoCapabilities?,
         prefs: PreferenceConfiguration,
     ): Boolean {
+        if (caps == null) {
+            return false
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val targetPerfPoint = MediaCodecInfo.VideoCapabilities.PerformancePoint(
                 initialWidth,
@@ -539,9 +543,10 @@ class MediaCodecDecoderRenderer(
 
     private fun configureAndStartDecoder(format: MediaFormat) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            if (currentHdrMetadata != null) {
+            val hdrMetadataBytes = currentHdrMetadata
+            if (hdrMetadataBytes != null) {
                 val hdrStaticInfo = ByteBuffer.allocate(25).order(ByteOrder.LITTLE_ENDIAN)
-                val hdrMetadata = ByteBuffer.wrap(currentHdrMetadata).order(ByteOrder.LITTLE_ENDIAN)
+                val hdrMetadata = ByteBuffer.wrap(hdrMetadataBytes).order(ByteOrder.LITTLE_ENDIAN)
 
                 hdrStaticInfo.put(0.toByte())
                 hdrStaticInfo.putShort(hdrMetadata.short)
@@ -599,8 +604,8 @@ class MediaCodecDecoderRenderer(
         try {
             val inF = videoDecoder!!.inputFormat
             val outF = videoDecoder!!.outputFormat
-            LimeLog.info("Decoder input format: " + (inF?.toString() ?: "<null>"))
-            LimeLog.info("Decoder output format: " + (outF?.toString() ?: "<null>"))
+            LimeLog.info("Decoder input format: " + inF.toString())
+            LimeLog.info("Decoder output format: " + outF.toString())
         } catch (_: Throwable) {
             LimeLog.info("Decoder formats unavailable after start")
         }
@@ -997,7 +1002,7 @@ class MediaCodecDecoderRenderer(
             val vsyncPeriodNs = (1_000_000_000L / displayHz).toLong()
 
             val tfps = if (targetFps > 0) targetFps else 60
-            val streamPeriodNs = (1_000_000_000L / max(1, tfps)).toLong()
+            val streamPeriodNs = 1_000_000_000L / max(1, tfps)
             val periodNs = if (preferLowerDelays) vsyncPeriodNs else max(vsyncPeriodNs, streamPeriodNs)
 
             val ewmaAlpha = 0.25
@@ -1827,6 +1832,36 @@ class MediaCodecDecoderRenderer(
         return minDecodeTimeFullLog
     }
 
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun appendDecoderCapabilities(
+        append: (String) -> Unit,
+        label: String,
+        mimeType: String,
+        decoder: MediaCodecInfo?,
+    ) {
+        if (decoder == null) {
+            return
+        }
+
+        val videoCapabilities = decoder.getCapabilitiesForType(mimeType).videoCapabilities
+        if (videoCapabilities == null) {
+            append("$label capabilities: UNAVAILABLE" + RendererException.DELIMITER)
+            return
+        }
+
+        append("$label supported width range: ${videoCapabilities.supportedWidths}" + RendererException.DELIMITER)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            append(
+                try {
+                    val fpsRange = videoCapabilities.getAchievableFrameRatesFor(initialWidth, initialHeight)
+                    "$label achievable FPS range: $fpsRange" + RendererException.DELIMITER
+                } catch (_: IllegalArgumentException) {
+                    "$label achievable FPS range: UNSUPPORTED!" + RendererException.DELIMITER
+                },
+            )
+        }
+    }
+
     class DecoderHungException(private val hangTimeMs: Int) : RuntimeException() {
         override fun toString(): String {
             var str = ""
@@ -1868,50 +1903,10 @@ class MediaCodecDecoderRenderer(
             str += "AVC Decoder: " + (renderer.avcDecoder?.name ?: "(none)") + DELIMITER
             str += "HEVC Decoder: " + (renderer.hevcDecoder?.name ?: "(none)") + DELIMITER
             str += "AV1 Decoder: " + (renderer.av1Decoder?.name ?: "(none)") + DELIMITER
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && renderer.avcDecoder != null) {
-                val avcWidthRange: Range<Int> =
-                    renderer.avcDecoder!!.getCapabilitiesForType("video/avc").videoCapabilities.supportedWidths
-                str += "AVC supported width range: " + avcWidthRange + DELIMITER
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    str += try {
-                        val avcFpsRange =
-                            renderer.avcDecoder!!.getCapabilitiesForType("video/avc").videoCapabilities
-                                .getAchievableFrameRatesFor(renderer.initialWidth, renderer.initialHeight)
-                        "AVC achievable FPS range: " + avcFpsRange + DELIMITER
-                    } catch (_: IllegalArgumentException) {
-                        "AVC achievable FPS range: UNSUPPORTED!" + DELIMITER
-                    }
-                }
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && renderer.hevcDecoder != null) {
-                val hevcWidthRange: Range<Int> =
-                    renderer.hevcDecoder!!.getCapabilitiesForType("video/hevc").videoCapabilities.supportedWidths
-                str += "HEVC supported width range: " + hevcWidthRange + DELIMITER
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    str += try {
-                        val hevcFpsRange =
-                            renderer.hevcDecoder!!.getCapabilitiesForType("video/hevc").videoCapabilities
-                                .getAchievableFrameRatesFor(renderer.initialWidth, renderer.initialHeight)
-                        "HEVC achievable FPS range: " + hevcFpsRange + DELIMITER
-                    } catch (_: IllegalArgumentException) {
-                        "HEVC achievable FPS range: UNSUPPORTED!" + DELIMITER
-                    }
-                }
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && renderer.av1Decoder != null) {
-                val av1WidthRange: Range<Int> =
-                    renderer.av1Decoder!!.getCapabilitiesForType("video/av01").videoCapabilities.supportedWidths
-                str += "AV1 supported width range: " + av1WidthRange + DELIMITER
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    str += try {
-                        val av1FpsRange =
-                            renderer.av1Decoder!!.getCapabilitiesForType("video/av01").videoCapabilities
-                                .getAchievableFrameRatesFor(renderer.initialWidth, renderer.initialHeight)
-                        "AV1 achievable FPS range: " + av1FpsRange + DELIMITER
-                    } catch (_: IllegalArgumentException) {
-                        "AV1 achievable FPS range: UNSUPPORTED!" + DELIMITER
-                    }
-                }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                renderer.appendDecoderCapabilities(append = { str += it }, "AVC", "video/avc", renderer.avcDecoder)
+                renderer.appendDecoderCapabilities(append = { str += it }, "HEVC", "video/hevc", renderer.hevcDecoder)
+                renderer.appendDecoderCapabilities(append = { str += it }, "AV1", "video/av01", renderer.av1Decoder)
             }
             str += "Configured format: " + renderer.configuredFormat + DELIMITER
             str += "Input format: " + renderer.inputFormat + DELIMITER

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecHelper.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecHelper.kt
@@ -997,7 +997,6 @@ class MediaCodecHelper {
 
                             if (preferStabilityDecoders &&
                                 i == 0 &&
-                                decoderName != null &&
                                 decoderName.lowercase(Locale.US).contains("low_latency")
                             ) {
                                 LimeLog.info("Skipping low-latency decoder for Auto Safe stability: $decoderName")

--- a/app/src/main/java/com/papi/nova/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/papi/nova/computers/ComputerManagerService.kt
@@ -59,6 +59,7 @@ class ComputerManagerService : Service() {
 
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private var discoveryBinder: DiscoveryService.DiscoveryBinder? = null
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     private val discoveryServiceLock = Object()
     private val discoveryServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, binder: IBinder) {
@@ -622,6 +623,7 @@ class ComputerManagerService : Service() {
         val address: ComputerDetails.AddressTuple?,
         val existingDetails: ComputerDetails,
     ) {
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
         val completionLock = Object()
         var complete = false
         var pollingThread: Thread? = null
@@ -833,6 +835,7 @@ class ComputerManagerService : Service() {
 
     inner class ApplistPoller(private val computer: ComputerDetails) {
         private var thread: Thread? = null
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
         private val pollEvent = Object()
         private var receivedAppList = false
 
@@ -992,7 +995,7 @@ class PollingTuple(@JvmField val computer: ComputerDetails) {
     var future: ScheduledFuture<*>? = null
 
     @JvmField
-    val networkLock: Any = Object()
+    val networkLock: Any = Any()
 
     @JvmField
     var lastSuccessfulPollMs: Long = 0

--- a/app/src/main/java/com/papi/nova/nvstream/NvConnection.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/NvConnection.kt
@@ -281,7 +281,7 @@ class NvConnection(
                             },
                         )
                     }
-                } else if (Objects.equals(NvApp.REMOTE_INPUT_UUID, app!!.appUUID)) {
+                } else if (Objects.equals(NvApp.REMOTE_INPUT_UUID, app.appUUID)) {
                     return launchNotRunningApp(h, context)
                 } else {
                     if (context.watchOnlyRequested) {
@@ -434,7 +434,7 @@ class NvConnection(
                     connectionListener.stageComplete(appName)
                 } catch (e: HostHttpResponseException) {
                     e.printStackTrace()
-                    connectionListener.displayMessage(e.message ?: e.toString())
+                    connectionListener.displayMessage(e.message)
                     retry = connectionListener.stageFailed(appName, 0, e.getErrorCode())
                     if (!retry) {
                         return@Thread

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -61,7 +61,7 @@ class NvHTTP @Throws(IOException::class) constructor(
 ) {
     private val deviceName: String = DeviceUtils.getModel()
     private val pm: PairingManager
-    private lateinit var baseUrlHttp: HttpUrl
+    private val baseUrlHttp: HttpUrl
 
     private lateinit var httpClientLongConnectTimeout: OkHttpClient
     private lateinit var httpClientLongConnectNoReadTimeout: OkHttpClient
@@ -79,7 +79,7 @@ class NvHTTP @Throws(IOException::class) constructor(
             if (addressString.contains(":") && addressString.contains(".")) {
                 val addr = InetAddress.getByName(addressString)
                 if (addr is Inet4Address) {
-                    addressString = addr.hostAddress
+                    addressString = addr.hostAddress ?: addressString
                 }
             }
 
@@ -319,13 +319,24 @@ class NvHTTP @Throws(IOException::class) constructor(
             throw IllegalArgumentException("Unexpected NvHTTP path")
         }
 
-        return baseUrl.newBuilder()
+        val completeUrl = baseUrl.newBuilder()
             .addPathSegments(path)
             .query(query)
             .addQueryParameter("devicename", deviceName)
             .addQueryParameter("uniqueid", uniqueId)
             .addQueryParameter("uuid", UUID.randomUUID().toString())
             .build()
+        if (!isExpectedNvHttpUrl(completeUrl, path)) {
+            throw IllegalArgumentException("Unexpected NvHTTP URL")
+        }
+        return completeUrl
+    }
+
+    private fun isExpectedNvHttpUrl(url: HttpUrl, path: String): Boolean {
+        return isExpectedBaseUrl(url) &&
+            url.encodedPath == "/$path" &&
+            url.username.isEmpty() &&
+            url.password.isEmpty()
     }
 
     @Throws(IOException::class)
@@ -341,6 +352,9 @@ class NvHTTP @Throws(IOException::class) constructor(
         }
 
         val completeUrl = getCompleteUrl(baseUrl, path, query)
+        if (!isExpectedNvHttpUrl(completeUrl, path)) {
+            throw IOException("Unexpected NvHTTP target")
+        }
         val builder = Request.Builder().url(completeUrl)
         val request = if (requestBody == null) {
             builder.get().build()
@@ -986,7 +1000,7 @@ class NvHTTP @Throws(IOException::class) constructor(
                         }
                     }
                     XmlPullParser.TEXT -> {
-                        val app = appList.last
+                        val app = appList.last()
                         when (currentTag.peek()) {
                             "AppTitle" -> app.appName = xpp.text
                             "UUID" -> app.appUUID = xpp.text

--- a/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
@@ -12,19 +12,38 @@ import java.io.InputStreamReader
 import java.io.OutputStream
 
 object CacheHelper {
-    private fun isSafePathComponent(component: String?): Boolean {
-        return component != null &&
-            component.isNotEmpty() &&
-            component != "." &&
-            !component.contains("..") &&
-            component.indexOf('/') == -1 &&
-            component.indexOf('\\') == -1
-    }
-
     private fun isUnderRoot(root: File, file: File): Boolean {
         val rootPath = root.path
         val filePath = file.path
         return filePath == rootPath || filePath.startsWith(rootPath + File.separator)
+    }
+
+    @Throws(IOException::class)
+    private fun resolveCacheFile(root: File, path: Array<out String?>): File {
+        val canonicalRoot = root.canonicalFile
+        var file = canonicalRoot
+
+        for (component in path) {
+            val safeComponent = component
+            if (
+                safeComponent == null ||
+                safeComponent.isEmpty() ||
+                safeComponent == "." ||
+                safeComponent.contains("..") ||
+                safeComponent.indexOf('/') != -1 ||
+                safeComponent.indexOf('\\') != -1
+            ) {
+                throw FileNotFoundException("Invalid cache path component")
+            }
+            file = File(file, safeComponent)
+        }
+
+        val canonicalFile = file.canonicalFile
+        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            throw FileNotFoundException("Cache path escapes root")
+        }
+
+        return canonicalFile
     }
 
     @JvmStatic
@@ -37,28 +56,35 @@ object CacheHelper {
             throw IllegalArgumentException("Unable to resolve cache root", e)
         }
 
-        var file = nonNullRoot
+        var file = canonicalRoot
         path.forEachIndexed { index, component ->
-            if (!isSafePathComponent(component)) {
+            val safeComponent = component
+            if (
+                safeComponent == null ||
+                safeComponent.isEmpty() ||
+                safeComponent == "." ||
+                safeComponent.contains("..") ||
+                safeComponent.indexOf('/') != -1 ||
+                safeComponent.indexOf('\\') != -1
+            ) {
                 throw IllegalArgumentException("Invalid cache path component")
             }
 
             if (index == path.lastIndex && createPath) {
                 file.mkdirs()
             }
-            file = File(file, component!!)
+            file = File(file, safeComponent)
         }
 
-        try {
+        return try {
             val canonicalFile = file.canonicalFile
             if (!isUnderRoot(canonicalRoot, canonicalFile)) {
                 throw IllegalArgumentException("Cache path escapes root")
             }
+            canonicalFile
         } catch (e: IOException) {
             throw IllegalArgumentException("Unable to resolve cache path", e)
         }
-
-        return file
     }
 
     @JvmStatic
@@ -79,40 +105,14 @@ object CacheHelper {
     @JvmStatic
     @Throws(IOException::class)
     fun openCacheFileForInput(root: File, vararg path: String?): InputStream {
-        val canonicalRoot = root.canonicalFile
-        var file = canonicalRoot
-        for (component in path) {
-            if (!isSafePathComponent(component)) {
-                throw FileNotFoundException("Invalid cache path component")
-            }
-            file = File(file, component!!)
-        }
-
-        val canonicalFile = file.canonicalFile
-        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
-            throw FileNotFoundException("Cache path escapes root")
-        }
-
+        val canonicalFile = resolveCacheFile(root, path)
         return BufferedInputStream(FileInputStream(canonicalFile))
     }
 
     @JvmStatic
     @Throws(IOException::class)
     fun openCacheFileForOutput(root: File, vararg path: String?): OutputStream {
-        val canonicalRoot = root.canonicalFile
-        var file = canonicalRoot
-        for (component in path) {
-            if (!isSafePathComponent(component)) {
-                throw FileNotFoundException("Invalid cache path component")
-            }
-            file = File(file, component!!)
-        }
-
-        val canonicalFile = file.canonicalFile
-        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
-            throw FileNotFoundException("Cache path escapes root")
-        }
-
+        val canonicalFile = resolveCacheFile(root, path)
         val parent = canonicalFile.parentFile
         if (parent == null || (!parent.isDirectory && !parent.mkdirs())) {
             throw FileNotFoundException("Unable to create cache parent path")

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
@@ -453,6 +453,8 @@ class ExternalDisplayControlActivity :
         }
 
         val broadcastIntent = Intent(this, StartExternalDisplayControlReceiver::class.java)
+            .setAction(StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL)
+            .setPackage(packageName)
         val pendingIntent = PendingIntent.getBroadcast(
             this,
             0,

--- a/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -151,6 +152,42 @@ class KotlinLaunchHelpersMigrationTest {
         assertEquals("nova", channel.getAsString("internal_provider_id"))
     }
 
+    @Test
+    fun artFileUrisRejectPrivateAndInternalContentTargets() {
+        val activity = Robolectric.buildActivity(ShortcutTrampoline::class.java).get()
+
+        assertFalse(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("file:///data/data/com.papi.nova/private.art")
+            )
+        )
+        assertFalse(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("content://${BuildConfig.APPLICATION_ID}.fileprovider/cache/private.art")
+            )
+        )
+        assertFalse(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("content://${PosterContentProvider.AUTHORITY}/boxart/host/private.art")
+            )
+        )
+        assertFalse(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("content://com.example.provider/document/not-art.txt")
+            )
+        )
+        assertTrue(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("file:///sdcard/Download/game.art")
+            )
+        )
+    }
+
     private fun newPrivateBuilder(className: String): Any {
         return try {
             val constructor: Constructor<*> = Class.forName(className).getDeclaredConstructor()
@@ -168,6 +205,16 @@ class KotlinLaunchHelpersMigrationTest {
             method.invoke(target, value)
         } catch (e: Exception) {
             throw AssertionError("Unable to call $methodName", e)
+        }
+    }
+
+    private fun isSafeArtFileUri(activity: ShortcutTrampoline, uri: Uri): Boolean {
+        return try {
+            val method = ShortcutTrampoline::class.java.getDeclaredMethod("isSafeArtFileUri", Uri::class.java)
+            method.isAccessible = true
+            method.invoke(activity, uri) as Boolean
+        } catch (e: Exception) {
+            throw AssertionError("Unable to call isSafeArtFileUri", e)
         }
     }
 

--- a/app/src/test/java/com/papi/nova/utils/CacheHelperTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/CacheHelperTest.kt
@@ -1,8 +1,11 @@
 package com.papi.nova.utils
 
+import java.io.File
 import java.io.IOException
+import java.nio.file.Files
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
+import org.junit.Assume.assumeNoException
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -43,6 +46,30 @@ class CacheHelperTest {
         try {
             CacheHelper.openCacheFileForInput(root, "boxart/escape.png")
             fail("Expected embedded separator to be rejected")
+        } catch (expected: IOException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun cacheStreamsRejectSymlinkEscapes() {
+        val root = temporaryFolder.newFolder("cache")
+        val outside = temporaryFolder.newFolder("outside")
+        val secret = File(outside, "secret.txt").apply {
+            writeText("secret")
+        }
+        val link = File(root, "link")
+        try {
+            Files.createSymbolicLink(link.toPath(), outside.toPath())
+        } catch (e: UnsupportedOperationException) {
+            assumeNoException(e)
+        } catch (e: IOException) {
+            assumeNoException(e)
+        }
+
+        try {
+            CacheHelper.openCacheFileForInput(root, "link", secret.name)
+            fail("Expected cache stream to reject symlink escape")
         } catch (expected: IOException) {
             // Expected.
         }

--- a/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
@@ -3,6 +3,7 @@ package com.papi.nova.utils
 import android.app.Activity
 import android.content.Context
 import android.view.View
+import com.papi.nova.StartExternalDisplayControlReceiver
 import com.papi.nova.nvstream.http.ComputerDetails
 import java.io.File
 import java.lang.reflect.Modifier
@@ -31,8 +32,19 @@ class KotlinExternalDisplayUiMigrationTest {
     fun externalDisplayUiHelpersKeepJavaCompatibleApis() {
         assertEquals("launchIntent", ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT)
         assertEquals(1, ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
+        assertEquals(
+            "com.papi.nova.action.START_EXTERNAL_DISPLAY_CONTROL",
+            StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL
+        )
         assertTrue(Modifier.isStatic(ExternalDisplayControlActivity::class.java.getField("EXTRA_LAUNCH_INTENT").modifiers))
         assertTrue(Modifier.isStatic(ExternalDisplayControlActivity::class.java.getField("instance").modifiers))
+        assertTrue(
+            Modifier.isStatic(
+                StartExternalDisplayControlReceiver::class.java
+                    .getField("ACTION_START_EXTERNAL_DISPLAY_CONTROL")
+                    .modifiers
+            )
+        )
         ExternalDisplayControlActivity::class.java.getConstructor()
         ExternalDisplayControlActivity::class.java.getMethod("closeExternalDisplayControl")
         ExternalDisplayControlActivity::class.java.getMethod("toggleKeyboard")
@@ -84,5 +96,15 @@ class KotlinExternalDisplayUiMigrationTest {
             Runnable::class.java
         )
         UiHelper::class.java.getMethod("dpToPx", Context::class.java, Float::class.javaPrimitiveType!!)
+    }
+
+    @Test
+    fun externalDisplayReceiverIsPrivateInManifest() {
+        val manifest = File("src/main/AndroidManifest.xml").readText()
+        assertTrue(
+            Regex(
+                """<receiver\s+android:name="\.StartExternalDisplayControlReceiver"\s+android:exported="false"\s*/>"""
+            ).containsMatchIn(manifest)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- harden NvHTTP URL construction and request targeting around known NVHTTP paths
- tighten Android entry points for external display notification and .art URI handling
- keep Kotlin runtime cleanup focused on null-safety and Java interop warnings
- add guard tests for cache path escapes, external display receiver contracts, and .art URI validation

## Test Plan
- ./gradlew -PnovaAbis=x86_64 compileNonRoot_gameDebugKotlin --console=plain --rerun-tasks
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.utils.CacheHelperTest' --tests 'com.papi.nova.utils.KotlinExternalDisplayUiMigrationTest' --tests 'com.papi.nova.KotlinLaunchHelpersMigrationTest' --tests 'com.papi.nova.nvstream.KotlinNvstreamRuntimeMigrationTest' --tests 'com.papi.nova.nvstream.http.NvHttpServerInfoParsingTest' --console=plain\n- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain\n- ./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain\n- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain\n- git diff --check