### PR TITLE
Expose runtime guards to CodeQL

### DIFF
--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -353,7 +353,40 @@ class ShortcutTrampoline : AppCompatActivity() {
             return null
         }
 
-        if (!isSafeArtFileUri(fileUri)) {
+        val scheme = fileUri.scheme
+        val path = fileUri.path
+        val authority = fileUri.authority
+        val canonicalPath = if (
+            (ContentResolver.SCHEME_CONTENT == scheme || ContentResolver.SCHEME_FILE == scheme) &&
+            path != null &&
+            path.lowercase(Locale.US).endsWith(".art") &&
+            (
+                ContentResolver.SCHEME_FILE == scheme ||
+                    (!authority.isNullOrEmpty() && !isNovaInternalContentAuthority(authority))
+                )
+        ) {
+            try {
+                File(path).canonicalPath
+            } catch (_: IOException) {
+                null
+            }
+        } else {
+            null
+        }
+
+        if (
+            canonicalPath == null ||
+            canonicalPath == "/data" ||
+            canonicalPath.startsWith("/data/") ||
+            canonicalPath == "/proc" ||
+            canonicalPath.startsWith("/proc/") ||
+            canonicalPath == "/sys" ||
+            canonicalPath.startsWith("/sys/") ||
+            canonicalPath == "/dev" ||
+            canonicalPath.startsWith("/dev/") ||
+            canonicalPath == "/acct" ||
+            canonicalPath.startsWith("/acct/")
+        ) {
             Dialog.displayDialog(
                 this@ShortcutTrampoline,
                 resources.getString(R.string.conn_error_title),

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -355,7 +355,19 @@ class NvHTTP @Throws(IOException::class) constructor(
         if (!isExpectedNvHttpUrl(completeUrl, path)) {
             throw IOException("Unexpected NvHTTP target")
         }
-        val builder = Request.Builder().url(completeUrl)
+        val baseUri = baseUrl.toUri()
+        val completeUri = completeUrl.toUri()
+        val requestUrl = if (
+            baseUri.host != null &&
+            baseUri.host.equals(completeUri.host) &&
+            baseUri.scheme.equals(completeUri.scheme) &&
+            baseUri.port == completeUri.port
+        ) {
+            completeUri.toURL()
+        } else {
+            throw IOException("Unexpected NvHTTP target")
+        }
+        val builder = Request.Builder().url(requestUrl)
         val request = if (requestBody == null) {
             builder.get().build()
         } else {

--- a/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
@@ -18,34 +18,6 @@ object CacheHelper {
         return filePath == rootPath || filePath.startsWith(rootPath + File.separator)
     }
 
-    @Throws(IOException::class)
-    private fun resolveCacheFile(root: File, path: Array<out String?>): File {
-        val canonicalRoot = root.canonicalFile
-        var file = canonicalRoot
-
-        for (component in path) {
-            val safeComponent = component
-            if (
-                safeComponent == null ||
-                safeComponent.isEmpty() ||
-                safeComponent == "." ||
-                safeComponent.contains("..") ||
-                safeComponent.indexOf('/') != -1 ||
-                safeComponent.indexOf('\\') != -1
-            ) {
-                throw FileNotFoundException("Invalid cache path component")
-            }
-            file = File(file, safeComponent)
-        }
-
-        val canonicalFile = file.canonicalFile
-        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
-            throw FileNotFoundException("Cache path escapes root")
-        }
-
-        return canonicalFile
-    }
-
     @JvmStatic
     fun openPath(createPath: Boolean, root: File?, vararg path: String?): File {
         val nonNullRoot = requireNotNull(root) { "Root cannot be null" }
@@ -105,14 +77,56 @@ object CacheHelper {
     @JvmStatic
     @Throws(IOException::class)
     fun openCacheFileForInput(root: File, vararg path: String?): InputStream {
-        val canonicalFile = resolveCacheFile(root, path)
+        val canonicalRoot = root.canonicalFile
+        var file = canonicalRoot
+        for (component in path) {
+            val safeComponent = component
+            if (
+                safeComponent == null ||
+                safeComponent.isEmpty() ||
+                safeComponent == "." ||
+                safeComponent.contains("..") ||
+                safeComponent.indexOf('/') != -1 ||
+                safeComponent.indexOf('\\') != -1
+            ) {
+                throw FileNotFoundException("Invalid cache path component")
+            }
+            file = File(file, safeComponent)
+        }
+
+        val canonicalFile = file.canonicalFile
+        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            throw FileNotFoundException("Cache path escapes root")
+        }
+
         return BufferedInputStream(FileInputStream(canonicalFile))
     }
 
     @JvmStatic
     @Throws(IOException::class)
     fun openCacheFileForOutput(root: File, vararg path: String?): OutputStream {
-        val canonicalFile = resolveCacheFile(root, path)
+        val canonicalRoot = root.canonicalFile
+        var file = canonicalRoot
+        for (component in path) {
+            val safeComponent = component
+            if (
+                safeComponent == null ||
+                safeComponent.isEmpty() ||
+                safeComponent == "." ||
+                safeComponent.contains("..") ||
+                safeComponent.indexOf('/') != -1 ||
+                safeComponent.indexOf('\\') != -1
+            ) {
+                throw FileNotFoundException("Invalid cache path component")
+            }
+            file = File(file, safeComponent)
+        }
+
+        val canonicalFile = file.canonicalFile
+        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            throw FileNotFoundException("Cache path escapes root")
+        }
+
         val parent = canonicalFile.parentFile
         if (parent == null || (!parent.isDirectory && !parent.mkdirs())) {
             throw FileNotFoundException("Unable to create cache parent path")


### PR DESCRIPTION
## Summary
- keep NvHTTP request targets inside an explicit URI host/scheme/port equality branch before creating the request URL
- inline .art URI validation before ContentResolver resolution so CodeQL can see the canonical path blocklist
- inline cache path validation before FileInputStream/FileOutputStream sinks while preserving canonical root checks

## Test Plan
- ./gradlew -PnovaAbis=x86_64 compileNonRoot_gameDebugKotlin --console=plain --rerun-tasks
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.utils.CacheHelperTest' --tests 'com.papi.nova.KotlinLaunchHelpersMigrationTest' --tests 'com.papi.nova.nvstream.KotlinNvstreamRuntimeMigrationTest' --tests 'com.papi.nova.nvstream.http.NvHttpServerInfoParsingTest' --console=plain\n- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain (first run hit a JVM SIGSEGV in the test process; rerun passed)\n- ./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain\n- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain\n- git diff --check