### PR TITLE
Close remaining CodeQL path alerts

### DIFF
--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -28,6 +28,7 @@ import com.papi.nova.utils.UiHelper
 import org.xmlpull.v1.XmlPullParserException
 import java.io.BufferedReader
 import java.io.File
+import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStreamReader
 import java.io.StringReader
@@ -302,20 +303,13 @@ class ShortcutTrampoline : AppCompatActivity() {
         }
 
         val scheme = fileUri.scheme
-        if (ContentResolver.SCHEME_CONTENT != scheme && ContentResolver.SCHEME_FILE != scheme) {
+        if (ContentResolver.SCHEME_FILE != scheme) {
             return false
         }
 
         val path = fileUri.path
         if (path == null || !path.lowercase(Locale.US).endsWith(".art")) {
             return false
-        }
-
-        val authority = fileUri.authority
-        if (ContentResolver.SCHEME_CONTENT == scheme) {
-            if (authority.isNullOrEmpty() || isNovaInternalContentAuthority(authority)) {
-                return false
-            }
         }
 
         val canonicalPath = try {
@@ -343,11 +337,6 @@ class ShortcutTrampoline : AppCompatActivity() {
         return true
     }
 
-    private fun isNovaInternalContentAuthority(authority: String): Boolean {
-        return authority == BuildConfig.APPLICATION_ID + ".fileprovider" ||
-            authority == PosterContentProvider.AUTHORITY
-    }
-
     private fun parseArtFileData(fileUri: Uri?): Map<String, String>? {
         if (fileUri == null) {
             return null
@@ -355,15 +344,10 @@ class ShortcutTrampoline : AppCompatActivity() {
 
         val scheme = fileUri.scheme
         val path = fileUri.path
-        val authority = fileUri.authority
         val canonicalPath = if (
-            (ContentResolver.SCHEME_CONTENT == scheme || ContentResolver.SCHEME_FILE == scheme) &&
+            ContentResolver.SCHEME_FILE == scheme &&
             path != null &&
-            path.lowercase(Locale.US).endsWith(".art") &&
-            (
-                ContentResolver.SCHEME_FILE == scheme ||
-                    (!authority.isNullOrEmpty() && !isNovaInternalContentAuthority(authority))
-                )
+            path.lowercase(Locale.US).endsWith(".art")
         ) {
             try {
                 File(path).canonicalPath
@@ -399,11 +383,7 @@ class ShortcutTrampoline : AppCompatActivity() {
         val artData = HashMap<String, String>()
 
         try {
-            contentResolver.openInputStream(fileUri).use { inputStream ->
-                if (inputStream == null) {
-                    throw IOException("Unable to open .art file")
-                }
-
+            FileInputStream(File(canonicalPath)).use { inputStream ->
                 BufferedReader(InputStreamReader(inputStream)).use { reader ->
                     var charsRead = 0
                     while (true) {

--- a/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/CacheHelper.kt
@@ -12,12 +12,6 @@ import java.io.InputStreamReader
 import java.io.OutputStream
 
 object CacheHelper {
-    private fun isUnderRoot(root: File, file: File): Boolean {
-        val rootPath = root.path
-        val filePath = file.path
-        return filePath == rootPath || filePath.startsWith(rootPath + File.separator)
-    }
-
     @JvmStatic
     fun openPath(createPath: Boolean, root: File?, vararg path: String?): File {
         val nonNullRoot = requireNotNull(root) { "Root cannot be null" }
@@ -50,7 +44,9 @@ object CacheHelper {
 
         return try {
             val canonicalFile = file.canonicalFile
-            if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+            val rootPath = canonicalRoot.path
+            val filePath = canonicalFile.path
+            if (filePath != rootPath && !filePath.startsWith(rootPath + File.separator)) {
                 throw IllegalArgumentException("Cache path escapes root")
             }
             canonicalFile
@@ -95,7 +91,9 @@ object CacheHelper {
         }
 
         val canonicalFile = file.canonicalFile
-        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+        val rootPath = canonicalRoot.path
+        val filePath = canonicalFile.path
+        if (filePath != rootPath && !filePath.startsWith(rootPath + File.separator)) {
             throw FileNotFoundException("Cache path escapes root")
         }
 
@@ -123,7 +121,9 @@ object CacheHelper {
         }
 
         val canonicalFile = file.canonicalFile
-        if (!isUnderRoot(canonicalRoot, canonicalFile)) {
+        val rootPath = canonicalRoot.path
+        val filePath = canonicalFile.path
+        if (filePath != rootPath && !filePath.startsWith(rootPath + File.separator)) {
             throw FileNotFoundException("Cache path escapes root")
         }
 

--- a/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinLaunchHelpersMigrationTest.kt
@@ -180,6 +180,12 @@ class KotlinLaunchHelpersMigrationTest {
                 Uri.parse("content://com.example.provider/document/not-art.txt")
             )
         )
+        assertFalse(
+            isSafeArtFileUri(
+                activity,
+                Uri.parse("content://com.example.provider/document/game.art")
+            )
+        )
         assertTrue(
             isSafeArtFileUri(
                 activity,


### PR DESCRIPTION
## Summary
- restrict .art imports to canonicalized file:// URIs to avoid resolving arbitrary content providers
- keep private path blocklists before reading .art files through FileInputStream
- inline CacheHelper canonical-root prefix checks where cache streams are opened
- add a guard assertion that content:// .art imports are rejected

## Test Plan
- ./gradlew -PnovaAbis=x86_64 compileNonRoot_gameDebugKotlin --console=plain
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.utils.CacheHelperTest' --tests 'com.papi.nova.KotlinLaunchHelpersMigrationTest' --console=plain\n- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain\n- ./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain\n- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain\n- git diff --check