### PR TITLE
Polish Nova stream HUD labels

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -74,6 +74,7 @@ data class NovaHudUiState(
     val lowOnePercentLabel: String,
     val streamModeLabel: String,
     val autopilotLabel: String,
+    val autopilotHudLabel: String,
     val autopilotCompactLabel: String,
     val fpsTone: NovaHudTone,
     val latencyTone: NovaHudTone,
@@ -159,6 +160,7 @@ data class NovaHudUiState(
                 lowOnePercentLabel = lowOnePercentFps.takeIf { it > 0.0 }?.roundToInt()?.let { "1%: $it" } ?: "--",
                 streamModeLabel = status?.let(::buildSessionModeLabel).orEmpty(),
                 autopilotLabel = autoQuality.label,
+                autopilotHudLabel = autoQuality.hudLabel(),
                 autopilotCompactLabel = autoQuality.compactLabel,
                 fpsTone = toneForFps(fps, targetFps),
                 latencyTone = toneForLatency(latencyMs),
@@ -274,6 +276,37 @@ data class NovaHudUiState(
             return listOf(mode, bitDepth, path, modeSource, lifecycle, optimization, normalized)
                 .filter { it.isNotBlank() }
                 .joinToString(" ")
+        }
+
+        private fun AutoQualityUiState.hudLabel(): String = when (state) {
+            AutoQualityUiState.State.OFF -> "Auto Off"
+            AutoQualityUiState.State.WATCHING -> "Auto Check"
+            AutoQualityUiState.State.OPTIMIZING -> "Optimizing"
+            AutoQualityUiState.State.STABLE -> when {
+                manualOverride -> "Quality Preset"
+                label.contains("cap", ignoreCase = true) -> "Auto Cap"
+                else -> "Auto Stable"
+            }
+            AutoQualityUiState.State.RECOVERING -> when {
+                compactLabel == "HOST" -> "AI Recovery"
+                label.contains("bitrate", ignoreCase = true) -> "Bitrate Recovery"
+                label.contains("FPS", ignoreCase = true) -> "FPS Recovery"
+                else -> "Recovering"
+            }
+            AutoQualityUiState.State.BLOCKED -> when {
+                label.contains("host", ignoreCase = true) -> "Host Limited"
+                label.contains("network", ignoreCase = true) -> "Network Limited"
+                label.contains("encoder", ignoreCase = true) -> "Encoder Limited"
+                label.contains("decoder", ignoreCase = true) -> "Decoder Limited"
+                else -> "Holding"
+            }
+            AutoQualityUiState.State.UPGRADE_AVAILABLE -> "Quality Ready"
+            AutoQualityUiState.State.MANUAL_OVERRIDE -> "Manual"
+            AutoQualityUiState.State.NEEDS_ATTENTION -> when {
+                label.contains("sync", ignoreCase = true) -> "Sync Attention"
+                label.contains("decoder", ignoreCase = true) -> "Decoder Pressure"
+                else -> "Attention"
+            }
         }
 
         private fun AutoQualityUiState.Tone.toHudTone(): NovaHudTone = when (this) {

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -88,11 +88,12 @@ private fun NovaStreamHudFull(state: NovaHudUiState, modifier: Modifier) {
             }
             Column(horizontalAlignment = Alignment.End) {
                 Text(
-                    text = state.autopilotLabel,
+                    text = state.autopilotHudLabel,
                     color = state.statusTone.hudColor(),
                     fontSize = 10.sp,
                     lineHeight = 12.sp,
                     fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.widthIn(max = 96.dp),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -144,23 +145,28 @@ private fun NovaStreamHudFull(state: NovaHudUiState, modifier: Modifier) {
 @Composable
 private fun NovaStreamHudBanner(state: NovaHudUiState, modifier: Modifier) {
     HudPanel(
-        modifier = modifier.widthIn(min = 0.dp),
+        modifier = modifier.width(320.dp),
         cornerRadius = 16.dp,
         padding = 8.dp
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             HudStatusDot(state.statusTone, height = 20.dp)
             Text(
                 text = state.autopilotCompactLabel,
                 color = state.statusTone.hudColor(),
                 fontSize = 9.sp,
+                lineHeight = 11.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
-                    .padding(start = 7.dp)
-                    .widthIn(min = 36.dp),
-                maxLines = 1
+                    .padding(start = 5.dp)
+                    .widthIn(min = 28.dp, max = 42.dp),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
-            HudDivider()
+            HudDivider(horizontalPadding = 5.dp)
             HudValueText(state.fpsLabel, state.fpsTone, size = 15)
             if (state.targetFpsLabel.isNotBlank()) {
                 Text(
@@ -169,19 +175,21 @@ private fun NovaStreamHudBanner(state: NovaHudUiState, modifier: Modifier) {
                     fontSize = 9.sp,
                     lineHeight = 11.sp,
                     fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(start = 1.dp)
+                    modifier = Modifier.padding(start = 1.dp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
-            HudCompactText(state.latencyLabel, state.latencyTone, minWidth = 36.dp)
-            HudCompactText(state.bitrateLabel, NovaHudTone.INFO, minWidth = 34.dp)
-            HudCompactText(state.resolutionLabel, NovaHudTone.MUTED)
-            HudCompactText(state.codecLabel, NovaHudTone.MUTED)
+            HudCompactText(state.latencyLabel, state.latencyTone, minWidth = 34.dp, startPadding = 5.dp)
+            HudCompactText(state.bitrateLabel, NovaHudTone.INFO, minWidth = 34.dp, startPadding = 5.dp)
+            HudCompactText(state.resolutionLabel, NovaHudTone.MUTED, minWidth = 34.dp, startPadding = 5.dp)
+            HudCompactText(state.codecLabel, NovaHudTone.MUTED, minWidth = 28.dp, startPadding = 5.dp)
             NovaHudSparkline(
                 samples = state.sparklineSamples,
                 tone = state.fpsTone,
                 modifier = Modifier
-                    .padding(start = 9.dp)
-                    .width(54.dp)
+                    .padding(start = 5.dp)
+                    .width(40.dp)
                     .height(15.dp)
             )
         }
@@ -354,10 +362,10 @@ private fun HudStatusDot(tone: NovaHudTone, height: Dp) {
 }
 
 @Composable
-private fun HudDivider() {
+private fun HudDivider(horizontalPadding: Dp = 8.dp) {
     Spacer(
         modifier = Modifier
-            .padding(horizontal = 8.dp)
+            .padding(horizontal = horizontalPadding)
             .width(1.dp)
             .height(16.dp)
             .background(LocalNovaComposeColors.current.accent.copy(alpha = 0.35f))

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -148,6 +148,40 @@ class NovaComposeSourceGuardTest {
         )
     }
 
+    @Test
+    fun streamHudUsesCompactBoundedLabels() {
+        val source = readNovaStreamHudContent()
+        val fullHud = source.section(
+            "private fun NovaStreamHudFull(",
+            "@Composable\nprivate fun NovaStreamHudBanner("
+        )
+        val banner = source.section(
+            "private fun NovaStreamHudBanner(",
+            "@Composable\nprivate fun NovaStreamHudFpsOnly("
+        )
+
+        assertTrue(
+            "full HUD should use the shorter HUD-specific status label",
+            fullHud.contains("text = state.autopilotHudLabel")
+        )
+        assertTrue(
+            "full HUD status label should have a max width so it cannot crowd the FPS label",
+            fullHud.contains(".widthIn(max = 96.dp)")
+        )
+        assertTrue(
+            "banner HUD should use a stable overlay width instead of unconstrained wrap content",
+            banner.contains("modifier = modifier.width(320.dp)")
+        )
+        assertTrue(
+            "banner compact status should be horizontally bounded",
+            banner.contains(".widthIn(min = 28.dp, max = 42.dp)")
+        )
+        assertTrue(
+            "banner HUD should use explicit compact line height for the status chip",
+            banner.contains("lineHeight = 11.sp")
+        )
+    }
+
     private fun readNovaLibraryActivity(): String =
         readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
 

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -53,6 +53,7 @@ class NovaHudUiStateTest {
         assertEquals("1920×1080", state.resolutionLabel)
         assertEquals("HEVC", state.codecLabel)
         assertEquals("Auto Quality Stable", state.autopilotLabel)
+        assertEquals("Auto Stable", state.autopilotHudLabel)
         assertEquals("OK", state.autopilotCompactLabel)
         assertEquals(NovaHudTone.STABLE, state.fpsTone)
         assertEquals(NovaHudTone.STABLE, state.latencyTone)
@@ -114,9 +115,65 @@ class NovaHudUiStateTest {
         )
 
         assertEquals("AI Recovery Profile", state.autopilotLabel)
+        assertEquals("AI Recovery", state.autopilotHudLabel)
         assertEquals("HOST", state.autopilotCompactLabel)
         assertEquals(NovaHudTone.WARNING, state.statusTone)
         assertEquals(NovaHudTone.WARNING, state.fpsTone)
+    }
+
+    @Test
+    fun hudLabelsStayCompactForSpaceConstrainedOverlay() {
+        val stable = NovaHudUiState.from(
+            mode = NovaHudMode.FULL,
+            fps = 118.7,
+            targetFps = 120.0,
+            latencyMs = 12,
+            codec = "hevc",
+            bitrateKbps = 30000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = emptyList()
+        )
+        val upgrade = NovaHudUiState.from(
+            mode = NovaHudMode.FULL,
+            fps = 118.7,
+            targetFps = 120.0,
+            latencyMs = 12,
+            codec = "hevc",
+            bitrateKbps = 30000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
+                    state = "upgrade_available"
+                )
+            ),
+            sparklineSamples = emptyList()
+        )
+        val attention = NovaHudUiState.from(
+            mode = NovaHudMode.FULL,
+            fps = 118.7,
+            targetFps = 120.0,
+            latencyMs = 12,
+            codec = "hevc",
+            bitrateKbps = 30000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                encoder = PolarisSessionStatus.EncoderStatus(targetResidency = "cpu")
+            ),
+            sparklineSamples = emptyList()
+        )
+
+        assertEquals("Auto Stable", stable.autopilotHudLabel)
+        assertEquals("Quality Ready", upgrade.autopilotHudLabel)
+        assertEquals("Attention", attention.autopilotHudLabel)
+        assertTrue(
+            listOf(stable, upgrade, attention).all {
+                it.autopilotHudLabel.length <= 16
+            }
+        )
     }
 
     private fun status(


### PR DESCRIPTION
## Summary
- add a HUD-specific Auto Quality label so the stream overlay can use short status text without changing full labels elsewhere
- bound the full HUD status label and tighten banner HUD spacing/width to reduce text clipping on handheld displays
- add HUD label and Compose source guards for the compact overlay layout

## Verification
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.ui.NovaHudUiStateTest' --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest' --console=plain
- ./gradlew -PnovaAbis=x86_64 compileNonRoot_gameDebugKotlin --console=plain
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain
- ./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain
- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain
- git diff --check