### PR TITLE
Pin Netty for Android test tooling

### DIFF
--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -43,4 +43,26 @@ class NovaComposeBuildConfigurationTest {
             appBuild.contains("androidx.compose.ui:ui-test-junit4")
         )
     }
+
+    @Test
+    fun gradlePinsNettyForToolingDependencyAlerts() {
+        val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
+
+        assertTrue(
+            "root build should keep a single patched Netty version for Gradle and Android test tooling",
+            rootBuild.contains("patchedNettyVersion = '4.1.133.Final'")
+        )
+        assertTrue(
+            "all project configurations should force Netty transitives onto the patched line",
+            rootBuild.contains("details.requested.group == 'io.netty'") &&
+                rootBuild.contains("details.useVersion patchedNettyVersion")
+        )
+        assertTrue(
+            "the existing buildscript classpath constraints should still cover settings/build-tool Netty transitives",
+            rootBuild.contains("classpath('io.netty:netty-codec:4.1.133.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-codec-http:4.1.133.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-codec-http2:4.1.133.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-handler-proxy:4.1.133.Final')")
+        )
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,19 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose' version '2.3.21' apply false
 }
 
+def patchedNettyVersion = '4.1.133.Final'
+
+allprojects { project ->
+    configurations.configureEach { configuration ->
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'io.netty') {
+                details.useVersion patchedNettyVersion
+                details.because 'Dependabot flags Netty from Gradle/Android test tooling transitives'
+            }
+        }
+    }
+}
+
 // Aggregate all variant/unit tests under the root `test` task
 gradle.projectsEvaluated {
     def agg = tasks.findByName('test') ?: tasks.register('test') {


### PR DESCRIPTION
## Summary
- force all Gradle project configurations to resolve io.netty modules to 4.1.133.Final
- keep existing buildscript classpath Netty constraints for settings/build-tool transitives
- add a Gradle source guard so the Dependabot security pin remains covered

## Dependabot
Addresses open Netty alerts #20-#28 reported from settings.gradle/tooling dependencies. The vulnerable Netty modules come through Android Unified Test Platform/gRPC tooling, not the app runtime classpath.

## Verification
- ./gradlew :app:dependencies --configuration unified-test-platform-core --console=plain
- ./gradlew :app:dependencyInsight --configuration unified-test-platform-core --dependency io.netty:netty-codec --console=plain
- ./gradlew :app:dependencyInsight --configuration unified-test-platform-core --dependency io.netty:netty-codec-http --console=plain
- ./gradlew :app:dependencyInsight --configuration unified-test-platform-core --dependency io.netty:netty-codec-http2 --console=plain
- ./gradlew :app:dependencyInsight --configuration unified-test-platform-core --dependency io.netty:netty-handler-proxy --console=plain
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.ui.NovaComposeBuildConfigurationTest' --console=plain
- ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain
- ./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain
- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug --console=plain
- git diff --check