### PR TITLE
Route runtime cleanup tasks through lifecycle scope

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -4205,18 +4205,22 @@ connected = false
 connecting = connected
 isStreamActive = false
 stopPolarisLiveSessionStatusRefresh()
+runtimeTasks.cancel("NovaBitrateAdjust")
  // Send AI session report before dismissing HUD
             if (novaHud != null && host != null)
 {
-var summary:Map<String, Any>? = novaHud!!.getSessionSummary()
-var reportHost:String? = host
-var reportDevice:String? = DeviceUtils.getModel()
-var reportGame:String? = if (appName != null) appName else ""
-Thread({ try
+val summary:Map<String, Any>? = novaHud!!.getSessionSummary()
+val reportHost:String? = host
+val reportHttpsPort:Int = httpsPort
+val reportServerCert:X509Certificate? = serverCert
+val reportDevice:String? = DeviceUtils.getModel()
+val reportUniqueId:String? = uniqueId
+val reportGame:String? = if (appName != null) appName else ""
+launchRuntimeIo("NovaSessionReport") { try
 {
-var client:com.papi.nova.api.PolarisApiClient = com.papi.nova.api.PolarisApiClient(this@Game, reportHost ?: "", httpsPort, serverCert)
+var client:com.papi.nova.api.PolarisApiClient = com.papi.nova.api.PolarisApiClient(this@Game, reportHost ?: "", reportHttpsPort, reportServerCert)
 client.sendSessionReport(
-reportDevice ?: "", uniqueId ?: "", reportGame ?: "",
+reportDevice ?: "", reportUniqueId ?: "", reportGame ?: "",
 getSummaryDouble(summary, "avg_fps", 0.0),
 getSummaryDouble(summary, "target_fps", 0.0),
 getSummaryDouble(summary, "low_1_percent_fps", 0.0),
@@ -4247,10 +4251,13 @@ getSummaryBoolean(summary, "safe_hdr"),
 getSummaryBoolean(summary, "relaunch_recommended") == true
 )
 }
+catch (e:kotlinx.coroutines.CancellationException) {
+throw e
+}
 catch (e:Exception) {
 com.papi.nova.LimeLog.warning("Nova: Session report failed: " + e!!.message)
 }
- }).start()
+ }
 novaHud!!.dismiss()
 novaHud = null
 }
@@ -4519,17 +4526,22 @@ novaHud!!.applySessionStatus(lastPolarisSessionStatus)
 
  // Wire proactive bitrate adjustment — HUD monitors quality and auto-adjusts
                     var streamHost:String? = host
+val streamHttpsPort:Int = httpsPort
+val streamServerCert:X509Certificate? = serverCert
 	novaHud!!.onBitrateAdjust = { newBitrate:Int ->
-Thread({ try
+launchReplacingRuntimeIo("NovaBitrateAdjust") { try
 {
-var client:com.papi.nova.api.PolarisApiClient = com.papi.nova.api.PolarisApiClient(this@Game, streamHost ?: "", httpsPort, serverCert)
+var client:com.papi.nova.api.PolarisApiClient = com.papi.nova.api.PolarisApiClient(this@Game, streamHost ?: "", streamHttpsPort, streamServerCert)
 client.setBitrate(newBitrate)
 com.papi.nova.LimeLog.info("Nova: Proactive bitrate adjust → " + newBitrate + " kbps")
+}
+catch (e:kotlinx.coroutines.CancellationException) {
+throw e
 }
 catch (e:Exception) {
 com.papi.nova.LimeLog.warning("Nova: Bitrate adjust failed: " + e!!.message)
 }
- }).start()
+ }
 	}
 schedulePolarisLiveSessionStatusRefresh(true)
 }
@@ -5092,6 +5104,10 @@ cursorVisibilitySyncExecutor!!.shutdownNow()
 
 internal fun launchRuntimeIo(name:String, block:suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {
 runtimeTasks.launchIo(name, block)
+}
+
+internal fun launchReplacingRuntimeIo(name:String, block:suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {
+runtimeTasks.launchIoReplacing(name, block)
 }
 
 internal suspend fun runOnMainIfRuntimeActive(block:() -> Unit) {

--- a/app/src/main/java/com/papi/nova/runtime/NovaRuntimeTasks.kt
+++ b/app/src/main/java/com/papi/nova/runtime/NovaRuntimeTasks.kt
@@ -24,6 +24,11 @@ internal class NovaRuntimeTasks(
     fun launchIo(name: String, block: suspend CoroutineScope.() -> Unit): Job =
         launch(name, Dispatchers.IO, block)
 
+    fun launchIoReplacing(name: String, block: suspend CoroutineScope.() -> Unit): Job {
+        cancel(name)
+        return launchIo(name, block)
+    }
+
     fun launchMain(name: String, block: suspend CoroutineScope.() -> Unit): Job =
         launch(name, Dispatchers.Main.immediate, block)
 

--- a/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
@@ -215,6 +215,34 @@ class KotlinGameRuntimeMigrationTest {
         )
     }
 
+    @Test
+    fun streamShutdownReportUsesRuntimeTasksInsteadOfRawThread() {
+        val source = readGameSource()
+        val stopConnection = source.substring(
+            source.indexOf("private fun stopConnection()"),
+            source.indexOf("override fun stageFailed(")
+        )
+        val sessionReport = stopConnection.substring(
+            stopConnection.indexOf("// Send AI session report before dismissing HUD"),
+            stopConnection.indexOf("novaHud!!.dismiss()")
+        )
+
+        assertTrue(sessionReport.contains("launchRuntimeIo(\"NovaSessionReport\")"))
+        assertFalse(sessionReport.contains("Thread({"))
+    }
+
+    @Test
+    fun hudBitrateAdjustUsesReplacingRuntimeTask() {
+        val source = readGameSource()
+        val bitrateAdjust = source.substring(
+            source.indexOf("// Wire proactive bitrate adjustment"),
+            source.indexOf("schedulePolarisLiveSessionStatusRefresh(true)", source.indexOf("// Wire proactive bitrate adjustment"))
+        )
+
+        assertTrue(bitrateAdjust.contains("launchReplacingRuntimeIo(\"NovaBitrateAdjust\")"))
+        assertFalse(bitrateAdjust.contains("Thread({"))
+    }
+
     private fun readGameSource(): String {
         return String(Files.readAllBytes(Path.of("src/main/java/com/papi/nova/Game.kt")), StandardCharsets.UTF_8)
     }

--- a/app/src/test/java/com/papi/nova/runtime/GameRuntimeTaskLifecycleTest.kt
+++ b/app/src/test/java/com/papi/nova/runtime/GameRuntimeTaskLifecycleTest.kt
@@ -63,6 +63,38 @@ class GameRuntimeTaskLifecycleTest {
         assertNoActiveJobs(tasks, "session")
     }
 
+    @Test
+    fun launchIoReplacingCancelsPreviousNamedRuntimeTask() {
+        val owner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        val tasks = NovaRuntimeTasks(owner)
+        val firstStarted = CountDownLatch(1)
+        val firstCancelled = CountDownLatch(1)
+        val secondStarted = CountDownLatch(1)
+
+        tasks.launchIoReplacing("bitrate") {
+            firstStarted.countDown()
+            try {
+                awaitCancellation()
+            } finally {
+                firstCancelled.countDown()
+            }
+        }
+
+        assertTrue(firstStarted.await(1, TimeUnit.SECONDS))
+
+        tasks.launchIoReplacing("bitrate") {
+            secondStarted.countDown()
+            awaitCancellation()
+        }
+
+        assertTrue(firstCancelled.await(1, TimeUnit.SECONDS))
+        assertTrue(secondStarted.await(1, TimeUnit.SECONDS))
+        assertEquals(1, tasks.activeJobCount("bitrate"))
+
+        tasks.cancel("bitrate")
+        assertNoActiveJobs(tasks, "bitrate")
+    }
+
     private fun assertNoActiveJobs(tasks: NovaRuntimeTasks, name: String) {
         repeat(20) {
             if (tasks.activeJobCount(name) == 0) {


### PR DESCRIPTION
## Summary
- Route session reporting through `NovaRuntimeTasks` instead of a raw shutdown thread.
- Add replacing runtime IO task support and use it for HUD bitrate adjustments.
- Cancel pending bitrate adjustment work during stream shutdown and preserve cancellation semantics.
- Add regression coverage for replacing runtime tasks and the Kotlin migration audit slice.

## Validation
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.runtime.GameRuntimeTaskLifecycleTest --tests com.papi.nova.KotlinGameRuntimeMigrationTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=x86_64 lintNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug --console=plain`
- `git diff --check`

## Device Smoke
- Installed `app-nonRoot_game-arm64-v8a-debug.apk` on Retroid Pocket Flip 2.
- Launched Steam Big Picture stream successfully after retry.
- Verified HEVC hardware decode, 60 Hz client presentation sync, and `stream_active` logs.
- Disconnected through the in-app quick menu and returned to `NovaLibraryActivity`.
- Crash buffer was empty; no fatal, ANR, session report, or bitrate adjust failures were found.