### PR TITLE
Extract video frame pacing policy

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/video/FramePacingPolicy.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/FramePacingPolicy.kt
@@ -1,0 +1,101 @@
+package com.papi.nova.binding.video
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+internal object FramePacingPolicy {
+    data class SmoothnessDropDecision(
+        val shouldDrop: Boolean,
+        val dropThresholdNs: Long,
+        val pressure: Double,
+        val factor: Double,
+    )
+
+    data class LatencyDropDecision(
+        val shouldDrop: Boolean,
+        val isLate: Boolean,
+        val nextLateStreak: Int,
+        val dropThresholdNs: Long,
+        val sinceLastPresentNs: Long,
+        val dropCooldownOk: Boolean,
+        val refreshMismatch: Double,
+        val factor: Double,
+    )
+
+    fun renderPeriodNs(preferLowerDelays: Boolean, vsyncPeriodNs: Long, streamPeriodNs: Long): Long =
+        if (preferLowerDelays) vsyncPeriodNs else max(vsyncPeriodNs, streamPeriodNs)
+
+    fun smoothnessDropDecision(
+        periodNs: Long,
+        vsyncPeriodNs: Long,
+        ewmaJitterNs: Double,
+        recentDrops: Int,
+        frameAgeNs: Long,
+    ): SmoothnessDropDecision {
+        val pressure = min(1.0, ewmaJitterNs / vsyncPeriodNs + recentDrops * 0.1)
+        val factor = max(1.05, min(1.2, 1.2 - 0.15 * (1.0 - pressure)))
+        val dropThresholdNs = (periodNs * factor).toLong()
+
+        return SmoothnessDropDecision(
+            shouldDrop = frameAgeNs >= dropThresholdNs,
+            dropThresholdNs = dropThresholdNs,
+            pressure = pressure,
+            factor = factor,
+        )
+    }
+
+    fun latencyDropDecision(
+        periodNs: Long,
+        vsyncPeriodNs: Long,
+        targetFps: Int,
+        displayHz: Float,
+        ewmaJitterNs: Double,
+        tryAgainStreak: Int,
+        previousLateStreak: Int,
+        lastPresentNs: Long,
+        lastDropNs: Long,
+        nowNs: Long,
+        frameAgeNs: Long,
+    ): LatencyDropDecision {
+        val backPressure = min(1.0, tryAgainStreak.toDouble() / 6.0)
+        val streamHz = max(1.0, targetFps.toDouble())
+        val mismatch = min(
+            2.0,
+            abs(
+                1_000_000_000.0 / streamHz -
+                    1_000_000_000.0 / max(1.0, displayHz.toDouble()),
+            ) / vsyncPeriodNs,
+        )
+
+        val factor = max(
+            1.0,
+            min(
+                1.15,
+                1.02 + 0.13 *
+                    (0.5 * (ewmaJitterNs / vsyncPeriodNs) + 0.3 * backPressure + 0.2 * mismatch),
+            ),
+        )
+        val dropThresholdNs = (periodNs * factor).toLong()
+
+        val sinceLastPresent = if (lastPresentNs == 0L) Long.MAX_VALUE else nowNs - lastPresentNs
+        val dropCooldownOk = nowNs - lastDropNs >= periodNs / 2
+        val isLate = frameAgeNs > dropThresholdNs
+        val nextLateStreak = if (isLate) previousLateStreak + 1 else 0
+        val shouldDrop = isLate &&
+            nextLateStreak >= 1 &&
+            sinceLastPresent < (periodNs * 0.5).toLong() &&
+            dropCooldownOk
+
+        return LatencyDropDecision(
+            shouldDrop = shouldDrop,
+            isLate = isLate,
+            nextLateStreak = nextLateStreak,
+            dropThresholdNs = dropThresholdNs,
+            sinceLastPresentNs = sinceLastPresent,
+            dropCooldownOk = dropCooldownOk,
+            refreshMismatch = mismatch,
+            factor = factor,
+        )
+    }
+}

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -97,8 +97,11 @@ class MediaCodecDecoderRenderer(
         }
     }
 
-    private fun dropFrame(bufferIndex: Int) {
+    private fun dropFrame(bufferIndex: Int, intentional: Boolean = false) {
         videoDecoder!!.releaseOutputBuffer(bufferIndex, false)
+        if (intentional) {
+            activeWindowVideoStats.intentionalFrameDrops++
+        }
     }
 
     private fun getOutputDequeueTimeoutUs(): Int =
@@ -1003,10 +1006,9 @@ class MediaCodecDecoderRenderer(
 
             val tfps = if (targetFps > 0) targetFps else 60
             val streamPeriodNs = 1_000_000_000L / max(1, tfps)
-            val periodNs = if (preferLowerDelays) vsyncPeriodNs else max(vsyncPeriodNs, streamPeriodNs)
+            val periodNs = FramePacingPolicy.renderPeriodNs(preferLowerDelays, vsyncPeriodNs, streamPeriodNs)
 
             val ewmaAlpha = 0.25
-            val minFactor = 1.00
 
             var lastDecoderPtsUs = 0L
             var lastPresentNs = 0L
@@ -1032,7 +1034,7 @@ class MediaCodecDecoderRenderer(
                         while (idx >= 0) {
                             if (last >= 0) {
                                 try {
-                                    videoDecoder!!.releaseOutputBuffer(last, false)
+                                    dropFrame(last, intentional = true)
                                 } catch (_: Throwable) {
                                 }
                             }
@@ -1095,7 +1097,7 @@ class MediaCodecDecoderRenderer(
                             while (true) {
                                 val nextOut = videoDecoder!!.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs().toLong())
                                 if (nextOut < 0) break
-                                videoDecoder!!.releaseOutputBuffer(lastIndex, false)
+                                dropFrame(lastIndex, intentional = true)
                                 frameDropped = true
 
                                 numFramesOut++
@@ -1109,12 +1111,16 @@ class MediaCodecDecoderRenderer(
                                 val nowNs = System.nanoTime()
                                 val frameAgeNs = nowNs - presentationTimeUs * 1000L
 
-                                val pressure = min(1.0, ewmaJitterNs / vsyncPeriodNs + recentDrops * 0.1)
-                                val factorSmooth = max(1.05, min(1.2, 1.2 - 0.15 * (1.0 - pressure)))
-                                val dropThresholdSmoothNs = (periodNs * factorSmooth).toLong()
+                                val dropDecision = FramePacingPolicy.smoothnessDropDecision(
+                                    periodNs = periodNs,
+                                    vsyncPeriodNs = vsyncPeriodNs,
+                                    ewmaJitterNs = ewmaJitterNs,
+                                    recentDrops = recentDrops,
+                                    frameAgeNs = frameAgeNs,
+                                )
 
-                                if (frameAgeNs >= dropThresholdSmoothNs) {
-                                    dropFrame(lastIndex)
+                                if (dropDecision.shouldDrop) {
+                                    dropFrame(lastIndex, intentional = true)
                                     frameDropped = true
                                     lastDropNs = nowNs
                                     recentDrops = min(10, recentDrops + 1)
@@ -1130,39 +1136,23 @@ class MediaCodecDecoderRenderer(
                                 val nowNs = System.nanoTime()
                                 val frameAgeNs = nowNs - presentationTimeUs * 1000L
 
-                                val backPressure = min(1.0, tryAgainStreak.toDouble() / 6.0)
-                                val streamHz = max(1.0, tfps.toDouble())
-                                val mismatch = min(
-                                    2.0,
-                                    abs(
-                                        1_000_000_000.0 / streamHz -
-                                            1_000_000_000.0 / max(1.0, displayHz.toDouble()),
-                                    ) / vsyncPeriodNs,
+                                val dropDecision = FramePacingPolicy.latencyDropDecision(
+                                    periodNs = periodNs,
+                                    vsyncPeriodNs = vsyncPeriodNs,
+                                    targetFps = tfps,
+                                    displayHz = displayHz,
+                                    ewmaJitterNs = ewmaJitterNs,
+                                    tryAgainStreak = tryAgainStreak,
+                                    previousLateStreak = lateStreak,
+                                    lastPresentNs = lastPresentNs,
+                                    lastDropNs = lastDropNs,
+                                    nowNs = nowNs,
+                                    frameAgeNs = frameAgeNs,
                                 )
+                                lateStreak = dropDecision.nextLateStreak
 
-                                val factorLatency = max(
-                                    minFactor,
-                                    min(
-                                        1.15,
-                                        1.02 + 0.13 *
-                                            (0.5 * (ewmaJitterNs / vsyncPeriodNs) + 0.3 * backPressure + 0.2 * mismatch),
-                                    ),
-                                )
-                                val dropThresholdNs = (periodNs * factorLatency).toLong()
-
-                                val sinceLastPresent =
-                                    if (lastPresentNs == 0L) Long.MAX_VALUE else nowNs - lastPresentNs
-                                val dropCooldownOk = nowNs - lastDropNs >= periodNs / 2
-                                val isLate = frameAgeNs > dropThresholdNs
-                                lateStreak = if (isLate) lateStreak + 1 else 0
-
-                                val shouldDrop = isLate &&
-                                    lateStreak >= 1 &&
-                                    sinceLastPresent < (periodNs * 0.5).toLong() &&
-                                    dropCooldownOk
-
-                                if (shouldDrop) {
-                                    dropFrame(lastIndex)
+                                if (dropDecision.shouldDrop) {
+                                    dropFrame(lastIndex, intentional = true)
                                     frameDropped = true
                                     lastDropNs = nowNs
                                     recentDrops = min(10, recentDrops + 1)
@@ -1171,7 +1161,7 @@ class MediaCodecDecoderRenderer(
 
                                 presentFrame(lastIndex, nowNs)
                                 lastPresentNs = nowNs
-                                if (!isLate) lateStreak = 0
+                                if (!dropDecision.isLate) lateStreak = 0
                                 recentDrops = max(0, recentDrops - 1)
                                 updateDecodeLatencyStats(presentationTimeUs)
                                 statsUpdated = true
@@ -1181,7 +1171,7 @@ class MediaCodecDecoderRenderer(
                         } else {
                             if (outputBufferQueue.size == OUTPUT_BUFFER_QUEUE_LIMIT) {
                                 try {
-                                    videoDecoder!!.releaseOutputBuffer(outputBufferQueue.take(), false)
+                                    dropFrame(outputBufferQueue.take(), intentional = true)
                                     frameDropped = true
                                 } catch (_: InterruptedException) {
                                     return@Thread
@@ -1197,8 +1187,10 @@ class MediaCodecDecoderRenderer(
                     } else {
                         when (outIndex) {
                             MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                                activeWindowVideoStats.decoderStarvationEvents++
                             }
                             MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                                activeWindowVideoStats.outputFormatChanges++
                                 LimeLog.info("Output format changed")
                                 outputFormat = videoDecoder!!.outputFormat
                                 LimeLog.info("New output format: $outputFormat")
@@ -1215,7 +1207,9 @@ class MediaCodecDecoderRenderer(
                     val nowNs = System.nanoTime()
                     if (nowNs - lastOutputNs > 1_200_000_000L) {
                         LimeLog.warning("Decoder watchdog: no output >1.2s, scheduling codec flush to recover...")
-                        codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_NONE, CR_RECOVERY_TYPE_FLUSH)
+                        if (codecRecoveryType.compareAndSet(CR_RECOVERY_TYPE_NONE, CR_RECOVERY_TYPE_FLUSH)) {
+                            activeWindowVideoStats.watchdogFlushes++
+                        }
                         try {
                             val poke = Bundle()
                             poke.putInt("priority", 0)
@@ -1930,6 +1924,10 @@ class MediaCodecDecoderRenderer(
             str += "Total frames rendered: " + renderer.globalVideoStats.totalFramesRendered + DELIMITER
             str += "Frame losses: " + renderer.globalVideoStats.framesLost + " in " +
                 renderer.globalVideoStats.frameLossEvents + " loss events" + DELIMITER
+            str += "Decoder pacing counters: starvation=" + renderer.globalVideoStats.decoderStarvationEvents +
+                ", intentionalDrops=" + renderer.globalVideoStats.intentionalFrameDrops +
+                ", watchdogFlushes=" + renderer.globalVideoStats.watchdogFlushes +
+                ", formatChanges=" + renderer.globalVideoStats.outputFormatChanges + DELIMITER
             str += "Average end-to-end client latency: " + renderer.getAverageEndToEndLatency() + "ms" + DELIMITER
             str += "Average hardware decoder latency: " + renderer.getAverageDecoderLatency() + "ms" + DELIMITER
             str += "Frame pacing mode: " + renderer.prefs.framePacing + DELIMITER

--- a/app/src/main/java/com/papi/nova/binding/video/VideoStats.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/VideoStats.kt
@@ -10,6 +10,10 @@ class VideoStats {
     @JvmField var totalFramesRendered: Int = 0
     @JvmField var frameLossEvents: Int = 0
     @JvmField var framesLost: Int = 0
+    @JvmField var decoderStarvationEvents: Int = 0
+    @JvmField var intentionalFrameDrops: Int = 0
+    @JvmField var watchdogFlushes: Int = 0
+    @JvmField var outputFormatChanges: Int = 0
     @JvmField var minHostProcessingLatency: Char = 0.toChar()
     @JvmField var maxHostProcessingLatency: Char = 0.toChar()
     @JvmField var totalHostProcessingLatency: Int = 0
@@ -24,6 +28,10 @@ class VideoStats {
         totalFramesRendered += other.totalFramesRendered
         frameLossEvents += other.frameLossEvents
         framesLost += other.framesLost
+        decoderStarvationEvents += other.decoderStarvationEvents
+        intentionalFrameDrops += other.intentionalFrameDrops
+        watchdogFlushes += other.watchdogFlushes
+        outputFormatChanges += other.outputFormatChanges
 
         minHostProcessingLatency = if (minHostProcessingLatency == 0.toChar()) {
             other.minHostProcessingLatency
@@ -49,6 +57,10 @@ class VideoStats {
         totalFramesRendered = other.totalFramesRendered
         frameLossEvents = other.frameLossEvents
         framesLost = other.framesLost
+        decoderStarvationEvents = other.decoderStarvationEvents
+        intentionalFrameDrops = other.intentionalFrameDrops
+        watchdogFlushes = other.watchdogFlushes
+        outputFormatChanges = other.outputFormatChanges
         minHostProcessingLatency = other.minHostProcessingLatency
         maxHostProcessingLatency = other.maxHostProcessingLatency
         totalHostProcessingLatency = other.totalHostProcessingLatency
@@ -64,6 +76,10 @@ class VideoStats {
         totalFramesRendered = 0
         frameLossEvents = 0
         framesLost = 0
+        decoderStarvationEvents = 0
+        intentionalFrameDrops = 0
+        watchdogFlushes = 0
+        outputFormatChanges = 0
         minHostProcessingLatency = 0.toChar()
         maxHostProcessingLatency = 0.toChar()
         totalHostProcessingLatency = 0

--- a/app/src/test/java/com/papi/nova/binding/video/FramePacingPolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/FramePacingPolicyTest.kt
@@ -1,0 +1,141 @@
+package com.papi.nova.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FramePacingPolicyTest {
+    private val vsync60Ns = 16_666_666L
+    private val stream30Ns = 33_333_333L
+
+    @Test
+    fun renderPeriodUsesVsyncForLowerDelayAndSlowerPeriodOtherwise() {
+        assertEquals(vsync60Ns, FramePacingPolicy.renderPeriodNs(true, vsync60Ns, stream30Ns))
+        assertEquals(stream30Ns, FramePacingPolicy.renderPeriodNs(false, vsync60Ns, stream30Ns))
+    }
+
+    @Test
+    fun smoothnessDecisionDropsAtAdaptiveThreshold() {
+        val decision = FramePacingPolicy.smoothnessDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            ewmaJitterNs = 0.0,
+            recentDrops = 0,
+            frameAgeNs = (vsync60Ns * 1.05).toLong(),
+        )
+
+        assertTrue(decision.shouldDrop)
+        assertEquals((vsync60Ns * 1.05).toLong(), decision.dropThresholdNs)
+    }
+
+    @Test
+    fun smoothnessDecisionKeepsFreshFrames() {
+        val decision = FramePacingPolicy.smoothnessDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            ewmaJitterNs = vsync60Ns * 0.1,
+            recentDrops = 0,
+            frameAgeNs = vsync60Ns,
+        )
+
+        assertFalse(decision.shouldDrop)
+    }
+
+    @Test
+    fun latencyDecisionDropsLateFrameOnlyInsideCooldownRules() {
+        val oldDropNs = 1_000_000_000L
+        val nowNs = oldDropNs + vsync60Ns
+        val lateAgeNs = (vsync60Ns * 1.03).toLong()
+
+        val decision = FramePacingPolicy.latencyDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            targetFps = 60,
+            displayHz = 60f,
+            ewmaJitterNs = 0.0,
+            tryAgainStreak = 0,
+            previousLateStreak = 0,
+            lastPresentNs = nowNs - vsync60Ns / 4,
+            lastDropNs = oldDropNs,
+            nowNs = nowNs,
+            frameAgeNs = lateAgeNs,
+        )
+
+        assertTrue(decision.isLate)
+        assertTrue(decision.dropCooldownOk)
+        assertEquals(1, decision.nextLateStreak)
+        assertTrue(decision.shouldDrop)
+
+        val recentDrop = FramePacingPolicy.latencyDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            targetFps = 60,
+            displayHz = 60f,
+            ewmaJitterNs = 0.0,
+            tryAgainStreak = 0,
+            previousLateStreak = 0,
+            lastPresentNs = nowNs - vsync60Ns / 4,
+            lastDropNs = nowNs - vsync60Ns / 4,
+            nowNs = nowNs,
+            frameAgeNs = lateAgeNs,
+        )
+
+        assertFalse(recentDrop.dropCooldownOk)
+        assertFalse(recentDrop.shouldDrop)
+    }
+
+    @Test
+    fun latencyDecisionDoesNotDropBeforeFirstPresentation() {
+        val decision = FramePacingPolicy.latencyDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            targetFps = 60,
+            displayHz = 60f,
+            ewmaJitterNs = 0.0,
+            tryAgainStreak = 0,
+            previousLateStreak = 0,
+            lastPresentNs = 0L,
+            lastDropNs = 0L,
+            nowNs = 2_000_000_000L,
+            frameAgeNs = (vsync60Ns * 1.03).toLong(),
+        )
+
+        assertTrue(decision.isLate)
+        assertEquals(Long.MAX_VALUE, decision.sinceLastPresentNs)
+        assertFalse(decision.shouldDrop)
+    }
+
+    @Test
+    fun latencyDecisionRaisesThresholdForRefreshMismatch() {
+        val matched = FramePacingPolicy.latencyDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            targetFps = 60,
+            displayHz = 60f,
+            ewmaJitterNs = 0.0,
+            tryAgainStreak = 0,
+            previousLateStreak = 0,
+            lastPresentNs = 1L,
+            lastDropNs = 0L,
+            nowNs = 2L,
+            frameAgeNs = 0L,
+        )
+        val mismatched = FramePacingPolicy.latencyDropDecision(
+            periodNs = vsync60Ns,
+            vsyncPeriodNs = vsync60Ns,
+            targetFps = 30,
+            displayHz = 60f,
+            ewmaJitterNs = 0.0,
+            tryAgainStreak = 0,
+            previousLateStreak = 0,
+            lastPresentNs = 1L,
+            lastDropNs = 0L,
+            nowNs = 2L,
+            frameAgeNs = 0L,
+        )
+
+        assertTrue(mismatched.dropThresholdNs > matched.dropThresholdNs)
+        assertEquals(1.0, mismatched.refreshMismatch, 0.01)
+    }
+}

--- a/app/src/test/java/com/papi/nova/binding/video/KotlinVideoStatsMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/KotlinVideoStatsMigrationTest.kt
@@ -26,6 +26,10 @@ class KotlinVideoStatsMigrationTest {
         first.totalFramesRendered = 24
         first.frameLossEvents = 1
         first.framesLost = 2
+        first.decoderStarvationEvents = 3
+        first.intentionalFrameDrops = 4
+        first.watchdogFlushes = 5
+        first.outputFormatChanges = 6
         first.minHostProcessingLatency = 8.toChar()
         first.maxHostProcessingLatency = 10.toChar()
         first.totalHostProcessingLatency = 18
@@ -40,6 +44,10 @@ class KotlinVideoStatsMigrationTest {
         second.totalFramesRendered = 9
         second.frameLossEvents = 3
         second.framesLost = 4
+        second.decoderStarvationEvents = 5
+        second.intentionalFrameDrops = 6
+        second.watchdogFlushes = 7
+        second.outputFormatChanges = 8
         second.minHostProcessingLatency = 4.toChar()
         second.maxHostProcessingLatency = 12.toChar()
         second.totalHostProcessingLatency = 16
@@ -55,6 +63,10 @@ class KotlinVideoStatsMigrationTest {
         assertEquals(33, first.totalFramesRendered)
         assertEquals(4, first.frameLossEvents)
         assertEquals(6, first.framesLost)
+        assertEquals(8, first.decoderStarvationEvents)
+        assertEquals(10, first.intentionalFrameDrops)
+        assertEquals(12, first.watchdogFlushes)
+        assertEquals(14, first.outputFormatChanges)
         assertEquals(4, first.minHostProcessingLatency.code)
         assertEquals(12, first.maxHostProcessingLatency.code)
         assertEquals(34, first.totalHostProcessingLatency)
@@ -65,12 +77,20 @@ class KotlinVideoStatsMigrationTest {
         copy.copy(first)
         assertEquals(first.decoderTimeMs, copy.decoderTimeMs)
         assertEquals(first.totalFramesRendered, copy.totalFramesRendered)
+        assertEquals(first.decoderStarvationEvents, copy.decoderStarvationEvents)
+        assertEquals(first.intentionalFrameDrops, copy.intentionalFrameDrops)
+        assertEquals(first.watchdogFlushes, copy.watchdogFlushes)
+        assertEquals(first.outputFormatChanges, copy.outputFormatChanges)
         assertEquals(first.minHostProcessingLatency, copy.minHostProcessingLatency)
         assertEquals(first.measurementStartTimestamp, copy.measurementStartTimestamp)
 
         copy.clear()
         assertEquals(0, copy.decoderTimeMs)
         assertEquals(0, copy.totalFramesRendered)
+        assertEquals(0, copy.decoderStarvationEvents)
+        assertEquals(0, copy.intentionalFrameDrops)
+        assertEquals(0, copy.watchdogFlushes)
+        assertEquals(0, copy.outputFormatChanges)
         assertEquals(0, copy.minHostProcessingLatency.code)
         assertEquals(0, copy.measurementStartTimestamp)
     }


### PR DESCRIPTION
## Summary
- Extract frame pacing/drop threshold math into `FramePacingPolicy`, a pure Kotlin policy object with no Android dependencies.
- Keep existing renderer thresholds and drop semantics intact while routing smoothness and latency decisions through the policy.
- Add decoder pacing counters for starvation, intentional drops, watchdog flushes, and output format changes.
- Add unit coverage for render period selection, smoothness drops, late-frame cooldown, first-presentation behavior, and refresh mismatch handling.

## Validation
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.binding.video.FramePacingPolicyTest --tests com.papi.nova.binding.video.KotlinVideoStatsMigrationTest --tests com.papi.nova.binding.video.KotlinVideoRuntimeMigrationTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 assembleNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=x86_64 lintNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug --console=plain`
- `git diff --check`

## Device Smoke
- Installed `app-nonRoot_game-arm64-v8a-debug.apk` on Retroid Pocket Flip 2.
- First stream attempt hit host-side `-408` connection timeout, matching prior transient host behavior.
- Retried Steam Big Picture successfully.
- Verified HEVC hardware decode, output format change, 60 Hz client presentation sync, and `stream_active` logs.
- Disconnected through the in-app quick menu and returned to `NovaLibraryActivity`.
- Crash buffer was empty; no fatal, ANR, decoder watchdog, session report, or bitrate adjust failures were found.