### PR TITLE
Schedule controller button releases without blocking input

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/input/ControllerButtonReleaseScheduler.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/ControllerButtonReleaseScheduler.kt
@@ -1,0 +1,78 @@
+package com.papi.nova.binding.input
+
+import android.os.Handler
+
+internal class ControllerButtonReleaseScheduler(
+    private val handler: Handler,
+    private val minimumButtonDownTimeMs: Int,
+) {
+    data class ReleaseKey(val keyCode: Int, val scanCode: Int)
+
+    private val pendingReleases = mutableMapOf<Any, MutableMap<ReleaseKey, Runnable>>()
+
+    fun scheduleIfNeeded(
+        owner: Any,
+        key: ReleaseKey,
+        downTimeMs: Long,
+        eventTimeMs: Long,
+        shouldSkip: () -> Boolean,
+        release: () -> Unit,
+    ): Boolean {
+        val delayMs = minimumButtonDownTimeMs - (eventTimeMs - downTimeMs)
+        if (delayMs <= 0) {
+            return false
+        }
+
+        cancel(owner, key)
+        lateinit var releaseRunnable: Runnable
+        releaseRunnable =
+            Runnable {
+                val releases = pendingReleases[owner] ?: return@Runnable
+                if (releases.remove(key) !== releaseRunnable) {
+                    return@Runnable
+                }
+                if (releases.isEmpty()) {
+                    pendingReleases.remove(owner)
+                }
+                if (!shouldSkip()) {
+                    release()
+                }
+            }
+
+        pendingReleases.getOrPut(owner) { mutableMapOf() }[key] = releaseRunnable
+        handler.postDelayed(releaseRunnable, delayMs)
+        return true
+    }
+
+    fun flushPendingRelease(owner: Any, key: ReleaseKey): Boolean {
+        val releaseRunnable = pendingReleases[owner]?.get(key) ?: return false
+        handler.removeCallbacks(releaseRunnable)
+        releaseRunnable.run()
+        return true
+    }
+
+    fun cancelOwner(owner: Any) {
+        val releases = pendingReleases.remove(owner) ?: return
+        for (release in releases.values) {
+            handler.removeCallbacks(release)
+        }
+    }
+
+    fun cancelAll() {
+        for (releases in pendingReleases.values) {
+            for (release in releases.values) {
+                handler.removeCallbacks(release)
+            }
+        }
+        pendingReleases.clear()
+    }
+
+    private fun cancel(owner: Any, key: ReleaseKey) {
+        val releases = pendingReleases[owner] ?: return
+        val release = releases.remove(key) ?: return
+        handler.removeCallbacks(release)
+        if (releases.isEmpty()) {
+            pendingReleases.remove(owner)
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/binding/input/ControllerHandler.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/ControllerHandler.kt
@@ -80,6 +80,8 @@ class ControllerHandler(
         activityContext.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     private val sceManager = SceManager(activityContext)
     private val mainThreadHandler = Handler(Looper.getMainLooper())
+    private val buttonReleaseScheduler =
+        ControllerButtonReleaseScheduler(mainThreadHandler, MINIMUM_BUTTON_DOWN_TIME_MS)
     private val backgroundHandlerThread = HandlerThread("ControllerHandler")
     private val backgroundThreadHandler: Handler
     private var hasGameController = false
@@ -161,6 +163,7 @@ class ControllerHandler(
         }
 
         stopped = true
+        buttonReleaseScheduler.cancelAll()
         inputManager.unregisterInputDeviceListener(this)
 
         for (i in 0 until inputDeviceContexts.size()) {
@@ -179,7 +182,8 @@ class ControllerHandler(
         }
 
         sceManager.stop()
-        backgroundHandlerThread.quit()
+        backgroundThreadHandler.removeCallbacksAndMessages(null)
+        backgroundHandlerThread.quitSafely()
     }
 
     fun disableSensors() {
@@ -1796,16 +1800,28 @@ class ControllerHandler(
             keyCode = handleFlipFaceButtons(keyCode)
         }
 
-        val buttonDownTime = (event.eventTime - event.downTime).toInt()
-        if (buttonDownTime < MINIMUM_BUTTON_DOWN_TIME_MS) {
-            try {
-                Thread.sleep((MINIMUM_BUTTON_DOWN_TIME_MS - buttonDownTime).toLong())
-            } catch (e: InterruptedException) {
-                e.printStackTrace()
-                Thread.currentThread().interrupt()
-            }
+        val releaseKey = ControllerButtonReleaseScheduler.ReleaseKey(keyCode, event.scanCode)
+        if (buttonReleaseScheduler.scheduleIfNeeded(
+                owner = context,
+                key = releaseKey,
+                downTimeMs = event.downTime,
+                eventTimeMs = event.eventTime,
+                shouldSkip = { stopped || context.destroyed },
+                release = { applyButtonUp(context, keyCode, event.scanCode, event.eventTime) },
+            )
+        ) {
+            return true
         }
 
+        return applyButtonUp(context, keyCode, event.scanCode, event.eventTime)
+    }
+
+    private fun applyButtonUp(
+        context: InputDeviceContext,
+        keyCode: Int,
+        scanCode: Int,
+        eventTime: Long,
+    ): Boolean {
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_MODE -> {
                 context.inputMap = context.inputMap and ControllerPacket.SPECIAL_BUTTON_FLAG.inv()
@@ -1814,7 +1830,7 @@ class ControllerHandler(
             KeyEvent.KEYCODE_BUTTON_START,
             KeyEvent.KEYCODE_MENU,
             -> {
-                context.startUpTime = event.eventTime
+                context.startUpTime = eventTime
                 if ((context.inputMap and ControllerPacket.PLAY_FLAG) != 0 &&
                     context.startUpTime - context.startDownTime > START_DOWN_TIME_MOUSE_MODE_MS
                 ) {
@@ -1893,12 +1909,12 @@ class ControllerHandler(
             KeyEvent.KEYCODE_BUTTON_Y -> context.inputMap = context.inputMap and ControllerPacket.Y_FLAG.inv()
             KeyEvent.KEYCODE_BUTTON_L1 -> {
                 context.inputMap = context.inputMap and ControllerPacket.LB_FLAG.inv()
-                context.lastLbUpTime = event.eventTime
+                context.lastLbUpTime = eventTime
             }
 
             KeyEvent.KEYCODE_BUTTON_R1 -> {
                 context.inputMap = context.inputMap and ControllerPacket.RB_FLAG.inv()
-                context.lastRbUpTime = event.eventTime
+                context.lastRbUpTime = eventTime
             }
 
             KeyEvent.KEYCODE_BUTTON_THUMBL -> {
@@ -1929,7 +1945,7 @@ class ControllerHandler(
 
             KeyEvent.KEYCODE_UNKNOWN -> {
                 if (context.hasPaddles) {
-                    when (event.scanCode) {
+                    when (scanCode) {
                         0x2c4 -> context.inputMap = context.inputMap and ControllerPacket.PADDLE1_FLAG.inv()
                         0x2c5 -> context.inputMap = context.inputMap and ControllerPacket.PADDLE2_FLAG.inv()
                         0x2c6 -> context.inputMap = context.inputMap and ControllerPacket.PADDLE3_FLAG.inv()
@@ -1991,6 +2007,11 @@ class ControllerHandler(
         if (prefConfig.flipFaceButtons) {
             keyCode = handleFlipFaceButtons(keyCode)
         }
+
+        buttonReleaseScheduler.flushPendingRelease(
+            context,
+            ControllerButtonReleaseScheduler.ReleaseKey(keyCode, event.scanCode),
+        )
 
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_MODE -> {
@@ -2265,6 +2286,7 @@ class ControllerHandler(
         var leftStickX: Short = 0
         var leftStickY: Short = 0
         var mouseEmulationActive = false
+        var destroyed = false
         var mouseEmulationXDown = false
         var mouseEmulationPixelMultiplier = 1
         var mouseEmulationLastInputMap = 0
@@ -2364,6 +2386,8 @@ class ControllerHandler(
         }
 
         open fun destroy() {
+            destroyed = true
+            buttonReleaseScheduler.cancelOwner(this)
             mouseEmulationActive = false
             mainThreadHandler.removeCallbacks(mouseEmulationRunnable)
         }
@@ -2431,12 +2455,20 @@ class ControllerHandler(
         val batteryStateUpdateRunnable: Runnable =
             object : Runnable {
                 override fun run() {
+                    if (stopped || destroyed) {
+                        return
+                    }
+
                     sendControllerBatteryPacket(this@InputDeviceContext)
                     backgroundThreadHandler.postDelayed(this, BATTERY_RECHECK_INTERVAL_MS.toLong())
                 }
             }
         val enableSensorRunnable =
             Runnable {
+                if (stopped || destroyed) {
+                    return@Runnable
+                }
+
                 if (accelReportRateHz.toInt() != 0 && accelListener == null) {
                     handleSetMotionEventState(controllerNumber, MoonBridge.LI_MOTION_TYPE_ACCEL, accelReportRateHz)
                 }
@@ -2636,6 +2668,10 @@ class ControllerHandler(
         }
 
         fun enableSensors() {
+            if (stopped || destroyed) {
+                return
+            }
+
             backgroundThreadHandler.postDelayed(enableSensorRunnable, 1000)
         }
     }

--- a/app/src/test/java/com/papi/nova/binding/input/KotlinControllerHandlerMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/input/KotlinControllerHandlerMigrationTest.kt
@@ -3,6 +3,8 @@ package com.papi.nova.binding.input
 import android.app.Activity
 import android.content.Context
 import android.hardware.input.InputManager
+import android.os.Handler
+import android.os.Looper
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -12,10 +14,16 @@ import com.papi.nova.nvstream.NvConnection
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.GameGestures
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -96,5 +104,90 @@ class KotlinControllerHandlerMigrationTest {
         )
         ControllerHandler::class.java.getMethod("deviceRemoved", AbstractController::class.java)
         ControllerHandler::class.java.getMethod("deviceAdded", AbstractController::class.java)
+    }
+
+    @Test
+    fun shortButtonUpSchedulesReleaseWithoutBlockingInputThread() {
+        val scheduler = ControllerButtonReleaseScheduler(Handler(Looper.getMainLooper()), minimumButtonDownTimeMs = 25)
+        val owner = Any()
+        val key = ControllerButtonReleaseScheduler.ReleaseKey(KeyEvent.KEYCODE_BUTTON_A, 0)
+        var releaseCount = 0
+
+        val scheduled = scheduler.scheduleIfNeeded(
+            owner = owner,
+            key = key,
+            downTimeMs = 100,
+            eventTimeMs = 101,
+            shouldSkip = { false },
+            release = { releaseCount++ }
+        )
+
+        assertTrue(scheduled)
+        assertEquals(0, releaseCount)
+
+        shadowOf(Looper.getMainLooper()).idleFor(23, TimeUnit.MILLISECONDS)
+        assertEquals(0, releaseCount)
+
+        shadowOf(Looper.getMainLooper()).idleFor(1, TimeUnit.MILLISECONDS)
+        assertEquals(1, releaseCount)
+    }
+
+    @Test
+    fun pendingButtonReleaseCanBeFlushedBeforeNextDownEvent() {
+        val scheduler = ControllerButtonReleaseScheduler(Handler(Looper.getMainLooper()), minimumButtonDownTimeMs = 25)
+        val owner = Any()
+        val key = ControllerButtonReleaseScheduler.ReleaseKey(KeyEvent.KEYCODE_BUTTON_A, 0)
+        var releaseCount = 0
+
+        assertTrue(
+            scheduler.scheduleIfNeeded(
+                owner = owner,
+                key = key,
+                downTimeMs = 100,
+                eventTimeMs = 101,
+                shouldSkip = { false },
+                release = { releaseCount++ }
+            )
+        )
+
+        assertTrue(scheduler.flushPendingRelease(owner, key))
+        assertEquals(1, releaseCount)
+
+        shadowOf(Looper.getMainLooper()).idleFor(25, TimeUnit.MILLISECONDS)
+        assertEquals(1, releaseCount)
+    }
+
+    @Test
+    fun pendingButtonReleaseCanBeCancelledForDestroyedContext() {
+        val scheduler = ControllerButtonReleaseScheduler(Handler(Looper.getMainLooper()), minimumButtonDownTimeMs = 25)
+        val owner = Any()
+        val key = ControllerButtonReleaseScheduler.ReleaseKey(KeyEvent.KEYCODE_BUTTON_A, 0)
+        var releaseCount = 0
+
+        assertTrue(
+            scheduler.scheduleIfNeeded(
+                owner = owner,
+                key = key,
+                downTimeMs = 100,
+                eventTimeMs = 101,
+                shouldSkip = { false },
+                release = { releaseCount++ }
+            )
+        )
+
+        scheduler.cancelOwner(owner)
+        shadowOf(Looper.getMainLooper()).idleFor(25, TimeUnit.MILLISECONDS)
+
+        assertEquals(0, releaseCount)
+    }
+
+    @Test
+    fun controllerButtonUpPathDoesNotUseThreadSleep() {
+        val source = String(
+            Files.readAllBytes(Path.of("src/main/java/com/papi/nova/binding/input/ControllerHandler.kt")),
+            StandardCharsets.UTF_8
+        )
+
+        assertFalse(source.contains("Thread.sleep((MINIMUM_BUTTON_DOWN_TIME_MS"))
     }
 }


### PR DESCRIPTION
## Summary
- replace the controller button-up `Thread.sleep` delay with a main-looper release scheduler
- flush pending releases before repeated same-button downs and cancel pending releases during controller teardown
- guard delayed sensor/battery callbacks after stop or context destroy
- add scheduler regression coverage plus a source guard for the old blocking path

## Validation
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`
- Flip smoke: installed ARM64 debug APK, streamed Steam Big Picture, injected short gamepad D-pad input, verified Steam selection moved, disconnected cleanly with no Nova fatal/ANR/input-timeout logs found