### PR TITLE
Memoize library UI state mapping

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -169,7 +169,7 @@ class NovaLibraryActivity : AppCompatActivity() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
             setContent {
                 NovaComposeTheme {
-                    val model = NovaLibraryUiStateMapper.build(allGames, searchQuery, filterState)
+                    val model = rememberNovaLibraryUiModel(allGames, searchQuery, filterState)
                     NovaLibraryScreen(
                         serverName = streamPcName,
                         serverHost = streamHost,
@@ -466,6 +466,21 @@ class NovaLibraryActivity : AppCompatActivity() {
             "desktop" -> getString(R.string.nova_library_filter_desktop)
             "vr" -> getString(R.string.nova_library_filter_vr)
             else -> getString(R.string.nova_library_filter_more)
+        }
+    }
+
+    @Composable
+    private fun rememberNovaLibraryUiModel(
+        games: List<PolarisGame>,
+        searchQuery: String,
+        filterState: NovaLibraryFilterState
+    ): NovaLibraryUiModel {
+        return remember(games, searchQuery, filterState) {
+            NovaLibraryUiStateMapper.build(
+                games = games,
+                search = searchQuery,
+                filterState = filterState
+            )
         }
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -40,6 +40,39 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
+    fun libraryUiModelMappingIsRememberedAcrossUnrelatedRecompositions() {
+        val source = readNovaLibraryActivity()
+        val setContent = source.section(
+            "setContent {",
+            "NovaLibraryScreen("
+        )
+        val helperStart = source.indexOf("private fun rememberNovaLibraryUiModel(")
+
+        assertTrue(
+            "library screen should use a remembered model helper",
+            helperStart >= 0
+        )
+
+        val rememberedModel = source.section(
+            "private fun rememberNovaLibraryUiModel(",
+            "@Composable\n    private fun NovaLibraryScreen("
+        )
+
+        assertTrue(
+            "library model mapping should be keyed to the data that affects filtering",
+            rememberedModel.contains("remember(games, searchQuery, filterState)")
+        )
+        assertTrue(
+            "remembered model helper should own the mapper call",
+            rememberedModel.contains("NovaLibraryUiStateMapper.build(")
+        )
+        assertFalse(
+            "setContent should not rebuild library filtering/sorting for unrelated state changes",
+            setContent.contains("NovaLibraryUiStateMapper.build(")
+        )
+    }
+
+    @Test
     fun librarySearchDoesNotEnterTextInputOnDpadFocus() {
         val searchField = readNovaLibraryActivity().section(
             "private fun NovaSearchField(",


### PR DESCRIPTION
## Summary
- Memoize the Nova library UI model so unrelated Compose recompositions do not rerun library filtering and sorting.
- Keep the mapper call in a small remembered helper keyed by games, search query, and filter state.
- Add a source guard that keeps the mapper out of the top-level setContent recomposition path.

## Validation
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`
- Installed the current arm64 debug APK on attached device `24c12bdd` (`Retroid Pocket 6`) and ran launcher/home navigation smoke. Crash buffer was empty. The connected device had the server in `Pair required`, so the retry could not enter the actual library screen from the supported launcher path.