### PR TITLE
Modernize Gradle task wiring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,7 +180,7 @@ android {
             }
 
             minifyEnabled true
-            shrinkResources true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -3,6 +3,7 @@ package com.papi.nova.ui
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -63,6 +64,38 @@ class NovaComposeBuildConfigurationTest {
                 rootBuild.contains("classpath('io.netty:netty-codec-http:4.1.133.Final')") &&
                 rootBuild.contains("classpath('io.netty:netty-codec-http2:4.1.133.Final')") &&
                 rootBuild.contains("classpath('io.netty:netty-handler-proxy:4.1.133.Final')")
+        )
+    }
+
+    @Test
+    fun rootTestAggregationUsesLazyTaskRegistration() {
+        val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
+
+        assertFalse(
+            "root test aggregation should not wait for projectsEvaluated",
+            rootBuild.contains("gradle.projectsEvaluated")
+        )
+        assertTrue(
+            "root test aggregation should register the test task lazily",
+            rootBuild.contains("def testAllUnitTests = tasks.register('test')")
+        )
+        assertTrue(
+            "root test aggregation should wire subproject unit-test tasks without realizing them early",
+            rootBuild.contains("tasks.matching { it.name.endsWith('UnitTest') }.configureEach")
+        )
+    }
+
+    @Test
+    fun releaseResourceShrinkingUsesGradleAssignmentSyntax() {
+        val appBuild = String(Files.readAllBytes(Paths.get("build.gradle")), StandardCharsets.UTF_8)
+
+        assertTrue(
+            "release resource shrinking should use Gradle 10-compatible assignment syntax",
+            appBuild.contains("shrinkResources = true")
+        )
+        assertFalse(
+            "release resource shrinking should not use deprecated Groovy space assignment",
+            appBuild.contains("shrinkResources true")
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,17 +55,15 @@ allprojects { project ->
     }
 }
 
-// Aggregate all variant/unit tests under the root `test` task
-gradle.projectsEvaluated {
-    def agg = tasks.findByName('test') ?: tasks.register('test') {
-        group = 'verification'
-        description = 'Runs every unit-test task in all sub-projects'
-    }
+// Aggregate all variant/unit tests under the root `test` task.
+def testAllUnitTests = tasks.register('test') {
+    group = 'verification'
+    description = 'Runs every unit-test task in all sub-projects'
+}
 
-    subprojects.each { p ->
-        p.tasks.matching { it.name.endsWith('UnitTest') }.all { t ->
-            agg.configure { dependsOn t }
-        }
+subprojects {
+    tasks.matching { it.name.endsWith('UnitTest') }.configureEach { testTask ->
+        testAllUnitTests.configure { dependsOn testTask }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the root `test` aggregate's `gradle.projectsEvaluated` wiring with lazy `tasks.register`/`configureEach` task wiring.
- Switch release `shrinkResources` to Gradle assignment syntax to remove the Gradle 10 Groovy DSL deprecation.
- Add build configuration source guards for the lazy root test aggregate and assignment syntax.

## Validation
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaComposeBuildConfigurationTest --console=plain` red before the build script changes, then green after.
- `./gradlew help --configuration-cache --console=plain` stores a configuration-cache entry.
- `./gradlew help --configuration-cache --console=plain` reuses that configuration-cache entry.
- `./gradlew help --no-configuration-cache --warning-mode all --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest assembleNonRoot_gameDebug --console=plain`
- `./gradlew -PnovaAbis=x86_64 lintNonRoot_gameDebug assembleNonRoot_gameRelease --console=plain`
- `./gradlew -PnovaAbis=x86_64 test --dry-run --configuration-cache --console=plain`
- `git diff --check`