### PR TITLE
Route cursor sync through runtime tasks

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -130,9 +130,6 @@ import java.util.Arrays
 import java.util.Date
 import java.util.HashMap
 import java.util.Locale
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 import android.view.SurfaceView
 import android.view.ViewGroup
@@ -214,10 +211,6 @@ private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
 @Volatile private var lastPolarisAppliedStreamSettings:JSONObject? = null
 private var clientPresentationReportInFlight:AtomicBoolean = AtomicBoolean(false)
 private var cursorVisibilitySyncLock:Any = Any()
-private var cursorVisibilitySyncExecutor:ExecutorService? = Executors.newSingleThreadExecutor({ r->
-var thread:Thread = Thread(r, "NovaCursorSync")
-thread.setDaemon(true)
-thread })
 private var pendingHostCursorVisible:Boolean = false
 private var hasPendingCursorVisibilitySync:Boolean = false
 private var cursorVisibilitySyncScheduled:Boolean = false
@@ -5047,18 +5040,7 @@ shouldSchedule = true
 
 if (shouldSchedule)
 {
-try
-{
-cursorVisibilitySyncExecutor!!.execute { drainCursorVisibilitySyncQueue() }
-}
-catch (e:RejectedExecutionException) {
-synchronized (cursorVisibilitySyncLock) {
-hasPendingCursorVisibilitySync = false
-cursorVisibilitySyncScheduled = false
-}
-com.papi.nova.LimeLog.warning("Nova: Cursor visibility sync executor unavailable")
-}
-
+launchRuntimeIo("NovaCursorSync") { drainCursorVisibilitySyncQueue() }
 }
 }
 
@@ -5099,7 +5081,7 @@ synchronized (cursorVisibilitySyncLock) {
 hasPendingCursorVisibilitySync = false
 cursorVisibilitySyncScheduled = false
 }
-cursorVisibilitySyncExecutor!!.shutdownNow()
+runtimeTasks.cancel("NovaCursorSync")
 }
 
 internal fun launchRuntimeIo(name:String, block:suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {

--- a/app/src/test/java/com/papi/nova/GameCursorSyncTest.kt
+++ b/app/src/test/java/com/papi/nova/GameCursorSyncTest.kt
@@ -5,7 +5,6 @@ import com.papi.nova.api.PolarisCapabilities
 import com.papi.nova.binding.input.capture.InputCaptureProvider
 import com.papi.nova.manager.FeatureFlagManager
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -110,6 +109,46 @@ class GameCursorSyncTest {
         }
     }
 
+    @Test
+    fun cursorVisibilitySyncRunsAsNamedRuntimeTask() {
+        val game = Game()
+        val finishSync = CountDownLatch(1)
+        try {
+            val client = Mockito.mock(PolarisApiClient::class.java)
+            val syncStarted = CountDownLatch(1)
+
+            doAnswer {
+                syncStarted.countDown()
+                assertTrue(finishSync.await(1, TimeUnit.SECONDS))
+                true
+            }.`when`(client).setCursorVisibility(true)
+
+            setField(game, "novaApiClient", client)
+            setField(game, "cursorVisible", false)
+            setCapabilities(
+                PolarisCapabilities(
+                    server = "polaris",
+                    version = "1.0.0",
+                    features = PolarisCapabilities.Features(cursorVisibilityControl = true),
+                    capture = PolarisCapabilities.CaptureInfo()
+                )
+            )
+
+            game.handleStreamStartedState()
+            assertTrue(syncStarted.await(1, TimeUnit.SECONDS))
+            assertTrue(runtimeTaskCount(game, "NovaCursorSync") > 0)
+
+            shutdownCursorVisibilitySync(game)
+            assertFalse(getBooleanField(game, "hasPendingCursorVisibilitySync"))
+            assertFalse(getBooleanField(game, "cursorVisibilitySyncScheduled"))
+            finishSync.countDown()
+            assertRuntimeTaskCountEventually(game, "NovaCursorSync", 0)
+        } finally {
+            finishSync.countDown()
+            shutdownCursorVisibilitySync(game)
+        }
+    }
+
     private fun setCapabilities(capabilities: PolarisCapabilities) {
         val field = FeatureFlagManager::class.java.getDeclaredField("capabilities")
         field.isAccessible = true
@@ -137,9 +176,28 @@ class GameCursorSyncTest {
         method.invoke(game, visible)
     }
 
-    private fun shutdownCursorVisibilitySync(game: Game) {
-        val field = Game::class.java.getDeclaredField("cursorVisibilitySyncExecutor")
+    private fun runtimeTaskCount(game: Game, name: String): Int {
+        val field = Game::class.java.getDeclaredField("runtimeTasks")
         field.isAccessible = true
-        (field.get(game) as ExecutorService).shutdownNow()
+        val runtimeTasks = field.get(game)
+        val method = runtimeTasks.javaClass.getDeclaredMethod("activeJobCount", String::class.java)
+        method.isAccessible = true
+        return method.invoke(runtimeTasks, name) as Int
+    }
+
+    private fun assertRuntimeTaskCountEventually(game: Game, name: String, expected: Int) {
+        repeat(20) {
+            if (runtimeTaskCount(game, name) == expected) {
+                return
+            }
+            Thread.sleep(25)
+        }
+        org.junit.Assert.assertEquals(expected, runtimeTaskCount(game, name))
+    }
+
+    private fun shutdownCursorVisibilitySync(game: Game) {
+        val method = Game::class.java.getDeclaredMethod("stopCursorVisibilitySync")
+        method.isAccessible = true
+        method.invoke(game)
     }
 }


### PR DESCRIPTION
## Summary
- Remove the cursor visibility sync executor and schedule the drain loop as `NovaCursorSync` through `NovaRuntimeTasks`.
- Keep the existing coalescing behavior where the newest pending host cursor state wins.
- Add a regression test that verifies the named runtime task and stop-time flag reset/cancellation behavior.

## Test Plan
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.GameCursorSyncTest.cursorVisibilitySyncRunsAsNamedRuntimeTask --console=plain` (red before production change, green after)
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.GameCursorSyncTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`
- Flip 2 smoke: installed `app-nonRoot_game-arm64-v8a-debug.apk`, launched Steam Big Picture, toggled local mouse cursor off/on (`Host cursor visibility synced -> false` then `-> true`), disconnected back to Nova Library, and checked logcat/crash buffers for fatal errors or ANRs.