### PR TITLE
Guard video metrics diagnostics

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -1826,6 +1826,13 @@ class MediaCodecDecoderRenderer(
         return minDecodeTimeFullLog
     }
 
+    private fun getCrashDiagnosticVideoStats(): VideoStats {
+        val stats = VideoStats()
+        stats.add(globalVideoStats)
+        stats.add(activeWindowVideoStats)
+        return stats
+    }
+
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private fun appendDecoderCapabilities(
         append: (String) -> Unit,
@@ -1893,6 +1900,8 @@ class MediaCodecDecoderRenderer(
                 "ErrorWhileStreaming"
             }
 
+            val videoStats = renderer.getCrashDiagnosticVideoStats()
+
             str += "Format: " + String.format("%x", renderer.videoFormat) + DELIMITER
             str += "AVC Decoder: " + (renderer.avcDecoder?.name ?: "(none)") + DELIMITER
             str += "HEVC Decoder: " + (renderer.hevcDecoder?.name ?: "(none)") + DELIMITER
@@ -1920,14 +1929,14 @@ class MediaCodecDecoderRenderer(
             str += "Bitrate: " + renderer.prefs.bitrate + " Kbps" + DELIMITER
             str += "CSD stats: " + renderer.numVpsIn + ", " + renderer.numSpsIn + ", " + renderer.numPpsIn + DELIMITER
             str += "Frames in-out: " + renderer.numFramesIn + ", " + renderer.numFramesOut + DELIMITER
-            str += "Total frames received: " + renderer.globalVideoStats.totalFramesReceived + DELIMITER
-            str += "Total frames rendered: " + renderer.globalVideoStats.totalFramesRendered + DELIMITER
-            str += "Frame losses: " + renderer.globalVideoStats.framesLost + " in " +
-                renderer.globalVideoStats.frameLossEvents + " loss events" + DELIMITER
-            str += "Decoder pacing counters: starvation=" + renderer.globalVideoStats.decoderStarvationEvents +
-                ", intentionalDrops=" + renderer.globalVideoStats.intentionalFrameDrops +
-                ", watchdogFlushes=" + renderer.globalVideoStats.watchdogFlushes +
-                ", formatChanges=" + renderer.globalVideoStats.outputFormatChanges + DELIMITER
+            str += "Total frames received: " + videoStats.totalFramesReceived + DELIMITER
+            str += "Total frames rendered: " + videoStats.totalFramesRendered + DELIMITER
+            str += "Frame losses: " + videoStats.framesLost + " in " +
+                videoStats.frameLossEvents + " loss events" + DELIMITER
+            str += "Decoder pacing counters: starvation=" + videoStats.decoderStarvationEvents +
+                ", intentionalDrops=" + videoStats.intentionalFrameDrops +
+                ", watchdogFlushes=" + videoStats.watchdogFlushes +
+                ", formatChanges=" + videoStats.outputFormatChanges + DELIMITER
             str += "Average end-to-end client latency: " + renderer.getAverageEndToEndLatency() + "ms" + DELIMITER
             str += "Average hardware decoder latency: " + renderer.getAverageDecoderLatency() + "ms" + DELIMITER
             str += "Frame pacing mode: " + renderer.prefs.framePacing + DELIMITER

--- a/app/src/main/java/com/papi/nova/binding/video/VideoStats.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/VideoStats.kt
@@ -33,10 +33,12 @@ class VideoStats {
         watchdogFlushes += other.watchdogFlushes
         outputFormatChanges += other.outputFormatChanges
 
-        minHostProcessingLatency = if (minHostProcessingLatency == 0.toChar()) {
-            other.minHostProcessingLatency
-        } else {
-            minOf(minHostProcessingLatency, other.minHostProcessingLatency)
+        if (other.minHostProcessingLatency != 0.toChar()) {
+            minHostProcessingLatency = if (minHostProcessingLatency == 0.toChar()) {
+                other.minHostProcessingLatency
+            } else {
+                minOf(minHostProcessingLatency, other.minHostProcessingLatency)
+            }
         }
         maxHostProcessingLatency = maxOf(maxHostProcessingLatency, other.maxHostProcessingLatency)
         totalHostProcessingLatency += other.totalHostProcessingLatency
@@ -46,7 +48,9 @@ class VideoStats {
             measurementStartTimestamp = other.measurementStartTimestamp
         }
 
-        assert(other.measurementStartTimestamp >= measurementStartTimestamp)
+        if (other.measurementStartTimestamp != 0L) {
+            assert(other.measurementStartTimestamp >= measurementStartTimestamp)
+        }
     }
 
     fun copy(other: VideoStats) {

--- a/app/src/test/java/com/papi/nova/binding/video/KotlinVideoRuntimeMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/KotlinVideoRuntimeMigrationTest.kt
@@ -7,6 +7,7 @@ import android.view.Choreographer
 import android.view.Surface
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.nvstream.av.video.VideoDecoderRenderer
+import com.papi.nova.nvstream.jni.MoonBridge
 import com.papi.nova.preferences.PreferenceConfiguration
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -17,6 +18,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -166,10 +168,100 @@ class KotlinVideoRuntimeMigrationTest {
         )
     }
 
+    @Test
+    fun rendererExceptionIncludesActiveVideoStatsBeforeWindowRollup() {
+        val renderer = createRendererForDiagnostics()
+        setPrivateField(renderer, "videoFormat", MoonBridge.VIDEO_FORMAT_H264)
+        setPrivateField(renderer, "initialWidth", 1920)
+        setPrivateField(renderer, "initialHeight", 1080)
+        setPrivateField(renderer, "refreshRate", 60)
+        setPrivateField(renderer, "numSpsIn", 1)
+        setPrivateField(renderer, "numPpsIn", 1)
+        setPrivateField(renderer, "numFramesIn", 17)
+        setPrivateField(renderer, "numFramesOut", 13)
+        setPrivateField(renderer, "outputFormat", MediaFormat.createVideoFormat("video/avc", 1920, 1080))
+
+        val globalStats = videoStatsField(renderer, "globalVideoStats")
+        globalStats.totalFramesReceived = 10
+        globalStats.totalFramesRendered = 9
+        globalStats.framesLost = 1
+        globalStats.frameLossEvents = 1
+        globalStats.decoderStarvationEvents = 2
+        globalStats.intentionalFrameDrops = 3
+        globalStats.watchdogFlushes = 4
+        globalStats.outputFormatChanges = 5
+        globalStats.measurementStartTimestamp = 100
+
+        val activeStats = videoStatsField(renderer, "activeWindowVideoStats")
+        activeStats.totalFramesReceived = 7
+        activeStats.totalFramesRendered = 4
+        activeStats.framesLost = 3
+        activeStats.frameLossEvents = 2
+        activeStats.decoderStarvationEvents = 5
+        activeStats.intentionalFrameDrops = 6
+        activeStats.watchdogFlushes = 7
+        activeStats.outputFormatChanges = 8
+        activeStats.measurementStartTimestamp = 200
+
+        val text = MediaCodecDecoderRenderer.RendererException(renderer, IllegalStateException("codec died")).toString()
+
+        assertTrue(text.contains("Total frames received: 17"))
+        assertTrue(text.contains("Total frames rendered: 13"))
+        assertTrue(text.contains("Frame losses: 4 in 3 loss events"))
+        assertTrue(
+            text.contains(
+                "Decoder pacing counters: starvation=7, intentionalDrops=9, watchdogFlushes=11, formatChanges=13"
+            )
+        )
+    }
+
     private fun readMediaCodecDecoderRendererSource(): String {
         return String(
             Files.readAllBytes(Path.of("src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt")),
             StandardCharsets.UTF_8
         )
+    }
+
+    private fun createRendererForDiagnostics(): MediaCodecDecoderRenderer {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val prefs = PreferenceConfiguration()
+        prefs.bitrate = 30000
+        prefs.fps = 60f
+        prefs.videoFormat = PreferenceConfiguration.FormatOption.AUTO
+        prefs.framePacing = PreferenceConfiguration.FRAME_PACING_CAP_FPS
+
+        MediaCodecHelper.initialize(activity, "Robolectric")
+
+        return MediaCodecDecoderRenderer(
+            activity,
+            prefs,
+            object : CrashListener {
+                override fun notifyCrash(e: Exception) = Unit
+            },
+            0,
+            false,
+            false,
+            false,
+            "Robolectric",
+            object : PerfOverlayListener {
+                override fun onPerfUpdate(text: String) = Unit
+            }
+        )
+    }
+
+    private fun videoStatsField(renderer: MediaCodecDecoderRenderer, fieldName: String): VideoStats {
+        return privateField(renderer, fieldName) as VideoStats
+    }
+
+    private fun privateField(target: Any, fieldName: String): Any? {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(target)
+    }
+
+    private fun setPrivateField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
     }
 }

--- a/app/src/test/java/com/papi/nova/binding/video/KotlinVideoStatsMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/KotlinVideoStatsMigrationTest.kt
@@ -94,4 +94,26 @@ class KotlinVideoStatsMigrationTest {
         assertEquals(0, copy.minHostProcessingLatency.code)
         assertEquals(0, copy.measurementStartTimestamp)
     }
+
+    @Test
+    fun addKeepsHostLatencyMinimumWhenNextWindowHasNoHostLatency() {
+        val accumulated = VideoStats()
+        accumulated.minHostProcessingLatency = 7.toChar()
+        accumulated.maxHostProcessingLatency = 11.toChar()
+        accumulated.totalHostProcessingLatency = 18
+        accumulated.framesWithHostProcessingLatency = 2
+        accumulated.measurementStartTimestamp = 100
+
+        val emptyLatencyWindow = VideoStats()
+        emptyLatencyWindow.totalFrames = 3
+        emptyLatencyWindow.totalFramesReceived = 3
+        emptyLatencyWindow.measurementStartTimestamp = 120
+
+        accumulated.add(emptyLatencyWindow)
+
+        assertEquals(7, accumulated.minHostProcessingLatency.code)
+        assertEquals(11, accumulated.maxHostProcessingLatency.code)
+        assertEquals(18, accumulated.totalHostProcessingLatency)
+        assertEquals(2, accumulated.framesWithHostProcessingLatency)
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve the existing host-processing latency minimum when a later `VideoStats` window has no host latency samples.
- Report crash diagnostic frame counters from rolled-up global stats plus the active in-flight video stats window.
- Add regression coverage for the existing Java-compatible `@JvmField` metrics surface without adding new public metrics.

## Test Plan
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.binding.video.KotlinVideoStatsMigrationTest.addKeepsHostLatencyMinimumWhenNextWindowHasNoHostLatency --tests com.papi.nova.binding.video.KotlinVideoRuntimeMigrationTest.rendererExceptionIncludesActiveVideoStatsBeforeWindowRollup --console=plain` (red before production change, green after)
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.binding.video.KotlinVideoStatsMigrationTest --tests com.papi.nova.binding.video.KotlinVideoRuntimeMigrationTest --tests com.papi.nova.binding.video.FramePacingPolicyTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`
- Flip 2 smoke: installed `app-nonRoot_game-arm64-v8a-debug.apk`, launched Steam Big Picture, toggled local mouse cursor off/on (`Host cursor visibility synced -> false` then `-> true`), disconnected back to Nova Library, and checked logcat/crash buffers for fatal errors or ANRs.