### PR TITLE
Track HUD latency samples independently

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -322,6 +322,7 @@ data class NovaHudUiState(
 class NovaHudSessionStats {
     private var sessionFpsSum = 0.0
     private var sessionLatencySum = 0.0
+    private var sessionLatencySamples = 0
     private var sessionPacketLossSum = 0.0
     private var sessionPacketLossSamples = 0
     private var sessionSamples = 0
@@ -355,6 +356,7 @@ class NovaHudSessionStats {
     fun reset() {
         sessionFpsSum = 0.0
         sessionLatencySum = 0.0
+        sessionLatencySamples = 0
         sessionPacketLossSum = 0.0
         sessionPacketLossSamples = 0
         sessionSamples = 0
@@ -405,6 +407,7 @@ class NovaHudSessionStats {
     fun recordLatency(ms: Int) {
         if (ms > 0) {
             sessionLatencySum += ms.toDouble()
+            sessionLatencySamples++
         }
     }
 
@@ -455,7 +458,7 @@ class NovaHudSessionStats {
     fun summary(nowMs: Long = System.currentTimeMillis()): Map<String, Any> {
         val durationS = if (sessionStartTime > 0) ((nowMs - sessionStartTime) / 1000).toInt() else 0
         val avgFps = if (sessionSamples > 0) sessionFpsSum / sessionSamples else 0.0
-        val avgLatency = if (sessionSamples > 0) sessionLatencySum / sessionSamples else 0.0
+        val avgLatency = if (sessionLatencySamples > 0) sessionLatencySum / sessionLatencySamples else 0.0
         val badPacingPct = if (sessionSamples > 0) {
             (sessionBadPacingSamples.toDouble() / sessionSamples.toDouble()) * 100.0
         } else {

--- a/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
@@ -32,6 +32,21 @@ class NovaHudSessionStatsTest {
     }
 
     @Test
+    fun summaryAveragesLatencyByLatencySamples() {
+        val stats = NovaHudSessionStats()
+
+        stats.recordFps(60.0, nowMs = 1_000)
+        stats.recordLatency(18)
+        stats.recordLatency(30)
+        stats.recordLatency(42)
+
+        val summary = stats.summary(nowMs = 2_000)
+
+        assertEquals(30.0, summary["avg_latency_ms"] as Double, 0.01)
+        assertEquals(1, summary["samples"])
+    }
+
+    @Test
     fun summaryRecommendsRelaunchForHighRefreshPacingFailure() {
         val stats = NovaHudSessionStats()
 


### PR DESCRIPTION
## Summary
- Add a regression test for HUD session latency averaging when latency samples arrive at a different cadence than FPS samples.
- Track latency sample count separately from FPS sample count so `avg_latency_ms` is measurement-accurate in session summaries/reports.
- Keep the change private to `NovaHudSessionStats`; no new public metrics or tuning behavior.

## Test Plan
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaHudSessionStatsTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain` (first run hit an OpenJDK 25 SIGSEGV in `ProfilesNavigationTest`; rerun passed)
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`

## Device Smoke
- Installed the freshly built debug APK on Retroid Pocket Flip2.
- App launched to `com.papi.nova.debug/com.papi.nova.ui.NovaLibraryActivity`.
- Attempted Steam Big Picture launch; host returned connection timeout/error -408 on ports 47984/47989 before video start.
- `adb logcat` fatal/ANR grep returned no matches; crash buffer was empty.
- Stopped `com.papi.nova.debug` after collecting logs.