### PR TITLE
Log sanitized HUD session summaries

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -40,6 +40,7 @@ import com.papi.nova.runtime.BackgroundResumePolicy
 import com.papi.nova.runtime.NovaRuntimeTasks
 import com.papi.nova.ui.ExternalControllerView
 import com.papi.nova.ui.GameGestures
+import com.papi.nova.ui.NovaHudSessionSummaryLog
 import com.papi.nova.ui.StreamContainer
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
@@ -4203,6 +4204,7 @@ runtimeTasks.cancel("NovaBitrateAdjust")
             if (novaHud != null && host != null)
 {
 val summary:Map<String, Any>? = novaHud!!.getSessionSummary()
+com.papi.nova.LimeLog.info("Nova: HUD session summary " + NovaHudSessionSummaryLog.format(summary ?: emptyMap()))
 val reportHost:String? = host
 val reportHttpsPort:Int = httpsPort
 val reportServerCert:X509Certificate? = serverCert

--- a/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
@@ -1,0 +1,49 @@
+package com.papi.nova.ui
+
+import com.google.gson.Gson
+
+internal object NovaHudSessionSummaryLog {
+    private val allowedKeys = listOf(
+        "avg_fps",
+        "target_fps",
+        "low_1_percent_fps",
+        "min_fps",
+        "frame_pacing_bad_pct",
+        "safe_target_fps",
+        "avg_latency_ms",
+        "avg_bitrate_kbps",
+        "packet_loss_pct",
+        "codec",
+        "duration_s",
+        "samples",
+        "optimization_source",
+        "optimization_confidence",
+        "recommendation_version",
+        "health_grade",
+        "primary_issue",
+        "issues",
+        "decoder_risk",
+        "hdr_risk",
+        "network_risk",
+        "capture_path",
+        "safe_bitrate_kbps",
+        "safe_codec",
+        "safe_display_mode",
+        "safe_hdr",
+        "relaunch_recommended"
+    )
+
+    fun format(summary: Map<String, Any?>): String {
+        val values = linkedMapOf<String, Any>()
+        allowedKeys.forEach { key ->
+            val value = summary[key] ?: return@forEach
+            when (value) {
+                is String -> if (value.isNotBlank()) values[key] = value
+                is Number -> values[key] = value
+                is Boolean -> values[key] = value
+                is Iterable<*> -> values[key] = value.filterNotNull()
+            }
+        }
+        return Gson().toJson(values)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
@@ -1,7 +1,9 @@
 package com.papi.nova.ui
 
 import com.papi.nova.api.PolarisSessionStatus
+import com.google.gson.JsonParser
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -95,5 +97,38 @@ class NovaHudSessionStatsTest {
         assertEquals("h264", summary["safe_codec"])
         assertEquals("desktop", summary["safe_display_mode"])
         assertEquals(true, summary["relaunch_recommended"])
+    }
+
+    @Test
+    fun sessionSummaryLogIncludesEvidenceFieldsAndExcludesIdentifiers() {
+        val summary = mapOf(
+            "avg_fps" to 59.5,
+            "target_fps" to 60.0,
+            "avg_latency_ms" to 24.0,
+            "avg_bitrate_kbps" to 18000,
+            "packet_loss_pct" to 0.25,
+            "codec" to "HEVC",
+            "duration_s" to 120,
+            "samples" to 118,
+            "health_grade" to "stable",
+            "primary_issue" to "none",
+            "issues" to listOf("decoder_watch"),
+            "safe_target_fps" to 60.0,
+            "relaunch_recommended" to false,
+            "device" to "Retroid Pocket Flip2",
+            "unique_id" to "abc123",
+            "host" to "pc-papi.lan"
+        )
+
+        val json = JsonParser.parseString(NovaHudSessionSummaryLog.format(summary)).asJsonObject
+
+        assertEquals(59.5, json["avg_fps"].asDouble, 0.01)
+        assertEquals(24.0, json["avg_latency_ms"].asDouble, 0.01)
+        assertEquals(18000, json["avg_bitrate_kbps"].asInt)
+        assertEquals("HEVC", json["codec"].asString)
+        assertEquals("decoder_watch", json["issues"].asJsonArray[0].asString)
+        assertFalse(json.has("device"))
+        assertFalse(json.has("unique_id"))
+        assertFalse(json.has("host"))
     }
 }


### PR DESCRIPTION
## Summary
- Add a small whitelist-based formatter for HUD session summaries so evidence fields can be copied from logcat without host/device identifiers.
- Log the sanitized summary on stream disconnect before the existing Polaris session report is sent.
- Cover the formatter with a regression test that preserves key video evidence fields and excludes `device`, `unique_id`, and `host`.

Closes #51.

## Test Plan
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaHudSessionStatsTest --console=plain`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --console=plain`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug lintNonRoot_gameDebug --console=plain`
- `git diff --check`

## Device Smoke
- Current host streaming ports were refusing connections during the pre-implementation master smoke, so a real disconnect summary log could not be captured yet.
- This PR does not change stream setup, decoder policy, frame pacing thresholds, or public metrics.