### PR TITLE
Honor paired RTSP launch profile

### DIFF
--- a/app/src/main/java/com/papi/nova/manager/StreamSyncManager.kt
+++ b/app/src/main/java/com/papi/nova/manager/StreamSyncManager.kt
@@ -32,6 +32,10 @@ class StreamSyncManager private constructor() {
             val safeTarget = safeProfile?.optInt("target_bitrate_kbps", 0) ?: 0
             val confirmedRecovery = isConfirmedRecoveryPolicy(optimization, stability)
 
+            if (target > 0 && hasPairedLaunchProfileOverride(optimization)) {
+                return if (confirmedRecovery && safeTarget > 0) minOf(target, safeTarget) else target
+            }
+
             var selected = configuredBitrateKbps
             if (target > 0 && shouldHonorOptimizerTarget(optimization, stability)) {
                 selected = target
@@ -61,6 +65,10 @@ class StreamSyncManager private constructor() {
             val optimized = parseDisplayModeResolution(optimization.optString("display_mode", ""))
             if (!optimized.isValid()) {
                 return configured
+            }
+
+            if (hasPairedLaunchProfileOverride(optimization)) {
+                return optimized
             }
 
             if (configured.isValid() && optimized.pixels() > configured.pixels()) {
@@ -95,7 +103,9 @@ class StreamSyncManager private constructor() {
                     0.0
                 }
 
-            if (
+            if (optimizedFps > 0f && hasPairedLaunchProfileOverride(optimization)) {
+                selected = optimizedFps
+            } else if (
                 optimizedFps > 0f &&
                 (optimizedFps >= selected || shouldHonorOptimizerFpsTarget(optimization, stability))
             ) {
@@ -299,6 +309,15 @@ class StreamSyncManager private constructor() {
         }
 
         private fun normalized(value: String?): String = value?.trim()?.lowercase(Locale.US) ?: ""
+
+        private fun hasPairedLaunchProfileOverride(optimization: JSONObject): Boolean {
+            if (optimization.optBoolean("paired_profile_applied", false)) {
+                return true
+            }
+
+            return normalized(optimization.optString("normalization_reason", ""))
+                .contains("paired client profile")
+        }
 
         @JvmStatic
         fun buildDeviceCapabilities(

--- a/app/src/test/java/com/papi/nova/manager/StreamSyncManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/manager/StreamSyncManagerTest.kt
@@ -34,6 +34,19 @@ class StreamSyncManagerTest {
     }
 
     @Test
+    fun resolveAutoSafeResolution_honorsPairedLaunchProfileUpscale() {
+        val optimization = JSONObject(
+            "{\"display_mode\":\"2560x1440x120\"," +
+                "\"normalization_reason\":\"Aligned launch optimization display mode to the paired client profile.\"}"
+        )
+
+        val resolution = StreamSyncManager.resolveAutoSafeResolution(1920, 1080, optimization)
+
+        assertEquals(2560, resolution.width)
+        assertEquals(1440, resolution.height)
+    }
+
+    @Test
     fun resolveAutoSafeResolution_ignoresInvalidDisplayMode() {
         val optimization = JSONObject("{\"display_mode\":\"headless\"}")
 
@@ -66,6 +79,19 @@ class StreamSyncManagerTest {
         val bitrate = StreamSyncManager.resolveAutoSafeBitrateKbps(16000, optimization)
 
         assertEquals(16000, bitrate)
+    }
+
+    @Test
+    fun resolveAutoSafeBitrate_honorsPairedLaunchProfileTarget() {
+        val optimization = JSONObject(
+            "{\"target_bitrate_kbps\":80000,\"confidence\":\"medium\"," +
+                "\"normalization_reason\":\"Aligned launch optimization bitrate to the paired client profile.\"," +
+                "\"stability\":{\"mode\":\"auto\",\"auto_action\":\"none\"}}"
+        )
+
+        val bitrate = StreamSyncManager.resolveAutoSafeBitrateKbps(30000, optimization)
+
+        assertEquals(80000, bitrate)
     }
 
     @Test
@@ -117,6 +143,19 @@ class StreamSyncManagerTest {
         )
 
         val targetFps = StreamSyncManager.resolveAutoSafeTargetFps(120f, optimization)
+
+        assertEquals(120f, targetFps, 0.01f)
+    }
+
+    @Test
+    fun resolveAutoSafeTargetFps_honorsPairedLaunchProfileTarget() {
+        val optimization = JSONObject(
+            "{\"display_mode\":\"2560x1440x120\",\"source\":\"client_profile\"," +
+                "\"normalization_reason\":\"Aligned launch optimization display mode to the paired client profile.\"," +
+                "\"stability\":{\"mode\":\"auto\",\"auto_action\":\"none\"}}"
+        )
+
+        val targetFps = StreamSyncManager.resolveAutoSafeTargetFps(60f, optimization)
 
         assertEquals(120f, targetFps, 0.01f)
     }


### PR DESCRIPTION
## Summary
- Let Auto Safe honor paired launch profile overrides for RTSP bitrate, resolution, and FPS.
- Keep confirmed recovery policy caps in place when Polaris is explicitly applying recovery.
- Add regression coverage for paired 2560x1440@120 and 80 Mbps launch profiles.

## Validation
- `./gradlew :app:testDebugUnitTest --tests com.papi.nova.manager.StreamSyncManagerTest --console=plain`
- `./gradlew :app:assembleNonRoot_gameRelease --console=plain`
- Installed `app/build/outputs/apk/nonRoot_game/release/app-nonRoot_game-arm64-v8a-release.apk` on Retroid 6.
- Retroid 6 smoke with Polaris SFE=2: Nova logged `Auto Safe launch bitrate 28000 -> 80000 kbps` and configured decoder output at `2560x1440`, `frame-rate=120`.