### PR TITLE
Refresh first-run welcome flow

### DIFF
--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -1098,6 +1098,16 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         }
 
         initializeViews(prefs)
+        handleWelcomeAction(intent.getStringExtra(NovaWelcomeActivity.EXTRA_WELCOME_ACTION))
+    }
+
+    private fun handleWelcomeAction(action: String?) {
+        if (action != NovaWelcomeActivity.ACTION_SCAN_QR) {
+            return
+        }
+
+        intent.removeExtra(NovaWelcomeActivity.EXTRA_WELCOME_ACTION)
+        window.decorView.post { launchQrScanner() }
     }
 
     private fun startComputerUpdates() {

--- a/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
@@ -1,9 +1,13 @@
 package com.papi.nova.ui
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import com.papi.nova.R
 import com.papi.nova.PcView
+import com.papi.nova.R
+import com.papi.nova.preferences.AddComputerManually
 
 /**
  * First-launch welcome screen. Shows once, then never again.
@@ -15,22 +19,39 @@ class NovaWelcomeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_nova_welcome)
 
-        findViewById<android.view.View>(R.id.welcome_start_btn).setOnClickListener {
-            // Mark as seen
-            getSharedPreferences("nova_prefs", MODE_PRIVATE).edit()
-                .putBoolean("welcome_seen", true)
-                .commit()
-            val next = android.content.Intent(this, PcView::class.java)
-            intent.extras?.let { next.putExtras(it) }
-            startActivity(next)
-            finish()
+        findViewById<View>(R.id.welcome_discover_btn).setOnClickListener {
+            finishWelcome(Intent(this, PcView::class.java))
+        }
+        findViewById<View>(R.id.welcome_add_manual_btn).setOnClickListener {
+            finishWelcome(Intent(this, AddComputerManually::class.java))
+        }
+        findViewById<View>(R.id.welcome_scan_qr_btn).setOnClickListener {
+            finishWelcome(
+                Intent(this, PcView::class.java)
+                    .putExtra(EXTRA_WELCOME_ACTION, ACTION_SCAN_QR),
+            )
         }
     }
 
+    private fun finishWelcome(next: Intent) {
+        getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+            .putBoolean(KEY_WELCOME_SEEN, true)
+            .commit()
+        intent.extras?.let { next.putExtras(it) }
+        next.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        startActivity(next)
+        finish()
+    }
+
     companion object {
-        fun shouldShow(context: android.content.Context): Boolean {
-            return !context.getSharedPreferences("nova_prefs", android.content.Context.MODE_PRIVATE)
-                .getBoolean("welcome_seen", false)
+        const val EXTRA_WELCOME_ACTION = "com.papi.nova.extra.WELCOME_ACTION"
+        const val ACTION_SCAN_QR = "scan_qr"
+        private const val PREFS_NAME = "nova_prefs"
+        private const val KEY_WELCOME_SEEN = "welcome_seen"
+
+        fun shouldShow(context: Context): Boolean {
+            return !context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getBoolean(KEY_WELCOME_SEEN, false)
         }
     }
 }

--- a/app/src/main/res/layout-land/activity_nova_welcome.xml
+++ b/app/src/main/res/layout-land/activity_nova_welcome.xml
@@ -5,238 +5,197 @@
     android:layout_height="match_parent"
     android:background="?android:colorBackground">
 
-    <!-- Space particles -->
     <com.papi.nova.ui.SpaceParticleView
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <!-- Two-column landscape layout -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="horizontal"
+        android:baselineAligned="false"
         android:gravity="center_vertical"
-        android:paddingHorizontal="32dp"
-        android:paddingVertical="24dp"
-        android:baselineAligned="false">
+        android:orientation="horizontal"
+        android:paddingHorizontal="36dp"
+        android:paddingVertical="24dp">
 
-        <!-- Left column: branding -->
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_weight="0.85"
+            android:gravity="center_horizontal"
             android:orientation="vertical"
-            android:gravity="center"
-            android:paddingEnd="24dp">
+            android:paddingEnd="28dp">
 
             <ImageView
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:src="@drawable/ic_nova_star_foreground"
+                android:layout_width="70dp"
+                android:layout_height="70dp"
+                android:layout_marginBottom="16dp"
                 android:importantForAccessibility="no"
-                android:layout_marginBottom="16dp" />
+                android:src="@drawable/ic_nova_star_foreground" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Welcome to Nova"
-                android:textSize="24sp"
-                android:textColor="@color/nova_ice"
                 android:fontFamily="sans-serif-light"
+                android:gravity="center"
                 android:letterSpacing="0.03"
-                android:layout_marginBottom="6dp" />
+                android:text="Welcome to Nova"
+                android:textColor="@color/nova_ice"
+                android:textSize="28sp" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Game streaming, designed for your device"
-                android:textSize="12sp"
-                android:textColor="@color/nova_text_muted"
+                android:layout_marginTop="10dp"
                 android:fontFamily="sans-serif"
-                android:gravity="center" />
+                android:gravity="center"
+                android:lineSpacingExtra="2dp"
+                android:text="A polished streaming home for Polaris, handhelds, TV, and Moonlight-compatible hosts."
+                android:textColor="@color/nova_text_secondary"
+                android:textSize="14sp" />
         </LinearLayout>
 
-        <!-- Right column: features + button -->
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_weight="1.15"
             android:orientation="vertical"
-            android:paddingStart="24dp">
+            android:paddingStart="28dp">
 
-            <!-- Feature 1 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:paddingBottom="12dp">
+                android:layout_marginBottom="10dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:padding="14dp">
 
                 <TextView
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:gravity="center"
-                    android:text="\uD83C\uDFAE"
-                    android:textSize="13sp"
-                    android:layout_marginEnd="12dp" />
-
-                <LinearLayout
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:letterSpacing="0.08"
+                    android:text="01  Find your host"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="10sp" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Stream your PC games"
-                        android:textSize="13sp"
-                        android:textColor="@color/nova_text_primary"
-                        android:fontFamily="sans-serif-medium" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Low-latency H.265/AV1 over your local network"
-                        android:textSize="10sp"
-                        android:textColor="@color/nova_text_muted"
-                        android:layout_marginTop="1dp" />
-                </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="Discover PCs on your network, or add an address manually."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="14sp" />
             </LinearLayout>
 
-            <!-- Feature 2 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:paddingBottom="12dp">
+                android:layout_marginBottom="10dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:padding="14dp">
 
                 <TextView
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:gravity="center"
-                    android:text="\uD83D\uDD17"
-                    android:textSize="13sp"
-                    android:layout_marginEnd="12dp" />
-
-                <LinearLayout
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:letterSpacing="0.08"
+                    android:text="02  Pair with confidence"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="10sp" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Instant pairing"
-                        android:textSize="13sp"
-                        android:textColor="@color/nova_text_primary"
-                        android:fontFamily="sans-serif-medium" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="TOFU auto-pair on your LAN, or scan a QR code"
-                        android:textSize="10sp"
-                        android:textColor="@color/nova_text_muted"
-                        android:layout_marginTop="1dp" />
-                </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="Use Moonlight pairing, or scan a Polaris pairing QR when available."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="14sp" />
             </LinearLayout>
 
-            <!-- Feature 3 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:paddingBottom="12dp">
+                android:layout_marginBottom="16dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:padding="14dp">
 
                 <TextView
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:gravity="center"
-                    android:text="\uD83D\uDCCA"
-                    android:textSize="13sp"
-                    android:layout_marginEnd="12dp" />
-
-                <LinearLayout
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:letterSpacing="0.08"
+                    android:text="03  Built for handhelds and TV"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="10sp" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Performance HUD"
-                        android:textSize="13sp"
-                        android:textColor="@color/nova_text_primary"
-                        android:fontFamily="sans-serif-medium" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="FPS sparkline, latency, bitrate — tap to cycle modes"
-                        android:textSize="10sp"
-                        android:textColor="@color/nova_text_muted"
-                        android:layout_marginTop="1dp" />
-                </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="Controller-first navigation, focus rings, touch controls, and HUDs are ready for streaming."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="14sp" />
             </LinearLayout>
 
-            <!-- Feature 4 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:paddingBottom="16dp">
+                android:baselineAligned="false"
+                android:orientation="horizontal">
 
-                <TextView
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:gravity="center"
-                    android:text="\u2728"
-                    android:textSize="13sp"
-                    android:layout_marginEnd="12dp" />
-
-                <LinearLayout
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/welcome_discover_btn"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="50dp"
                     android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:focusable="true"
+                    android:nextFocusRight="@id/welcome_add_manual_btn"
+                    android:text="Discover hosts"
+                    android:textAllCaps="false"
+                    android:textColor="@android:color/white"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    app:backgroundTint="@color/nova_accent"
+                    app:cornerRadius="25dp"
+                    app:strokeColor="@color/nova_focus_stroke_selector"
+                    app:strokeWidth="2dp" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="AI-optimized quality"
-                        android:textSize="13sp"
-                        android:textColor="@color/nova_text_primary"
-                        android:fontFamily="sans-serif-medium" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/welcome_add_manual_btn"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:focusable="true"
+                    android:nextFocusLeft="@id/welcome_discover_btn"
+                    android:nextFocusRight="@id/welcome_scan_qr_btn"
+                    android:text="Add manually"
+                    android:textAllCaps="false"
+                    android:textColor="@color/nova_text_primary"
+                    app:cornerRadius="25dp"
+                    app:strokeColor="@color/nova_focus_stroke_selector"
+                    app:strokeWidth="2dp" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Polaris tunes encoding per device, per game"
-                        android:textSize="10sp"
-                        android:textColor="@color/nova_text_muted"
-                        android:layout_marginTop="1dp" />
-                </LinearLayout>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/welcome_scan_qr_btn"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:focusable="true"
+                    android:nextFocusLeft="@id/welcome_add_manual_btn"
+                    android:text="Scan QR"
+                    android:textAllCaps="false"
+                    android:textColor="@color/nova_text_primary"
+                    app:cornerRadius="25dp"
+                    app:strokeColor="@color/nova_focus_stroke_selector"
+                    app:strokeWidth="2dp" />
             </LinearLayout>
-
-            <!-- Get Started button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/welcome_start_btn"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:text="Get Started"
-                android:textSize="16sp"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:textAllCaps="false"
-                app:backgroundTint="@color/nova_accent"
-                app:cornerRadius="24dp" />
-
         </LinearLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/activity_nova_welcome.xml
+++ b/app/src/main/res/layout/activity_nova_welcome.xml
@@ -5,7 +5,6 @@
     android:layout_height="match_parent"
     android:background="?android:colorBackground">
 
-    <!-- Space particles -->
     <com.papi.nova.ui.SpaceParticleView
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
@@ -19,227 +18,165 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:gravity="center_horizontal"
-            android:paddingHorizontal="40dp"
-            android:paddingTop="48dp"
-            android:paddingBottom="32dp">
+            android:orientation="vertical"
+            android:paddingHorizontal="28dp"
+            android:paddingTop="40dp"
+            android:paddingBottom="28dp">
 
-            <!-- Logo + title -->
             <ImageView
-                android:layout_width="80dp"
-                android:layout_height="80dp"
-                android:src="@drawable/ic_nova_star_foreground"
+                android:layout_width="78dp"
+                android:layout_height="78dp"
+                android:layout_marginBottom="18dp"
                 android:importantForAccessibility="no"
-                android:layout_marginBottom="20dp" />
+                android:src="@drawable/ic_nova_star_foreground" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Welcome to Nova"
-                android:textSize="26sp"
-                android:textColor="@color/nova_ice"
                 android:fontFamily="sans-serif-light"
+                android:gravity="center"
                 android:letterSpacing="0.03"
-                android:layout_marginBottom="6dp" />
+                android:text="Welcome to Nova"
+                android:textColor="@color/nova_ice"
+                android:textSize="28sp" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Game streaming, designed for your device"
-                android:textSize="13sp"
-                android:textColor="@color/nova_text_muted"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="28dp"
                 android:fontFamily="sans-serif"
-                android:layout_marginBottom="36dp" />
+                android:gravity="center"
+                android:lineSpacingExtra="2dp"
+                android:text="A polished streaming home for Polaris, handhelds, TV, and Moonlight-compatible hosts."
+                android:textColor="@color/nova_text_secondary"
+                android:textSize="14sp" />
 
-            <!-- Feature list -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:background="@drawable/nova_card_bg_focusable"
                 android:orientation="vertical"
-                android:paddingHorizontal="4dp"
-                android:layout_marginBottom="36dp">
+                android:padding="18dp">
 
-                <!-- Feature 1 -->
-                <LinearLayout
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:letterSpacing="0.08"
+                    android:text="01  Find your host"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="11sp" />
+
+                <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    android:paddingBottom="16dp">
-
-                    <TextView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:gravity="center"
-                        android:text="\uD83C\uDFAE"
-                        android:textSize="14sp"
-                        android:layout_marginEnd="14dp" />
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Stream your PC games"
-                            android:textSize="14sp"
-                            android:textColor="@color/nova_text_primary"
-                            android:fontFamily="sans-serif-medium" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Low-latency H.265/AV1 over your local network"
-                            android:textSize="11sp"
-                            android:textColor="@color/nova_text_muted"
-                            android:layout_marginTop="2dp" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- Feature 2 -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    android:paddingBottom="16dp">
-
-                    <TextView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:gravity="center"
-                        android:text="\uD83D\uDD17"
-                        android:textSize="14sp"
-                        android:layout_marginEnd="14dp" />
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Instant pairing"
-                            android:textSize="14sp"
-                            android:textColor="@color/nova_text_primary"
-                            android:fontFamily="sans-serif-medium" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="TOFU auto-pair on your LAN, or scan a QR code"
-                            android:textSize="11sp"
-                            android:textColor="@color/nova_text_muted"
-                            android:layout_marginTop="2dp" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- Feature 3 -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    android:paddingBottom="16dp">
-
-                    <TextView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:gravity="center"
-                        android:text="\uD83D\uDCCA"
-                        android:textSize="14sp"
-                        android:layout_marginEnd="14dp" />
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Performance HUD"
-                            android:textSize="14sp"
-                            android:textColor="@color/nova_text_primary"
-                            android:fontFamily="sans-serif-medium" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="FPS sparkline, latency, bitrate — tap to cycle modes"
-                            android:textSize="11sp"
-                            android:textColor="@color/nova_text_muted"
-                            android:layout_marginTop="2dp" />
-                    </LinearLayout>
-                </LinearLayout>
-
-                <!-- Feature 4 -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-
-                    <TextView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:gravity="center"
-                        android:text="\u2728"
-                        android:textSize="14sp"
-                        android:layout_marginEnd="14dp" />
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="AI-optimized quality"
-                            android:textSize="14sp"
-                            android:textColor="@color/nova_text_primary"
-                            android:fontFamily="sans-serif-medium" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Polaris tunes encoding per device, per game"
-                            android:textSize="11sp"
-                            android:textColor="@color/nova_text_muted"
-                            android:layout_marginTop="2dp" />
-                    </LinearLayout>
-                </LinearLayout>
-
+                    android:layout_marginTop="8dp"
+                    android:text="Nova discovers PCs on your local network and keeps manual entry close when discovery is not enough."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="16sp" />
             </LinearLayout>
 
-            <!-- Spacer pushes button to bottom when viewport is larger -->
-            <View
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:padding="18dp">
 
-            <!-- Get Started button -->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:letterSpacing="0.08"
+                    android:text="02  Pair with confidence"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="11sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="Use standard Moonlight pairing, or scan a Polaris pairing QR when your host shows one."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="16sp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:padding="18dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:letterSpacing="0.08"
+                    android:text="03  Built for the screen in your hands"
+                    android:textAllCaps="true"
+                    android:textColor="@color/nova_accent"
+                    android:textSize="11sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="Controller-first navigation, touch-friendly controls, TV focus rings, and performance HUDs are ready when you stream."
+                    android:textColor="@color/nova_text_primary"
+                    android:textSize="16sp" />
+            </LinearLayout>
+
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/welcome_start_btn"
+                android:id="@+id/welcome_discover_btn"
                 android:layout_width="match_parent"
                 android:layout_height="52dp"
-                android:text="Get Started"
-                android:textSize="18sp"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
+                android:focusable="true"
+                android:nextFocusDown="@id/welcome_add_manual_btn"
+                android:text="Discover hosts"
                 android:textAllCaps="false"
+                android:textColor="@android:color/white"
+                android:textSize="17sp"
+                android:textStyle="bold"
                 app:backgroundTint="@color/nova_accent"
-                app:cornerRadius="26dp" />
+                app:cornerRadius="26dp"
+                app:strokeColor="@color/nova_focus_stroke_selector"
+                app:strokeWidth="2dp" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/welcome_add_manual_btn"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginTop="10dp"
+                android:focusable="true"
+                android:nextFocusUp="@id/welcome_discover_btn"
+                android:nextFocusDown="@id/welcome_scan_qr_btn"
+                android:text="Add manually"
+                android:textAllCaps="false"
+                android:textColor="@color/nova_text_primary"
+                app:cornerRadius="25dp"
+                app:strokeColor="@color/nova_focus_stroke_selector"
+                app:strokeWidth="2dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/welcome_scan_qr_btn"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginTop="10dp"
+                android:focusable="true"
+                android:nextFocusUp="@id/welcome_add_manual_btn"
+                android:text="Scan Polaris QR"
+                android:textAllCaps="false"
+                android:textColor="@color/nova_text_primary"
+                app:cornerRadius="25dp"
+                app:strokeColor="@color/nova_focus_stroke_selector"
+                app:strokeWidth="2dp" />
         </LinearLayout>
     </ScrollView>
 </FrameLayout>

--- a/app/src/test/java/com/papi/nova/ui/NovaWelcomeRefreshTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaWelcomeRefreshTest.kt
@@ -1,0 +1,61 @@
+package com.papi.nova.ui
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaWelcomeRefreshTest {
+    @Test
+    fun welcomeLayoutsExposeThreeControllerActions() {
+        val layouts = arrayOf(
+            "src/main/res/layout/activity_nova_welcome.xml",
+            "src/main/res/layout-land/activity_nova_welcome.xml",
+        )
+
+        for (layout in layouts) {
+            val xml = readFile(layout)
+            assertTrue("$layout should expose Discover hosts", xml.contains("@+id/welcome_discover_btn"))
+            assertTrue("$layout should expose Add manually", xml.contains("@+id/welcome_add_manual_btn"))
+            assertTrue("$layout should expose Scan QR", xml.contains("@+id/welcome_scan_qr_btn"))
+            assertTrue("$layout primary action should be D-pad focusable", buttonBlock(xml, "welcome_discover_btn").contains("android:focusable=\"true\""))
+            assertTrue("$layout manual action should be D-pad focusable", buttonBlock(xml, "welcome_add_manual_btn").contains("android:focusable=\"true\""))
+            assertTrue("$layout QR action should be D-pad focusable", buttonBlock(xml, "welcome_scan_qr_btn").contains("android:focusable=\"true\""))
+        }
+    }
+
+    @Test
+    fun welcomeCopyStaysScopedToVerifiedFlows() {
+        val portrait = readFile("src/main/res/layout/activity_nova_welcome.xml")
+        val landscape = readFile("src/main/res/layout-land/activity_nova_welcome.xml")
+        val copy = portrait + landscape
+
+        assertTrue("welcome should mention Polaris", copy.contains("Polaris"))
+        assertTrue("welcome should mention Moonlight compatibility", copy.contains("Moonlight-compatible") || copy.contains("Moonlight pairing"))
+        assertTrue("welcome should frame QR as Polaris pairing only", copy.contains("Polaris pairing QR"))
+        assertFalse("welcome should not overclaim automatic QR or TOFU pairing", copy.contains("TOFU auto-pair"))
+        assertFalse("welcome should not overclaim AI tuning", copy.contains("AI-optimized"))
+    }
+
+    @Test
+    fun welcomeActivityKeepsSeenFlagAndRoutesActions() {
+        val welcomeSource = readFile("src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt")
+        val pcViewSource = readFile("src/main/java/com/papi/nova/PcView.kt")
+
+        assertTrue("welcome_seen should still be persisted", welcomeSource.contains("KEY_WELCOME_SEEN") && welcomeSource.contains("putBoolean(KEY_WELCOME_SEEN, true)"))
+        assertTrue("welcome completion should still commit synchronously before leaving", welcomeSource.contains(".commit()"))
+        assertTrue("manual add action should use the existing manual add screen", welcomeSource.contains("AddComputerManually::class.java"))
+        assertTrue("QR action should be explicit", welcomeSource.contains("EXTRA_WELCOME_ACTION") && welcomeSource.contains("ACTION_SCAN_QR"))
+        assertTrue("PcView should handle the welcome QR action through the wired scanner", pcViewSource.contains("handleWelcomeAction") && pcViewSource.contains("launchQrScanner()"))
+    }
+
+    private fun buttonBlock(xml: String, id: String): String {
+        val idIndex = xml.indexOf("@+id/$id")
+        assertTrue("missing $id", idIndex >= 0)
+        val start = xml.lastIndexOf('<', idIndex).coerceAtLeast(0)
+        val end = xml.indexOf("/>", idIndex).let { if (it >= 0) it + 2 else xml.length }
+        return xml.substring(start, end)
+    }
+
+    private fun readFile(path: String): String = File(path).readText()
+}


### PR DESCRIPTION
## Summary
- Reworks the first-run welcome into three concise Nova panels covering Polaris, Moonlight-compatible hosts, and handheld/TV play
- Adds controller/D-pad focusable actions for Discover hosts, Add manually, and Scan QR
- Wires the welcome QR action through the existing Nova QR scanner and keeps welcome_seen committed before navigation

## User-facing impact
First launch now feels more polished and explains what Nova is for without overclaiming. Users can choose discovery, manual setup, or a Polaris pairing QR from the welcome screen with touch or controller navigation.

## Test Plan
- [x] ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaWelcomeRefreshTest

## Notes
- QR copy is scoped to Polaris pairing QR because that path is already wired through NovaQrScanActivity.
- No device/runtime smoke was run for this card.
