### PR TITLE
ci: bound emulator smoke runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
     name: Emulator smoke test
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v5
@@ -67,6 +68,7 @@ jobs:
         run: sdkmanager "ndk;27.0.12077973"
 
       - name: Run instrumentation smoke test
+        timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
@@ -74,8 +76,9 @@ jobs:
           profile: Nexus 6
           target: default
           disk-size: 1024M
+          emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot -no-metrics
-          script: ./gradlew -PnovaAbis=x86_64 connectedNonRoot_gameDebugAndroidTest
+          script: ./gradlew -PnovaAbis=x86_64 connectedNonRoot_gameDebugAndroidTest --stacktrace
 
   build:
     name: Assemble release APK


### PR DESCRIPTION
## Summary
- Add a 35-minute job timeout for the emulator smoke job
- Add a 30-minute timeout around the emulator-runner step
- Set an explicit 15-minute emulator boot timeout and enable Gradle stacktraces for better failure logs

## User-facing impact
- No app behavior changes.
- CI should fail clearly instead of hanging indefinitely when the emulator runner stalls.

## Test plan
- Parsed .github/workflows/build.yml with Python YAML loader
- Ran git diff --check
- actionlint was not installed locally