### PR TITLE
test: sync game detail compose smoke parameters

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
@@ -66,8 +66,8 @@ class NovaGameDetailSheetComposeTest {
                         resetProfileLabel = "Reset Game Profile",
                         resetProfileWorking = false,
                         mangoHudEnabled = false,
-                        mangoHudLabel = "MangoHud Overlay",
-                        mangoHudCaption = "Next launch only",
+                        mangoHudStatusLabel = "MangoHud Overlay",
+                        mangoHudStatusCaption = "Next launch only",
                         mangoHudWarning = false,
                         steamLaunchLabel = "Steam Launch",
                         steamLaunchModeLabel = "Direct",
@@ -81,10 +81,10 @@ class NovaGameDetailSheetComposeTest {
                         coverContentDescription = "Game cover art",
                         onPrimaryLaunch = {},
                         onLaunchOptions = {},
+                        onLaunchModeSelected = {},
                         onProfilePreference = {},
                         onRetryHighFps = {},
                         onResetProfile = {},
-                        onMangoHudChanged = {},
                         onSteamLaunchMode = {},
                         coverLoader = {}
                     )


### PR DESCRIPTION
## Summary
- Updates the emulator smoke androidTest callsite for `NovaGameDetailSheetContent` after the MangoHud launch controls refactor.
- Restores the tag-only `connectedNonRoot_gameDebugAndroidTest` compile gate that blocked the v1.1.0 release workflow.

## Verification
- `./gradlew -PnovaAbis=x86_64 compileNonRoot_gameDebugAndroidTestKotlin --stacktrace --no-daemon`
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest compileNonRoot_gameDebugAndroidTestKotlin --no-daemon`

## Release note
- v1.1.0 tag currently points at the pre-fix master commit and produced no GitHub release. After this PR merges, the tag will be deleted/recreated at the fixed master commit per maintainer direction.
