### PR TITLE
fix: add native submodule onboarding preflight

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Run JVM tests
         run: ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest
 
-      - name: Run smoke helper tests
-        run: python3 -m unittest tools.test_nova_retroid_smoke
+      - name: Run helper and onboarding tests
+        run: python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight
 
   android-smoke:
     name: Emulator smoke test

--- a/README.md
+++ b/README.md
@@ -245,7 +245,15 @@ cd nova
 ./gradlew assembleNonRoot_gameDebug
 ```
 
-Local builds produce split APKs for `arm64-v8a`, `armeabi-v7a`, and `x86_64` by default. Release builds, test commands, local ABI overrides, and the architecture diagram live in [Technical Overview](docs/technical-overview.md).
+If you cloned without `--recursive`, initialize the native streaming submodule before building:
+
+```bash
+git submodule update --init --recursive
+```
+
+Nova pins Android NDK `27.0.12077973`. Local builds produce split APKs for `arm64-v8a`, `armeabi-v7a`, and `x86_64` by default. Release builds, test commands, local ABI overrides, and the architecture diagram live in [Technical Overview](docs/technical-overview.md).
+
+Nova currently builds the checked-out native streaming tree directly. Any move to prebuilt native artifacts or AAR packaging should be handled as a separate release-engineering decision, not as a silent replacement for the source build.
 
 ## FAQ
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,48 @@ def targetAbis = (project.findProperty("novaAbis") ?: "arm64-v8a,armeabi-v7a,x86
         .findAll { !it.isEmpty() }
 def fdroidBuild = project.findProperty("novaFdroid")?.toString()?.toBoolean() ?: false
 
+def moonlightCommonCPath = "src/main/jni/moonlight-core/moonlight-common-c"
+def moonlightCommonCDir = file(moonlightCommonCPath)
+def moonlightCommonCRequiredPaths = [
+        "src/Connection.c",
+        "enet/include/enet/enet.h",
+        "reedsolomon/rs.c",
+]
+def moonlightCommonCRequiredFiles = moonlightCommonCRequiredPaths.collect { relativePath ->
+    [relativePath: relativePath, sourceFile: file("${moonlightCommonCPath}/${relativePath}")]
+}
+
+TaskProvider<Task> verifyMoonlightCommonCSubmodule = tasks.register("verifyMoonlightCommonCSubmodule") {
+    group = "verification"
+    description = "Verifies that the moonlight-common-c git submodule is initialized before native builds run."
+
+    doLast {
+        def missingPaths = moonlightCommonCRequiredFiles.findAll { requiredFile ->
+            !requiredFile.sourceFile.isFile()
+        }.collect { requiredFile ->
+            requiredFile.relativePath
+        }
+
+        if (!moonlightCommonCDir.isDirectory() || !missingPaths.isEmpty()) {
+            throw new GradleException("""
+Nova's native streaming sources are missing from ${moonlightCommonCPath}.
+
+The moonlight-common-c git submodule must be initialized before Android native builds can run.
+From the repository root, run:
+
+    git submodule update --init --recursive
+
+If you are cloning from scratch, prefer:
+
+    git clone --recursive https://github.com/papi-ux/nova.git
+
+Missing expected files:
+${missingPaths.collect { "  - ${moonlightCommonCPath}/${it}" }.join("\n")}
+""".stripIndent().trim())
+        }
+    }
+}
+
 android {
     ndkVersion = "27.0.12077973"
 
@@ -260,6 +302,12 @@ baselineProfile {
         nonRoot_gameRelease {
             from project(':baselineprofile')
         }
+    }
+}
+
+tasks.configureEach { task ->
+    if (task.name.contains("externalNativeBuild")) {
+        task.dependsOn(verifyMoonlightCommonCSubmodule)
     }
 }
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -78,6 +78,10 @@ If the repo was cloned without submodules:
 git submodule update --init --recursive
 ```
 
+Android native builds run a preflight check for `app/src/main/jni/moonlight-core/moonlight-common-c` before invoking ndk-build. If that tree is missing, run the submodule command above instead of chasing downstream C compiler errors.
+
+Nova currently builds the checked-out native streaming tree directly. Prebuilt native artifacts or AAR packaging may be useful later, but that should be a separate release-engineering decision with its own review and provenance checks.
+
 ## Build
 
 ```bash

--- a/tools/test_native_submodule_preflight.py
+++ b/tools/test_native_submodule_preflight.py
@@ -1,0 +1,54 @@
+import pathlib
+import re
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+APP_BUILD = REPO_ROOT / "app" / "build.gradle"
+README = REPO_ROOT / "README.md"
+TECHNICAL_OVERVIEW = REPO_ROOT / "docs" / "technical-overview.md"
+
+
+class NativeSubmodulePreflightTest(unittest.TestCase):
+    def test_gradle_declares_actionable_moonlight_common_c_preflight(self):
+        build_gradle = APP_BUILD.read_text(encoding="utf-8")
+
+        self.assertIn("verifyMoonlightCommonCSubmodule", build_gradle)
+        self.assertIn("moonlight-common-c", build_gradle)
+        self.assertIn("git submodule update --init --recursive", build_gradle)
+        self.assertIn("src/main/jni/moonlight-core/moonlight-common-c", build_gradle)
+
+        required_paths = [
+            "src/Connection.c",
+            "enet/include/enet/enet.h",
+            "reedsolomon/rs.c",
+        ]
+        for required_path in required_paths:
+            self.assertIn(required_path, build_gradle)
+
+    def test_preflight_runs_before_native_build_tasks(self):
+        build_gradle = APP_BUILD.read_text(encoding="utf-8")
+
+        self.assertRegex(
+            build_gradle,
+            re.compile(
+                r"tasks\.configureEach\s*\{.*externalNativeBuild.*dependsOn\(verifyMoonlightCommonCSubmodule\)",
+                re.DOTALL,
+            ),
+        )
+
+    def test_docs_describe_clone_recovery_ndk_and_prebuilt_scope(self):
+        readme = README.read_text(encoding="utf-8")
+        overview = TECHNICAL_OVERVIEW.read_text(encoding="utf-8")
+        combined_docs = f"{readme}\n{overview}"
+
+        self.assertIn("git clone --recursive https://github.com/papi-ux/nova.git", combined_docs)
+        self.assertIn("git submodule update --init --recursive", combined_docs)
+        self.assertIn("27.0.12077973", combined_docs)
+        self.assertIn("moonlight-common-c", combined_docs)
+        self.assertIn("prebuilt native artifacts", combined_docs)
+        self.assertIn("separate release-engineering decision", combined_docs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Gradle preflight task that fails early when `moonlight-common-c` submodule files are missing
- wire that preflight before AGP external native build tasks so missing sources do not cascade into opaque ndk-build errors
- document clone/submodule recovery, pinned NDK version, and keep prebuilt native artifacts/AAR packaging as a separate release-engineering decision
- add a Python regression/source test and wire it into the helper/onboarding CI step

Closes #57

## Validation
- `python3 -m unittest tools.test_native_submodule_preflight` — pass on MacPapi
- `python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight` — pass on MacPapi
- pc-papi clean worktree smoke before submodule init: `./gradlew :app:verifyMoonlightCommonCSubmodule --stacktrace` fails with the new actionable submodule message
- pc-papi after `git submodule update --init --recursive`: `./gradlew :app:verifyMoonlightCommonCSubmodule --stacktrace` — pass
- pc-papi: `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug testNonRoot_gameDebugUnitTest --stacktrace` — pass
- pc-papi: `./gradlew -PnovaAbis=x86_64 :app:assembleNonRoot_gameDebug --stacktrace` — pass

## Caveats
- MacPapi local Gradle remains blocked by missing Android SDK/local.properties, so Android Gradle verification ran on pc-papi.
- pc-papi ARM64 debug assemble currently hits an NDK 27 clang frontend crash in `moonlight-common-c/src/Misc.c`; x86_64 assemble and the submodule preflight pass, so this PR does not hide that separate native toolchain issue.
