### PR TITLE
chore: prepare Nova 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.1 - 2026-05-28
+
+- Prepared the public 1.1 release candidate from the current `master` branch instead of rewriting the older `v1.1.0` tag.
+- Added an actionable Gradle preflight for missing `moonlight-common-c` submodule sources before Android native build errors cascade.
+- Hardened Compose smoke assertions around the settings refactor so the release line tracks the current settings/library surfaces.
+- Kept release workflow checks green across lint, unit tests, CodeQL, public hygiene, dependency submission, and release APK assembly.
+
 ## 1.1.0 - 2026-05-20
 
 - Added structured stream performance samples from the video renderer so NovaHUD can consume typed metrics without reparsing the legacy overlay text path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.1 - 2026-05-28
 
+Nova 1.1.1 is the public release candidate for the 1.1 line. It keeps the 1.1 feature set intact and focuses on release readiness, contributor build guardrails, and current-surface smoke stability instead of rewriting the older `v1.1.0` tag.
+
+### Release hardening
+
 - Prepared the public 1.1 release candidate from the current `master` branch instead of rewriting the older `v1.1.0` tag.
 - Added an actionable Gradle preflight for missing `moonlight-common-c` submodule sources before Android native build errors cascade.
 - Hardened Compose smoke assertions around the settings refactor so the release line tracks the current settings/library surfaces.
@@ -9,15 +13,75 @@
 
 ## 1.1.0 - 2026-05-20
 
-- Added structured stream performance samples from the video renderer so NovaHUD can consume typed metrics without reparsing the legacy overlay text path.
-- Reworked the NovaHUD sparkline path around a fixed primitive ring buffer and focused snapshots to reduce stream-loop allocation pressure.
-- Routed structured performance samples into NovaHUD while preserving the legacy performance overlay behavior.
-- Expanded Baseline Profile coverage for library detail, settings, and launch-adjacent Compose surfaces.
-- Documented the JNI bridge measurement gate for future `@FastNative` and `@CriticalNative` work instead of annotating JNI calls before profiling proves they are safe.
-- Kept the lock-screen overlay retryable by treating Polaris unlock responses as successful only when the host reports `success: true`.
-- Normalized raw `idle` stream progress into the initializing overlay state so handheld users do not see an internal state label.
-- Added saved-host port recovery so Nova retries a stale local address on the default Polaris HTTP port and persists the corrected port after a successful poll.
-- Verified the debug ARM64 APK on a Retroid Pocket 6 over wireless ADB with Polaris library launch, HEVC stream resume, NovaHUD enablement, Command Center disconnect, and clean log/crash-buffer checks.
+Nova 1.1.0 is a major handheld-focused polish release for Polaris-backed play. It upgrades the Library, launch flow, Command Center, NovaHUD, stream startup states, controller behavior, and release validation path so Nova feels less like a generic Moonlight-style grid and more like a purpose-built Android console client for real couch and handheld sessions.
+
+### Highlights
+
+- **Richer Polaris Library experience**
+  - Refined the Polaris-backed Library into a more console-like browsing surface with stronger game cards, clearer launch context, better focus behavior, and more useful session state.
+  - Improved game detail and launch sheets so Headless, Virtual Display, active-session, watch/resume, and host recommendation states are easier to understand before launching.
+  - Added more explicit launch-profile summaries so Nova can explain what the host is about to do instead of hiding launch-mode decisions behind generic buttons.
+
+- **Command Center and NovaHUD polish**
+  - Improved the in-stream Command Center as the main operations surface for tuning, overlays, session actions, and disconnect behavior.
+  - Routed structured stream performance samples from the video renderer into NovaHUD while preserving the legacy overlay text path.
+  - Reworked NovaHUD sparkline sampling around a fixed primitive ring buffer to reduce stream-loop allocation pressure.
+  - Improved HUD state handling for target FPS, host-render-limited state, stream health, and Polaris-backed tuning/session context.
+
+- **Better stream startup and recovery states**
+  - Normalized raw stream progress states so users see readable startup language instead of internal labels like `idle`.
+  - Improved lock-screen/unlock retry behavior by only treating Polaris unlock responses as successful when the host reports a real success.
+  - Improved reconnect/resume confidence for active Polaris sessions.
+  - Added saved-host port recovery so Nova can retry a stale local address on the default Polaris HTTP port and persist the corrected port after a successful poll.
+
+- **Direct launch and shortcut reliability**
+  - Improved Polaris preflight handling for direct launches and shortcut-driven flows.
+  - Strengthened launch behavior when Nova enters through launcher shortcuts, host grids, or Library detail flows.
+  - Added regression coverage around launch profile summaries, Polaris API parsing, stream sync, and shortcut state.
+
+- **Focus, motion, and handheld UX**
+  - Added Nova's focus motion system for clearer controller/D-pad navigation.
+  - Improved focus visibility across Compose and legacy Android views.
+  - Refined handheld-first Library, detail, overlay, and settings surfaces with more consistent Nova visual language.
+  - Added source guards and tests to prevent polished surfaces from regressing back into cramped generic Android layouts.
+
+- **Performance hardening**
+  - Expanded Baseline Profile coverage for startup, Library detail, settings, and launch-adjacent Compose journeys.
+  - Reduced hot-path HUD allocation overhead during streams.
+  - Documented a measured JNI bridge policy for future `@FastNative` and `@CriticalNative` work instead of applying risky annotations before profiling proves they help.
+  - Kept stream-loop work focused on measured improvements rather than speculative native/JNI changes.
+
+- **Settings and release polish**
+  - Refined settings copy, version display, and profile/default state handling.
+  - Updated public release notes, reliability notes, and 1.1 release documentation.
+  - Added/hardened tests for settings definitions, settings UI state, theme resources, HUD state, launch summaries, Library state, quick menu state, focus drawables, and stream overlays.
+
+- **Build, CI, and contributor guardrails**
+  - Added actionable Gradle/native-build preflight behavior for missing `moonlight-common-c` submodule sources before opaque NDK errors cascade.
+  - Bounded emulator smoke runtime in CI.
+  - Kept release workflow checks aligned across lint, unit tests, CodeQL, dependency submission, public hygiene, and release APK assembly.
+  - Added/updated Retroid smoke tooling for repeatable handheld validation.
+
+### Device validation
+
+- Verified the ARM64 debug APK on Retroid hardware over ADB with:
+  - Polaris Library launch
+  - HEVC stream resume
+  - NovaHUD enablement from Command Center
+  - Command Center disconnect back to the Library
+  - bounded logcat/crash-buffer checks
+
+### Upgrade notes
+
+- Nova 1.1.0 keeps compatibility with Moonlight/GameStream-style hosts, but the richest new Library, launch, tuning, session, and HUD states require a recent Polaris host.
+- Existing installs that already received the 1.0.10 stream-resolution migration keep those repaired stream defaults.
+- Contributors building from source should initialize submodules with:
+
+  ```bash
+  git submodule update --init --recursive
+  ```
+
+  Nova now fails earlier with a clearer message when required native submodule sources are missing.
 
 ## 1.0.10 - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ If a sleeping host does not report a MAC address, open the host menu and choose 
 
 ## What's New in v1.1.1
 
-Nova `v1.1.1` is the public release candidate for the 1.1 line: stream performance, release hardening, and contributor build guardrails for Polaris-backed play.
+Nova `v1.1.1` is the public release candidate for the 1.1 line. The 1.1 release upgrades Nova's Polaris-backed Library, launch flow, Command Center, NovaHUD, stream startup states, controller focus, and release validation path so handheld play feels more like a purpose-built Android console client and less like a generic game grid.
 
-- **Lower-overhead HUD metrics**: NovaHUD now consumes structured stream samples from the video renderer while preserving the legacy overlay text path.
-- **Hot-path allocation cleanup**: HUD sparkline samples use a fixed primitive buffer instead of rebuilding collection state during a stream.
-- **Smoother first-run surfaces**: Baseline Profile generation now covers library detail, settings, and launch-adjacent Compose paths.
-- **Measured JNI policy**: the JNI bridge now has a documented profiling gate for future `@FastNative` and `@CriticalNative` work.
-- **Native build onboarding**: local source builds now fail early with a clear `moonlight-common-c` submodule recovery command instead of cascading into opaque ndk-build errors.
-- **Retroid 6 validation**: the ARM64 debug APK was smoke tested over wireless ADB with Polaris library launch, HEVC stream resume, NovaHUD, Command Center disconnect, and clean log/crash-buffer checks.
+- **Richer Polaris Library**: improved game cards, focus behavior, launch detail sheets, active-session states, and Polaris-backed launch context.
+- **Clearer launch choices**: Headless, Virtual Display, resume/watch, host recommendations, and next-launch tuning are easier to understand before starting a stream.
+- **Command Center polish**: in-stream tuning, overlay controls, NovaHUD toggles, and safe disconnect actions are easier to reach during play.
+- **Lower-overhead NovaHUD**: structured renderer samples and a fixed sparkline buffer reduce stream-loop allocation pressure while keeping legacy overlay compatibility.
+- **Better startup/recovery states**: stream initialization, lock-screen unlock, reconnect, stale host ports, and direct launch preflight paths are more reliable and readable.
+- **Controller-first focus polish**: Nova's focus motion system improves D-pad/controller navigation across Library, detail, settings, and overlay surfaces.
+- **Release hardening**: expanded Baseline Profile coverage, clearer native submodule preflight errors, bounded emulator smoke, and Retroid ARM64 validation.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 
@@ -166,7 +167,7 @@ Nova opens on a controller-friendly dashboard for servers, themes, help, and str
 
 ### Polaris Library
 
-The Polaris library gives Nova the context a plain app list cannot: cover art, filters, source badges, launch modes, Continue/watch states, and per-game guidance.
+The Polaris library gives Nova the context a plain app list cannot: cover art, filters, source badges, launch modes, Continue/watch states, host recommendations, and per-game guidance before you start a stream.
 
 <table>
   <tr>
@@ -187,7 +188,7 @@ The Polaris library gives Nova the context a plain app list cannot: cover art, f
 
 ### Stream Controls
 
-During a stream, Nova shifts from browsing to operations: HUD modes, quick controls, reconnect state, tuning actions, and input helpers stay reachable without leaving the session.
+During a stream, Nova shifts from browsing to operations: Command Center, HUD modes, tuning actions, reconnect state, input helpers, and disconnect controls stay reachable without leaving the session.
 
 <table>
   <tr>
@@ -233,6 +234,7 @@ For the deeper source layout and build model, see [Technical Overview](docs/tech
 | [F-Droid Packaging Notes](docs/fdroid.md) | F-Droid and IzzyOnDroid packaging status |
 | [Kotlin Optimization Audit](docs/kotlin_optimization_audit.md) | Kotlin migration and optimization notes |
 | [Video Baseline Evidence](docs/video_baseline_evidence.md) | Baseline profile and release-performance evidence |
+| [JNI Bridge Measurement](docs/jni_bridge_measurement.md) | Measurement gate for future JNI annotation work |
 | [Multi-platform Study](docs/multi_platform_monorepo.md) | Native client expansion notes |
 | [Steam Deck Native Port Study](docs/steam_deck_native_port_study.md) | Steam Deck client research |
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tuning instead of hiding everything behind a generic game grid.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Quick Start](#quick-start) · [What's New](#whats-new-in-v110) · [Install](#install) · [Compatibility](#compatibility) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Docs](#docs) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Quick Start](#quick-start) · [What's New](#whats-new-in-v111) · [Install](#install) · [Compatibility](#compatibility) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Docs](#docs) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -51,15 +51,16 @@ tuning instead of hiding everything behind a generic game grid.
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## What's New in v1.1.0
+## What's New in v1.1.1
 
-Nova `v1.1.0` is a stream performance and release-hardening update for Polaris-backed play.
+Nova `v1.1.1` is the public release candidate for the 1.1 line: stream performance, release hardening, and contributor build guardrails for Polaris-backed play.
 
-- **Lower-overhead HUD metrics**: NovaHUD now consumes structured stream samples from the video renderer while preserving the legacy overlay path.
+- **Lower-overhead HUD metrics**: NovaHUD now consumes structured stream samples from the video renderer while preserving the legacy overlay text path.
 - **Hot-path allocation cleanup**: HUD sparkline samples use a fixed primitive buffer instead of rebuilding collection state during a stream.
 - **Smoother first-run surfaces**: Baseline Profile generation now covers library detail, settings, and launch-adjacent Compose paths.
 - **Measured JNI policy**: the JNI bridge now has a documented profiling gate for future `@FastNative` and `@CriticalNative` work.
-- **Retroid 6 validation**: the ARM64 debug APK was smoke tested over wireless ADB with Polaris library launch, HEVC stream resume, NovaHUD, Command Center disconnect, and clean crash checks.
+- **Native build onboarding**: local source builds now fail early with a clear `moonlight-common-c` submodule recovery command instead of cascading into opaque ndk-build errors.
+- **Retroid 6 validation**: the ARM64 debug APK was smoke tested over wireless ADB with Polaris library launch, HEVC stream resume, NovaHUD, Command Center disconnect, and clean log/crash-buffer checks.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.1.0"
-        versionCode = 26
+        versionName "1.1.1"
+        versionCode = 27
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/fastlane/metadata/android/en-US/changelogs/27.txt
+++ b/fastlane/metadata/android/en-US/changelogs/27.txt
@@ -1,0 +1,8 @@
+Nova 1.1.1
+
+- Refines the Polaris Library with clearer game cards, launch detail, active-session state, and controller focus.
+- Improves Command Center and NovaHUD for in-stream tuning, overlays, stream health, and disconnect.
+- Adds lower-overhead structured HUD performance samples.
+- Improves stream startup, lock-screen unlock retry, direct launch preflight, and stale host port recovery.
+- Adds focus motion polish and stronger handheld/Retroid validation.
+- Hardens release builds with Baseline Profile coverage and clearer native submodule setup errors.


### PR DESCRIPTION
## Summary
- bump Nova to `versionName 1.1.1` / `versionCode 27`
- update README top section to point at the 1.1.1 public release candidate notes
- add a 1.1.1 changelog entry so we avoid rewriting the existing `v1.1.0` tag

## Validation
- `python3 -m unittest tools.test_native_submodule_preflight`
- `git diff --check`
- staged credential assignment/private-key scan (clean)
- current `origin/master` candidate CI is green for Build Nova APK, CodeQL, Dependency Submission, and Public Hygiene

## Release plan after merge
- tag current master as `v1.1.1`
- let the existing tag workflow build/upload APK release assets
- verify `Nova-Android-arm64-v8a.apk`, `Nova-Android-armeabi-v7a.apk`, `Nova-Android-x86_64.apk`, and checksums on the GitHub Release
