### PR TITLE
Null ex

### DIFF
--- a/app/src/main/java/com/papi/nova/grid/AppGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/AppGridAdapter.kt
@@ -180,7 +180,7 @@ class AppGridAdapter(
         parentView: View,
         imgView: ImageView,
         gridMask: RelativeLayout?,
-        prgView: ProgressBar,
+        prgView: ProgressBar?,
         txtView: TextView,
         overlayView: ImageView,
         obj: AppView.AppObject

--- a/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.kt
@@ -30,7 +30,7 @@ abstract class GenericGridAdapter<T>(
         @JvmField val gridMask: RelativeLayout? = itemView.findViewById(R.id.grid_mask)
         @JvmField val overlayView: ImageView = itemView.findViewById(R.id.grid_overlay)
         @JvmField val txtView: TextView = itemView.findViewById(R.id.grid_text)
-        @JvmField val prgView: ProgressBar = itemView.findViewById(R.id.grid_spinner)
+        @JvmField val prgView: ProgressBar? = itemView.findViewById(R.id.grid_spinner)
     }
 
     fun setOnItemClickListener(listener: OnItemClickListener<T>?) {
@@ -68,7 +68,7 @@ abstract class GenericGridAdapter<T>(
         parentView: View,
         imgView: ImageView,
         gridMask: RelativeLayout?,
-        prgView: ProgressBar,
+        prgView: ProgressBar?,
         txtView: TextView,
         overlayView: ImageView,
         obj: T

--- a/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
@@ -68,12 +68,12 @@ class PcGridAdapter(
         parentView: View,
         imgView: ImageView,
         gridMask: RelativeLayout?,
-        prgView: ProgressBar,
+        prgView: ProgressBar?,
         txtView: TextView,
         overlayView: ImageView,
         obj: PcViewModel.ComputerObject
     ) {
-        applyCardTheme(parentView, imgView, prgView, txtView)
+        applyCardTheme(parentView, imgView, prgView!!, txtView)
 
         imgView.setImageResource(R.drawable.ic_computer)
         imgView.setColorFilter(NovaThemeManager.getTextSecondaryColor(context))

--- a/app/src/main/java/com/papi/nova/grid/assets/CachedAppAssetLoader.kt
+++ b/app/src/main/java/com/papi/nova/grid/assets/CachedAppAssetLoader.kt
@@ -238,7 +238,7 @@ class CachedAppAssetLoader(
             return null
         }
 
-        val drawable: Drawable = imageView.drawable
+        val drawable: Drawable? = imageView.drawable
         return if (drawable is AsyncDrawable) {
             drawable.getLoaderTask()
         } else {


### PR DESCRIPTION
## Summary

This app_grid_item view is opened when selecting "show all apps" on a Sunshine host. As it doesn't contain a "grid_spinner" definition, the app would terminate with a "findViewById must not be null" exception. 

Also got another "cannot be null"-exception in getLoaderTask.

## Testing

- [x] I tested the affected build, pairing, stream, input, or UI path.
- [x] I tested on a real device or emulator when the change affects Android behavior.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

