### PR TITLE
fix(deps): pin Wire runtime transitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ plugins {
 }
 
 def patchedNettyVersion = '4.1.133.Final'
+def patchedWireVersion = '6.3.0'
+def patchedWireModules = ['wire-runtime', 'wire-runtime-jvm'] as Set
 
 allprojects { project ->
     configurations.configureEach { configuration ->
@@ -52,6 +54,10 @@ allprojects { project ->
             if (details.requested.group == 'io.netty') {
                 details.useVersion patchedNettyVersion
                 details.because 'Dependabot flags Netty from Gradle/Android test tooling transitives'
+            }
+            if (details.requested.group == 'com.squareup.wire' && patchedWireModules.contains(details.requested.name)) {
+                details.useVersion patchedWireVersion
+                details.because 'Dependabot flags Wire from AndroidX benchmark/baseline-profile transitives'
             }
         }
     }


### PR DESCRIPTION
## Summary
- Pins AndroidX benchmark / baseline-profile Wire transitives to `6.3.0`
- Resolves Dependabot alert #29 for `com.squareup.wire:wire-runtime` (`GHSA-7xpr-hc2w-34m9` / `CVE-2026-45799`)
- Keeps the existing build-tool dependency pin style in root `build.gradle`

## Validation
- `:baselineprofile:dependencyInsight --dependency com.squareup.wire:wire-runtime --configuration nonRoot_gameBenchmarkReleaseCompileClasspath`
  - confirmed `wire-runtime:6.0.0 -> 6.3.0`
  - confirmed `wire-runtime-jvm:6.3.0`
- `:baselineprofile:compileNonRoot_gameBenchmarkReleaseKotlin :baselineprofile:compileNonRoot_gameBenchmarkReleaseJavaWithJavac`
- `-PnovaAbis=x86_64 :baselineprofile:assembleNonRoot_gameBenchmarkRelease`
- `:app:testNonRoot_gameDebugUnitTest`

All validation passed from an isolated pc-papi copy of this clean PR branch.