### PR TITLE
fix(deps): bump Netty toolchain pins

### DIFF
--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -51,7 +51,7 @@ class NovaComposeBuildConfigurationTest {
 
         assertTrue(
             "root build should keep a single patched Netty version for Gradle and Android test tooling",
-            rootBuild.contains("patchedNettyVersion = '4.1.133.Final'")
+            rootBuild.contains("patchedNettyVersion = '4.1.135.Final'")
         )
         assertTrue(
             "all project configurations should force Netty transitives onto the patched line",
@@ -60,10 +60,10 @@ class NovaComposeBuildConfigurationTest {
         )
         assertTrue(
             "the existing buildscript classpath constraints should still cover settings/build-tool Netty transitives",
-            rootBuild.contains("classpath('io.netty:netty-codec:4.1.133.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-codec-http:4.1.133.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-codec-http2:4.1.133.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-handler-proxy:4.1.133.Final')")
+            rootBuild.contains("classpath('io.netty:netty-codec:4.1.135.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-codec-http:4.1.135.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-codec-http2:4.1.135.Final')") &&
+                rootBuild.contains("classpath('io.netty:netty-handler-proxy:4.1.135.Final')")
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,22 +3,22 @@ buildscript {
     dependencies {
         constraints {
             // These pins only affect the Gradle/AGP build toolchain, not the app's runtime graph.
-            classpath('io.netty:netty-codec:4.1.133.Final') {
+            classpath('io.netty:netty-codec:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-codec-http:4.1.133.Final') {
+            classpath('io.netty:netty-codec-http:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-codec-http2:4.1.133.Final') {
+            classpath('io.netty:netty-codec-http2:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-common:4.1.133.Final') {
+            classpath('io.netty:netty-common:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-handler:4.1.133.Final') {
+            classpath('io.netty:netty-handler:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-handler-proxy:4.1.133.Final') {
+            classpath('io.netty:netty-handler-proxy:4.1.135.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
             classpath('org.apache.commons:commons-lang3:3.18.0') {
@@ -44,7 +44,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose' version '2.3.21' apply false
 }
 
-def patchedNettyVersion = '4.1.133.Final'
+def patchedNettyVersion = '4.1.135.Final'
 def patchedWireVersion = '6.3.0'
 def patchedWireModules = ['wire-runtime', 'wire-runtime-jvm'] as Set
 


### PR DESCRIPTION
## Summary
- Bump Nova's Gradle/Android test tooling Netty pins from `4.1.133.Final` to `4.1.135.Final`
- Update the build configuration source guard to expect the new patched Netty version
- Addresses Dependabot security alert #30 / GHSA-3qp7-7mw8-wx86 / CVE-2026-44249 for `io.netty:netty-handler`

## Validation
- `./gradlew --no-daemon --no-configuration-cache :app:dependencyInsight --dependency io.netty:netty-handler --configuration unified-test-platform-core :baselineprofile:dependencyInsight --dependency io.netty:netty-handler --configuration unified-test-platform-core --console=plain --stacktrace`
  - Confirms `io.netty:netty-handler:4.1.135.Final` selected by rule through `com.google.testing.platform:core` / `io.grpc:grpc-netty`
- `./gradlew --no-daemon --no-configuration-cache -PnovaAbis=x86_64 :app:assembleNonRoot_gameDebug :baselineprofile:assembleNonRoot_gameBenchmarkRelease --console=plain --stacktrace`
- `./gradlew --no-daemon --no-configuration-cache -PnovaAbis=x86_64 :app:testNonRoot_gameDebugUnitTest --console=plain --stacktrace`

All validation ran on an isolated pc-papi copy because the MacPapi hub checkout does not have the Android SDK configured for local Gradle.
