### PR TITLE
fix(nova): harden fallback app-list truth layer

### DIFF
--- a/app/src/main/java/com/papi/nova/AppView.kt
+++ b/app/src/main/java/com/papi/nova/AppView.kt
@@ -86,13 +86,13 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
 
                     val uuid = uuidString
                     if (uuid == null) {
-                        finish()
+                        showAppListError(getString(R.string.applist_error_invalid_host))
                         return@Thread
                     }
 
                     val loadedComputer = localBinder.getComputer(uuid)
                     if (loadedComputer == null) {
-                        finish()
+                        showAppListError(getString(R.string.applist_error_host_missing))
                         return@Thread
                     }
                     computer = loadedComputer
@@ -210,6 +210,14 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
                         return
                     }
 
+                    if (details.appListLoadError != null &&
+                        (appGridAdapter?.getTotalAppCount() ?: 0) == 0
+                    ) {
+                        activeComputer.update(details)
+                        showAppListError(details.appListLoadError ?: getString(R.string.applist_error_message))
+                        return
+                    }
+
                     if (details.rawAppList == null || details.rawAppList == lastRawAppList) {
                         activeComputer.update(details)
                         if (details.runningGameId != lastRunningAppId) {
@@ -224,17 +232,17 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
                     lastRawAppList = details.rawAppList
 
                     try {
+                        clearAppListError()
                         updateUiWithAppList(NvHTTP.getAppListByReader(StringReader(details.rawAppList)))
                         updateUiWithServerInfo(details)
 
-                        if (blockingLoadSpinner != null) {
-                            blockingLoadSpinner?.dismiss()
-                            blockingLoadSpinner = null
-                        }
+                        runOnUiThread { dismissBlockingLoadSpinner() }
                     } catch (e: XmlPullParserException) {
-                        LimeLog.warning(Log.getStackTraceString(e))
+                        handleAppListLoadFailure(e)
                     } catch (e: IOException) {
-                        LimeLog.warning(Log.getStackTraceString(e))
+                        handleAppListLoadFailure(e)
+                    } catch (e: RuntimeException) {
+                        handleAppListLoadFailure(e)
                     }
                 }
             },
@@ -304,6 +312,8 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
 
         findViewById<View>(R.id.profilesButton)
             .setOnClickListener { startActivity(Intent(this, ProfilesActivity::class.java)) }
+        findViewById<View>(R.id.appListRetryButton)
+            ?.setOnClickListener { retryAppListLoad() }
 
         showHiddenApps = intent.getBooleanExtra(SHOW_HIDDEN_APPS_EXTRA, false)
         uuidString = intent.getStringExtra(UUID_EXTRA)
@@ -372,6 +382,8 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
             handleCachedAppListLoadFailure(e)
         } catch (e: XmlPullParserException) {
             handleCachedAppListLoadFailure(e)
+        } catch (e: RuntimeException) {
+            handleCachedAppListLoadFailure(e)
         }
     }
 
@@ -392,6 +404,51 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
                 resources.getString(R.string.applist_refresh_msg),
                 true,
             )
+    }
+
+    private fun dismissBlockingLoadSpinner() {
+        if (blockingLoadSpinner != null) {
+            blockingLoadSpinner?.dismiss()
+            blockingLoadSpinner = null
+        }
+    }
+
+    private fun handleAppListLoadFailure(e: Exception) {
+        LimeLog.warning(Log.getStackTraceString(e))
+        val detail = e.message ?: e.javaClass.simpleName
+        showAppListError(detail)
+    }
+
+    private fun showAppListError(message: String) {
+        runOnUiThread {
+            dismissBlockingLoadSpinner()
+            val swipeRefresh = findViewById<SwipeRefreshLayout>(R.id.appSwipeRefresh)
+            swipeRefresh?.isRefreshing = false
+
+            val errorCard = findViewById<View>(R.id.appListErrorCard) ?: return@runOnUiThread
+            val detailView = findViewById<TextView>(R.id.appListErrorDetail)
+            val retryButton = findViewById<View>(R.id.appListRetryButton)
+
+            detailView?.text = getString(R.string.applist_error_detail_format, message)
+            detailView?.visibility = if (message.isBlank()) View.GONE else View.VISIBLE
+            retryButton?.requestFocus()
+            errorCard.visibility = View.VISIBLE
+        }
+    }
+
+    private fun clearAppListError() {
+        runOnUiThread {
+            findViewById<View>(R.id.appListErrorCard)?.visibility = View.GONE
+        }
+    }
+
+    private fun retryAppListLoad() {
+        clearAppListError()
+        loadAppsBlocking()
+        poller?.pollNow()
+        if (poller == null) {
+            startComputerUpdates()
+        }
     }
 
     override fun finish() {

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -216,6 +216,8 @@ private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
 @Volatile private var lastReportedClientPresentationKey:String = ""
 @Volatile private var lastPolarisDeviceCapabilities:JSONObject? = null
 @Volatile private var lastPolarisAppliedStreamSettings:JSONObject? = null
+@Volatile private var lastClientProfileProvenance:com.papi.nova.manager.ClientProfileProvenance =
+com.papi.nova.manager.ClientProfileProvenance(com.papi.nova.manager.ClientProfileSource.LOCAL_DEFAULT)
 private var launchProfilePreference:String = "auto"
 private var launchOptimizationJson:String? = null
 private var clientPresentationReportInFlight:AtomicBoolean = AtomicBoolean(false)
@@ -739,6 +741,7 @@ return
 }
 
 var launchOptimization:JSONObject? = if (watchOnlyRequested) null else loadLaunchOptimization(appName)
+lastClientProfileProvenance = com.papi.nova.manager.StreamSyncManager.resolveProfileProvenance(launchOptimization, manualOverride = isManualProfileOverride())
 
  // Initialize the MediaCodec helper before creating the decoder
         var glPrefs:GlPreferences? = GlPreferences.readPreferences(this)
@@ -1891,6 +1894,10 @@ getConfiguredStreamFrameRateFps() > 0f &&
 getConfiguredStreamFrameRateFps() <= 60f &&
 !preferStableRefreshMultipleForAutoSafe &&
 !isOnExternalDisplay)
+}
+
+private fun isManualProfileOverride():Boolean {
+return launchProfilePreference.isNotBlank() && !launchProfilePreference.equals("auto", ignoreCase = true)
 }
 
 private fun loadLaunchOptimization(appName:String?):JSONObject? {
@@ -5297,18 +5304,33 @@ if ((novaApiClient == null || !com.papi.nova.manager.FeatureFlagManager.hasClien
 return false
 }
 
+var targetRefreshRateHz:Float = 0f
+var refreshRatePolicy:String = ""
+try
+{
+if (clientPresentation != null)
+{
+targetRefreshRateHz = clientPresentation!!.optDouble("target_refresh_rate_hz", 0.0).toFloat()
+refreshRatePolicy = clientPresentation!!.optString("refresh_rate_policy", "")
+}
+}
+catch (ignored:Exception) {}
 var runtime:JSONObject? = com.papi.nova.manager.StreamSyncManager.buildClientRuntime(
 this,
 decoderRenderer,
 if (lastClientPresentationRefreshRate > 0f) lastClientPresentationRefreshRate else desiredRefreshRate,
 lastClientPresentationDisplayModeId,
 lastClientPresentationDisplayMode,
-if (prefConfig != null) prefConfig!!.framePacing else 0
+if (prefConfig != null) prefConfig!!.framePacing else 0,
+lastClientProfileProvenance,
+targetRefreshRateHz,
+refreshRatePolicy
 )
 
+var manualProfileOverride:Boolean = isManualProfileOverride()
 var syncStatus:com.papi.nova.api.PolarisSessionStatus.SyncStatus? = novaApiClient!!.reportClientSettings(
 com.papi.nova.manager.StreamSyncManager.SYNC_MODE_AUTO_SAFE,
-false,
+manualProfileOverride,
 lastPolarisDeviceCapabilities,
 runtime,
 lastPolarisAppliedStreamSettings,

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -187,6 +187,40 @@ class PolarisApiClient @JvmOverloads constructor(
         }
 
         @JvmStatic
+        internal fun buildClientSettingsBody(
+            syncMode: String,
+            manualOverride: Boolean,
+            deviceCapabilities: JSONObject?,
+            clientRuntime: JSONObject?,
+            appliedStreamSettings: JSONObject?,
+            clientPresentation: JSONObject?
+        ): JSONObject = JSONObject().apply {
+            put("sync_mode", syncMode)
+            put("manual_override", manualOverride)
+            deviceCapabilities?.let { put("device_capabilities", it) }
+            clientRuntime?.let { put("client_runtime", it) }
+            appliedStreamSettings?.let { put("applied_stream_settings", it) }
+            clientPresentation?.let { put("client_presentation", it) }
+        }
+
+        @JvmStatic
+        fun buildClientSettingsBodyForTest(
+            syncMode: String,
+            manualOverride: Boolean,
+            deviceCapabilities: JSONObject?,
+            clientRuntime: JSONObject?,
+            appliedStreamSettings: JSONObject?,
+            clientPresentation: JSONObject?
+        ): JSONObject = buildClientSettingsBody(
+            syncMode = syncMode,
+            manualOverride = manualOverride,
+            deviceCapabilities = deviceCapabilities,
+            clientRuntime = clientRuntime,
+            appliedStreamSettings = appliedStreamSettings,
+            clientPresentation = clientPresentation
+        )
+
+        @JvmStatic
         fun buildClientSettingsUpdateBody(
             streamDisplayMode: String? = null,
             displayMode: String? = null,
@@ -1107,14 +1141,14 @@ class PolarisApiClient @JvmOverloads constructor(
                              appliedStreamSettings: JSONObject? = null,
                              clientPresentation: JSONObject? = null): PolarisSessionStatus.SyncStatus? {
         return try {
-            val body = org.json.JSONObject().apply {
-                put("sync_mode", syncMode)
-                put("manual_override", manualOverride)
-                deviceCapabilities?.let { put("device_capabilities", it) }
-                clientRuntime?.let { put("client_runtime", it) }
-                appliedStreamSettings?.let { put("applied_stream_settings", it) }
-                clientPresentation?.let { put("client_presentation", it) }
-            }
+            val body = buildClientSettingsBody(
+                syncMode = syncMode,
+                manualOverride = manualOverride,
+                deviceCapabilities = deviceCapabilities,
+                clientRuntime = clientRuntime,
+                appliedStreamSettings = appliedStreamSettings,
+                clientPresentation = clientPresentation
+            )
             val request = Request.Builder()
                 .url("$baseUrl/client-settings")
                 .post(okhttp3.RequestBody.create(

--- a/app/src/main/java/com/papi/nova/computers/ComputerManagerService.kt
+++ b/app/src/main/java/com/papi/nova/computers/ComputerManagerService.kt
@@ -850,10 +850,23 @@ class ComputerManagerService : Service() {
             return pollingTuples[details.uuid]
         }
 
+        private fun reportAppListLoadFailure(message: String, e: Exception? = null) {
+            if (e != null) {
+                LimeLog.warning("$message (${e.javaClass.simpleName}: ${e.message ?: "no details"})")
+                e.printStackTrace()
+            } else {
+                LimeLog.warning(message)
+            }
+
+            computer.appListLoadError = message
+            if (listener != null && thread != null) {
+                listener!!.notifyComputerUpdated(computer)
+            }
+        }
+
         fun start() {
             thread = object : Thread() {
                 override fun run() {
-                    var emptyAppListResponses = 0
                     do {
                         // Can't poll if it's not online or paired
                         if (computer.state != ComputerDetails.State.ONLINE ||
@@ -895,16 +908,7 @@ class ComputerManagerService : Service() {
                             }
 
                             val list: List<NvApp> = NvHTTP.getAppListByReader(StringReader(appList))
-                            if (list.isEmpty()) {
-                                LimeLog.warning("Empty app list received from " + computer.uuid)
-
-                                // The app list might actually be empty, so if we get an empty response a few times
-                                // in a row, we'll go ahead and believe it.
-                                emptyAppListResponses++
-                            }
-                            if (appList.isNotEmpty() &&
-                                (list.isNotEmpty() || emptyAppListResponses >= EMPTY_LIST_THRESHOLD)
-                            ) {
+                            if (appList.isNotEmpty() && list.isNotEmpty()) {
                                 // Open the cache file
                                 try {
                                     val cacheOut: OutputStream = CacheHelper.openCacheFileForOutput(
@@ -919,13 +923,9 @@ class ComputerManagerService : Service() {
                                     e.printStackTrace()
                                 }
 
-                                // Reset empty count if it wasn't empty this time
-                                if (list.isNotEmpty()) {
-                                    emptyAppListResponses = 0
-                                }
-
                                 // Update the computer
                                 computer.rawAppList = appList
+                                computer.appListLoadError = null
                                 receivedAppList = true
 
                                 // Notify that the app list has been updated
@@ -934,12 +934,29 @@ class ComputerManagerService : Service() {
                                     listener!!.notifyComputerUpdated(computer)
                                 }
                             } else if (appList.isEmpty()) {
-                                LimeLog.warning("Null app list received from " + computer.uuid)
+                                reportAppListLoadFailure(
+                                    "The host returned an empty standard app list response.",
+                                )
+                            } else {
+                                reportAppListLoadFailure(
+                                    "The host did not advertise any standard app list entries.",
+                                )
                             }
                         } catch (e: IOException) {
-                            e.printStackTrace()
+                            reportAppListLoadFailure(
+                                "Couldn't load the standard app list from this host.",
+                                e,
+                            )
                         } catch (e: XmlPullParserException) {
-                            e.printStackTrace()
+                            reportAppListLoadFailure(
+                                "The host returned malformed standard app list data.",
+                                e,
+                            )
+                        } catch (e: RuntimeException) {
+                            reportAppListLoadFailure(
+                                "The host returned unsupported standard app list data.",
+                                e,
+                            )
                         }
                     } while (waitPollingDelay())
                 }
@@ -966,7 +983,6 @@ class ComputerManagerService : Service() {
         private const val MDNS_QUERY_PERIOD_MS = 1000
         private const val OFFLINE_POLL_TRIES = 3
         private const val INITIAL_POLL_TRIES = 2
-        private const val EMPTY_LIST_THRESHOLD = 3
         private const val POLL_DATA_TTL_MS = 30000
 
         @JvmStatic

--- a/app/src/main/java/com/papi/nova/manager/ClientRuntimeSnapshot.kt
+++ b/app/src/main/java/com/papi/nova/manager/ClientRuntimeSnapshot.kt
@@ -1,0 +1,136 @@
+package com.papi.nova.manager
+
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * Compact client-side truth Nova can report to Polaris and show in debug UI.
+ */
+enum class ClientProfileSource(val wireValue: String, val displayLabel: String) {
+    LOCAL_DEFAULT("local_default", "Local defaults"),
+    POLARIS_LIVE("polaris_live", "Polaris live"),
+    POLARIS_CACHED("polaris_cached", "Polaris cached"),
+    HISTORY_SAFE("history_safe", "History safe"),
+    MANUAL_OVERRIDE("manual_override", "Manual override"),
+    UNKNOWN("unknown", "Unknown")
+}
+
+data class ClientProfileProvenance(
+    val source: ClientProfileSource,
+    val sourceValue: String = source.wireValue,
+    val version: Int = 0,
+    val hash: String = "",
+    val confidence: String = "",
+    val cacheStatus: String = "",
+    val manualOverride: Boolean = false
+) {
+    val displayLabel: String
+        get() = source.displayLabel
+
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("source", source.wireValue)
+        put("source_value", sourceValue.ifBlank { source.wireValue })
+        put("manual_override", manualOverride)
+        if (version > 0) put("version", version)
+        if (hash.isNotBlank()) put("hash", hash)
+        if (confidence.isNotBlank()) put("confidence", confidence)
+        if (cacheStatus.isNotBlank()) put("cache_status", cacheStatus)
+        put("display_label", displayLabel)
+    }
+
+    companion object {
+        @JvmStatic
+        fun fromOptimization(optimization: JSONObject?, manualOverride: Boolean): ClientProfileProvenance {
+            val rawSource = optimization?.optString("source", "")?.trim().orEmpty()
+            val sourceValue = rawSource.ifBlank {
+                if (manualOverride) ClientProfileSource.MANUAL_OVERRIDE.wireValue else ClientProfileSource.LOCAL_DEFAULT.wireValue
+            }
+            val mappedSource = if (manualOverride) {
+                ClientProfileSource.MANUAL_OVERRIDE
+            } else {
+                sourceFromWireValue(sourceValue)
+            }
+
+            return ClientProfileProvenance(
+                source = mappedSource,
+                sourceValue = sourceValue,
+                version = optimization?.optInt("recommendation_version", 0) ?: 0,
+                hash = firstNonBlank(
+                    optimization?.optString("recommendation_hash", ""),
+                    optimization?.optString("profile_hash", ""),
+                    optimization?.optString("hash", "")
+                ),
+                confidence = optimization?.optString("confidence", "")?.trim().orEmpty(),
+                cacheStatus = optimization?.optString("cache_status", "")?.trim().orEmpty(),
+                manualOverride = manualOverride
+            )
+        }
+
+        @JvmStatic
+        fun sourceFromWireValue(value: String?): ClientProfileSource {
+            val normalized = value?.trim()?.lowercase(Locale.US).orEmpty()
+            return when {
+                normalized.isEmpty() || normalized == "local" || normalized == "local_default" ->
+                    ClientProfileSource.LOCAL_DEFAULT
+                normalized == "polaris_live" || normalized == "ai_live" || normalized == "live" ||
+                    normalized == "ai_optimizer" || normalized == "optimizer" ->
+                    ClientProfileSource.POLARIS_LIVE
+                normalized == "polaris_cached" || normalized == "ai_cached" || normalized == "cached" ->
+                    ClientProfileSource.POLARIS_CACHED
+                normalized.contains("history_safe") || normalized == "recovery" || normalized == "safe" ->
+                    ClientProfileSource.HISTORY_SAFE
+                normalized == "manual_override" || normalized == "manual" ->
+                    ClientProfileSource.MANUAL_OVERRIDE
+                else -> ClientProfileSource.UNKNOWN
+            }
+        }
+
+        private fun firstNonBlank(vararg values: String?): String =
+            values.firstOrNull { !it.isNullOrBlank() }?.trim().orEmpty()
+    }
+}
+
+data class ClientRuntimeSnapshot(
+    val deviceModel: String,
+    val androidSdk: Int,
+    val decoder: String = "",
+    val targetRefreshRateHz: Double = 0.0,
+    val appliedRefreshRateHz: Double = 0.0,
+    val displayMode: String = "",
+    val refreshRatePolicy: String = "",
+    val profile: ClientProfileProvenance = ClientProfileProvenance(ClientProfileSource.LOCAL_DEFAULT)
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("device_model", deviceModel)
+        if (androidSdk > 0) put("android_sdk", androidSdk)
+        if (decoder.isNotBlank()) put("decoder", decoder)
+        if (targetRefreshRateHz > 0.0) put("target_refresh_rate_hz", targetRefreshRateHz)
+        if (appliedRefreshRateHz > 0.0) put("applied_refresh_rate_hz", appliedRefreshRateHz)
+        if (displayMode.isNotBlank()) put("display_mode", displayMode)
+        if (refreshRatePolicy.isNotBlank()) put("refresh_rate_policy", refreshRatePolicy)
+        put("profile", profile.toJson())
+    }
+
+    companion object {
+        @JvmStatic
+        fun fromAppliedStream(
+            deviceModel: String,
+            androidSdk: Int,
+            decoder: String = "",
+            targetRefreshRateHz: Double = 0.0,
+            appliedRefreshRateHz: Double = 0.0,
+            displayMode: String = "",
+            refreshRatePolicy: String = "",
+            profile: ClientProfileProvenance = ClientProfileProvenance(ClientProfileSource.LOCAL_DEFAULT)
+        ): ClientRuntimeSnapshot = ClientRuntimeSnapshot(
+            deviceModel = deviceModel,
+            androidSdk = androidSdk,
+            decoder = decoder,
+            targetRefreshRateHz = targetRefreshRateHz,
+            appliedRefreshRateHz = appliedRefreshRateHz,
+            displayMode = displayMode,
+            refreshRatePolicy = refreshRatePolicy,
+            profile = profile
+        )
+    }
+}

--- a/app/src/main/java/com/papi/nova/manager/StreamSyncManager.kt
+++ b/app/src/main/java/com/papi/nova/manager/StreamSyncManager.kt
@@ -23,6 +23,15 @@ class StreamSyncManager private constructor() {
         private const val BALANCED_FLOOR_HEIGHT = 1080
 
         @JvmStatic
+        fun resolveProfileProvenance(
+            optimization: JSONObject?,
+            manualOverride: Boolean
+        ): ClientProfileProvenance = ClientProfileProvenance.fromOptimization(
+            optimization = optimization,
+            manualOverride = manualOverride
+        )
+
+        @JvmStatic
         fun resolveAutoSafeBitrateKbps(configuredBitrateKbps: Int, optimization: JSONObject?): Int {
             if (optimization == null) {
                 return configuredBitrateKbps
@@ -467,27 +476,60 @@ class StreamSyncManager private constructor() {
         }
 
         @JvmStatic
+        @JvmOverloads
         fun buildClientRuntime(
             context: Context,
             renderer: MediaCodecDecoderRenderer?,
             appliedRefreshRateHz: Float,
             displayModeId: Int,
             displayMode: String?,
-            framePacing: Int
+            framePacing: Int,
+            profile: ClientProfileProvenance? = null,
+            targetRefreshRateHz: Float = 0f,
+            refreshRatePolicy: String = ""
         ): JSONObject {
-            val json = JSONObject()
+            val decoderName = renderer?.activeDecoderName ?: ""
+            val json = ClientRuntimeSnapshot.fromAppliedStream(
+                deviceModel = Build.MODEL ?: "",
+                androidSdk = Build.VERSION.SDK_INT,
+                decoder = decoderName,
+                targetRefreshRateHz = targetRefreshRateHz.toDouble(),
+                appliedRefreshRateHz = appliedRefreshRateHz.toDouble(),
+                displayMode = displayMode ?: "",
+                refreshRatePolicy = refreshRatePolicy,
+                profile = profile ?: ClientProfileProvenance(ClientProfileSource.LOCAL_DEFAULT)
+            ).toJson()
             put(json, "sync_mode", SYNC_MODE_AUTO_SAFE)
             put(json, "metered_network", isMetered(context))
             put(json, "frame_pacing", framePacing)
-            if (appliedRefreshRateHz > 0f) put(json, "applied_refresh_rate_hz", appliedRefreshRateHz)
             if (displayModeId > 0) put(json, "display_mode_id", displayModeId)
-            if (!displayMode.isNullOrEmpty()) put(json, "display_mode", displayMode)
             if (renderer != null) {
                 put(json, "active_decoder", renderer.activeDecoderName)
                 put(json, "active_video_format", renderer.activeVideoFormat)
             }
             return json
         }
+
+        @JvmStatic
+        fun buildClientRuntimeSnapshotForTest(
+            deviceModel: String,
+            androidSdk: Int,
+            decoder: String,
+            targetRefreshRateHz: Double,
+            appliedRefreshRateHz: Double,
+            displayMode: String,
+            refreshRatePolicy: String,
+            profile: ClientProfileProvenance
+        ): JSONObject = ClientRuntimeSnapshot.fromAppliedStream(
+            deviceModel = deviceModel,
+            androidSdk = androidSdk,
+            decoder = decoder,
+            targetRefreshRateHz = targetRefreshRateHz,
+            appliedRefreshRateHz = appliedRefreshRateHz,
+            displayMode = displayMode,
+            refreshRatePolicy = refreshRatePolicy,
+            profile = profile
+        ).toJson()
 
         @JvmStatic
         fun buildAppliedStreamSettings(

--- a/app/src/main/java/com/papi/nova/nvstream/http/ComputerDetails.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/ComputerDetails.kt
@@ -84,6 +84,7 @@ class ComputerDetails {
     @JvmField var currentGameOwnerName: String? = null
     @JvmField var currentGameViewerCount: Int = 0
     @JvmField var rawAppList: String? = null
+    @JvmField var appListLoadError: String? = null
     @JvmField var nvidiaServer: Boolean = false
     @JvmField var serverMaxLaunchRefreshRate: Int = 0
     @JvmField var libraryState: LibraryState = LibraryState.UNKNOWN
@@ -160,6 +161,7 @@ class ComputerDetails {
         currentGameViewerCount = details.currentGameViewerCount
         nvidiaServer = details.nvidiaServer
         rawAppList = details.rawAppList
+        appListLoadError = details.appListLoadError
         serverMaxLaunchRefreshRate = details.serverMaxLaunchRefreshRate
         if (details.libraryState != LibraryState.UNKNOWN ||
             state != State.ONLINE ||

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvApp.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvApp.kt
@@ -56,7 +56,6 @@ class NvApp {
     fun setAppIndex(appIndex: String?) {
         try {
             this.appIndex = Integer.parseInt(appIndex ?: "null")
-            initialized = true
         } catch (e: NumberFormatException) {
             LimeLog.warning("Malformed app index: $appIndex")
         }

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -1019,13 +1019,15 @@ class NvHTTP @Throws(IOException::class) constructor(
                         }
                     }
                     XmlPullParser.TEXT -> {
-                        val app = appList.last()
-                        when (currentTag.peek()) {
-                            "AppTitle" -> app.appName = xpp.text
-                            "UUID" -> app.appUUID = xpp.text
-                            "IDX" -> app.appIndex = xpp.text.toInt()
-                            "ID" -> app.setAppId(xpp.text)
-                            "IsHdrSupported" -> app.isHdrSupported = xpp.text == "1"
+                        if (currentTag.isNotEmpty() && currentTag.contains("App") && appList.isNotEmpty()) {
+                            val app = appList.last()
+                            when (currentTag.peek()) {
+                                "AppTitle" -> app.appName = xpp.text
+                                "UUID" -> app.appUUID = xpp.text
+                                "IDX" -> app.setAppIndex(xpp.text)
+                                "ID" -> app.setAppId(xpp.text)
+                                "IsHdrSupported" -> app.isHdrSupported = xpp.text == "1"
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -64,14 +64,14 @@ internal fun buildNovaLaunchProfileSummary(
         effectiveFps + 0.5 >= requestedFps
     val selectedLabel = when {
         trialProfile -> "High FPS trial"
-        highFpsRequestSatisfied -> "High FPS profile"
+        highFpsRequestSatisfied -> "High FPS stream"
         else -> launchProfileDisplayLabel(rawSelectedLabel)
     }
 
     val primaryLabel = when {
-        trialProfile && effectiveFps > 0.0 -> "Try High FPS profile ${formatFps(effectiveFps)} FPS"
-        selectedLabel.equals("High FPS profile", ignoreCase = true) && effectiveFps > 0.0 ->
-            "Launch High FPS profile ${formatFps(effectiveFps)} FPS"
+        trialProfile && effectiveFps > 0.0 -> "Try High FPS stream ${formatFps(effectiveFps)} FPS"
+        selectedLabel.equals("High FPS stream", ignoreCase = true) && effectiveFps > 0.0 ->
+            "Launch High FPS stream ${formatFps(effectiveFps)} FPS"
         selectedLabel.equals("Recovery profile", ignoreCase = true) && effectiveFps > 0.0 ->
             "Launch Recovery profile ${formatFps(effectiveFps)} FPS"
         effectiveFps > 0.0 -> "Launch ${formatFps(effectiveFps)} FPS"
@@ -187,7 +187,7 @@ private fun meaningfulIssue(value: String): String {
 private fun preferenceLabel(preference: String): String {
     return when (preference) {
         "quality" -> "Quality profile"
-        "high_fps" -> "High FPS profile"
+        "high_fps" -> "High FPS stream"
         "stability" -> "Stability profile"
         else -> "Auto"
     }
@@ -195,8 +195,9 @@ private fun preferenceLabel(preference: String): String {
 
 private fun launchProfileDisplayLabel(label: String): String {
     return when {
-        label.equals("High FPS", ignoreCase = true) -> "High FPS profile"
-        label.equals("Prefer High FPS", ignoreCase = true) -> "High FPS profile"
+        label.equals("High FPS", ignoreCase = true) -> "High FPS stream"
+        label.equals("Prefer High FPS", ignoreCase = true) -> "High FPS stream"
+        label.equals("High FPS profile", ignoreCase = true) -> "High FPS stream"
         label.equals("High FPS Trial", ignoreCase = true) -> "High FPS trial"
         label.equals("Recovery", ignoreCase = true) -> "Recovery profile"
         label.equals("Prefer Quality", ignoreCase = true) -> "Quality profile"

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -935,6 +935,12 @@ class NovaLibraryActivity : AppCompatActivity() {
                                         NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
                                     }
                                 },
+                                onSecondaryAction = {
+                                    when (model.hero.secondaryAction) {
+                                        NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
+                                        null -> Unit
+                                    }
+                                },
                                 onGameFocused = onGameFocused
                             )
                             NovaLibraryContent(
@@ -993,6 +999,12 @@ class NovaLibraryActivity : AppCompatActivity() {
                                         NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
                                         NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
                                         NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
+                                    }
+                                },
+                                onSecondaryAction = {
+                                    when (model.hero.secondaryAction) {
+                                        NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
+                                        null -> Unit
                                     }
                                 },
                                 onGameFocused = onGameFocused
@@ -1185,6 +1197,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         hero: NovaLibraryHeroState,
         compact: Boolean,
         onPrimaryAction: () -> Unit,
+        onSecondaryAction: (() -> Unit)? = null,
         onGameFocused: (PolarisGame) -> Unit
     ) {
         val colors = LocalNovaComposeColors.current
@@ -1301,13 +1314,28 @@ class NovaLibraryActivity : AppCompatActivity() {
                 subtitle = hero.artworkFallbackSubtitle,
                 compact = compact
             )
-            NovaActionButton(
-                text = hero.actionLabel,
-                onClick = onPrimaryAction,
+            Column(
                 modifier = Modifier.widthIn(min = if (compact) 104.dp else 148.dp),
-                minHeight = if (compact) 34.dp else 48.dp,
-                fontSize = if (compact) 10.sp else 14.sp
-            )
+                verticalArrangement = Arrangement.spacedBy(if (compact) 3.dp else 6.dp)
+            ) {
+                NovaActionButton(
+                    text = hero.actionLabel,
+                    onClick = onPrimaryAction,
+                    modifier = Modifier.fillMaxWidth(),
+                    minHeight = if (compact) 28.dp else 48.dp,
+                    fontSize = if (compact) 9.sp else 14.sp
+                )
+                if (hero.secondaryActionLabel != null && onSecondaryAction != null) {
+                    NovaActionButton(
+                        text = hero.secondaryActionLabel,
+                        onClick = onSecondaryAction,
+                        modifier = Modifier.fillMaxWidth(),
+                        primary = false,
+                        minHeight = if (compact) 26.dp else 40.dp,
+                        fontSize = if (compact) 9.sp else 13.sp
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -76,6 +76,10 @@ enum class NovaLibraryHeroPrimaryAction {
     CLEAR_FILTERS
 }
 
+enum class NovaLibraryHeroSecondaryAction {
+    END_SESSION
+}
+
 enum class NovaLibraryRecoveryAction {
     RETRY,
     MANAGE_LIBRARY,
@@ -106,7 +110,8 @@ data class NovaLibraryHeroState(
     val supportingLine: String,
     val artworkFallbackTitle: String,
     val artworkFallbackSubtitle: String,
-    val secondaryActionLabel: String? = null
+    val secondaryActionLabel: String? = null,
+    val secondaryAction: NovaLibraryHeroSecondaryAction? = null
 )
 
 data class NovaLibraryUiModel(
@@ -383,7 +388,7 @@ object NovaLibraryUiStateMapper {
             title = session.gameName.ifBlank { "Active session" },
             subtitle = ownerDetail,
             caption = if (session.ownedByClient) {
-                "Resume the current stream and quality settings."
+                "Resume this stream, or end it if the host game is stale."
             } else {
                 "Watch-only view; owner stays in control."
             },
@@ -400,7 +405,13 @@ object NovaLibraryUiStateMapper {
             artworkFallbackTitle = session.gameName.ifBlank { "Active session" },
             artworkFallbackSubtitle = listOf("Active session", ownerDetail)
                 .filter { it.isNotBlank() }
-                .joinToString(" • ")
+                .joinToString(" • "),
+            secondaryActionLabel = if (session.ownedByClient) "End session" else null,
+            secondaryAction = if (session.ownedByClient) {
+                NovaLibraryHeroSecondaryAction.END_SESSION
+            } else {
+                null
+            }
         )
     }
 

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -193,16 +193,73 @@
         </LinearLayout>
 
         <!-- App grid -->
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/appSwipeRefresh"
+        <FrameLayout
+            android:id="@+id/appListContent"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1">
-            <FrameLayout
-                android:id="@+id/appFragmentContainer"
+
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/appSwipeRefresh"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+                android:layout_height="match_parent">
+                <FrameLayout
+                    android:id="@+id/appFragmentContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+            <LinearLayout
+                android:id="@+id/appListErrorCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="24dp"
+                android:background="@drawable/nova_card_bg_focusable"
+                android:orientation="vertical"
+                android:paddingStart="22dp"
+                android:paddingTop="22dp"
+                android:paddingEnd="22dp"
+                android:paddingBottom="22dp"
+                android:focusable="true"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/appListErrorTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/applist_error_title"
+                    android:textColor="@color/nova_ice"
+                    android:textSize="20sp"
+                    android:fontFamily="sans-serif-medium" />
+
+                <TextView
+                    android:id="@+id/appListErrorMessage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/applist_error_message"
+                    android:textColor="@color/nova_text_secondary"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/appListErrorDetail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:textColor="@color/nova_text_muted"
+                    android:textSize="12sp"
+                    android:visibility="gone" />
+
+                <Button
+                    android:id="@+id/appListRetryButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    android:text="@string/applist_error_retry" />
+            </LinearLayout>
+        </FrameLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,12 @@
     <string name="server_library_label">Server Library</string>
     <string name="server_library_search_hint">Search games…</string>
     <string name="badge_streaming">Streaming</string>
+    <string name="applist_error_title">Standard app list unavailable</string>
+    <string name="applist_error_message">Nova couldn’t load the Moonlight-compatible app list from this Apollo/Sunshine host. The app is still open; retry when the host is ready.</string>
+    <string name="applist_error_detail_format">Host detail: %1$s</string>
+    <string name="applist_error_retry">Retry</string>
+    <string name="applist_error_invalid_host">Nova cannot identify this host. Go back and select it again.</string>
+    <string name="applist_error_host_missing">This host disappeared from Nova’s service state. Go back and select it again, or retry after discovery refreshes.</string>
 
     <!-- Alignments -->
     <string name="align_left">Align Left</string>
@@ -85,7 +91,7 @@
     <string name="pcview_empty_hint_no_streaming">Start a session from a server to see it here.</string>
     <string name="pcview_empty_title_no_pairing">Nothing needs pairing</string>
     <string name="pcview_empty_hint_no_pairing">All discovered servers are already paired or offline.</string>
-    <string name="pcview_card_action_open_apps">Open Apps</string>
+    <string name="pcview_card_action_open_apps">Open App List</string>
     <string name="pcview_card_action_open_library">Open Library</string>
     <string name="pcview_card_action_checking_library">Checking</string>
     <string name="pcview_card_action_resume">Resume</string>
@@ -106,7 +112,7 @@
     <string name="pcview_card_hint_streaming">Resume or watch the active stream.</string>
     <string name="pcview_card_hint_open_library">Open the Polaris game library.</string>
     <string name="pcview_card_hint_checking_library">Waiting for Polaris library readiness.</string>
-    <string name="pcview_card_hint_open_apps">Use the legacy app list for this host.</string>
+    <string name="pcview_card_hint_open_apps">Open the standard Moonlight-compatible app list for Apollo, Sunshine, and other compatible hosts.</string>
     <string name="pcview_card_hint_wake">Wake this host or check the network.</string>
     <string name="pcview_card_hint_offline_no_wake">This host is offline and has no wake target saved.</string>
     <string name="pcview_card_hint_refreshing">Refreshing host status.</string>

--- a/app/src/test/java/com/papi/nova/GameClientRuntimeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/GameClientRuntimeSourceGuardTest.kt
@@ -1,0 +1,41 @@
+package com.papi.nova
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GameClientRuntimeSourceGuardTest {
+
+    @Test
+    fun gameResolvesLaunchProfileProvenanceBeforeReportingRuntime() {
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val launchSetup = game.section(
+            "var launchOptimization:JSONObject? = if (watchOnlyRequested) null else loadLaunchOptimization(appName)",
+            " // Initialize the MediaCodec helper before creating the decoder"
+        )
+        val reportSnapshot = game.section(
+            "private fun reportPolarisClientSettingsSnapshot(clientPresentation:JSONObject?):Boolean",
+            "private fun updateAppliedStreamSettingsFromStatus("
+        )
+
+        assertTrue(
+            "Game should derive profile provenance from the actual launch optimization before stream sync reporting",
+            game.contains("lastClientProfileProvenance") &&
+                launchSetup.contains("StreamSyncManager.resolveProfileProvenance(launchOptimization")
+        )
+        assertTrue(
+            "client runtime reports should carry the same provenance into the client_runtime payload",
+            reportSnapshot.contains("lastClientProfileProvenance") &&
+                reportSnapshot.contains("buildClientRuntime(") &&
+                reportSnapshot.indexOf("lastClientProfileProvenance") < reportSnapshot.indexOf("reportClientSettings(")
+        )
+    }
+
+    private fun readSource(path: String): String =
+        String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
+
+    private fun String.section(startMarker: String, endMarker: String): String =
+        substring(indexOf(startMarker), indexOf(endMarker))
+}

--- a/app/src/test/java/com/papi/nova/KotlinActivityShellMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinActivityShellMigrationTest.kt
@@ -76,6 +76,26 @@ class KotlinActivityShellMigrationTest {
     }
 
     @Test
+    fun appViewKeepsFallbackAppListErrorsInActivityWithRetry() {
+        val appViewSource = readSource("src/main/java/com/papi/nova/AppView.kt")
+        val appViewLayout = readSource("src/main/res/layout/activity_app_view.xml")
+        val strings = readSource("src/main/res/values/strings.xml")
+
+        assertTrue(appViewSource.contains("private fun showAppListError"))
+        assertTrue(appViewSource.contains("private fun retryAppListLoad"))
+        assertTrue(appViewSource.contains("R.id.appListErrorCard"))
+        assertTrue(appViewSource.contains("R.id.appListRetryButton"))
+        assertTrue(appViewSource.contains("poller?.pollNow()"))
+        assertTrue(appViewSource.contains("catch (e: RuntimeException)"))
+        assertTrue(appViewLayout.contains("@+id/appListErrorCard"))
+        assertTrue(appViewLayout.contains("@+id/appListErrorDetail"))
+        assertTrue(appViewLayout.contains("@+id/appListRetryButton"))
+        assertTrue(strings.contains("name=\"applist_error_title\""))
+        assertTrue(strings.contains("name=\"applist_error_message\""))
+        assertTrue(strings.contains("name=\"applist_error_retry\""))
+    }
+
+    @Test
     fun pcViewPolarisBackgroundWorkUsesRuntimeTasks() {
         val pcViewSource = readSource("src/main/java/com/papi/nova/PcView.kt")
 

--- a/app/src/test/java/com/papi/nova/PcViewFallbackRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/PcViewFallbackRoutingSourceGuardTest.kt
@@ -1,0 +1,145 @@
+package com.papi.nova
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PcViewFallbackRoutingSourceGuardTest {
+
+    @Test
+    fun hostTapRoutesByLibraryReadinessWithStandardAppListFallback() {
+        val pcView = readSource("src/main/java/com/papi/nova/PcView.kt")
+        val openBestPlaySurface = pcView.section(
+            "private fun openBestPlaySurface(",
+            "private fun syncComputerList()"
+        )
+
+        val resumeIndex = openBestPlaySurface.indexOf("resumeOrWatchRunningGame(computer)")
+        val libraryAvailableIndex = openBestPlaySurface.indexOf(
+            "computer.libraryState == ComputerDetails.LibraryState.AVAILABLE"
+        )
+        val libraryUnknownIndex = openBestPlaySurface.indexOf(
+            "computer.libraryState == ComputerDetails.LibraryState.UNKNOWN"
+        )
+        val appListFallbackIndex = openBestPlaySurface.indexOf("doAppList(computer, false, false)")
+
+        assertTrue(
+            "running sessions should still route to resume/watch before choosing a library or app-list surface",
+            resumeIndex >= 0 && resumeIndex < libraryAvailableIndex
+        )
+        assertTrue(
+            "Polaris-capable hosts should open Nova Library only after the capability probe marks the library available",
+            libraryAvailableIndex >= 0 &&
+                openBestPlaySurface.contains("doNovaLibrary(computer)")
+        )
+        assertTrue(
+            "unknown library capability should trigger the Polaris probe and stay on the dashboard instead of falling through to the app list",
+            libraryUnknownIndex > libraryAvailableIndex &&
+                openBestPlaySurface.contains("maybeProbeLibraryReadiness(computerObject)") &&
+                openBestPlaySurface.contains("R.string.pcview_library_checking")
+        )
+        assertTrue(
+            "Apollo/Sunshine/non-Polaris hosts must fall back to the standard app-list flow after the available/unknown library branches",
+            appListFallbackIndex > libraryUnknownIndex
+        )
+    }
+
+    @Test
+    fun libraryCapabilityHelpersDoNotTreatFallbackHostsAsPolarisLibraryReady() {
+        val pcView = readSource("src/main/java/com/papi/nova/PcView.kt")
+        val canUseLibrary = pcView.section(
+            "private fun canUseLibrary(",
+            "private fun canProbeLibrary("
+        )
+        val canProbeLibrary = pcView.section(
+            "private fun canProbeLibrary(",
+            "private fun resetLibraryReadiness("
+        )
+        val probeLibraryReadiness = pcView.section(
+            "private fun maybeProbeLibraryReadiness(",
+            "private fun findComputerObject("
+        )
+
+        assertTrue(
+            "Nova Library should require an online, paired host with an active address and AVAILABLE library state",
+            canUseLibrary.contains("details.state == ComputerDetails.State.ONLINE") &&
+                canUseLibrary.contains("!needsPairing(details)") &&
+                canUseLibrary.contains("details.activeAddress != null") &&
+                canUseLibrary.contains("details.libraryState == ComputerDetails.LibraryState.AVAILABLE")
+        )
+        assertTrue(
+            "only UNKNOWN hosts should be probed; UNAVAILABLE fallback hosts should not keep re-probing or block app-list routing",
+            canProbeLibrary.contains("details.state == ComputerDetails.State.ONLINE") &&
+                canProbeLibrary.contains("!needsPairing(details)") &&
+                canProbeLibrary.contains("details.activeAddress != null") &&
+                canProbeLibrary.contains("details.libraryState == ComputerDetails.LibraryState.UNKNOWN") &&
+                !canProbeLibrary.contains("ComputerDetails.LibraryState.UNAVAILABLE")
+        )
+        assertTrue(
+            "a failed/missing Polaris Library capability probe should settle the host as UNAVAILABLE so Apollo/Sunshine can use the app-list fallback",
+            probeLibraryReadiness.contains("var state = ComputerDetails.LibraryState.UNAVAILABLE") &&
+                probeLibraryReadiness.contains("ComputerDetails.LibraryState.AVAILABLE") &&
+                probeLibraryReadiness.contains("state = ComputerDetails.LibraryState.UNAVAILABLE")
+        )
+    }
+
+    @Test
+    fun dashboardCopyAndCardStatesDistinguishPolarisLibraryFromStandardAppList() {
+        val strings = readSource("src/main/res/values/strings.xml")
+        val pcGridAdapter = readSource("src/main/java/com/papi/nova/grid/PcGridAdapter.kt")
+        val onlineCardState = pcGridAdapter.section(
+            "if (obj.details.pairState == PairingManager.PairState.PAIRED",
+            "        } else if (obj.details.state == ComputerDetails.State.OFFLINE)"
+        )
+
+        assertTrue(
+            "fallback host copy should name the standard Moonlight-compatible app list for Apollo/Sunshine users",
+            strings.contains("<string name=\"pcview_card_hint_open_apps\">Open the standard Moonlight-compatible app list for Apollo, Sunshine, and other compatible hosts.</string>") &&
+                strings.contains("<string name=\"applist_error_title\">Standard app list unavailable</string>") &&
+                strings.contains("Moonlight-compatible app list from this Apollo/Sunshine host")
+        )
+        assertFalse(
+            "fallback host copy should not call the standard app-list path legacy",
+            strings.contains("legacy app list")
+        )
+
+        val availableIndex = onlineCardState.indexOf(
+            "obj.details.libraryState == ComputerDetails.LibraryState.AVAILABLE"
+        )
+        val unknownIndex = onlineCardState.indexOf(
+            "obj.details.libraryState == ComputerDetails.LibraryState.UNKNOWN"
+        )
+        val openAppsIndex = onlineCardState.indexOf("R.string.pcview_card_action_open_apps")
+        assertTrue(
+            "host cards should advertise Open Library only for AVAILABLE Polaris Library hosts",
+            availableIndex >= 0 &&
+                onlineCardState.contains("R.string.pcview_card_action_open_library") &&
+                onlineCardState.contains("R.string.pcview_card_hint_open_library")
+        )
+        assertTrue(
+            "host cards should show a checking state while Polaris Library capability is UNKNOWN",
+            unknownIndex > availableIndex &&
+                onlineCardState.contains("R.string.pcview_card_action_checking_library") &&
+                onlineCardState.contains("R.string.pcview_card_hint_checking_library")
+        )
+        assertTrue(
+            "UNAVAILABLE/non-Polaris host cards should fall through to the standard app-list action and hint",
+            openAppsIndex > unknownIndex &&
+                onlineCardState.contains("R.string.pcview_card_hint_open_apps")
+        )
+    }
+
+    private fun readSource(path: String): String =
+        String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
+
+    private fun String.section(startMarker: String, endMarker: String): String {
+        val startIndex = indexOf(startMarker)
+        val endIndex = indexOf(endMarker, startIndex + startMarker.length)
+        assertTrue("Missing source marker: $startMarker", startIndex >= 0)
+        assertTrue("Missing source marker after $startMarker: $endMarker", endIndex > startIndex)
+        return substring(startIndex, endIndex)
+    }
+}

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientPayloadTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientPayloadTest.kt
@@ -1,0 +1,55 @@
+package com.papi.nova.api
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class PolarisApiClientPayloadTest {
+
+    @Test
+    fun buildClientSettingsBody_includesClientRuntimeProfile() {
+        val runtime = JSONObject()
+            .put("device_model", "Retroid Pocket")
+            .put("profile", JSONObject().put("source", "polaris_cached"))
+
+        val body = PolarisApiClient.buildClientSettingsBodyForTest(
+            syncMode = "auto_safe",
+            manualOverride = false,
+            deviceCapabilities = null,
+            clientRuntime = runtime,
+            appliedStreamSettings = null,
+            clientPresentation = null
+        )
+
+        assertEquals("auto_safe", body.getString("sync_mode"))
+        assertEquals("Retroid Pocket", body.getJSONObject("client_runtime").getString("device_model"))
+        assertEquals("polaris_cached", body.getJSONObject("client_runtime").getJSONObject("profile").getString("source"))
+    }
+
+    @Test
+    fun buildClientSettingsBody_preservesAllOptionalContracts() {
+        val capabilities = JSONObject().put("model", "Retroid Pocket")
+        val runtime = JSONObject().put("device_model", "Retroid Pocket")
+        val applied = JSONObject().put("target_bitrate_kbps", 24000)
+        val presentation = JSONObject().put("status", "synced")
+
+        val body = PolarisApiClient.buildClientSettingsBodyForTest(
+            syncMode = "auto_safe",
+            manualOverride = true,
+            deviceCapabilities = capabilities,
+            clientRuntime = runtime,
+            appliedStreamSettings = applied,
+            clientPresentation = presentation
+        )
+
+        assertEquals(true, body.getBoolean("manual_override"))
+        assertEquals("Retroid Pocket", body.getJSONObject("device_capabilities").getString("model"))
+        assertEquals(24000, body.getJSONObject("applied_stream_settings").getInt("target_bitrate_kbps"))
+        assertEquals("synced", body.getJSONObject("client_presentation").getString("status"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/computers/KotlinComputerServiceMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/computers/KotlinComputerServiceMigrationTest.kt
@@ -95,6 +95,20 @@ class KotlinComputerServiceMigrationTest {
     }
 
     @Test
+    fun appListPollerReportsHostDataFailuresInsteadOfEscapingRuntimeExceptions() {
+        val serviceSource = File("src/main/java/com/papi/nova/computers/ComputerManagerService.kt").readText()
+        val detailsSource = File("src/main/java/com/papi/nova/nvstream/http/ComputerDetails.kt").readText()
+
+        assertTrue(serviceSource.contains("private fun reportAppListLoadFailure"))
+        assertTrue(serviceSource.contains("computer.appListLoadError"))
+        assertTrue(serviceSource.contains("catch (e: RuntimeException)"))
+        assertTrue(serviceSource.contains("The host did not advertise any standard app list entries."))
+        assertFalse(serviceSource.contains("EMPTY_LIST_THRESHOLD"))
+        assertFalse(serviceSource.contains("emptyAppListResponses"))
+        assertTrue(detailsSource.contains("var appListLoadError: String? = null"))
+    }
+
+    @Test
     fun blankUuidManualPollAcceptsReturnedComputerUuid() {
         val service = ComputerManagerService()
         val matcher = ComputerManagerService::class.java.getDeclaredMethod(

--- a/app/src/test/java/com/papi/nova/manager/ClientRuntimeSnapshotTest.kt
+++ b/app/src/test/java/com/papi/nova/manager/ClientRuntimeSnapshotTest.kt
@@ -1,0 +1,110 @@
+package com.papi.nova.manager
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class ClientRuntimeSnapshotTest {
+
+    @Test
+    fun profileProvenanceDefaultsToLocalWhenOptimizationIsMissing() {
+        val provenance = ClientProfileProvenance.fromOptimization(null, manualOverride = false)
+
+        assertEquals(ClientProfileSource.LOCAL_DEFAULT, provenance.source)
+        assertEquals("local_default", provenance.sourceValue)
+        assertFalse(provenance.manualOverride)
+        assertEquals("Local defaults", provenance.displayLabel)
+    }
+
+    @Test
+    fun profileProvenanceUsesPolarisCachedSourceAndVersion() {
+        val optimization = JSONObject(
+            "{\"source\":\"ai_cached\",\"recommendation_version\":4," +
+                "\"confidence\":\"high\",\"cache_status\":\"hit\"}"
+        )
+
+        val provenance = ClientProfileProvenance.fromOptimization(optimization, manualOverride = false)
+
+        assertEquals(ClientProfileSource.POLARIS_CACHED, provenance.source)
+        assertEquals(4, provenance.version)
+        assertEquals("high", provenance.confidence)
+        assertEquals("hit", provenance.cacheStatus)
+    }
+
+    @Test
+    fun profileProvenanceManualOverridePreservesRecommendationVersion() {
+        val optimization = JSONObject("{\"source\":\"ai_cached\",\"recommendation_version\":2}")
+
+        val provenance = ClientProfileProvenance.fromOptimization(optimization, manualOverride = true)
+
+        assertEquals(ClientProfileSource.MANUAL_OVERRIDE, provenance.source)
+        assertEquals("ai_cached", provenance.sourceValue)
+        assertEquals(2, provenance.version)
+    }
+
+    @Test
+    fun runtimeSnapshotSerializesStableJsonKeys() {
+        val snapshot = ClientRuntimeSnapshot(
+            deviceModel = "Retroid Pocket",
+            androidSdk = 35,
+            decoder = "c2.qti.hevc.decoder.low_latency",
+            targetRefreshRateHz = 120.0,
+            appliedRefreshRateHz = 120.0,
+            displayMode = "refresh_rate:120.0",
+            refreshRatePolicy = "exact_match_internal",
+            profile = ClientProfileProvenance(
+                source = ClientProfileSource.POLARIS_LIVE,
+                version = 7,
+                hash = "abc123",
+                confidence = "high",
+                cacheStatus = "miss",
+                manualOverride = false
+            )
+        )
+
+        val json = snapshot.toJson()
+
+        assertEquals("Retroid Pocket", json.getString("device_model"))
+        assertEquals(35, json.getInt("android_sdk"))
+        assertEquals("c2.qti.hevc.decoder.low_latency", json.getString("decoder"))
+        assertEquals(120.0, json.getDouble("target_refresh_rate_hz"), 0.01)
+        assertEquals(120.0, json.getDouble("applied_refresh_rate_hz"), 0.01)
+        assertEquals("refresh_rate:120.0", json.getString("display_mode"))
+        assertEquals("exact_match_internal", json.getString("refresh_rate_policy"))
+        assertEquals("polaris_live", json.getJSONObject("profile").getString("source"))
+        assertEquals(7, json.getJSONObject("profile").getInt("version"))
+        assertEquals("abc123", json.getJSONObject("profile").getString("hash"))
+    }
+
+    @Test
+    fun fromAppliedStreamBuildsRuntimeSnapshot() {
+        val provenance = ClientProfileProvenance(
+            source = ClientProfileSource.HISTORY_SAFE,
+            confidence = "medium",
+            manualOverride = false
+        )
+
+        val snapshot = ClientRuntimeSnapshot.fromAppliedStream(
+            deviceModel = "Retroid Pocket",
+            androidSdk = 35,
+            decoder = "c2.qti.hevc.decoder.low_latency",
+            targetRefreshRateHz = 60.0,
+            appliedRefreshRateHz = 120.0,
+            displayMode = "1920x1080x120",
+            refreshRatePolicy = "whole_multiple",
+            profile = provenance
+        )
+
+        val json = snapshot.toJson()
+
+        assertEquals("Retroid Pocket", json.getString("device_model"))
+        assertEquals("whole_multiple", json.getString("refresh_rate_policy"))
+        assertEquals("history_safe", json.getJSONObject("profile").getString("source"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/manager/StreamSyncManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/manager/StreamSyncManagerTest.kt
@@ -14,6 +14,56 @@ import org.robolectric.annotation.Config
 class StreamSyncManagerTest {
 
     @Test
+    fun resolveProfileProvenance_marksManualOverride() {
+        val optimization = JSONObject("{\"source\":\"ai_cached\",\"recommendation_version\":2}")
+
+        val provenance = StreamSyncManager.resolveProfileProvenance(optimization, manualOverride = true)
+
+        assertEquals(ClientProfileSource.MANUAL_OVERRIDE, provenance.source)
+        assertTrue(provenance.manualOverride)
+        assertEquals(2, provenance.version)
+    }
+
+    @Test
+    fun resolveProfileProvenance_preservesHistorySafeRecoverySource() {
+        val optimization = JSONObject(
+            "{\"source\":\"history_safe\",\"confidence\":\"medium\"," +
+                "\"stability\":{\"mode\":\"stability_first\",\"auto_action\":\"apply_recovery\"}}"
+        )
+
+        val provenance = StreamSyncManager.resolveProfileProvenance(optimization, manualOverride = false)
+
+        assertEquals(ClientProfileSource.HISTORY_SAFE, provenance.source)
+        assertEquals("medium", provenance.confidence)
+    }
+
+    @Test
+    fun buildClientRuntime_includesProfileProvenance() {
+        val profile = ClientProfileProvenance(
+            source = ClientProfileSource.POLARIS_CACHED,
+            version = 4,
+            confidence = "high",
+            cacheStatus = "hit",
+            manualOverride = false
+        )
+
+        val runtime = StreamSyncManager.buildClientRuntimeSnapshotForTest(
+            deviceModel = "Retroid Pocket",
+            androidSdk = 35,
+            decoder = "c2.qti.hevc.decoder.low_latency",
+            targetRefreshRateHz = 60.0,
+            appliedRefreshRateHz = 120.0,
+            displayMode = "1920x1080x120",
+            refreshRatePolicy = "whole_multiple",
+            profile = profile
+        )
+
+        assertEquals("Retroid Pocket", runtime.getString("device_model"))
+        assertEquals("polaris_cached", runtime.getJSONObject("profile").getString("source"))
+        assertEquals(4, runtime.getJSONObject("profile").getInt("version"))
+    }
+
+    @Test
     fun resolveAutoSafeResolution_keepsBalancedFloorForCached720Profile() {
         val optimization = JSONObject("{\"display_mode\":\"1280x720x60\",\"source\":\"ai_cached\"}")
 

--- a/app/src/test/java/com/papi/nova/nvstream/http/NvHttpServerInfoParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/nvstream/http/NvHttpServerInfoParsingTest.kt
@@ -1,5 +1,6 @@
 package com.papi.nova.nvstream.http
 
+import java.io.StringReader
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -12,6 +13,64 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class NvHttpServerInfoParsingTest {
+
+    @Test
+    fun parsesPrettyPrintedApolloAppListWithWhitespace() {
+        val appList = """
+            <root status_code="200">
+              <App>
+                <AppTitle>Steam Big Picture</AppTitle>
+                <UUID>steam-uuid</UUID>
+                <ID>123</ID>
+                <IDX>1</IDX>
+                <IsHdrSupported>1</IsHdrSupported>
+              </App>
+            </root>
+        """.trimIndent()
+
+        val apps = NvHTTP.getAppListByReader(StringReader(appList))
+
+        assertEquals(1, apps.size)
+        val app = apps.first()
+        assertEquals("Steam Big Picture", app.appName)
+        assertEquals("steam-uuid", app.appUUID)
+        assertEquals(123, app.appId)
+        assertEquals(1, app.appIndex)
+        assertTrue(app.isHdrSupported)
+    }
+
+    @Test
+    fun prettyPrintedEmptyApolloAppListReturnsEmptyList() {
+        val appList = """
+            <root status_code="200">
+            </root>
+        """.trimIndent()
+
+        assertTrue(NvHTTP.getAppListByReader(StringReader(appList)).isEmpty())
+    }
+
+    @Test
+    fun malformedApolloAppListIndexDoesNotAbortParse() {
+        val appList = """
+            <root status_code="200"><App><AppTitle>Bad IDX</AppTitle><ID>44</ID><IDX>not-a-number</IDX></App></root>
+        """.trimIndent()
+
+        val apps = NvHTTP.getAppListByReader(StringReader(appList))
+
+        assertEquals(1, apps.size)
+        assertEquals("Bad IDX", apps.first().appName)
+        assertEquals(44, apps.first().appId)
+        assertEquals(0, apps.first().appIndex)
+    }
+
+    @Test
+    fun appListEntryWithOnlyIndexIsDroppedAsIncomplete() {
+        val appList = """
+            <root status_code="200"><App><AppTitle>Missing ID</AppTitle><IDX>7</IDX></App></root>
+        """.trimIndent()
+
+        assertTrue(NvHTTP.getAppListByReader(StringReader(appList)).isEmpty())
+    }
 
     @Test
     fun parsesAdvertisedServerMaxLaunchRefreshRate() {

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -462,7 +462,7 @@ class NovaComposeSourceGuardTest {
         assertEquals(
             "home hero should not grow a duplicate primary launch/resume button beside the mapped CTA",
             1,
-            hero.split("NovaActionButton(").size - 1
+            hero.split("text = hero.actionLabel").size - 1
         )
         assertTrue(
             "hero should render the mapped caption so filtered, recent, active, and empty states explain the CTA",
@@ -1801,6 +1801,29 @@ class NovaComposeSourceGuardTest {
                 source.contains("ServerHelper.doQuit(") &&
                 source.contains("activeSession = null") &&
                 source.contains("scheduleActiveSessionFollowUpRefreshes(clearOnly = true)")
+        )
+    }
+
+    @Test
+    fun libraryHeroExposesEndSessionForOwnedActiveStreams() {
+        val source = readNovaLibraryActivity()
+        val mapper = readSource("src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt")
+        val hero = source.section(
+            "private fun NovaLibraryHomeHero(",
+            "private fun NovaLibraryHeroFallbackArtwork("
+        )
+
+        assertTrue(
+            "owned active-session hero should expose a direct End session recovery action for stale host/game sessions",
+            mapper.contains("secondaryActionLabel = if (session.ownedByClient) \"End session\" else null") &&
+                mapper.contains("Resume this stream, or end it if the host game is stale.")
+        )
+        assertTrue(
+            "Library screen should wire the hero secondary action to the confirmed end-session path",
+            source.contains("onSecondaryAction = {") &&
+                source.contains("activeSession?.let(onEndSession)") &&
+                hero.contains("hero.secondaryActionLabel") &&
+                hero.contains("onSecondaryAction")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
@@ -47,7 +47,7 @@ class NovaLaunchProfileSummaryTest {
 
         requireNotNull(summary)
         assertEquals("Launch Recovery profile 40 FPS", summary.primaryLaunchLabel)
-        assertEquals("Requested: High FPS profile / 120 FPS", summary.requestedLine)
+        assertEquals("Requested: High FPS stream / 120 FPS", summary.requestedLine)
         assertEquals("Selected: Recovery profile / 40 FPS", summary.selectedLine)
         assertEquals("Limited by: Decoder path", summary.limitingLine)
         assertEquals("Recovery active from last session · 1 min ago", summary.freshnessLine)
@@ -89,8 +89,8 @@ class NovaLaunchProfileSummaryTest {
         )
 
         requireNotNull(summary)
-        assertEquals("Try High FPS profile 120 FPS", summary.primaryLaunchLabel)
-        assertEquals("Requested: High FPS profile / 120 FPS", summary.requestedLine)
+        assertEquals("Try High FPS stream 120 FPS", summary.primaryLaunchLabel)
+        assertEquals("Requested: High FPS stream / 120 FPS", summary.requestedLine)
         assertEquals("Selected: High FPS trial / 120 FPS", summary.selectedLine)
         assertFalse(summary.showRetryHighFps)
     }
@@ -124,8 +124,8 @@ class NovaLaunchProfileSummaryTest {
         )
 
         requireNotNull(summary)
-        assertEquals("Launch High FPS profile 120 FPS", summary.primaryLaunchLabel)
-        assertEquals("Selected: High FPS profile / 120 FPS", summary.selectedLine)
+        assertEquals("Launch High FPS stream 120 FPS", summary.primaryLaunchLabel)
+        assertEquals("Selected: High FPS stream / 120 FPS", summary.selectedLine)
         assertFalse(summary.showRetryHighFps)
     }
 
@@ -159,7 +159,7 @@ class NovaLaunchProfileSummaryTest {
     }
 
     @Test
-    fun highFpsRecommendationReadsLikeANovaLaunchProfile() {
+    fun highFpsRecommendationNamesStreamTargetInsteadOfGameRenderPromise() {
         val summary = buildNovaLaunchProfileSummary(
             JSONObject(
                 "{" +
@@ -179,9 +179,9 @@ class NovaLaunchProfileSummaryTest {
         )
 
         requireNotNull(summary)
-        assertEquals("Launch High FPS profile 120 FPS", summary.primaryLaunchLabel)
-        assertEquals("Requested: High FPS profile / 120 FPS", summary.requestedLine)
-        assertEquals("Selected: High FPS profile / 120 FPS", summary.selectedLine)
+        assertEquals("Launch High FPS stream 120 FPS", summary.primaryLaunchLabel)
+        assertEquals("Requested: High FPS stream / 120 FPS", summary.requestedLine)
+        assertEquals("Selected: High FPS stream / 120 FPS", summary.selectedLine)
         assertEquals("Reason: Nova recommends High FPS for this game.", summary.reasonLine)
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -199,7 +199,7 @@ class NovaLibraryUiStateTest {
     }
 
     @Test
-    fun heroHomeStatePrioritizesOwnedActiveSessionWithSingleResumeAction() {
+    fun heroHomeStatePrioritizesOwnedActiveSessionWithResumeAndEndActions() {
         val games = listOf(
             game("recent", "Recent Game", lastLaunched = 100),
             game("active", "Active Game", lastLaunched = 10)
@@ -229,13 +229,13 @@ class NovaLibraryUiStateTest {
         assertEquals(NovaLibraryHeroPrimaryAction.RESUME, hero.primaryAction)
         assertEquals("Retroid Pocket", hero.subtitle)
         assertEquals("Resume stream", hero.actionLabel)
-        assertNull(hero.secondaryActionLabel)
+        assertEquals("End session", hero.secondaryActionLabel)
         assertEquals("Resume • Retroid Pocket • 1920×1080 60fps", hero.supportingLine)
         assertEquals("Active Game", hero.artworkFallbackTitle)
         assertEquals("Active session • Retroid Pocket", hero.artworkFallbackSubtitle)
         assertTrue(hero.badges.contains("Active session"))
         assertTrue(hero.badges.contains("Virtual display"))
-        assertEquals("Resume the current stream and quality settings.", hero.caption)
+        assertEquals("Resume this stream, or end it if the host game is stale.", hero.caption)
         assertTrue(hero.badges.contains("1920×1080 60fps"))
         assertFalse(
             NovaLibraryUiStateMapper.showLandscapeRecentRail(


### PR DESCRIPTION
## Summary

- Hardens Nova's fallback app-list path when Polaris metadata is not available.
- Keeps incomplete fallback data out of the Library instead of letting bad data look like a real empty library.
- Adds client runtime/profile provenance to the existing sync path so Nova can explain which client/runtime facts shaped a launch.
- Adds a first-screen stale-stream escape hatch: owned active-session Library heroes now show `End session` next to `Resume stream`, routed through the existing confirmed quit path.
- Renames High FPS launch copy to `High FPS stream` so 120 FPS reads as the stream target, not a promise that the game itself is rendering at 120 FPS.

## Scope note

This does not add GameNative support, depend on GameNative, or turn Nova into a GameNative-compatible platform. A few product ideas were inspired by looking at that separate project, but the implementation here is Nova-only fallback handling, runtime truth, and session-recovery polish.

## Validation

- GitHub `public-hygiene`: passed.
- GitHub `Lint and unit test`: passed.
- GitHub `Analyze Java/Kotlin`: passed.
- GitHub `CodeQL`: passed.
- GitHub `Assemble release APK`: passed.
- Local privacy/public-surface checks before the sanitized force-push:
  - `scripts/check-public-surface.sh`
  - added-line scan for private paths, maintainer names, emails, private-key blocks, and secret-looking assignments
  - `git diff --check origin/master..HEAD`

## Caveats

- No fresh device screenshot was captured after the final stale-session/copy polish. That slice is covered by UI-state/source-guard tests plus build/lint.
- The Wukong runtime result that motivated the stale-session/copy polish came from host-side settings, not a Nova runtime-code fix.
