### PR TITLE
feat(nova): expose Insert quick key

### DIFF
--- a/app/src/main/java/com/papi/nova/GameMenu.kt
+++ b/app/src/main/java/com/papi/nova/GameMenu.kt
@@ -116,6 +116,9 @@ class GameMenu(
             options.add(MenuOption(getString(R.string.game_menu_send_keys_f11), Runnable {
                 sendKeys(shortArrayOf(KeyboardTranslator.VK_F11.toShort()))
             }))
+            options.add(MenuOption(getString(R.string.game_menu_send_keys_insert), Runnable {
+                sendKeys(shortArrayOf(KeyboardTranslator.VK_INSERT.toShort()))
+            }))
             options.add(MenuOption(getString(R.string.game_menu_send_keys_alt_f4), Runnable {
                 sendKeys(shortArrayOf(KeyboardTranslator.VK_LMENU.toShort(), KeyboardTranslator.VK_F4.toShort()))
             }))

--- a/app/src/main/java/com/papi/nova/binding/input/KeyboardTranslator.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/KeyboardTranslator.kt
@@ -103,7 +103,7 @@ class KeyboardTranslator(private val prefConfig: PreferenceConfiguration) : Inpu
                 KeyEvent.KEYCODE_EQUALS -> 0xbb
                 KeyEvent.KEYCODE_ESCAPE -> VK_ESCAPE
                 KeyEvent.KEYCODE_FORWARD_DEL -> 0x2e
-                KeyEvent.KEYCODE_INSERT -> 0x2d
+                KeyEvent.KEYCODE_INSERT -> VK_INSERT
                 KeyEvent.KEYCODE_LEFT_BRACKET -> 0xdb
                 KeyEvent.KEYCODE_META_LEFT -> 0x5b
                 KeyEvent.KEYCODE_META_RIGHT -> 0x5c
@@ -193,6 +193,7 @@ class KeyboardTranslator(private val prefConfig: PreferenceConfiguration) : Inpu
         const val VK_BACK_SPACE = 8
         const val VK_EQUALS = 61
         const val VK_ESCAPE = 27
+        const val VK_INSERT = 45
         const val VK_F1 = 112
         const val VK_F12 = 123
         const val VK_END = 35

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -167,6 +167,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 NovaQuickMenuActionId.QUICK_ALT_ENTER -> keys(KeyboardTranslator.VK_LMENU, KeyboardTranslator.VK_RETURN)
                 NovaQuickMenuActionId.QUICK_ALT_F4 -> keys(KeyboardTranslator.VK_LMENU, KeyboardTranslator.VK_F4)
                 NovaQuickMenuActionId.QUICK_F11 -> keys(KeyboardTranslator.VK_F11)
+                NovaQuickMenuActionId.QUICK_INSERT -> keys(KeyboardTranslator.VK_INSERT)
                 NovaQuickMenuActionId.QUICK_META -> keys(KeyboardTranslator.VK_LWIN)
                 NovaQuickMenuActionId.QUICK_CTRL_V -> keys(KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_V)
                 else -> return

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -93,6 +93,7 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_ALT_ENTER,
             NovaQuickMenuActionId.QUICK_ALT_F4,
             NovaQuickMenuActionId.QUICK_F11,
+            NovaQuickMenuActionId.QUICK_INSERT,
             NovaQuickMenuActionId.QUICK_META,
             NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -25,6 +25,7 @@ enum class NovaQuickMenuActionId {
     QUICK_ALT_ENTER,
     QUICK_ALT_F4,
     QUICK_F11,
+    QUICK_INSERT,
     QUICK_META,
     QUICK_CTRL_V,
     NOVA_HUD,
@@ -697,6 +698,10 @@ data class NovaQuickMenuUiState(
             NovaQuickMenuAction(
                 id = NovaQuickMenuActionId.QUICK_F11,
                 label = context.getString(R.string.game_menu_send_keys_f11)
+            ),
+            NovaQuickMenuAction(
+                id = NovaQuickMenuActionId.QUICK_INSERT,
+                label = context.getString(R.string.game_menu_send_keys_insert)
             ),
             NovaQuickMenuAction(
                 id = NovaQuickMenuActionId.QUICK_META,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,6 +732,7 @@
     <string name="game_menu_send_keys">Send special keys</string>
     <string name="game_menu_send_keys_esc">ESC</string>
     <string name="game_menu_send_keys_f11">F11</string>
+    <string name="game_menu_send_keys_insert">Insert</string>
     <string name="game_menu_send_keys_alt_f4">Alt + F4</string>
     <string name="game_menu_send_keys_ctrl_v">Ctrl + V</string>
     <string name="game_menu_send_keys_win">Win (Meta)</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1739,6 +1739,39 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
+    fun commandCenterExposesInsertThroughExistingSpecialKeyTranslator() {
+        val state = readSource("src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt")
+        val content = readNovaQuickMenuContent()
+        val menu = readNovaQuickMenu()
+        val legacyGameMenu = readSource("src/main/java/com/papi/nova/GameMenu.kt")
+        val strings = readSource("src/main/res/values/strings.xml")
+
+        assertTrue(
+            "Command Center Quick Keys should expose Insert for OptiScaler without hiding it behind a keyboard pairing workaround",
+            state.contains("QUICK_INSERT") &&
+                state.contains("R.string.game_menu_send_keys_insert")
+        )
+        assertTrue(
+            "Insert quick key should route through the same Command Center quick-key callback bucket as the other special keys",
+            content.contains("NovaQuickMenuActionId.QUICK_INSERT,") &&
+                content.contains("NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)")
+        )
+        assertTrue(
+            "Insert quick key should route through the existing Windows VK_INSERT translator path",
+            menu.contains("NovaQuickMenuActionId.QUICK_INSERT -> keys(KeyboardTranslator.VK_INSERT)")
+        )
+        assertTrue(
+            "legacy Send special keys menu should also expose Insert for users entering through More Keys",
+            legacyGameMenu.contains("R.string.game_menu_send_keys_insert") &&
+                legacyGameMenu.contains("KeyboardTranslator.VK_INSERT.toShort()")
+        )
+        assertTrue(
+            "Insert label should be public-resource backed like the other special keys",
+            strings.contains("<string name=\"game_menu_send_keys_insert\">Insert</string>")
+        )
+    }
+
+    @Test
     fun legacyAppLibraryHeroExposesEndSessionForOwnedStreams() {
         val layout = readSource("src/main/res/layout/activity_app_view.xml")
         val source = readSource("src/main/java/com/papi/nova/AppView.kt")

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -115,6 +115,7 @@ class NovaQuickMenuUiStateTest {
         assertEquals("End session", state.endAction.label)
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_ESC && it.label == "ESC" })
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_CTRL_V && it.label == "Ctrl + V" })
+        assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_INSERT && it.label == "Insert" })
         assertTrue(state.overlayRows.any { it.id == NovaQuickMenuActionId.PERF_STATS && it.label == "Stats Overlay" })
         assertTrue(state.advancedRows.any { it.id == NovaQuickMenuActionId.MANGOHUD && it.label == "MangoHud" })
         assertTrue(state.sessionRows.any { it.id == NovaQuickMenuActionId.MORE_KEYS && it.label == "More Keys" })


### PR DESCRIPTION
## Summary
- Adds `Insert` to Command Center Quick Keys for OptiScaler-style overlays.
- Adds `Insert` to the legacy / More Keys "Send special keys" menu.
- Routes both affordances through Nova's existing Windows `VK_INSERT` key path.

## Validation
- RED verified first on an isolated pc-papi copy: focused issue #71 tests failed before implementation because `QUICK_INSERT` was missing.
- Focused tests passed:
  - `NovaQuickMenuUiStateTest.previewStateExposesCoreActionsForComposeContent`
  - `NovaComposeSourceGuardTest.commandCenterExposesInsertThroughExistingSpecialKeyTranslator`
- `bash scripts/check-public-surface.sh`
- `git diff --check`
- staged credential/privacy scan
- pc-papi isolated Gradle gates:
  - `./gradlew :app:testNonRoot_gameDebugUnitTest --tests ...`
  - `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true :app:lintNonRoot_gameDebug`
  - `./gradlew -PnovaAbis=x86_64 :app:testNonRoot_gameDebugUnitTest`
  - `./gradlew -PnovaAbis=arm64-v8a :app:assembleNonRoot_gameDebug`

Closes #71
