### PR TITLE
feat: polish NovaHUD diagnostics for v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.1.2 - 2026-06-12
+
+Nova 1.1.2 is a confidence patch for the 1.1 line. It keeps the Polaris-backed Library and stream surfaces honest when host data or sessions get weird, adds the requested Insert key affordance, and rolls in current dependency/security pins.
+
+### Highlights
+
+- **Safer Library and launch truth**
+  - Prevented incomplete fallback app-list data from showing up as reliable Library entries when Polaris metadata is not available.
+  - Keeps fallback failures in-app with clearer provenance instead of confusing legacy wording.
+  - Adds a first-screen **End session** escape hatch next to **Resume stream** for owned active sessions, so stale streams can be cleared without resuming into a dead surface.
+
+- **Command Center and special keys**
+  - Adds **Insert** to Command Center Quick Keys and More Keys / Send special keys for overlays and tools that use Insert, including OptiScaler-style workflows.
+  - Updates high-FPS launch copy to say **High FPS stream**, making 120 FPS read as a stream target instead of a guaranteed game-render promise.
+
+- **Input, crash, and dependency hardening**
+  - Sends stylus pen events before pointer-capture mouse gates so pressure-capable touch/stylus paths are not swallowed.
+  - Avoids app-grid null crashes on malformed or incomplete app data.
+  - Updates Netty and Wire runtime dependency pins and keeps the release build checks green.
+
+### Device validation
+
+- Verified the current `master` ARM64 debug APK on Retroid Pocket 6 after the Insert key merge:
+  - populated Polaris Library grid returned after cleanup,
+  - Steam Big Picture reached the stream Activity with HEVC, audio, and `stream_active` lifecycle logs,
+  - Command Center exposed **Disconnect** and **End session**,
+  - Quick Keys exposed **Insert** after scrolling the Command Center controls,
+  - confirmed **End session** returned to the Library, with `Nova SSE: Stopped` and no Nova fatal crash in the bounded log window.
+
+### Caveats
+
+- The Retroid smoke reached the stream launch surface, not a gameplay movement pass.
+- The smoke helper still expected the old `End` label; manual cleanup confirmed the current **End session** path.
+- No fresh MagicPad / MagicOS / Apollo device logcat was collected in this release pass.
+
 ## 1.1.1 - 2026-05-28
 
 Nova 1.1.1 is the public release candidate for the 1.1 line. It keeps the 1.1 feature set intact and focuses on release readiness, contributor build guardrails, and current-surface smoke stability instead of rewriting the older `v1.1.0` tag.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ while you play, and what is safe to do when you leave.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Why Nova](#why-nova) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v111) · [Install](#install) · [Compatibility](#compatibility) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Docs](#docs) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Why Nova](#why-nova) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v112) · [Install](#install) · [Compatibility](#compatibility) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Docs](#docs) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -81,17 +81,16 @@ Nova is built for that messy reality.
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.1.1
+## Latest release: v1.1.2
 
-Nova `v1.1.1` is the public release candidate for the 1.1 line. The 1.1 release upgrades the Polaris Library, launch flow, Command Center, NovaHUD, startup states, controller focus, and release validation path so handheld play feels less like a generic grid and more like a small Android console.
+Nova `v1.1.2` is a confidence patch for the 1.1 line. It makes the Polaris Library more truthful when host metadata is incomplete, improves stale-session recovery, adds the requested Insert key affordance, and rolls in crash/input/dependency hardening from the current release branch.
 
-- **Richer Polaris Library**: improved game cards, focus behavior, launch detail sheets, active-session states, and Polaris-backed launch context.
-- **Clearer launch choices**: Private Stream, Virtual Display, resume/watch, host recommendations, and next-launch tuning are easier to understand before starting a stream.
-- **Command Center polish**: in-stream tuning, overlay controls, NovaHUD toggles, and safe disconnect actions are easier to reach during play.
-- **Lower-overhead NovaHUD**: structured renderer samples and a fixed sparkline buffer reduce stream-loop allocation pressure while keeping legacy overlay compatibility.
-- **Better startup/recovery states**: stream initialization, lock-screen unlock, reconnect, stale host ports, and direct launch preflight paths are more reliable and readable.
-- **Controller-first focus polish**: Nova's focus motion system improves D-pad/controller navigation across Library, detail, settings, and overlay surfaces.
-- **Release hardening**: expanded Baseline Profile coverage, clearer native submodule preflight errors, bounded emulator smoke, and Retroid ARM64 validation.
+- **Safer Library truth**: incomplete fallback app-list data stays out of the Library, and fallback failures use clearer in-app provenance instead of confusing legacy wording.
+- **Stale stream recovery**: owned active sessions now expose **End session** next to **Resume stream**, so users have a first-screen escape hatch when a host session goes stale.
+- **Insert in Quick Keys**: Command Center Quick Keys and More Keys / Send special keys now include **Insert** for tools and overlays that bind to it.
+- **Clearer high-FPS copy**: 120 FPS wording now describes the **High FPS stream** target instead of implying the game itself is guaranteed to render at 120.
+- **Input and crash hardening**: stylus pen events reach the pressure-capable path before pointer-capture mouse gates, and malformed app data no longer trips the app grid.
+- **Release validation**: current master passed public hygiene, lint/unit, CodeQL, dependency submission, release APK assembly, and a Retroid ARM64 stream/control cleanup smoke.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.1.1"
-        versionCode = 27
+        versionName "1.1.2"
+        versionCode = 28
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5615,6 +5615,14 @@ novaHud?.dismiss()
 novaHud = null
 }
 
+fun copyNovaHudDiagnostics() {
+val diagnosticText:String = novaHud?.getDiagnosticSummaryText()
+    ?: "Nova stream diagnostics\nNo active Nova HUD sample yet. Enable Nova HUD during a stream and try again."
+val clipboard:ClipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+clipboard.setPrimaryClip(ClipData.newPlainText("Nova HUD diagnostics", diagnosticText))
+Toast.makeText(this, R.string.nova_quick_menu_hud_diagnostics_copied, Toast.LENGTH_SHORT).show()
+}
+
 fun showNovaHud():com.papi.nova.ui.NovaStreamHud {
 if (::prefConfig.isInitialized && prefConfig!!.enablePerfOverlay)
 {
@@ -5628,7 +5636,9 @@ configureNovaHud(hud!!)
 return hud!!
 }
 
-hud = com.papi.nova.ui.NovaStreamHud(this@Game)
+hud = com.papi.nova.ui.NovaStreamHud(this@Game) {
+showGameMenu(null)
+}
 novaHud = hud
 hud!!.show()
 configureNovaHud(hud!!)

--- a/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
@@ -47,3 +47,77 @@ internal object NovaHudSessionSummaryLog {
         return Gson().toJson(values)
     }
 }
+
+internal object NovaHudDiagnosticReport {
+    fun format(summary: Map<String, Any?>): String {
+        val lines = mutableListOf<String>()
+        lines += "Nova stream diagnostics"
+        lines += "Observed: ${formatFps(summary["avg_fps"])} / target ${formatFps(summary["target_fps"])}"
+        suggestedLine(summary)?.let { lines += it }
+        lines += "Video: ${formatBitrate(summary["avg_bitrate_kbps"])} / ${safeString(summary["codec"], "unknown codec")}"
+        lines += "Network: ${formatMs(summary["avg_latency_ms"])} RTT / ${formatPercent(summary["packet_loss_pct"])} loss"
+        lines += "Health: ${safeString(summary["health_grade"], "unknown")} / ${safeString(summary["primary_issue"], "none")}"
+        issuesLine(summary)?.let { lines += it }
+        return lines.joinToString("\n")
+    }
+
+    private fun suggestedLine(summary: Map<String, Any?>): String? {
+        val relaunch = summary["relaunch_recommended"] as? Boolean ?: false
+        val safeTarget = (summary["safe_target_fps"] as? Number)?.toDouble() ?: 0.0
+        return when {
+            relaunch && safeTarget > 0.0 -> "Suggested: relaunch at ${formatNumber(safeTarget)} FPS"
+            safeTarget > 0.0 -> "Suggested: ${formatNumber(safeTarget)} FPS recovery profile"
+            relaunch -> "Suggested: relaunch with recovery profile"
+            else -> null
+        }
+    }
+
+    private fun issuesLine(summary: Map<String, Any?>): String? {
+        val issues = (summary["issues"] as? Iterable<*>)
+            ?.mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+            ?.takeIf { it.isNotEmpty() }
+            ?: return null
+        return "Issues: ${issues.joinToString(", ")}"
+    }
+
+    private fun safeString(value: Any?, fallback: String): String {
+        return value?.toString()?.takeIf { it.isNotBlank() } ?: fallback
+    }
+
+    private fun formatFps(value: Any?): String {
+        val fps = (value as? Number)?.toDouble() ?: return "-- FPS"
+        return "${formatNumber(fps)} FPS"
+    }
+
+    private fun formatBitrate(value: Any?): String {
+        val kbps = (value as? Number)?.toInt() ?: return "-- Mbps"
+        if (kbps <= 0) return "-- Mbps"
+        return "${formatNumber(kbps / 1000.0)} Mbps"
+    }
+
+    private fun formatMs(value: Any?): String {
+        val ms = (value as? Number)?.toDouble() ?: return "-- ms"
+        return "${formatNumber(ms)} ms"
+    }
+
+    private fun formatPercent(value: Any?): String {
+        val pct = (value as? Number)?.toDouble() ?: return "--%"
+        val formatted = when {
+            kotlin.math.abs(pct - pct.toInt()) < 0.01 -> pct.toInt().toString()
+            kotlin.math.abs((pct * 10.0) - kotlin.math.round(pct * 10.0)) < 0.01 ->
+                String.format(java.util.Locale.US, "%.1f", pct)
+            else -> String.format(java.util.Locale.US, "%.2f", pct)
+                .trimEnd('0')
+                .trimEnd('.')
+        }
+        return "$formatted%"
+    }
+
+    private fun formatNumber(value: Double): String {
+        return if (kotlin.math.abs(value - value.toInt()) < 0.01) {
+            value.toInt().toString()
+        } else {
+            String.format(java.util.Locale.US, "%.1f", value)
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -35,6 +35,11 @@ enum class NovaHudTone {
     MUTED
 }
 
+data class NovaHudLayerHealth(
+    val label: String,
+    val tone: NovaHudTone
+)
+
 data class NovaHudPerfSample(
     val fps: Double? = null,
     val width: Int? = null,
@@ -85,6 +90,11 @@ data class NovaHudUiState(
     val fpsTone: NovaHudTone,
     val latencyTone: NovaHudTone,
     val statusTone: NovaHudTone,
+    val healthReasonLabel: String,
+    val healthReasonTone: NovaHudTone,
+    val streamTruthLabel: String,
+    val layerHealth: List<NovaHudLayerHealth>,
+    val eventBreadcrumbLabel: String,
     val sparklineSamples: List<Float>
 ) {
     companion object {
@@ -152,9 +162,11 @@ data class NovaHudUiState(
             height: Int,
             status: PolarisSessionStatus?,
             sparklineSamples: List<Float>,
+            eventBreadcrumbLabel: String = "",
             lowOnePercentFps: Double = calculateLowOnePercent(sparklineSamples)
         ): NovaHudUiState {
             val autoQuality = AutoQualityUiState.from(status, targetFps, fps)
+            val healthReason = buildHealthReason(status, fps, targetFps, latencyMs)
             return NovaHudUiState(
                 mode = mode,
                 fpsLabel = fps.takeIf { it > 0.0 }?.toInt()?.toString() ?: "--",
@@ -171,6 +183,11 @@ data class NovaHudUiState(
                 fpsTone = toneForFps(fps, targetFps),
                 latencyTone = toneForLatency(latencyMs),
                 statusTone = autoQuality.tone.toHudTone(),
+                healthReasonLabel = healthReason.first,
+                healthReasonTone = healthReason.second,
+                streamTruthLabel = buildStreamTruth(status, targetFps, codec, height),
+                layerHealth = buildLayerHealth(status, latencyMs),
+                eventBreadcrumbLabel = eventBreadcrumbLabel,
                 sparklineSamples = sparklineSamples.takeLast(60)
             )
         }
@@ -253,6 +270,82 @@ data class NovaHudUiState(
             else -> NovaHudTone.DANGER
         }
 
+        private fun buildHealthReason(
+            status: PolarisSessionStatus?,
+            fps: Double,
+            targetFps: Double,
+            latencyMs: Int
+        ): Pair<String, NovaHudTone> {
+            val primaryIssue = status?.health?.primaryIssue.orEmpty().lowercase()
+            val issues = status?.health?.issues.orEmpty().map { it.lowercase() }
+            return when {
+                status?.isHostRenderLimited == true || primaryIssue == "host_render_limited" || issues.contains("host_render_limited") ->
+                    "Host capped" to NovaHudTone.WARNING
+                primaryIssue.contains("network") || status?.health?.networkRisk?.isNotBlank() == true ->
+                    "Network jitter" to NovaHudTone.WARNING
+                primaryIssue.contains("decoder") || status?.health?.decoderRisk?.isNotBlank() == true ->
+                    "Decoder late" to NovaHudTone.WARNING
+                latencyMs > 50 -> "High latency" to NovaHudTone.DANGER
+                targetFps > 0.0 && fps > 0.0 && fps < targetFps * 0.75 ->
+                    "FPS below target" to NovaHudTone.WARNING
+                status == null -> "Waiting" to NovaHudTone.MUTED
+                else -> "Stable" to NovaHudTone.STABLE
+            }
+        }
+
+        private fun buildStreamTruth(
+            status: PolarisSessionStatus?,
+            targetFps: Double,
+            codec: String,
+            height: Int
+        ): String {
+            val target = targetFps.takeIf { it > 0.0 }?.roundToInt()
+            val streamLabel = when {
+                target != null -> "Stream $target"
+                height > 0 -> "Stream ${height}p"
+                else -> "Stream"
+            }
+            val safeTarget = status?.health?.safeTargetFps?.takeIf { it > 0.0 }?.roundToInt()
+            return when {
+                status?.isHostRenderLimited == true && safeTarget != null -> "$streamLabel • Game capped $safeTarget"
+                status?.isHostRenderLimited == true -> "$streamLabel • Host capped"
+                status?.profileState?.preferenceLabel?.isNotBlank() == true ->
+                    "$streamLabel • ${status.profileState.preferenceLabel} profile"
+                codec.isNotBlank() -> "$streamLabel • ${normalizeCodecLabel(codec)}"
+                status != null -> "$streamLabel • ${status.sessionModeLabel}"
+                else -> streamLabel
+            }
+        }
+
+        private fun buildLayerHealth(status: PolarisSessionStatus?, latencyMs: Int): List<NovaHudLayerHealth> {
+            val primaryIssue = status?.health?.primaryIssue.orEmpty().lowercase()
+            val issues = status?.health?.issues.orEmpty().map { it.lowercase() }
+            val hostTone = when {
+                status?.isHostRenderLimited == true || primaryIssue.contains("host") || issues.any { it.contains("host") } ->
+                    NovaHudTone.WARNING
+                status?.health?.grade.equals("degraded", ignoreCase = true) -> NovaHudTone.WARNING
+                else -> NovaHudTone.STABLE
+            }
+            val networkTone = when {
+                primaryIssue.contains("network") || issues.any { it.contains("network") } ||
+                    status?.health?.networkRisk?.isNotBlank() == true -> NovaHudTone.WARNING
+                latencyMs > 50 -> NovaHudTone.DANGER
+                latencyMs > 20 -> NovaHudTone.WARNING
+                else -> NovaHudTone.STABLE
+            }
+            val clientTone = when {
+                primaryIssue.contains("decoder") || issues.any { it.contains("decoder") } ||
+                    status?.health?.decoderRisk?.isNotBlank() == true -> NovaHudTone.WARNING
+                status?.encoder?.targetResidency.equals("cpu", ignoreCase = true) -> NovaHudTone.WARNING
+                else -> NovaHudTone.STABLE
+            }
+            return listOf(
+                NovaHudLayerHealth("HOST", hostTone),
+                NovaHudLayerHealth("NET", networkTone),
+                NovaHudLayerHealth("CLIENT", clientTone)
+            )
+        }
+
         private fun buildSessionModeLabel(status: PolarisSessionStatus): String {
             val mode = status.sessionModeLabel
             val bitDepth = if (status.isTenBitActive) "10b" else "8b"
@@ -324,6 +417,54 @@ data class NovaHudUiState(
             AutoQualityUiState.Tone.WARNING -> NovaHudTone.WARNING
             AutoQualityUiState.Tone.DANGER -> NovaHudTone.DANGER
         }
+    }
+}
+
+class NovaHudEventTrail(private val capacity: Int = 4) {
+    private val labels = ArrayDeque<String>()
+
+    val latestLabel: String
+        get() = labels.lastOrNull().orEmpty()
+
+    fun clear() {
+        labels.clear()
+    }
+
+    fun record(label: String) {
+        val clean = label.trim()
+        if (clean.isBlank() || clean == latestLabel) {
+            return
+        }
+        labels.addLast(clean)
+        while (labels.size > capacity.coerceAtLeast(1)) {
+            labels.removeFirst()
+        }
+    }
+
+    fun recordBitrateChange(fromKbps: Int, toKbps: Int) {
+        if (fromKbps <= 0 || toKbps <= 0 || fromKbps == toKbps) {
+            return
+        }
+        val direction = if (toKbps < fromKbps) "lowered" else "recovered"
+        record("Bitrate $direction: ${formatHudMbps(fromKbps)} → ${formatHudMbps(toKbps)}")
+    }
+
+    fun recordRecoveryProfile(targetFps: Double) {
+        if (targetFps <= 0.0) {
+            return
+        }
+        record("Recovery profile ready: ${targetFps.roundToInt()} FPS")
+    }
+}
+
+private fun formatHudMbps(kbps: Int): String {
+    if (kbps <= 0) return "--"
+    val mbps = kbps / 1000.0
+    val rounded = mbps.roundToInt()
+    return if (kotlin.math.abs(mbps - rounded) < 0.05) {
+        "${rounded}M"
+    } else {
+        "${String.format(java.util.Locale.US, "%.1f", mbps)}M"
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -926,6 +926,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                             NovaLibraryHomeHero(
                                 hero = model.hero,
                                 compact = true,
+                                apiClient = apiClient,
                                 onPrimaryAction = {
                                     when (model.hero.primaryAction) {
                                         NovaLibraryHeroPrimaryAction.RESUME,
@@ -992,6 +993,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                             NovaLibraryHomeHero(
                                 hero = model.hero,
                                 compact = false,
+                                apiClient = apiClient,
                                 onPrimaryAction = {
                                     when (model.hero.primaryAction) {
                                         NovaLibraryHeroPrimaryAction.RESUME,
@@ -1196,6 +1198,7 @@ class NovaLibraryActivity : AppCompatActivity() {
     private fun NovaLibraryHomeHero(
         hero: NovaLibraryHeroState,
         compact: Boolean,
+        apiClient: PolarisApiClient,
         onPrimaryAction: () -> Unit,
         onSecondaryAction: (() -> Unit)? = null,
         onGameFocused: (PolarisGame) -> Unit
@@ -1246,6 +1249,13 @@ class NovaLibraryActivity : AppCompatActivity() {
             horizontalArrangement = Arrangement.spacedBy(if (compact) 6.dp else 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            NovaLibraryHeroArtwork(
+                game = heroGame,
+                apiClient = apiClient,
+                fallbackTitle = hero.artworkFallbackTitle,
+                fallbackSubtitle = hero.artworkFallbackSubtitle,
+                compact = compact
+            )
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(if (compact) 1.dp else 5.dp)
@@ -1309,13 +1319,8 @@ class NovaLibraryActivity : AppCompatActivity() {
                     }
                 }
             }
-            NovaLibraryHeroFallbackArtwork(
-                title = hero.artworkFallbackTitle,
-                subtitle = hero.artworkFallbackSubtitle,
-                compact = compact
-            )
             Column(
-                modifier = Modifier.widthIn(min = if (compact) 104.dp else 148.dp),
+                modifier = Modifier.width(if (compact) 132.dp else 168.dp),
                 verticalArrangement = Arrangement.spacedBy(if (compact) 3.dp else 6.dp)
             ) {
                 NovaActionButton(
@@ -1336,6 +1341,63 @@ class NovaLibraryActivity : AppCompatActivity() {
                     )
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun NovaLibraryHeroArtwork(
+        game: PolarisGame?,
+        apiClient: PolarisApiClient,
+        fallbackTitle: String,
+        fallbackSubtitle: String,
+        compact: Boolean
+    ) {
+        val targetGame = game
+        if (targetGame == null) {
+            NovaLibraryHeroFallbackArtwork(
+                title = fallbackTitle,
+                subtitle = fallbackSubtitle,
+                compact = compact
+            )
+            return
+        }
+
+        val surfaces = LocalNovaLibrarySurfaces.current
+        val shape = RoundedCornerShape(if (compact) 14.dp else 18.dp)
+        Box(
+            modifier = Modifier
+                .width(if (compact) 58.dp else 108.dp)
+                .fillMaxHeight()
+                .clip(shape)
+                .background(surfaces.mediaPlaceholder)
+                .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f), shape)
+        ) {
+            key(targetGame.id, targetGame.coverUrl) {
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { context ->
+                        ImageView(context).apply {
+                            scaleType = ImageView.ScaleType.CENTER_CROP
+                            setBackgroundColor(surfaces.mediaPlaceholder.toArgb())
+                            contentDescription = context.getString(R.string.nova_a11y_game_cover)
+                            apiClient.loadCoverInto(this, targetGame)
+                        }
+                    }
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.0f to surfaces.mediaScrimTop.copy(alpha = 0.18f),
+                                0.62f to surfaces.mediaScrimTop.copy(alpha = 0.08f),
+                                1.0f to surfaces.mediaScrimBottom.copy(alpha = 0.68f)
+                            )
+                        )
+                    )
+            )
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -2148,7 +2148,12 @@ class NovaLibraryActivity : AppCompatActivity() {
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(gridColumns),
                             modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(10.dp),
+                            contentPadding = PaddingValues(
+                                start = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
+                                top = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
+                                end = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
+                                bottom = NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape).dp
+                            ),
                             verticalArrangement = Arrangement.spacedBy(10.dp),
                             horizontalArrangement = Arrangement.spacedBy(10.dp)
                         ) {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -106,6 +106,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
 import com.papi.nova.LimeLog
 import com.papi.nova.NovaSessionEndSignal
 import com.papi.nova.R
@@ -194,6 +195,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         }
 
         apiClient = PolarisApiClient(this, streamHost, streamHttpsPort, streamServerCert)
+        optionsState = optionsState.copy(showPosterTitles = loadPosterTitlesPreference())
 
         onBackPressedDispatcher.addCallback(
             this,
@@ -249,6 +251,10 @@ class NovaLibraryActivity : AppCompatActivity() {
                         onOpenAbout = ::showAboutNova,
                         onSortMode = { sortMode -> optionsState = optionsState.copy(sortMode = sortMode) },
                         onLayoutMode = { layoutMode -> optionsState = optionsState.copy(layoutMode = layoutMode) },
+                        onPosterTitlesVisible = { showPosterTitles ->
+                            optionsState = optionsState.copy(showPosterTitles = showPosterTitles)
+                            persistPosterTitlesPreference(showPosterTitles)
+                        },
                         onDismissFilterSheet = { activeFilterSheet = null },
                         onSourceFilter = ::applySourceFilter,
                         onCategoryFilter = ::applyCategoryFilter,
@@ -301,6 +307,18 @@ class NovaLibraryActivity : AppCompatActivity() {
             }
             else -> false
         }
+    }
+
+    private fun loadPosterTitlesPreference(): Boolean {
+        return PreferenceManager.getDefaultSharedPreferences(this)
+            .getBoolean(POSTER_TITLES_PREF, true)
+    }
+
+    private fun persistPosterTitlesPreference(showPosterTitles: Boolean) {
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .edit()
+            .putBoolean(POSTER_TITLES_PREF, showPosterTitles)
+            .apply()
     }
 
     override fun onResume() {
@@ -839,6 +857,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         onOpenAbout: () -> Unit,
         onSortMode: (NovaLibrarySortMode) -> Unit,
         onLayoutMode: (NovaLibraryLayoutMode) -> Unit,
+        onPosterTitlesVisible: (Boolean) -> Unit,
         onDismissFilterSheet: () -> Unit,
         onSourceFilter: (String?) -> Unit,
         onCategoryFilter: (String) -> Unit,
@@ -967,6 +986,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                                     games = model.recentGames,
                                     apiClient = apiClient,
                                     restoreFocusGameId = restoreFocusGameId,
+                                    showPosterTitles = model.optionsState.showPosterTitles,
                                     onGameFocused = onGameFocused,
                                     onOpenDetail = onOpenDetail
                                 )
@@ -1016,6 +1036,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                                     games = model.recentGames,
                                     apiClient = apiClient,
                                     restoreFocusGameId = restoreFocusGameId,
+                                    showPosterTitles = model.optionsState.showPosterTitles,
                                     onGameFocused = onGameFocused,
                                     onOpenDetail = onOpenDetail
                                 )
@@ -1084,7 +1105,8 @@ class NovaLibraryActivity : AppCompatActivity() {
                         onOpenSystemMenu = onOpenSystemMenu,
                         onRefresh = onRefresh,
                         onSortMode = onSortMode,
-                        onLayoutMode = onLayoutMode
+                        onLayoutMode = onLayoutMode,
+                        onPosterTitlesVisible = onPosterTitlesVisible
                     )
                 }
                 activeFilterSheet != null -> {
@@ -2140,6 +2162,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                                     apiClient = apiClient,
                                     compact = compactCards,
                                     listStyle = listCards,
+                                    showPosterTitle = model.optionsState.showPosterTitles,
                                     isLandscape = isLandscape,
                                     restoreFocus = game.id == restoreFocusGameId,
                                     onFocused = { onGameFocused(game) },
@@ -2158,6 +2181,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         games: List<PolarisGame>,
         apiClient: PolarisApiClient,
         restoreFocusGameId: String?,
+        showPosterTitles: Boolean,
         onGameFocused: (PolarisGame) -> Unit,
         onOpenDetail: (PolarisGame) -> Unit
     ) {
@@ -2204,6 +2228,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                                 game = game,
                                 apiClient = apiClient,
                                 compact = true,
+                                showPosterTitle = showPosterTitles,
                                 isLandscape = false,
                                 modifier = Modifier.width(cardWidth),
                                 restoreFocus = game.id == restoreFocusGameId,
@@ -2224,6 +2249,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         apiClient: PolarisApiClient,
         compact: Boolean,
         listStyle: Boolean = false,
+        showPosterTitle: Boolean = true,
         isLandscape: Boolean,
         modifier: Modifier = Modifier,
         restoreFocus: Boolean = false,
@@ -2418,38 +2444,40 @@ class NovaLibraryActivity : AppCompatActivity() {
                         .align(Alignment.TopStart)
                         .padding(7.dp)
                 )
-                NovaLibraryCardTitleScrim(
-                    compact = compact,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                )
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .fillMaxWidth()
-                        .padding(8.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(surfaces.mediaScrimBottom.copy(alpha = 0.34f))
-                        .padding(horizontal = 7.dp, vertical = 5.dp),
-                    verticalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
-                    Text(
-                        text = title,
-                        color = surfaces.onMedia,
-                        fontSize = if (compact) 13.sp else 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = if (compact) 1 else 2,
-                        overflow = TextOverflow.Ellipsis
+                if (showPosterTitle) {
+                    NovaLibraryCardTitleScrim(
+                        compact = compact,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
                     )
-                    if (meta.isNotBlank()) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(surfaces.mediaScrimBottom.copy(alpha = 0.34f))
+                            .padding(horizontal = 7.dp, vertical = 5.dp),
+                        verticalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
                         Text(
-                            text = meta,
-                            color = surfaces.onMediaSecondary,
-                            fontSize = 11.sp,
-                            maxLines = 1,
+                            text = title,
+                            color = surfaces.onMedia,
+                            fontSize = if (compact) 13.sp else 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = if (compact) 1 else 2,
                             overflow = TextOverflow.Ellipsis
                         )
+                        if (meta.isNotBlank()) {
+                            Text(
+                                text = meta,
+                                color = surfaces.onMediaSecondary,
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
             }
@@ -2986,7 +3014,8 @@ class NovaLibraryActivity : AppCompatActivity() {
         onOpenSystemMenu: () -> Unit,
         onRefresh: () -> Unit,
         onSortMode: (NovaLibrarySortMode) -> Unit,
-        onLayoutMode: (NovaLibraryLayoutMode) -> Unit
+        onLayoutMode: (NovaLibraryLayoutMode) -> Unit,
+        onPosterTitlesVisible: (Boolean) -> Unit
     ) {
         val colors = LocalNovaComposeColors.current
         val surfaces = LocalNovaLibrarySurfaces.current
@@ -3166,6 +3195,28 @@ class NovaLibraryActivity : AppCompatActivity() {
                             onClick = { onLayoutMode(layoutMode) }
                         )
                     }
+                    Text(
+                        text = stringResource(R.string.nova_library_options_poster_titles_title),
+                        color = colors.textSecondary,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.7.sp,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                    NovaSelectableChip(
+                        label = stringResource(R.string.nova_library_options_poster_titles_show),
+                        detail = stringResource(R.string.nova_library_options_poster_titles_show_hint),
+                        selected = optionsState.showPosterTitles,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { onPosterTitlesVisible(true) }
+                    )
+                    NovaSelectableChip(
+                        label = stringResource(R.string.nova_library_options_poster_titles_hide),
+                        detail = stringResource(R.string.nova_library_options_poster_titles_hide_hint),
+                        selected = !optionsState.showPosterTitles,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { onPosterTitlesVisible(false) }
+                    )
                     Spacer(modifier = Modifier.height(14.dp))
                 }
             }
@@ -3465,6 +3516,7 @@ class NovaLibraryActivity : AppCompatActivity() {
         const val EXTRA_PC_UUID = "pc_uuid"
         const val EXTRA_SERVER_COMMANDS = "server_commands"
         const val EXTRA_SERVER_CERT = "server_cert"
+        private const val POSTER_TITLES_PREF = "nova_library_poster_titles"
         private val ACTIVE_SESSION_RESUME_REFRESH_DELAYS_MS = longArrayOf(1500L, 2000L, 3000L, 5000L, 8000L)
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -2355,104 +2355,140 @@ class NovaLibraryActivity : AppCompatActivity() {
                                 overflow = TextOverflow.Ellipsis
                             )
                         }
-                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            if (game.hdrSupported) {
-                                NovaMiniBadge(text = stringResource(R.string.badge_hdr))
-                            }
-                            if (game.lastLaunched > 0) {
-                                NovaMiniBadge(text = stringResource(R.string.nova_library_filter_recent))
-                            }
-                        }
+                        NovaLibraryCardBadgeRow(
+                            game = game,
+                            compact = compact
+                        )
                     }
                     if (focused) {
                         NovaMiniBadge(text = stringResource(R.string.nova_library_card_action_details))
                     }
                 }
             } else {
-            key(game.id, game.coverUrl) {
-                AndroidView(
-                    modifier = Modifier.fillMaxSize(),
-                    factory = { context ->
-                        ImageView(context).apply {
-                            scaleType = ImageView.ScaleType.CENTER_CROP
-                            setBackgroundColor(surfaces.mediaPlaceholder.toArgb())
-                            contentDescription = context.getString(R.string.nova_a11y_game_cover)
-                            apiClient.loadCoverInto(this, game)
+                key(game.id, game.coverUrl) {
+                    AndroidView(
+                        modifier = Modifier.fillMaxSize(),
+                        factory = { context ->
+                            ImageView(context).apply {
+                                scaleType = ImageView.ScaleType.CENTER_CROP
+                                setBackgroundColor(surfaces.mediaPlaceholder.toArgb())
+                                contentDescription = context.getString(R.string.nova_a11y_game_cover)
+                                apiClient.loadCoverInto(this, game)
+                            }
                         }
-                    }
-                )
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            colorStops = arrayOf(
-                                0.0f to surfaces.mediaScrimTop,
-                                0.50f to surfaces.mediaScrimTop,
-                                1.0f to surfaces.mediaScrimBottom
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colorStops = arrayOf(
+                                    0.0f to surfaces.mediaScrimTop,
+                                    0.50f to surfaces.mediaScrimTop,
+                                    1.0f to surfaces.mediaScrimBottom
+                                )
                             )
                         )
+                )
+                if (focused) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(surfaces.focusHalo.copy(alpha = 0.28f))
                     )
-            )
-            if (focused) {
-                Box(
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .border(4.dp, surfaces.focusRing, RoundedCornerShape(14.dp))
+                            .padding(4.dp)
+                            .border(2.dp, colors.onAccent.copy(alpha = 0.82f), RoundedCornerShape(10.dp))
+                    )
+                    NovaMiniBadge(
+                        text = stringResource(R.string.nova_library_card_action_details),
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(8.dp)
+                    )
+                }
+                NovaLibraryCardBadgeRow(
+                    game = game,
+                    compact = compact,
                     modifier = Modifier
-                        .fillMaxSize()
-                        .background(surfaces.focusHalo.copy(alpha = 0.28f))
+                        .align(Alignment.TopStart)
+                        .padding(7.dp)
                 )
-                Box(
+                NovaLibraryCardTitleScrim(
+                    compact = compact,
                     modifier = Modifier
-                        .fillMaxSize()
-                        .border(4.dp, surfaces.focusRing, RoundedCornerShape(14.dp))
-                        .padding(4.dp)
-                        .border(2.dp, colors.onAccent.copy(alpha = 0.82f), RoundedCornerShape(10.dp))
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
                 )
-                NovaMiniBadge(
-                    text = stringResource(R.string.nova_library_card_action_details),
+                Column(
                     modifier = Modifier
-                        .align(Alignment.TopEnd)
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
                         .padding(8.dp)
-                )
-            }
-            Row(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                if (game.hdrSupported) {
-                    NovaMiniBadge(text = stringResource(R.string.badge_hdr))
-                }
-                if (game.lastLaunched > 0) {
-                    NovaMiniBadge(text = stringResource(R.string.nova_library_filter_recent))
-                }
-            }
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(10.dp),
-                verticalArrangement = Arrangement.spacedBy(3.dp)
-            ) {
-                Text(
-                    text = title,
-                    color = surfaces.onMedia,
-                    fontSize = if (compact) 13.sp else 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = if (compact) 1 else 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                if (meta.isNotBlank()) {
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(surfaces.mediaScrimBottom.copy(alpha = 0.34f))
+                        .padding(horizontal = 7.dp, vertical = 5.dp),
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
                     Text(
-                        text = meta,
-                        color = surfaces.onMediaSecondary,
-                        fontSize = 11.sp,
-                        maxLines = 1,
+                        text = title,
+                        color = surfaces.onMedia,
+                        fontSize = if (compact) 13.sp else 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = if (compact) 1 else 2,
                         overflow = TextOverflow.Ellipsis
                     )
+                    if (meta.isNotBlank()) {
+                        Text(
+                            text = meta,
+                            color = surfaces.onMediaSecondary,
+                            fontSize = 11.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun NovaLibraryCardTitleScrim(compact: Boolean, modifier: Modifier = Modifier) {
+        val surfaces = LocalNovaLibrarySurfaces.current
+        Box(
+            modifier = modifier
+                .height(if (compact) 64.dp else 88.dp)
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to surfaces.mediaScrimBottom.copy(alpha = 0f),
+                            0.36f to surfaces.mediaScrimBottom.copy(alpha = 0.64f),
+                            1.0f to surfaces.mediaScrimBottom.copy(alpha = 0.96f)
+                        )
+                    )
+                )
+        )
+    }
+
+    @Composable
+    private fun NovaLibraryCardBadgeRow(
+        game: PolarisGame,
+        compact: Boolean,
+        modifier: Modifier = Modifier
+    ) {
+        Row(
+            modifier = modifier.widthIn(max = if (compact) 92.dp else 128.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            if (game.hdrSupported) {
+                NovaMiniBadge(text = stringResource(R.string.badge_hdr))
+            }
+            if (game.lastLaunched > 0) {
+                NovaMiniBadge(text = stringResource(R.string.nova_library_filter_recent))
             }
         }
     }
@@ -2463,14 +2499,14 @@ class NovaLibraryActivity : AppCompatActivity() {
         Text(
             text = text,
             color = surfaces.onMedia,
-            fontSize = 9.sp,
+            fontSize = 8.sp,
             fontWeight = FontWeight.Bold,
-            lineHeight = 10.sp,
+            lineHeight = 9.sp,
             modifier = modifier
                 .clip(RoundedCornerShape(999.dp))
-                .background(surfaces.mediaScrimBottom.copy(alpha = 0.68f))
-                .border(1.dp, surfaces.onMedia.copy(alpha = 0.22f), RoundedCornerShape(999.dp))
-                .padding(horizontal = 6.dp, vertical = 2.dp)
+                .background(surfaces.mediaScrimBottom.copy(alpha = 0.60f))
+                .border(1.dp, surfaces.onMedia.copy(alpha = 0.20f), RoundedCornerShape(999.dp))
+                .padding(horizontal = 5.dp, vertical = 1.dp)
         )
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -465,7 +465,7 @@ object NovaLibraryUiStateMapper {
             subtitle = subtitle,
             caption = caption,
             eyebrow = eyebrow,
-            actionLabel = "Launch options",
+            actionLabel = "Launch",
             badges = badges,
             reason = reason,
             primaryAction = NovaLibraryHeroPrimaryAction.OPEN_DETAIL,
@@ -734,7 +734,8 @@ object NovaLibraryUiStateMapper {
                 widthDp >= 960 -> 5
                 widthDp >= 720 -> 4
                 widthDp >= 600 -> 3
-                else -> 3
+                widthDp >= 520 -> 3
+                else -> 2
             }
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -199,6 +199,8 @@ object NovaLibraryUiStateMapper {
     const val RECENT_RAIL_VISIBLE_COLUMNS = 4
     private const val RECENT_RAIL_HORIZONTAL_PADDING_DP = 24
     private const val GAME_CARD_GAP_DP = 10
+    private const val GRID_CONTENT_PADDING_DP = 10
+    private const val LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP = 24
     private const val MIN_RECENT_RAIL_CARD_WIDTH_DP = 72
     private const val RAIL_SCROLL_BOTTOM_PADDING_DP = 96
     private const val RAIL_VERTICAL_SPACING_DP = 4
@@ -212,7 +214,7 @@ object NovaLibraryUiStateMapper {
     private const val LANDSCAPE_SCREEN_PADDING_DP = 8
     private const val PORTRAIT_SCREEN_PADDING_DP = 8
     private const val LANDSCAPE_CONTENT_SPACING_DP = 6
-    private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 32
+    private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 48
     private const val PORTRAIT_CONTROLLER_HINT_BOTTOM_PADDING_DP = 40
 
     fun build(
@@ -773,6 +775,12 @@ object NovaLibraryUiStateMapper {
         val gapWidth = GAME_CARD_GAP_DP * (columns - 1)
         return ((availableWidthDp - RECENT_RAIL_HORIZONTAL_PADDING_DP - gapWidth) / columns)
             .coerceAtLeast(MIN_RECENT_RAIL_CARD_WIDTH_DP)
+    }
+
+    fun gridContentPaddingDp(): Int = GRID_CONTENT_PADDING_DP
+
+    fun gridBottomContentPaddingDp(isLandscape: Boolean): Int {
+        return if (isLandscape) LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP else GRID_CONTENT_PADDING_DP
     }
 
     fun gameCardHeightDp(compact: Boolean, isLandscape: Boolean): Int {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -44,7 +44,8 @@ enum class NovaLibraryLayoutMode {
 
 data class NovaLibraryOptionsState(
     val sortMode: NovaLibrarySortMode = NovaLibrarySortMode.LIBRARY_ORDER,
-    val layoutMode: NovaLibraryLayoutMode = NovaLibraryLayoutMode.GRID
+    val layoutMode: NovaLibraryLayoutMode = NovaLibraryLayoutMode.GRID,
+    val showPosterTitles: Boolean = true
 )
 
 enum class NovaLibraryEmptyState {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -396,6 +396,9 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                             }
                             game.toggleHUD()
                         }
+                        NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> {
+                            game.copyNovaHudDiagnostics()
+                        }
                         else -> Unit
                     }
                     refreshState()

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -97,7 +97,8 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_META,
             NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,
-            NovaQuickMenuActionId.PERF_STATS -> onOverlayAction(action.id)
+            NovaQuickMenuActionId.PERF_STATS,
+            NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> onOverlayAction(action.id)
             NovaQuickMenuActionId.MOUSE_MODE,
             NovaQuickMenuActionId.CONTROLLER,
             NovaQuickMenuActionId.KEYBOARD -> onControlAction(action.id)
@@ -750,6 +751,7 @@ private fun toneColor(tone: NovaQuickMenuTone): Color {
         NovaQuickMenuTone.ACTIVE -> Color(0xFF4ADE80)
         NovaQuickMenuTone.INACTIVE -> colors.textSecondary
         NovaQuickMenuTone.MUTED -> colors.textMuted
+        NovaQuickMenuTone.INFO -> colors.accent
         NovaQuickMenuTone.WARNING -> colors.warning
         NovaQuickMenuTone.DANGER -> Color(0xFFF87171)
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -8,6 +8,7 @@ enum class NovaQuickMenuTone {
     ACTIVE,
     INACTIVE,
     MUTED,
+    INFO,
     WARNING,
     DANGER
 }
@@ -30,6 +31,7 @@ enum class NovaQuickMenuActionId {
     QUICK_CTRL_V,
     NOVA_HUD,
     PERF_STATS,
+    COPY_HUD_DIAGNOSTICS,
     MOUSE_MODE,
     CONTROLLER,
     KEYBOARD,
@@ -287,6 +289,7 @@ data class NovaQuickMenuUiState(
                 NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.NOVA_HUD,
                     label = context.getString(R.string.nova_quick_menu_nova_hud),
+                    caption = context.getString(R.string.nova_quick_menu_nova_hud_caption),
                     chip = onOffChip(context, hudShowing),
                     enabled = true
                 ),
@@ -294,6 +297,13 @@ data class NovaQuickMenuUiState(
                     id = NovaQuickMenuActionId.PERF_STATS,
                     label = context.getString(R.string.nova_quick_menu_perf_stats),
                     chip = onOffChip(context, perfOverlayEnabled),
+                    enabled = true
+                ),
+                NovaQuickMenuAction(
+                    id = NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS,
+                    label = context.getString(R.string.nova_quick_menu_copy_hud_diagnostics),
+                    caption = context.getString(R.string.nova_quick_menu_copy_hud_diagnostics_caption),
+                    chip = chip(context.getString(R.string.nova_quick_menu_safe), NovaQuickMenuTone.INFO),
                     enabled = true
                 )
             )

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -1,9 +1,12 @@
 package com.papi.nova.ui
 
 import android.app.Activity
+import android.os.Handler
+import android.os.Looper
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.runtime.mutableStateOf
@@ -21,10 +24,15 @@ import kotlin.math.abs
  * The public methods are intentionally kept stable for Game.java:
  * show/dismiss, metric updates, Polaris status updates, and session summary reporting.
  */
-class NovaStreamHud(private val activity: Activity) {
+class NovaStreamHud(
+    private val activity: Activity,
+    private val onCommandCenterRequested: (() -> Unit)? = null
+) {
     private var hudView: ComposeView? = null
     private val hudState = mutableStateOf(NovaHudUiState.empty())
     private val sessionStats = NovaHudSessionStats()
+    private val eventTrail = NovaHudEventTrail()
+    private val longPressHandler = Handler(Looper.getMainLooper())
 
     private var currentMode = NovaHudMode.MINIMAL
     private var targetFps = 0.0
@@ -51,6 +59,8 @@ class NovaStreamHud(private val activity: Activity) {
     private var viewStartX = 0f
     private var viewStartY = 0f
     private var isDragging = false
+    private var longPressTriggered = false
+    private var pendingLongPress: Runnable? = null
 
     fun show() {
         activity.runOnUiThread {
@@ -84,6 +94,9 @@ class NovaStreamHud(private val activity: Activity) {
             }
             val rootView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
             rootView.addView(composeView, params)
+            rootView.post {
+                restoreHudPosition(composeView, rootView, margin.toFloat())
+            }
         }
     }
 
@@ -93,6 +106,7 @@ class NovaStreamHud(private val activity: Activity) {
         degradedFrames = 0
         recoveredFrames = 0
         bitrateReduced = false
+        eventTrail.clear()
     }
 
     private fun setupTouchHandler(view: View) {
@@ -104,6 +118,8 @@ class NovaStreamHud(private val activity: Activity) {
                     viewStartX = touchedView.x
                     viewStartY = touchedView.y
                     isDragging = false
+                    longPressTriggered = false
+                    scheduleLongPress(touchedView)
                     true
                 }
                 MotionEvent.ACTION_MOVE -> {
@@ -111,6 +127,7 @@ class NovaStreamHud(private val activity: Activity) {
                     val dy = event.rawY - dragStartY
                     if (abs(dx) > DRAG_THRESHOLD || abs(dy) > DRAG_THRESHOLD) {
                         isDragging = true
+                        cancelLongPress()
                     }
                     if (isDragging) {
                         touchedView.x = viewStartX + dx
@@ -119,14 +136,37 @@ class NovaStreamHud(private val activity: Activity) {
                     true
                 }
                 MotionEvent.ACTION_UP -> {
-                    if (!isDragging) {
-                        cycleMode()
+                    cancelLongPress()
+                    when {
+                        longPressTriggered -> Unit
+                        isDragging -> clampAndSaveHudPosition(touchedView)
+                        else -> cycleMode()
                     }
+                    true
+                }
+                MotionEvent.ACTION_CANCEL -> {
+                    cancelLongPress()
                     true
                 }
                 else -> false
             }
         }
+    }
+
+    private fun scheduleLongPress(view: View) {
+        cancelLongPress()
+        val task = Runnable {
+            longPressTriggered = true
+            view.performHapticFeedback(android.view.HapticFeedbackConstants.LONG_PRESS)
+            onCommandCenterRequested?.invoke()
+        }
+        pendingLongPress = task
+        longPressHandler.postDelayed(task, ViewConfiguration.getLongPressTimeout().toLong())
+    }
+
+    private fun cancelLongPress() {
+        pendingLongPress?.let(longPressHandler::removeCallbacks)
+        pendingLongPress = null
     }
 
     fun cycleMode() {
@@ -145,6 +185,7 @@ class NovaStreamHud(private val activity: Activity) {
         view.post {
             view.x = savedX
             view.y = savedY
+            clampAndSaveHudPosition(view)
         }
     }
 
@@ -227,6 +268,10 @@ class NovaStreamHud(private val activity: Activity) {
             hostAdaptiveBitrateActive = status?.tuning?.adaptiveBitrateEnabled == true ||
                 status?.adaptiveBitrateEnabled == true
             streamPolicy = StreamPolicyUiState.from(status, lastBitrateKbps, targetFps)
+            val safeTarget = status?.health?.safeTargetFps ?: 0.0
+            if (status?.health?.relaunchRecommended == true && safeTarget > 0.0) {
+                eventTrail.recordRecoveryProfile(safeTarget)
+            }
             if (streamPolicy.effectiveBitrateKbps > 0) {
                 currentBitrateKbps = streamPolicy.effectiveBitrateKbps
             }
@@ -260,8 +305,10 @@ class NovaStreamHud(private val activity: Activity) {
             degradedFrames++
             recoveredFrames = 0
             if (degradedFrames >= 3 && !bitrateReduced && currentBitrateKbps > 3000) {
+                val previousBitrate = currentBitrateKbps
                 val newBitrate = (currentBitrateKbps * 0.75).toInt().coerceAtLeast(2000)
                 onBitrateAdjust?.invoke(newBitrate)
+                eventTrail.recordBitrateChange(previousBitrate, newBitrate)
                 currentBitrateKbps = newBitrate
                 bitrateReduced = true
                 degradedFrames = 0
@@ -270,8 +317,10 @@ class NovaStreamHud(private val activity: Activity) {
             recoveredFrames++
             degradedFrames = 0
             if (recoveredFrames >= 10 && bitrateReduced) {
+                val previousBitrate = currentBitrateKbps
                 val newBitrate = (currentBitrateKbps * 1.15).toInt().coerceAtMost(lastBitrateKbps)
                 onBitrateAdjust?.invoke(newBitrate)
+                eventTrail.recordBitrateChange(previousBitrate, newBitrate)
                 currentBitrateKbps = newBitrate
                 if (currentBitrateKbps >= lastBitrateKbps) {
                     bitrateReduced = false
@@ -314,8 +363,52 @@ class NovaStreamHud(private val activity: Activity) {
             height = height,
             status = lastSessionStatus,
             sparklineSamples = sparklineData.snapshot(),
+            eventBreadcrumbLabel = eventTrail.latestLabel,
             lowOnePercentFps = sparklineData.lowOnePercent()
         )
+    }
+
+    private fun restoreHudPosition(view: View, rootView: ViewGroup, fallbackMargin: Float) {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
+        val savedX = prefs.getFloat(PREF_HUD_X, Float.NaN)
+        val savedY = prefs.getFloat(PREF_HUD_Y, Float.NaN)
+        if (savedX.isNaN() || savedY.isNaN()) {
+            return
+        }
+        val clamped = clampHudPosition(view, rootView, savedX, savedY, fallbackMargin)
+        view.x = clamped.first
+        view.y = clamped.second
+    }
+
+    private fun clampAndSaveHudPosition(view: View) {
+        val rootView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
+        val margin = HUD_SAFE_MARGIN_DP * activity.resources.displayMetrics.density
+        val clamped = clampHudPosition(view, rootView, view.x, view.y, margin)
+        view.x = clamped.first
+        view.y = clamped.second
+        saveHudPosition(clamped.first, clamped.second)
+    }
+
+    private fun clampHudPosition(
+        view: View,
+        rootView: ViewGroup,
+        desiredX: Float,
+        desiredY: Float,
+        margin: Float
+    ): Pair<Float, Float> {
+        val viewWidth = view.width.takeIf { it > 0 } ?: view.measuredWidth.takeIf { it > 0 } ?: 1
+        val viewHeight = view.height.takeIf { it > 0 } ?: view.measuredHeight.takeIf { it > 0 } ?: 1
+        val maxX = (rootView.width - viewWidth - margin).coerceAtLeast(margin)
+        val maxY = (rootView.height - viewHeight - margin).coerceAtLeast(margin)
+        return desiredX.coerceIn(margin, maxX) to desiredY.coerceIn(margin, maxY)
+    }
+
+    private fun saveHudPosition(x: Float, y: Float) {
+        PreferenceManager.getDefaultSharedPreferences(activity)
+            .edit()
+            .putFloat(PREF_HUD_X, x)
+            .putFloat(PREF_HUD_Y, y)
+            .apply()
     }
 
     private fun resolveTargetFps(status: PolarisSessionStatus): Double {
@@ -345,10 +438,15 @@ class NovaStreamHud(private val activity: Activity) {
 
     fun getSessionSummary(): Map<String, Any> = sessionStats.summary()
 
+    fun getDiagnosticSummaryText(): String = NovaHudDiagnosticReport.format(getSessionSummary())
+
     val isShowing get() = hudView != null
 
     companion object {
         private const val DRAG_THRESHOLD = 12f
+        private const val HUD_SAFE_MARGIN_DP = 12f
+        private const val PREF_HUD_X = "nova_polaris_hud_x"
+        private const val PREF_HUD_Y = "nova_polaris_hud_y"
 
         fun isEnabled(activity: Activity): Boolean {
             return PreferenceManager.getDefaultSharedPreferences(activity)

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -121,6 +121,9 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
                 .height(22.dp)
                 .padding(top = 7.dp)
         )
+        HudDiagnosticStrip(state)
+        HudLayerHealthRow(state.layerHealth)
+        HudEventBreadcrumb(state.eventBreadcrumbLabel)
 
         Row(
             modifier = Modifier
@@ -195,6 +198,8 @@ private fun NovaStreamHudPerformance(state: NovaHudUiState, modifier: Modifier) 
                     .height(15.dp)
             )
         }
+        HudCompactDiagnosticStrip(state)
+        HudEventBreadcrumb(state.eventBreadcrumbLabel)
     }
 }
 
@@ -243,6 +248,9 @@ private fun NovaStreamHudMinimal(state: NovaHudUiState, modifier: Modifier) {
                 )
             }
         }
+        if (state.eventBreadcrumbLabel.isNotBlank()) {
+            HudEventBreadcrumb(state.eventBreadcrumbLabel)
+        }
     }
 }
 
@@ -263,6 +271,107 @@ private fun HudPanel(
             .border(1.dp, surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border), panelShape)
             .padding(padding),
         content = content
+    )
+}
+
+@Composable
+private fun HudDiagnosticStrip(state: NovaHudUiState) {
+    if (state.healthReasonLabel.isBlank() && state.streamTruthLabel.isBlank()) return
+    val surfaces = LocalNovaLibrarySurfaces.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 7.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .padding(horizontal = 7.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = state.healthReasonLabel,
+            color = state.healthReasonTone.hudColor(),
+            fontSize = 10.sp,
+            lineHeight = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(0.7f)
+        )
+        Text(
+            text = state.streamTruthLabel,
+            color = LocalNovaComposeColors.current.textSecondary,
+            fontSize = 9.sp,
+            lineHeight = 11.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1.3f)
+        )
+    }
+}
+
+@Composable
+private fun HudCompactDiagnosticStrip(state: NovaHudUiState) {
+    if (state.healthReasonLabel == "Stable" && state.streamTruthLabel.isBlank()) return
+    Text(
+        text = listOf(state.healthReasonLabel, state.streamTruthLabel).filter { it.isNotBlank() }.joinToString(" · "),
+        color = state.healthReasonTone.hudColor(),
+        fontSize = 8.sp,
+        lineHeight = 10.sp,
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.padding(top = 5.dp)
+    )
+}
+
+@Composable
+private fun HudLayerHealthRow(layers: List<NovaHudLayerHealth>) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        layers.forEach { layer ->
+            HudLayerChip(layer, Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun HudLayerChip(layer: NovaHudLayerHealth, modifier: Modifier = Modifier) {
+    val surfaces = LocalNovaLibrarySurfaces.current
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(9.dp))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .padding(horizontal = 6.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = layer.label,
+            color = layer.tone.hudColor(),
+            fontSize = 8.sp,
+            lineHeight = 9.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun HudEventBreadcrumb(label: String) {
+    if (label.isBlank()) return
+    Text(
+        text = label,
+        color = LocalNovaComposeColors.current.accent,
+        fontSize = 8.sp,
+        lineHeight = 10.sp,
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.padding(top = 5.dp)
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,11 @@
     <string name="nova_library_options_layout_compact_grid_hint">More games on screen for fast controller sweeps.</string>
     <string name="nova_library_options_layout_list">List</string>
     <string name="nova_library_options_layout_list_hint">One-column rows for quick title scanning.</string>
+    <string name="nova_library_options_poster_titles_title">Poster titles</string>
+    <string name="nova_library_options_poster_titles_show">Show titles</string>
+    <string name="nova_library_options_poster_titles_show_hint">Keep the readable title bar on poster cards.</string>
+    <string name="nova_library_options_poster_titles_hide">Plain artwork</string>
+    <string name="nova_library_options_poster_titles_hide_hint">Hide the title bar so posters show as clean artwork.</string>
     <string name="nova_library_layout_toast_format">Layout: %1$s</string>
     <string name="nova_system_menu_title">System</string>
     <string name="nova_system_menu_host_format">Host: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -796,7 +796,12 @@
     <string name="nova_quick_menu_controls">Controls</string>
     <string name="nova_quick_menu_session">Session</string>
     <string name="nova_quick_menu_nova_hud">Nova HUD</string>
+    <string name="nova_quick_menu_nova_hud_caption">Tap HUD to cycle modes; long-press to open Command Center.</string>
     <string name="nova_quick_menu_perf_stats">Stats Overlay</string>
+    <string name="nova_quick_menu_copy_hud_diagnostics">Copy HUD Diagnostics</string>
+    <string name="nova_quick_menu_copy_hud_diagnostics_caption">Privacy-safe stream summary for bug reports.</string>
+    <string name="nova_quick_menu_hud_diagnostics_copied">Nova HUD diagnostics copied</string>
+    <string name="nova_quick_menu_safe">Safe</string>
     <string name="nova_quick_menu_mouse">Mouse</string>
     <string name="nova_quick_menu_controller">Touch Controls</string>
     <string name="nova_quick_menu_touch_controls_caption">On-screen overlay; physical gamepad stays active.</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -564,6 +564,33 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
+    fun libraryGridKeepsPosterRowsAboveFooterChrome() {
+        val activity = readNovaLibraryActivity()
+        val mapper = readSource("src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt")
+        val screen = activity.section(
+            "private fun NovaLibraryScreen(",
+            "@Composable\n    private fun NovaLibraryFocusedBackdrop("
+        )
+        val content = activity.section(
+            "private fun NovaLibraryContent(",
+            "private fun NovaLibraryRecentRail("
+        )
+
+        assertTrue(
+            "landscape shell should reserve a mapper-owned footer gutter for the overlaid controller hints instead of letting poster rows render under the bar",
+            screen.contains("NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape).dp") &&
+                mapper.contains("private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 48")
+        )
+        assertTrue(
+            "game grid should use mapper-owned inner padding with extra bottom scroll room so the final poster row can settle above the footer",
+            content.contains("contentPadding = PaddingValues(") &&
+                content.contains("NovaLibraryUiStateMapper.gridContentPaddingDp().dp") &&
+                content.contains("bottom = NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape).dp") &&
+                mapper.contains("fun gridBottomContentPaddingDp(isLandscape: Boolean): Int")
+        )
+    }
+
+    @Test
     fun libraryEmptyAndOfflineRecoveryStatesUseDeliberateCtas() {
         val activity = readNovaLibraryActivity()
         val mapper = readSource("src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt")

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -70,29 +70,42 @@ class NovaComposeSourceGuardTest {
                 optionsSheet.contains("NovaLibraryLayoutMode.entries")
         )
         assertTrue(
-            "quick options sheet should expose Sort and Layout sections rather than hiding browsing decisions in the rail",
+            "quick options sheet should expose Sort, Layout, and Poster title sections rather than hiding browsing decisions in the rail",
             optionsSheet.contains("R.string.nova_library_options_sort_title") &&
                 optionsSheet.contains("R.string.nova_library_options_layout_title") &&
+                optionsSheet.contains("R.string.nova_library_options_poster_titles_title") &&
                 optionsSheet.contains("onSortMode(sortMode)") &&
-                optionsSheet.contains("onLayoutMode(layoutMode)")
+                optionsSheet.contains("onLayoutMode(layoutMode)") &&
+                optionsSheet.contains("onPosterTitlesVisible(true)") &&
+                optionsSheet.contains("onPosterTitlesVisible(false)")
         )
         assertTrue(
-            "layout modes should be wired into the actual library card density, including the Y shortcut list mode",
+            "poster-title visibility should be persisted from the Library drawer so users can keep plain artwork posters across launches",
+            activity.contains("POSTER_TITLES_PREF") &&
+                activity.contains("loadPosterTitlesPreference()") &&
+                activity.contains("persistPosterTitlesPreference(showPosterTitles)") &&
+                activity.contains("optionsState.copy(showPosterTitles = showPosterTitles)")
+        )
+        assertTrue(
+            "layout modes and poster-title visibility should be wired into actual library card rendering",
             activity.contains("val layoutMode = model.optionsState.layoutMode") &&
                 activity.contains("val compactCards = layoutMode == NovaLibraryLayoutMode.COMPACT_GRID") &&
                 activity.contains("val listCards = layoutMode == NovaLibraryLayoutMode.LIST") &&
                 activity.contains("compact = compactCards") &&
-                activity.contains("listStyle = listCards")
+                activity.contains("listStyle = listCards") &&
+                activity.contains("showPosterTitle = model.optionsState.showPosterTitles")
         )
         assertTrue(
-            "quick options strings should cover the GameNative-inspired Sort/Layout surface",
+            "quick options strings should cover the Sort/Layout/Poster title surface",
             strings.contains("name=\"nova_library_options_title\">Library Options") &&
                 strings.contains("name=\"nova_library_options_sort_recent\">Recent") &&
                 strings.contains("name=\"nova_library_options_sort_name_asc\">Name A-Z") &&
                 strings.contains("name=\"nova_library_options_sort_name_desc\">Name Z-A") &&
                 strings.contains("name=\"nova_library_options_sort_source\">Source") &&
                 strings.contains("name=\"nova_library_options_sort_hdr_first\">HDR first") &&
-                strings.contains("name=\"nova_library_options_layout_compact_grid\">Compact grid")
+                strings.contains("name=\"nova_library_options_layout_compact_grid\">Compact grid") &&
+                strings.contains("name=\"nova_library_options_poster_titles_title\">Poster titles") &&
+                strings.contains("name=\"nova_library_options_poster_titles_hide\">Plain artwork")
         )
     }
 
@@ -820,7 +833,14 @@ class NovaComposeSourceGuardTest {
         }
 
         assertTrue(
-            "grid game cards should draw a dedicated title-safe scrim above cover art before title text",
+            "grid game cards should gate the poster title/caption overlay so users can choose plain artwork posters",
+            gameCard.contains("showPosterTitle: Boolean = true") &&
+                gameCard.contains("if (showPosterTitle) {") &&
+                gameCard.contains("NovaLibraryCardTitleScrim(") &&
+                gameCard.indexOf("if (showPosterTitle) {") in 0 until gameCard.lastIndexOf("text = title")
+        )
+        assertTrue(
+            "grid game cards should draw a dedicated title-safe scrim above cover art before title text when titles are enabled",
             gameCard.contains("NovaLibraryCardTitleScrim(") &&
                 gameCard.indexOf("NovaLibraryCardTitleScrim(") in 0 until gameCard.lastIndexOf("text = title")
         )

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -804,23 +804,72 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
+    fun libraryGameCardsReserveReadableTitleBandOnBusyArtwork() {
+        val activity = readNovaLibraryActivity()
+        val gameCard = activity.section(
+            "private fun NovaLibraryGameCard(",
+            "private fun NovaMiniBadge("
+        )
+        val titleScrim = if (activity.contains("private fun NovaLibraryCardTitleScrim(")) {
+            activity.section(
+                "private fun NovaLibraryCardTitleScrim(",
+                "private fun NovaLibraryCardBadgeRow("
+            )
+        } else {
+            ""
+        }
+
+        assertTrue(
+            "grid game cards should draw a dedicated title-safe scrim above cover art before title text",
+            gameCard.contains("NovaLibraryCardTitleScrim(") &&
+                gameCard.indexOf("NovaLibraryCardTitleScrim(") in 0 until gameCard.lastIndexOf("text = title")
+        )
+        assertTrue(
+            "title scrim should be a bounded bottom band, not a weak full-card wash that leaves white logo art behind white text",
+            titleScrim.contains(".height(if (compact) 64.dp else 88.dp)") &&
+                titleScrim.contains("0.36f to surfaces.mediaScrimBottom.copy(alpha = 0.64f)") &&
+                titleScrim.contains("1.0f to surfaces.mediaScrimBottom.copy(alpha = 0.96f)")
+        )
+        assertTrue(
+            "title and metadata should sit inside a small padded caption panel for extra contrast over noisy cover art",
+            gameCard.contains(".background(surfaces.mediaScrimBottom.copy(alpha = 0.34f))") &&
+                gameCard.contains(".padding(horizontal = 7.dp, vertical = 5.dp)")
+        )
+    }
+
+    @Test
     fun libraryMiniBadgesStaySmallOnDenseCards() {
-        val miniBadge = readNovaLibraryActivity().section(
+        val activity = readNovaLibraryActivity()
+        val miniBadge = activity.section(
             "private fun NovaMiniBadge(",
             "@Composable\n    private fun NovaLibraryLoadingGrid("
         )
+        val badgeRow = if (activity.contains("private fun NovaLibraryCardBadgeRow(")) {
+            activity.section(
+                "private fun NovaLibraryCardBadgeRow(",
+                "private fun NovaMiniBadge("
+            )
+        } else {
+            ""
+        }
 
         assertTrue(
             "library card badges should use compact text",
-            miniBadge.contains("fontSize = 9.sp")
+            miniBadge.contains("fontSize = 8.sp")
         )
         assertTrue(
             "library card badges should pin a compact line height",
-            miniBadge.contains("lineHeight = 10.sp")
+            miniBadge.contains("lineHeight = 9.sp")
         )
         assertTrue(
             "library card badges should use tighter pill padding",
-            miniBadge.contains(".padding(horizontal = 6.dp, vertical = 2.dp)")
+            miniBadge.contains(".padding(horizontal = 5.dp, vertical = 1.dp)")
+        )
+        assertTrue(
+            "grid cards should render badges through a bounded row so repeated HDR/Recent chips do not dominate cover art",
+            badgeRow.contains("private fun NovaLibraryCardBadgeRow(") &&
+                badgeRow.contains(".widthIn(max = if (compact) 92.dp else 128.dp)") &&
+                badgeRow.contains("horizontalArrangement = Arrangement.spacedBy(4.dp)")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -475,10 +475,12 @@ class NovaComposeSourceGuardTest {
                 hero.contains("if (compact && hero.supportingLine.isNotBlank())")
         )
         assertTrue(
-            "hero should render a deterministic fallback artwork tile so blank cover/backdrop art still has a useful console identity",
-            hero.contains("NovaLibraryHeroFallbackArtwork(") &&
-                hero.contains("title = hero.artworkFallbackTitle") &&
-                hero.contains("subtitle = hero.artworkFallbackSubtitle")
+            "hero should render the selected game's real cover before falling back to a deterministic Nova artwork tile",
+            hero.contains("NovaLibraryHeroArtwork(") &&
+                hero.contains("game = heroGame") &&
+                hero.contains("apiClient = apiClient") &&
+                hero.contains("fallbackTitle = hero.artworkFallbackTitle") &&
+                hero.contains("fallbackSubtitle = hero.artworkFallbackSubtitle")
         )
         assertTrue(
             "hero height should be mapper-driven so Retroid landscape can shrink the resume surface without source spelunking",
@@ -520,6 +522,31 @@ class NovaComposeSourceGuardTest {
         assertTrue(
             "hero focus should update the focused backdrop/focus restore model for D-pad users",
             hero.contains("onGameFocused(heroGame)")
+        )
+    }
+
+    @Test
+    fun libraryHomeHeroKeepsTitleVisibleBesideBoundedCoverAndCta() {
+        val source = readNovaLibraryActivity()
+        val hero = source.section(
+            "private fun NovaLibraryHomeHero(",
+            "private fun NovaLibraryHeroFallbackArtwork("
+        )
+
+        assertTrue(
+            "home hero needs the Polaris API client so selected games use the same cover loader as grid/detail cards",
+            hero.contains("apiClient: PolarisApiClient") &&
+                source.contains("private fun NovaLibraryHeroArtwork(") &&
+                source.contains("apiClient.loadCoverInto(this, targetGame)")
+        )
+        assertTrue(
+            "compact landscape hero should place artwork, title context, and a bounded launch CTA in that order",
+            hero.indexOf("NovaLibraryHeroArtwork(") in 0 until hero.indexOf("Column(\n                modifier = Modifier.weight(1f)") &&
+                hero.contains("Modifier.width(if (compact) 132.dp else 168.dp)")
+        )
+        assertFalse(
+            "hero CTA column must not use unconstrained widthIn + fillMaxWidth because it gobbles the row and hides the title",
+            hero.contains("Modifier.widthIn(min = if (compact) 104.dp else 148.dp)")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
@@ -115,9 +115,9 @@ class NovaHudSessionStatsTest {
             "issues" to listOf("decoder_watch"),
             "safe_target_fps" to 60.0,
             "relaunch_recommended" to false,
-            "device" to "Retroid Pocket Flip2",
+            "device" to "Generic Handheld",
             "unique_id" to "abc123",
-            "host" to "pc-papi.lan"
+            "host" to "example-stream-host.lan"
         )
 
         val json = JsonParser.parseString(NovaHudSessionSummaryLog.format(summary)).asJsonObject
@@ -130,5 +130,35 @@ class NovaHudSessionStatsTest {
         assertFalse(json.has("device"))
         assertFalse(json.has("unique_id"))
         assertFalse(json.has("host"))
+    }
+
+    @Test
+    fun diagnosticReportIsHumanReadableAndPrivacySafe() {
+        val summary = mapOf(
+            "avg_fps" to 59.5,
+            "target_fps" to 120.0,
+            "safe_target_fps" to 60.0,
+            "avg_latency_ms" to 24.0,
+            "avg_bitrate_kbps" to 18000,
+            "packet_loss_pct" to 0.25,
+            "codec" to "HEVC",
+            "primary_issue" to "host_render_limited",
+            "health_grade" to "watch",
+            "relaunch_recommended" to true,
+            "device" to "Generic Handheld",
+            "host" to "example-stream-host.lan",
+            "unique_id" to "abc123"
+        )
+
+        val text = NovaHudDiagnosticReport.format(summary)
+
+        assertTrue(text.contains("Nova stream diagnostics"))
+        assertTrue(text.contains("Observed: 59.5 FPS / target 120 FPS"))
+        assertTrue(text.contains("Suggested: relaunch at 60 FPS"))
+        assertTrue(text.contains("Health: watch / host_render_limited"))
+        assertTrue(text.contains("Network: 24 ms RTT / 0.25% loss"))
+        assertFalse(text.contains("Generic Handheld"))
+        assertFalse(text.contains("example-stream-host"))
+        assertFalse(text.contains("abc123"))
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -256,6 +256,68 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun diagnosticsExplainHealthReasonStreamTruthAndLayerHealth() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 59.2,
+            targetFps = 120.0,
+            latencyMs = 18,
+            codec = "hevc_nvenc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "watch",
+                    primaryIssue = "host_render_limited",
+                    hostRenderLimited = true,
+                    safeTargetFps = 60.0,
+                    relaunchRecommended = true
+                )
+            ),
+            sparklineSamples = listOf(58f, 60f, 59f)
+        )
+
+        assertEquals("Host capped", state.healthReasonLabel)
+        assertEquals(NovaHudTone.WARNING, state.healthReasonTone)
+        assertEquals("Stream 120 • Game capped 60", state.streamTruthLabel)
+        assertEquals(
+            listOf(
+                NovaHudLayerHealth("HOST", NovaHudTone.WARNING),
+                NovaHudLayerHealth("NET", NovaHudTone.STABLE),
+                NovaHudLayerHealth("CLIENT", NovaHudTone.STABLE)
+            ),
+            state.layerHealth
+        )
+    }
+
+    @Test
+    fun eventBreadcrumbTrailKeepsLatestActionableHudEvent() {
+        val trail = NovaHudEventTrail(capacity = 3)
+
+        trail.recordBitrateChange(fromKbps = 30000, toKbps = 22000)
+        assertEquals("Bitrate lowered: 30M → 22M", trail.latestLabel)
+
+        trail.recordRecoveryProfile(targetFps = 60.0)
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.PERFORMANCE,
+            fps = 59.0,
+            targetFps = 120.0,
+            latencyMs = 20,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = listOf(59f),
+            eventBreadcrumbLabel = trail.latestLabel
+        )
+
+        assertEquals("Recovery profile ready: 60 FPS", trail.latestLabel)
+        assertEquals("Recovery profile ready: 60 FPS", state.eventBreadcrumbLabel)
+    }
+
+    @Test
     fun sparklineBufferKeepsLatestSixtySamplesInOrder() {
         val buffer = NovaHudSparklineBuffer(capacity = 60)
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -620,17 +620,32 @@ class NovaLibraryUiStateTest {
             NovaLibraryUiStateMapper.landscapeContentSpacingDp() <= 6
         )
         assertTrue(
-            "Retroid landscape footer reserve should clear the controller hint bar without eating another game row",
-            NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true) <= 32
+            "Retroid landscape footer reserve should clear the full controller hint bar plus breathing room so poster rows do not sit underneath it",
+            NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true) in 44..52
         )
         assertEquals(
             "portrait footer reserve should stay unchanged while the compact landscape shell is tightened",
             40,
             NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = false)
         )
+        assertEquals(
+            "default grid inset should keep the first poster row tucked inside the glass panel",
+            10,
+            NovaLibraryUiStateMapper.gridContentPaddingDp()
+        )
+        assertTrue(
+            "landscape grid scroll padding should leave the final poster row clear of the footer hint chrome",
+            NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape = true) >=
+                NovaLibraryUiStateMapper.gridContentPaddingDp() + 12
+        )
+        assertEquals(
+            "portrait grid bottom inset should stay compact because portrait already reserves a taller footer",
+            NovaLibraryUiStateMapper.gridContentPaddingDp(),
+            NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape = false)
+        )
         assertTrue(
             "compact landscape persistent chrome should leave the game grid as the visual primary surface",
-            persistentChromeBudget <= 140
+            persistentChromeBudget <= 156
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -95,6 +95,7 @@ class NovaLibraryUiStateTest {
 
         assertEquals(NovaLibrarySortMode.LIBRARY_ORDER, model.optionsState.sortMode)
         assertEquals(NovaLibraryLayoutMode.GRID, model.optionsState.layoutMode)
+        assertTrue(model.optionsState.showPosterTitles)
         assertEquals(listOf("Beta", "Alpha", "Charlie"), model.filteredGames.map { it.name })
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -264,7 +264,7 @@ class NovaLibraryUiStateTest {
         assertEquals("match", model.hero.game?.id)
         assertEquals(NovaLibraryHeroReason.FIRST_FILTERED, model.hero.reason)
         assertEquals("Filtered library", model.hero.eyebrow)
-        assertEquals("Launch options", model.hero.actionLabel)
+        assertEquals("Launch", model.hero.actionLabel)
         assertEquals("Filters active - clear to browse every game.", model.hero.caption)
     }
 
@@ -374,7 +374,7 @@ class NovaLibraryUiStateTest {
         assertEquals(NovaLibraryHeroReason.LAST_PLAYED, hero.reason)
         assertEquals(NovaLibraryHeroPrimaryAction.OPEN_DETAIL, hero.primaryAction)
         assertEquals("Continue playing", hero.eyebrow)
-        assertEquals("Launch options", hero.actionLabel)
+        assertEquals("Launch", hero.actionLabel)
         assertNull(hero.secondaryActionLabel)
         assertEquals("Continue • Steam", hero.supportingLine)
         assertEquals("Recent Game", hero.artworkFallbackTitle)
@@ -511,7 +511,7 @@ class NovaLibraryUiStateTest {
         assertEquals(NovaLibraryHeroPrimaryAction.OPEN_DETAIL, hero.primaryAction)
         assertEquals("Heroic", hero.subtitle)
         assertEquals("Ready when you are", hero.eyebrow)
-        assertEquals("Launch options", hero.actionLabel)
+        assertEquals("Launch", hero.actionLabel)
         assertEquals("Choose profile, display, and stream settings.", hero.caption)
 
         assertEquals(NovaLibraryHeroReason.EMPTY, emptyHero.reason)
@@ -523,6 +523,7 @@ class NovaLibraryUiStateTest {
 
     @Test
     fun gridColumnsMatchCurrentBreakpoints() {
+        assertEquals(2, NovaLibraryUiStateMapper.gridColumns(widthDp = 430, isLandscape = false))
         assertEquals(3, NovaLibraryUiStateMapper.gridColumns(widthDp = 540, isLandscape = false))
         assertEquals(3, NovaLibraryUiStateMapper.gridColumns(widthDp = 600, isLandscape = false))
         assertEquals(4, NovaLibraryUiStateMapper.gridColumns(widthDp = 720, isLandscape = false))
@@ -538,6 +539,7 @@ class NovaLibraryUiStateTest {
         assertFalse(NovaLibraryUiStateMapper.showLandscapeControlRail())
         assertEquals(813, NovaLibraryUiStateMapper.contentWidthDp(widthDp = 833, isLandscape = true))
         assertEquals(4, NovaLibraryUiStateMapper.gridColumnsForScreen(widthDp = 833, isLandscape = true))
+        assertEquals(2, NovaLibraryUiStateMapper.gridColumnsForScreen(widthDp = 430, isLandscape = false))
         assertEquals(3, NovaLibraryUiStateMapper.gridColumnsForScreen(widthDp = 720, isLandscape = true))
         assertEquals(5, NovaLibraryUiStateMapper.gridColumnsForScreen(widthDp = 960, isLandscape = false))
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -121,6 +121,17 @@ class NovaQuickMenuUiStateTest {
         assertTrue(state.sessionRows.any { it.id == NovaQuickMenuActionId.MORE_KEYS && it.label == "More Keys" })
     }
 
+    @Test
+    fun overlayRowsExposePrivacySafeHudDiagnosticCopy() {
+        val state = quickState(status = status(), currentGameName = "Portal")
+        val diagnostics = state.overlayRows.first { it.id == NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS }
+
+        assertEquals("Copy HUD Diagnostics", diagnostics.label)
+        assertEquals("Privacy-safe stream summary for bug reports.", diagnostics.caption)
+        assertEquals("Safe", diagnostics.chip!!.label)
+        assertEquals(NovaQuickMenuTone.INFO, diagnostics.chip.tone)
+    }
+
     private fun quickState(
         status: PolarisSessionStatus?,
         apiAvailable: Boolean = true,

--- a/app/src/test/java/com/papi/nova/ui/NovaStreamHudModeTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaStreamHudModeTest.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.preference.PreferenceManager
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -38,5 +39,21 @@ class NovaStreamHudModeTest {
         )
 
         hud.dismiss()
+    }
+
+    @Test
+    fun hudLongPressOpensCommandCenterAndPositionPersistsInsideSafeZone() {
+        val source = String(
+            java.nio.file.Files.readAllBytes(java.nio.file.Path.of("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")),
+            java.nio.charset.StandardCharsets.UTF_8
+        )
+
+        assertTrue(source.contains("onCommandCenterRequested?.invoke()"))
+        assertTrue(source.contains("ViewConfiguration.getLongPressTimeout()"))
+        assertTrue(source.contains("saveHudPosition"))
+        assertTrue(source.contains("restoreHudPosition"))
+        assertTrue(source.contains("clampHudPosition"))
+        assertTrue(source.contains("nova_polaris_hud_x"))
+        assertTrue(source.contains("nova_polaris_hud_y"))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/28.txt
+++ b/fastlane/metadata/android/en-US/changelogs/28.txt
@@ -1,0 +1,8 @@
+Nova 1.1.2
+
+- Adds Insert to Command Center Quick Keys and More Keys / Send special keys.
+- Adds a first-screen End session path for owned active streams stuck on Resume.
+- Hardens fallback app-list data so incomplete host results stay out of Library.
+- Improves High FPS stream wording so 120 FPS is clearly the stream target.
+- Fixes app-grid null crashes and preserves stylus pressure paths before mouse capture.
+- Updates Netty/Wire dependency pins and current release validation.

--- a/tools/nova_retroid_smoke.py
+++ b/tools/nova_retroid_smoke.py
@@ -65,8 +65,10 @@ COMMAND_CENTER_LABELS = (
     "ESC",
     "Alt + Enter",
     "Alt + F4",
+    "F11",
+    "Insert",
     "Stats Overlay",
-    "End",
+    "End session",
     "Disconnect",
 )
 TOUCH_CONTROLS_CAPTION = "On-screen overlay; physical gamepad stays active."
@@ -1174,7 +1176,7 @@ def end_stream_from_command_center(adb: Adb, args: argparse.Namespace, prefix: P
     for attempt in range(1, 5):
         xml_path = prefix.with_name(f"{prefix.name}_end_attempt_{attempt}").with_suffix(".xml")
         xml_text = dump_xml(adb, xml_path)
-        if tap_first_label(adb, xml_text, "End"):
+        if tap_first_label(adb, xml_text, "End session") or tap_first_label(adb, xml_text, "End"):
             time.sleep(0.8)
             confirm_xml = dump_xml(adb, prefix.with_name(prefix.name + "_end_confirm").with_suffix(".xml"))
             confirmed = tap_first_label(adb, confirm_xml, "YES") or tap_first_label(adb, confirm_xml, "Yes")

--- a/tools/test_nova_retroid_smoke.py
+++ b/tools/test_nova_retroid_smoke.py
@@ -383,7 +383,7 @@ class NovaRetroidSmokeHelpersTest(unittest.TestCase):
 
         args = type("Args", (), {"activity": "com.papi.nova.ui.NovaLibraryActivity", "timeout": 45})()
         xmls = [
-            '<hierarchy><node text="End" bounds="[825,220][934,276]" /></hierarchy>',
+            '<hierarchy><node text="End session" bounds="[825,220][934,276]" /></hierarchy>',
             '<hierarchy><node text="Yes" bounds="[700,600][900,700]" /></hierarchy>',
         ]
 
@@ -409,7 +409,7 @@ class NovaRetroidSmokeHelpersTest(unittest.TestCase):
 
         args = type("Args", (), {"activity": "com.papi.nova.ui.NovaLibraryActivity", "timeout": 45})()
         xmls = [
-            '<hierarchy><node text="End" bounds="[825,220][934,276]" /></hierarchy>',
+            '<hierarchy><node text="End session" bounds="[825,220][934,276]" /></hierarchy>',
             '<hierarchy><node text="Cancel" bounds="[700,600][900,700]" /></hierarchy>',
         ]
 


### PR DESCRIPTION
## Summary

- Polishes the Nova Library/release prep surface for v1.1.2 with clearer artwork, card readability, and release metadata.
- Adds actionable NovaHUD diagnostics: health reason, stream truth, event breadcrumbs, host/network/client split, safe-zone dragging, long-press Command Center access, and privacy-safe diagnostic copy.
- Keeps the HUD mode model compatible with existing preferences while making Debug/diagnostic behavior more useful for stream troubleshooting.

## Validation

- Focused NovaHUD/Quick Menu unit coverage: 27 tests passed.
- `:app:testNonRoot_gameDebugUnitTest :app:assembleNonRoot_gameDebug` passed.
- `:app:lintNonRoot_gameDebug` passed.
- ARM64 debug APK assembled and installed successfully on a Retroid handheld without clearing app data.
- Retroid smoke reached Black Myth: Wukong gameplay, verified movement/camera input, NovaHUD visibility/cycle/drag/long-press, Command Center over gameplay, and clean Disconnect back to Library.

## Notes for reviewers

- Diagnostic copy intentionally avoids host/device identifiers and keeps support output privacy-safe.
- HUD tap-to-cycle behavior is preserved; long-press opens Command Center.
- Debug/full telemetry remains behind the existing `debug` preference value for compatibility.
