### PR TITLE
feat(deck): use read-only library snapshot in Deck shell

### DIFF
--- a/clients/deck/fixtures/sample_polaris_library.json
+++ b/clients/deck/fixtures/sample_polaris_library.json
@@ -17,21 +17,30 @@
       "category": "fast_action",
       "installed": true,
       "cover_url": "/polaris/v1/games/game-123/cover",
-      "genres": ["Action", "Puzzle"],
+      "genres": [
+        "Action",
+        "Puzzle"
+      ],
       "last_launched": 1718187600000,
       "mangohud": true,
       "hdr_supported": true,
       "launch_mode": {
         "preferred_mode": "virtual_display",
         "recommended_mode": "headless",
-        "allowed_modes": ["headless", "virtual_display"],
+        "allowed_modes": [
+          "headless",
+          "virtual_display"
+        ],
         "mode_reason": "Host default is headless."
       },
       "steam_launch": {
         "available": true,
         "mode": "big-picture",
         "recommended_mode": "direct",
-        "allowed_modes": ["direct", "big-picture"],
+        "allowed_modes": [
+          "direct",
+          "big-picture"
+        ],
         "mode_reason": "Steam Input fallback."
       }
     },
@@ -50,23 +59,46 @@
       "category": "fast_action",
       "installed": true,
       "cover_url": "/polaris/v1/games/game-456/cover",
-      "genres": ["Action", "Roguelike"],
+      "genres": [
+        "Action",
+        "Roguelike"
+      ],
       "last_launched": 1718191200000,
       "mangohud": true,
       "hdr_supported": false,
       "launch_mode": {
         "preferred_mode": "headless",
         "recommended_mode": "virtual_display",
-        "allowed_modes": ["headless", "virtual_display"],
+        "allowed_modes": [
+          "headless",
+          "virtual_display"
+        ],
         "mode_reason": "Virtual display is available for this host."
       },
       "steam_launch": {
         "available": true,
         "mode": "direct",
         "recommended_mode": "big-picture",
-        "allowed_modes": ["direct", "big-picture"],
+        "allowed_modes": [
+          "direct",
+          "big-picture"
+        ],
         "mode_reason": "Big Picture is controller-friendly."
       }
+    }
+  ],
+  "hosts": [
+    {
+      "id": "host-snapshot-primary",
+      "display_name": "Polaris Snapshot Primary",
+      "status_label": "Ready from read-only library snapshot",
+      "subtitle": "Read-only host snapshot fixture \u2014 not discovered from the network."
+    },
+    {
+      "id": "host-snapshot-living-room",
+      "display_name": "Polaris Snapshot Living Room",
+      "status_label": "Available from read-only library snapshot",
+      "subtitle": "Read-only host snapshot fixture \u2014 not discovered from the network."
     }
   ]
 }

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -85,6 +85,36 @@ ApplicationWindow {
         refreshLaunchPreviewBinding()
     }
 
+    function focusSelectedLibraryItem() {
+        for (let i = 0; i < libraryGameRepeater.count; ++i) {
+            const gameItem = libraryGameRepeater.itemAt(i)
+            if (gameItem !== null && selectedGameForPreview && gameItem.objectName === selectedGameForPreview.id) {
+                gameItem.forceActiveFocus()
+                return
+            }
+        }
+        for (let i = 0; i < hostRepeater.count; ++i) {
+            const hostItem = hostRepeater.itemAt(i)
+            if (hostItem !== null && selectedHostForPreview && hostItem.objectName === selectedHostForPreview.id) {
+                hostItem.forceActiveFocus()
+                return
+            }
+        }
+        if (novaLibraryHosts.length === 0) {
+            emptyHostState.forceActiveFocus()
+            return
+        }
+        if (novaLibraryGames.length === 0 && emptyGameState.visible) {
+            emptyGameState.forceActiveFocus()
+            return
+        }
+        if (hostRepeater.itemAt(0) !== null) {
+            hostRepeater.itemAt(0).forceActiveFocus()
+        } else {
+            emptyHostState.forceActiveFocus()
+        }
+    }
+
     function activateLaunchPreviewCopyFromController() {
         const canCopyPreview = launchPreviewCopyAction.enabled
             && launchPreviewCopyAction.previewText.length > 0
@@ -232,13 +262,13 @@ ApplicationWindow {
                             Keys.onEnterPressed: selectHostForPreview(modelData)
                             Keys.onSpacePressed: selectHostForPreview(modelData)
                             Keys.onDownPressed: {
-                                const next = hostRepeater.itemAt(index + 1)
+                                const next = hostRepeater.itemAt((index + 1) % hostRepeater.count)
                                 if (next !== null) {
                                     next.forceActiveFocus()
                                 }
                             }
                             Keys.onUpPressed: {
-                                const previous = hostRepeater.itemAt(index - 1)
+                                const previous = hostRepeater.itemAt((index + hostRepeater.count - 1) % hostRepeater.count)
                                 if (previous !== null) {
                                     previous.forceActiveFocus()
                                 }
@@ -261,6 +291,14 @@ ApplicationWindow {
                                     color: "#B8C2F0"
                                     font.pixelSize: 16
                                 }
+
+                                Label {
+                                    visible: selectedHostForPreview.id === modelData.id
+                                    text: "Selected host"
+                                    color: "#8AFFC1"
+                                    font.pixelSize: 12
+                                    font.bold: true
+                                }
                             }
                         }
                     }
@@ -281,10 +319,49 @@ ApplicationWindow {
 
                     Label {
                         Layout.preferredWidth: sampleTextWidth
-                        text: novaLibraryFixtureSource + (novaLibraryReadOnly ? " · read-only" : "")
+                        text: novaLibraryFixtureSource + (novaLibraryReadOnly ? " · read-only · Read-only snapshot loaded" : " · Snapshot unavailable in this preview shell — no backend request will be made")
                         color: "#A8B0D8"
                         font.pixelSize: 13
                         wrapMode: Text.WordWrap
+                    }
+
+                    Rectangle {
+                        id: emptyGameState
+                        objectName: "game-empty-state"
+                        visible: novaLibraryGames.length === 0
+                        Layout.preferredWidth: sampleCardWidth
+                        Layout.preferredHeight: visible ? 116 : 0
+                        radius: 18
+                        color: activeFocus ? "#202B55" : "#151D39"
+                        border.color: activeFocus ? "#B8C2FF" : "#39466F"
+                        border.width: activeFocus ? 5 : 2
+                        focus: visible
+                        activeFocusOnTab: visible
+                        KeyNavigation.left: novaLibraryHosts.length > 0 ? hostRepeater.itemAt(0) : emptyHostState
+                        KeyNavigation.right: hostDetailPanel
+                        Keys.onLeftPressed: focusSelectedLibraryItem()
+                        Keys.onRightPressed: hostDetailPanel.forceActiveFocus()
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 16
+                            spacing: 5
+
+                            Label {
+                                text: "No games in read-only snapshot"
+                                color: "#E9ECFF"
+                                font.pixelSize: 20
+                                font.bold: true
+                            }
+
+                            Label {
+                                Layout.preferredWidth: sampleTextWidth
+                                text: "Snapshot unavailable in this preview shell — no backend request will be made."
+                                color: "#A8B0D8"
+                                font.pixelSize: 12
+                                wrapMode: Text.WordWrap
+                            }
+                        }
                     }
 
                     Repeater {
@@ -314,24 +391,18 @@ ApplicationWindow {
                             Keys.onEnterPressed: selectGameForPreview(modelData)
                             Keys.onSpacePressed: selectGameForPreview(modelData)
                             Keys.onDownPressed: {
-                                const next = libraryGameRepeater.itemAt(index + 1)
+                                const next = libraryGameRepeater.itemAt((index + 1) % libraryGameRepeater.count)
                                 if (next !== null) {
                                     next.forceActiveFocus()
                                 }
                             }
                             Keys.onUpPressed: {
-                                const previous = libraryGameRepeater.itemAt(index - 1)
+                                const previous = libraryGameRepeater.itemAt((index + libraryGameRepeater.count - 1) % libraryGameRepeater.count)
                                 if (previous !== null) {
                                     previous.forceActiveFocus()
                                 }
                             }
-                            Keys.onLeftPressed: {
-                                if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
-                                    hostRepeater.itemAt(0).forceActiveFocus()
-                                } else {
-                                    emptyHostState.forceActiveFocus()
-                                }
-                            }
+                            Keys.onLeftPressed: focusSelectedLibraryItem()
 
                             ColumnLayout {
                                 anchors.fill: parent
@@ -356,6 +427,14 @@ ApplicationWindow {
                                     color: "#A8B0D8"
                                     font.pixelSize: 12
                                 }
+
+                                Label {
+                                    visible: selectedGameForPreview.id === modelData.id
+                                    text: "Selected game"
+                                    color: "#8AFFC1"
+                                    font.pixelSize: 11
+                                    font.bold: true
+                                }
                             }
                         }
                     }
@@ -377,14 +456,10 @@ ApplicationWindow {
                         focus: true
                         activeFocusOnTab: true
                         KeyNavigation.left: hostRepeater.itemAt(0) !== null ? hostRepeater.itemAt(0) : emptyHostState
+                        KeyNavigation.up: copyPreviewButton
                         KeyNavigation.down: launchCtaPlaceholder
-                        Keys.onLeftPressed: {
-                            if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
-                                hostRepeater.itemAt(0).forceActiveFocus()
-                            } else {
-                                emptyHostState.forceActiveFocus()
-                            }
-                        }
+                        Keys.onLeftPressed: focusSelectedLibraryItem()
+                        Keys.onUpPressed: copyPreviewButton.forceActiveFocus()
                         Keys.onDownPressed: launchCtaPlaceholder.forceActiveFocus()
 
                         ColumnLayout {
@@ -448,13 +523,7 @@ ApplicationWindow {
                         Keys.onReturnPressed: activateLaunchPreviewCopyFromController()
                         Keys.onEnterPressed: activateLaunchPreviewCopyFromController()
                         Keys.onSpacePressed: activateLaunchPreviewCopyFromController()
-                        Keys.onLeftPressed: {
-                            if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
-                                hostRepeater.itemAt(0).forceActiveFocus()
-                            } else {
-                                emptyHostState.forceActiveFocus()
-                            }
-                        }
+                        Keys.onLeftPressed: focusSelectedLibraryItem()
 
                         ColumnLayout {
                             anchors.fill: parent
@@ -518,14 +587,10 @@ ApplicationWindow {
                                 focusPolicy: Qt.StrongFocus
                                 activeFocusOnTab: true
                                 KeyNavigation.up: launchCtaPlaceholder
+                                KeyNavigation.down: hostDetailPanel
                                 Keys.onUpPressed: launchCtaPlaceholder.forceActiveFocus()
-                                Keys.onLeftPressed: {
-                                    if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
-                                        hostRepeater.itemAt(0).forceActiveFocus()
-                                    } else {
-                                        emptyHostState.forceActiveFocus()
-                                    }
-                                }
+                                Keys.onDownPressed: hostDetailPanel.forceActiveFocus()
+                                Keys.onLeftPressed: focusSelectedLibraryItem()
                                 Keys.onReturnPressed: activateLaunchPreviewCopyFromController()
                                 Keys.onEnterPressed: activateLaunchPreviewCopyFromController()
                                 Keys.onSpacePressed: activateLaunchPreviewCopyFromController()
@@ -535,7 +600,7 @@ ApplicationWindow {
                             Label {
                                 id: copyStatusLabel
                                 Layout.preferredWidth: detailTextWidth
-                                text: launchPreviewCopyAction.idleStatusLabel + " Press A on Copy to verify."
+                                text: launchPreviewCopyAction.idleStatusLabel + " Press A on Copy to verify. A copies the preview URI locally only."
                                 color: "#FFDDA8"
                                 font.pixelSize: 12
                                 wrapMode: Text.WordWrap

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -31,7 +31,7 @@ ApplicationWindow {
     property var launchPreviewCopyAction: novaLaunchPreviewCopyAction
 
     function selectedHostSubtitle() {
-        return "Demo host detail only — not discovered from the network."
+        return "Read-only host detail only — not discovered from the network."
     }
 
     function previewComponent(value) {
@@ -123,7 +123,7 @@ ApplicationWindow {
         focus: true
         Component.onCompleted: Qt.callLater(function() {
             refreshLaunchPreviewBinding()
-            if (novaDemoHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
+            if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
                 hostRepeater.itemAt(0).forceActiveFocus()
             } else {
                 emptyHostState.forceActiveFocus()
@@ -164,7 +164,7 @@ ApplicationWindow {
                     spacing: deckPanelSpacing
 
                     Label {
-                        text: "Demo hosts"
+                        text: "Library hosts"
                         color: "#E9ECFF"
                         font.pixelSize: 28
                         font.bold: true
@@ -173,7 +173,7 @@ ApplicationWindow {
                     Rectangle {
                         id: emptyHostState
                         objectName: "host-empty-state"
-                        visible: novaDemoHosts.length === 0
+                        visible: novaLibraryHosts.length === 0
                         Layout.preferredWidth: hostColumnWidth
                         Layout.preferredHeight: visible ? 120 : 0
                         radius: 20
@@ -207,7 +207,7 @@ ApplicationWindow {
 
                     Repeater {
                         id: hostRepeater
-                        model: novaDemoHosts
+                        model: novaLibraryHosts
 
                         delegate: Rectangle {
                             required property int index
@@ -326,7 +326,7 @@ ApplicationWindow {
                                 }
                             }
                             Keys.onLeftPressed: {
-                                if (novaDemoHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
+                                if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
                                     hostRepeater.itemAt(0).forceActiveFocus()
                                 } else {
                                     emptyHostState.forceActiveFocus()
@@ -379,7 +379,7 @@ ApplicationWindow {
                         KeyNavigation.left: hostRepeater.itemAt(0) !== null ? hostRepeater.itemAt(0) : emptyHostState
                         KeyNavigation.down: launchCtaPlaceholder
                         Keys.onLeftPressed: {
-                            if (novaDemoHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
+                            if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
                                 hostRepeater.itemAt(0).forceActiveFocus()
                             } else {
                                 emptyHostState.forceActiveFocus()
@@ -393,7 +393,7 @@ ApplicationWindow {
                             spacing: 8
 
                             Label {
-                                text: "Demo host detail"
+                                text: "Read-only host detail"
                                 color: "#7C88B8"
                                 font.pixelSize: 16
                             }
@@ -449,7 +449,7 @@ ApplicationWindow {
                         Keys.onEnterPressed: activateLaunchPreviewCopyFromController()
                         Keys.onSpacePressed: activateLaunchPreviewCopyFromController()
                         Keys.onLeftPressed: {
-                            if (novaDemoHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
+                            if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
                                 hostRepeater.itemAt(0).forceActiveFocus()
                             } else {
                                 emptyHostState.forceActiveFocus()
@@ -520,7 +520,7 @@ ApplicationWindow {
                                 KeyNavigation.up: launchCtaPlaceholder
                                 Keys.onUpPressed: launchCtaPlaceholder.forceActiveFocus()
                                 Keys.onLeftPressed: {
-                                    if (novaDemoHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
+                                    if (novaLibraryHosts.length > 0 && hostRepeater.itemAt(0) !== null) {
                                         hostRepeater.itemAt(0).forceActiveFocus()
                                     } else {
                                         emptyHostState.forceActiveFocus()

--- a/clients/deck/src/deck_layout.cpp
+++ b/clients/deck/src/deck_layout.cpp
@@ -12,7 +12,7 @@ constexpr std::string_view kPreviewStateLabel = "Preview only — not executable
 constexpr std::string_view kPreviewBoundaryId = "deck-launch-preview-only";
 constexpr std::string_view kPreviewBoundaryLabel = "Preview-only typed intent boundary";
 constexpr std::string_view kPreviewBoundaryReason = "Deck shell may build copyable preview text, but launch execution is blocked.";
-constexpr std::string_view kCopyIdleStatusLabel = "Copy action is preview-only and not executable.";
+constexpr std::string_view kCopyIdleStatusLabel = "A copies the preview URI locally only — no launch, stream, backend, or Moonlight.";
 constexpr std::string_view kCopySuccessToast = "Preview text copied for inspection only — still not executable.";
 constexpr std::string_view kCopyInertToast = "No preview text to copy — preview-only action stayed inert.";
 
@@ -237,6 +237,61 @@ std::vector<DeckLibraryGameCard> libraryGameCardsFor(const PolarisGameLibraryFix
     return cards;
 }
 
+std::string_view initialLibraryGameFocusTarget(const std::vector<DeckLibraryGameCard>& games) {
+    const auto initial = std::ranges::find_if(games, [](const DeckLibraryGameCard& game) {
+        return game.initialFocus;
+    });
+
+    if (initial != games.end()) {
+        return initial->id;
+    }
+
+    if (!games.empty()) {
+        return games.front().id;
+    }
+
+    return "game-empty-state";
+}
+
+std::string_view nextLibraryGameFocusTarget(
+    const std::vector<DeckLibraryGameCard>& games,
+    const std::string_view currentId,
+    const DeckFocusDirection direction) {
+    if (games.empty()) {
+        return "game-empty-state";
+    }
+
+    const auto current = std::ranges::find_if(games, [currentId](const DeckLibraryGameCard& game) {
+        return game.id == currentId;
+    });
+
+    if (current == games.end()) {
+        return initialLibraryGameFocusTarget(games);
+    }
+
+    const int verticalDelta = direction == DeckFocusDirection::Up ? -1 : direction == DeckFocusDirection::Down ? 1 : 0;
+    if (verticalDelta == 0) {
+        return current->id;
+    }
+
+    const auto next = std::ranges::find_if(games, [&](const DeckLibraryGameCard& game) {
+        return game.row == current->row + verticalDelta;
+    });
+
+    if (next != games.end()) {
+        return next->id;
+    }
+
+    if (direction == DeckFocusDirection::Up) {
+        return games.back().id;
+    }
+    if (direction == DeckFocusDirection::Down) {
+        return games.front().id;
+    }
+
+    return current->id;
+}
+
 std::string_view initialHostFocusTarget(const std::vector<DeckHostListItem>& hosts) {
     const auto initial = std::ranges::find_if(hosts, [](const DeckHostListItem& host) {
         return host.initialFocus;
@@ -280,6 +335,13 @@ std::string_view nextHostFocusTarget(
 
     if (next != hosts.end()) {
         return next->id;
+    }
+
+    if (direction == DeckFocusDirection::Up) {
+        return hosts.back().id;
+    }
+    if (direction == DeckFocusDirection::Down) {
+        return hosts.front().id;
     }
 
     return current->id;
@@ -397,7 +459,7 @@ DeckLaunchPreviewCopyAction copyLaunchPreviewActionFor(const DeckLaunchPreview& 
     const bool hasPreviewText = !preview.text.empty();
     return DeckLaunchPreviewCopyAction{
         .id = "host-detail-copy-preview",
-        .label = "Copy preview text",
+        .label = "Copy preview URI (no launch)",
         .previewText = preview.text,
         .idleStatusLabel = hasPreviewText ? std::string(kCopyIdleStatusLabel) : std::string(kCopyInertToast),
         .successToast = std::string(kCopySuccessToast),
@@ -514,6 +576,13 @@ std::string_view nextHostDetailFocusTarget(
 
     if (next != targets.end()) {
         return next->id;
+    }
+
+    if (direction == DeckFocusDirection::Up) {
+        return targets.back().id;
+    }
+    if (direction == DeckFocusDirection::Down) {
+        return targets.front().id;
     }
 
     return current->id;

--- a/clients/deck/src/deck_layout.cpp
+++ b/clients/deck/src/deck_layout.cpp
@@ -209,6 +209,23 @@ std::vector<DeckHostListItem> demoHostListState() {
     };
 }
 
+std::vector<DeckHostListItem> libraryHostListStateFor(const PolarisGameLibraryFixture& library) {
+    std::vector<DeckHostListItem> hosts;
+    hosts.reserve(library.hosts.size());
+    int row = 0;
+    for (const auto& host : library.hosts) {
+        hosts.push_back(DeckHostListItem{
+            .id = host.id.empty() ? std::string_view("library-host") : std::string_view(host.id),
+            .displayName = host.displayName.empty() ? std::string_view("Read-only library host") : std::string_view(host.displayName),
+            .statusLabel = host.statusLabel.empty() ? std::string_view("Available from read-only library snapshot") : std::string_view(host.statusLabel),
+            .row = row,
+            .initialFocus = row == 0,
+        });
+        ++row;
+    }
+    return hosts;
+}
+
 std::vector<DeckLibraryGameCard> libraryGameCardsFor(const PolarisGameLibraryFixture& library) {
     std::vector<DeckLibraryGameCard> cards;
     cards.reserve(library.games.size());

--- a/clients/deck/src/deck_layout.h
+++ b/clients/deck/src/deck_layout.h
@@ -164,6 +164,13 @@ std::vector<DeckHostListItem> libraryHostListStateFor(const PolarisGameLibraryFi
 
 std::vector<DeckLibraryGameCard> libraryGameCardsFor(const PolarisGameLibraryFixture& library);
 
+std::string_view initialLibraryGameFocusTarget(const std::vector<DeckLibraryGameCard>& games);
+
+std::string_view nextLibraryGameFocusTarget(
+    const std::vector<DeckLibraryGameCard>& games,
+    std::string_view currentId,
+    DeckFocusDirection direction);
+
 std::string_view initialHostFocusTarget(const std::vector<DeckHostListItem>& hosts);
 
 std::string_view nextHostFocusTarget(

--- a/clients/deck/src/deck_layout.h
+++ b/clients/deck/src/deck_layout.h
@@ -160,6 +160,8 @@ std::vector<DeckHostListItem> emptyHostListState();
 
 std::vector<DeckHostListItem> demoHostListState();
 
+std::vector<DeckHostListItem> libraryHostListStateFor(const PolarisGameLibraryFixture& library);
+
 std::vector<DeckLibraryGameCard> libraryGameCardsFor(const PolarisGameLibraryFixture& library);
 
 std::string_view initialHostFocusTarget(const std::vector<DeckHostListItem>& hosts);

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -235,12 +235,12 @@ int main(int argc, char *argv[]) {
     const auto profile = nova::deck::defaultWindowProfile();
     const auto sampleLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
     const auto libraryGames = nova::deck::libraryGameCardsFor(sampleLibrary);
-    const auto demoHosts = nova::deck::demoHostListState();
+    const auto libraryHosts = nova::deck::libraryHostListStateFor(sampleLibrary);
     const std::string initialGameId = sampleLibrary.games.empty() ? std::string{} : sampleLibrary.games.front().id;
     const auto selectedBinding = nova::deck::resolveLaunchPreviewBinding(
-        demoHosts,
+        libraryHosts,
         sampleLibrary,
-        nova::deck::initialHostFocusTarget(demoHosts),
+        nova::deck::initialHostFocusTarget(libraryHosts),
         initialGameId);
     const auto& selectedHostDetail = selectedBinding.hostDetail;
     const auto& launchIntent = selectedBinding.intent;
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaLibraryFixtureSource", toQString(sampleLibrary.sourceLabel));
     engine.rootContext()->setContextProperty("novaLibraryReadOnly", sampleLibrary.readOnly);
     engine.rootContext()->setContextProperty("novaLibraryGames", toLibraryGameModel(libraryGames));
-    engine.rootContext()->setContextProperty("novaDemoHosts", toHostModel(demoHosts));
+    engine.rootContext()->setContextProperty("novaLibraryHosts", toHostModel(libraryHosts));
     engine.rootContext()->setContextProperty("novaSelectedHostDetail", toHostDetailModel(selectedHostDetail));
     engine.rootContext()->setContextProperty("novaSelectedGameCard", toLibraryGameCardModel(selectedBinding.gameCard));
     engine.rootContext()->setContextProperty("novaSelectedLaunchPreviewText", toQString(selectedBinding.preview.text));
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaLaunchPreviewCopyAction", toPreviewCopyActionModel(launchPreviewCopyAction));
     engine.rootContext()->setContextProperty("novaLocalClipboard", &localClipboard);
     engine.rootContext()->setContextProperty("novaGamepad", &gamepadBridge);
-    engine.rootContext()->setContextProperty("novaInitialHostFocusTarget", toQString(nova::deck::initialHostFocusTarget(demoHosts)));
+    engine.rootContext()->setContextProperty("novaInitialHostFocusTarget", toQString(nova::deck::initialHostFocusTarget(libraryHosts)));
     engine.rootContext()->setContextProperty("novaEmptyHostFocusTarget", toQString(nova::deck::initialHostFocusTarget(nova::deck::emptyHostListState())));
 
     const bool smokeExit = QCoreApplication::arguments().contains("--smoke-exit");

--- a/clients/deck/src/polaris_game_fixture.cpp
+++ b/clients/deck/src/polaris_game_fixture.cpp
@@ -248,6 +248,15 @@ std::vector<std::string> readObjectArray(const std::string& json, const std::str
     throw std::runtime_error("Unterminated object array in Polaris fixture: " + std::string(key));
 }
 
+PolarisHostFixture parsePolarisHostFixtureJson(const std::string& json) {
+    PolarisHostFixture host;
+    host.id = readString(json, "id");
+    host.displayName = readString(json, "display_name");
+    host.statusLabel = readString(json, "status_label");
+    host.subtitle = readOptionalString(json, "subtitle", "Read-only host snapshot fixture — not discovered from the network.");
+    return host;
+}
+
 PolarisGameFixture parsePolarisGameFixtureJson(const std::string& json) {
     const auto launchModeStart = objectStart(json, "launch_mode");
     const auto steamLaunchStart = objectStart(json, "steam_launch");
@@ -319,6 +328,10 @@ PolarisGameLibraryFixture loadPolarisGameLibraryFixture(const std::filesystem::p
     PolarisGameLibraryFixture library;
     library.sourceLabel = readOptionalString(json, "fixture_source", "Shared Polaris contract fixture");
     library.readOnly = readOptionalBool(json, "read_only", true);
+
+    for (const auto& objectJson : readObjectArray(json, "hosts")) {
+        library.hosts.push_back(parsePolarisHostFixtureJson(objectJson));
+    }
 
     for (const auto& objectJson : readObjectArray(json, "games")) {
         library.games.push_back(parsePolarisGameFixtureJson(objectJson));

--- a/clients/deck/src/polaris_game_fixture.h
+++ b/clients/deck/src/polaris_game_fixture.h
@@ -22,6 +22,13 @@ struct PolarisSteamLaunchFixture {
     std::string modeReason;
 };
 
+struct PolarisHostFixture {
+    std::string id;
+    std::string displayName;
+    std::string statusLabel;
+    std::string subtitle;
+};
+
 struct PolarisGameFixture {
     std::string id;
     int appId = 0;
@@ -48,6 +55,7 @@ struct PolarisGameFixture {
 struct PolarisGameLibraryFixture {
     std::string sourceLabel;
     bool readOnly = true;
+    std::vector<PolarisHostFixture> hosts;
     std::vector<PolarisGameFixture> games;
 };
 

--- a/clients/deck/tests/deck_layout_test.cpp
+++ b/clients/deck/tests/deck_layout_test.cpp
@@ -83,6 +83,12 @@ int main() {
     assert(mainQml.find("selectedGameForPreview") != std::string::npos);
     assert(mainQml.find("refreshLaunchPreviewBinding") != std::string::npos);
     assert(mainQml.find("selectedLaunchPreviewText") != std::string::npos);
+    assert(mainQml.find("Selected host") != std::string::npos);
+    assert(mainQml.find("Selected game") != std::string::npos);
+    assert(mainQml.find("No games in read-only snapshot") != std::string::npos);
+    assert(mainQml.find("Read-only snapshot loaded") != std::string::npos);
+    assert(mainQml.find("Snapshot unavailable in this preview shell") != std::string::npos);
+    assert(mainQml.find("A copies the preview URI locally only") != std::string::npos);
 
     assert(nova::deck::decodeGamepadAction(nova::deck::DeckGamepadEvent{
         .timeMs = 10,
@@ -151,6 +157,8 @@ int main() {
     assert(nova::deck::nextHostFocusTarget(demoHosts, "host-living-room-pc", nova::deck::DeckFocusDirection::Up)
         == std::string_view("host-gaming-pc"));
     assert(nova::deck::nextHostFocusTarget(demoHosts, "host-living-room-pc", nova::deck::DeckFocusDirection::Down)
+        == std::string_view("host-gaming-pc"));
+    assert(nova::deck::nextHostFocusTarget(demoHosts, "host-gaming-pc", nova::deck::DeckFocusDirection::Up)
         == std::string_view("host-living-room-pc"));
 
     const auto detail = nova::deck::resolveHostDetail(demoHosts, "host-gaming-pc");
@@ -253,9 +261,9 @@ int main() {
 
     const auto copyAction = nova::deck::copyLaunchPreviewActionFor(commandPreview);
     assert(copyAction.id == std::string_view("host-detail-copy-preview"));
-    assert(copyAction.label == std::string_view("Copy preview text"));
+    assert(copyAction.label == std::string_view("Copy preview URI (no launch)"));
     assert(copyAction.previewText == commandPreview.text);
-    assert(copyAction.idleStatusLabel == "Copy action is preview-only and not executable.");
+    assert(copyAction.idleStatusLabel == "A copies the preview URI locally only — no launch, stream, backend, or Moonlight.");
     assert(copyAction.successToast == "Preview text copied for inspection only — still not executable.");
     assert(copyAction.inertToast == "No preview text to copy — preview-only action stayed inert.");
     assert(copyAction.copyOnly);
@@ -320,7 +328,7 @@ int main() {
     assert(detailFocus[0].id == std::string_view("host-detail-panel"));
     assert(detailFocus[1].id == std::string_view("host-detail-launch-cta"));
     assert(detailFocus[2].id == std::string_view("host-detail-copy-preview"));
-    assert(detailFocus[2].label == std::string_view("Copy preview text"));
+    assert(detailFocus[2].label == std::string_view("Copy preview URI (no launch)"));
     assert(nova::deck::nextHostDetailFocusTarget(detailFocus, "host-detail-panel", nova::deck::DeckFocusDirection::Down)
         == std::string_view("host-detail-launch-cta"));
     assert(nova::deck::nextHostDetailFocusTarget(detailFocus, "host-detail-launch-cta", nova::deck::DeckFocusDirection::Down)
@@ -330,6 +338,8 @@ int main() {
     assert(nova::deck::nextHostDetailFocusTarget(detailFocus, "host-detail-launch-cta", nova::deck::DeckFocusDirection::Up)
         == std::string_view("host-detail-panel"));
     assert(nova::deck::nextHostDetailFocusTarget(detailFocus, "host-detail-copy-preview", nova::deck::DeckFocusDirection::Down)
+        == std::string_view("host-detail-panel"));
+    assert(nova::deck::nextHostDetailFocusTarget(detailFocus, "host-detail-panel", nova::deck::DeckFocusDirection::Up)
         == std::string_view("host-detail-copy-preview"));
 
     assert(nova::deck::isDeckNativeAspect(1280, 800));
@@ -368,6 +378,16 @@ int main() {
     assert(libraryCards[1].sourceRuntimeLabel == "Steam · Linux · Proton");
     assert(libraryCards[1].launchModeLabel == "Stream: virtual_display · Steam: big-picture");
     assert(!libraryCards[1].initialFocus);
+    assert(nova::deck::initialLibraryGameFocusTarget({}) == std::string_view("game-empty-state"));
+    assert(nova::deck::initialLibraryGameFocusTarget(libraryCards) == std::string_view("game-123"));
+    assert(nova::deck::nextLibraryGameFocusTarget(libraryCards, "game-123", nova::deck::DeckFocusDirection::Down)
+        == std::string_view("game-456"));
+    assert(nova::deck::nextLibraryGameFocusTarget(libraryCards, "game-456", nova::deck::DeckFocusDirection::Down)
+        == std::string_view("game-123"));
+    assert(nova::deck::nextLibraryGameFocusTarget(libraryCards, "game-123", nova::deck::DeckFocusDirection::Up)
+        == std::string_view("game-456"));
+    assert(nova::deck::nextLibraryGameFocusTarget({}, "missing-game", nova::deck::DeckFocusDirection::Up)
+        == std::string_view("game-empty-state"));
 
     const auto hadesLaunchCta = nova::deck::inertLaunchCtaFor(detail, library.games[1]);
     assert(hadesLaunchCta.previewText == std::string_view("preview://nova-deck/launch?host=host-gaming-pc&game=Hades&state=copy-preview-only"));

--- a/clients/deck/tests/deck_layout_test.cpp
+++ b/clients/deck/tests/deck_layout_test.cpp
@@ -73,6 +73,7 @@ int main() {
     assert(mainQml.find("target: novaGamepad") != std::string::npos);
     assert(mainQml.find("onPrimaryActionPressed") != std::string::npos);
     assert(mainQml.find("novaLibraryGames") != std::string::npos);
+    assert(mainQml.find("novaLibraryHosts") != std::string::npos);
     assert(mainQml.find("libraryGameRepeater") != std::string::npos);
     assert(mainQml.find("Read-only Polaris library") != std::string::npos);
     assert(mainQml.find("novaLaunchIntentBoundary") != std::string::npos);
@@ -132,6 +133,19 @@ int main() {
     assert(demoHosts[1].id == std::string_view("host-living-room-pc"));
     assert(demoHosts[1].displayName == std::string_view("Living Room PC"));
     assert(nova::deck::initialHostFocusTarget(demoHosts) == std::string_view("host-gaming-pc"));
+
+    const auto realLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
+    const auto libraryHosts = nova::deck::libraryHostListStateFor(realLibrary);
+    assert(libraryHosts.size() == 2);
+    assert(libraryHosts[0].id == std::string_view("host-snapshot-primary"));
+    assert(libraryHosts[0].displayName == std::string_view("Polaris Snapshot Primary"));
+    assert(libraryHosts[0].statusLabel == std::string_view("Ready from read-only library snapshot"));
+    assert(libraryHosts[0].initialFocus);
+    assert(libraryHosts[1].id == std::string_view("host-snapshot-living-room"));
+    assert(libraryHosts[1].displayName == std::string_view("Polaris Snapshot Living Room"));
+    assert(libraryHosts[1].statusLabel == std::string_view("Available from read-only library snapshot"));
+    assert(!libraryHosts[1].initialFocus);
+    assert(nova::deck::initialHostFocusTarget(libraryHosts) == std::string_view("host-snapshot-primary"));
     assert(nova::deck::nextHostFocusTarget(demoHosts, "host-gaming-pc", nova::deck::DeckFocusDirection::Down)
         == std::string_view("host-living-room-pc"));
     assert(nova::deck::nextHostFocusTarget(demoHosts, "host-living-room-pc", nova::deck::DeckFocusDirection::Up)


### PR DESCRIPTION
## Summary

- Adds a Deck-side read-only Polaris library snapshot boundary for host/game data.
- Populates the Deck shell with real-shaped host/game/detail data instead of pure fake/sample UI state.
- Refines controller focus wrapping, selected host/game affordances, empty/read-only copy, and the copy-preview CTA.

## Scope / non-goals

- This does **not** add backend launch execution.
- This does **not** add streaming, host discovery, pairing, or HostStore persistence.
- This does **not** add Moonlight support, wiring, invocation, or dependency.
- Preview URIs remain display/copy-only artifacts.

## Validation

- `git diff --check origin/master...HEAD -- clients/deck`
- Rebuilt focused fallback Deck test target and ran `ctest`: `nova_deck_controller_library_smoke` passed.
- Rebuilt focused Qt Deck target and ran `ctest`: `nova_deck_controller_library_smoke` and `nova_deck_qt_shell_smoke` passed.
- Private Steam Deck Game Mode smoke previously passed for this branch: Deck shell launched at 1280x800, selected host/game affordances rendered, copy-preview wording stayed non-executable, and controller-style focus/navigation changed visible UI.

## Notes

The Deck shell now consumes a read-only snapshot-shaped data boundary and keeps the launch/streaming boundary explicit in UI copy. Launch execution and backend/runtime integration should remain separate future work.
