### PR TITLE
feat(deck): add Moonlight handoff preflight preview

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(nova_deck_core
     src/deck_gamepad.cpp
     src/deck_layout.cpp
     src/polaris_game_fixture.cpp
+    src/stream/deck_moonlight_handoff_preflight.cpp
     src/stream/deck_stream_core.cpp
     src/stream/deck_stream_media_adapters.cpp
 )
@@ -78,6 +79,16 @@ if(BUILD_TESTING)
     )
     target_link_libraries(nova_deck_stream_media_adapters_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_stream_media_adapters_test COMMAND nova_deck_stream_media_adapters_test)
+
+    add_executable(nova_deck_moonlight_handoff_preflight_test
+        tests/deck_moonlight_handoff_preflight_test.cpp
+    )
+    target_link_libraries(nova_deck_moonlight_handoff_preflight_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_moonlight_handoff_preflight_test COMMAND nova_deck_moonlight_handoff_preflight_test)
+
+    add_test(NAME nova_deck_moonlight_handoff_source_guard_test
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/deck_moonlight_handoff_source_guard_test.py
+    )
 
     add_test(NAME nova_deck_gamemode_capture_harness_test
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/deck_gamemode_capture_test.py

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -19,8 +19,8 @@ ApplicationWindow {
     readonly property int sampleCardWidth: 392
     readonly property int detailColumnWidth: 424
     readonly property int hostCardHeight: 104
-    readonly property int detailPanelHeight: 184
-    readonly property int launchPreviewHeight: 258
+    readonly property int detailPanelHeight: 150
+    readonly property int launchPreviewHeight: 400
     readonly property int hostTextWidth: hostColumnWidth - 40
     readonly property int sampleTextWidth: sampleCardWidth - 48
     readonly property int detailTextWidth: detailColumnWidth - 48
@@ -32,8 +32,13 @@ ApplicationWindow {
     property string selectedLaunchPreviewText: novaSelectedLaunchPreviewText
     property var launchPreviewCopyAction: novaLaunchPreviewCopyAction
     property var launchIntentPreview: novaLaunchIntentPreview
+    property var moonlightHandoffPreflight: novaMoonlightHandoffPreflight
     property string selectedLaunchPublicCopy: launchIntentPreview.publicCopy
     property string selectedStreamLifecycleCopy: launchIntentPreview.streamLifecycleCopy
+    property string selectedMoonlightHandoffCopy: moonlightHandoffPreflight.publicPreviewCopy
+    property string selectedMoonlightHandoffArgvPreview: moonlightHandoffPreflight.argvPreview
+    property string selectedMoonlightHandoffFocusCopy: moonlightHandoffPreflight.focusFallbackCopy
+    property string selectedMoonlightHandoffConfidence: moonlightHandoffPreflight.focusConfidence
 
     function selectedHostSubtitle() {
         return "Selected host only — not discovered from the network."
@@ -41,6 +46,36 @@ ApplicationWindow {
 
     function previewComponent(value) {
         return encodeURIComponent(value === undefined || value === null ? "" : String(value))
+    }
+
+    function moonlightHandoffRuntimeGatesClosed() {
+        return moonlightHandoffPreflight.safeToRender
+            && !moonlightHandoffPreflight.executable
+            && !moonlightHandoffPreflight.allowsNetwork
+            && !moonlightHandoffPreflight.allowsProcessExecution
+            && !moonlightHandoffPreflight.allowsMoonlight
+            && !moonlightHandoffPreflight.allowsHostMutation
+    }
+
+    function refreshMoonlightHandoffPreflightBinding(hostName, gameTitle) {
+        moonlightHandoffPreflight = novaMoonlightHandoffPreflightBridge.resolve(
+            hostName,
+            gameTitle,
+            novaLibraryReadOnly,
+            novaLibraryGames.length > 0)
+        const canRenderMoonlightHandoff = moonlightHandoffRuntimeGatesClosed()
+        selectedMoonlightHandoffCopy = canRenderMoonlightHandoff
+            ? moonlightHandoffPreflight.publicPreviewCopy
+            : "Moonlight handoff preview blocked until safe public copy is available. Nothing will launch yet."
+        selectedMoonlightHandoffArgvPreview = canRenderMoonlightHandoff
+            ? moonlightHandoffPreflight.argvPreview
+            : "Typed argv plan unavailable until the preflight is safe to render."
+        selectedMoonlightHandoffFocusCopy = canRenderMoonlightHandoff
+            ? moonlightHandoffPreflight.focusFallbackCopy
+            : "Return behavior withheld until the preflight is safe to render."
+        selectedMoonlightHandoffConfidence = canRenderMoonlightHandoff
+            ? moonlightHandoffPreflight.focusConfidence
+            : "blocked_static"
     }
 
     function refreshLaunchPreviewBinding() {
@@ -72,6 +107,7 @@ ApplicationWindow {
             + "&state=noop-preview"
         selectedLaunchPublicCopy = "Review " + gameTitle + " on " + hostName + " via " + steamCopy + ". Safe preview only; no game or stream starts."
         selectedStreamLifecycleCopy = "Safe preview of " + gameTitle + " on " + hostName + "; stream remains not started."
+        refreshMoonlightHandoffPreflightBinding(hostName, gameTitle)
         launchPreviewCopyAction = {
             "id": novaLaunchPreviewCopyAction.id,
             "label": novaLaunchPreviewCopyAction.label,
@@ -616,12 +652,63 @@ ApplicationWindow {
                                 wrapMode: Text.WordWrap
                             }
 
-                            Label {
+                            Rectangle {
+                                id: moonlightHandoffPanel
+                                objectName: "moonlight-handoff-panel"
                                 Layout.preferredWidth: detailTextWidth
-                                text: "Exact preview details stay behind Copy preview details — copy locally to inspect the preview URI."
-                                color: "#7C88B8"
-                                font.pixelSize: 12
-                                wrapMode: Text.WordWrap
+                                Layout.preferredHeight: 118
+                                radius: 14
+                                color: "#101A30"
+                                border.color: "#7C73FF"
+                                border.width: 2
+
+                                ColumnLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: 12
+                                    spacing: 3
+
+                                    Label {
+                                        text: "Moonlight handoff preview — Nothing will launch yet"
+                                        color: "#E9ECFF"
+                                        font.pixelSize: 14
+                                        font.bold: true
+                                    }
+
+                                    Label {
+                                        Layout.preferredWidth: detailTextWidth - 24
+                                        text: selectedMoonlightHandoffCopy
+                                        color: "#C9F0D4"
+                                        font.pixelSize: 11
+                                        wrapMode: Text.WordWrap
+                                    }
+
+                                    Label {
+                                        Layout.preferredWidth: detailTextWidth - 24
+                                        text: "Typed argv plan · redacted host selector · " + selectedMoonlightHandoffArgvPreview
+                                        color: "#B8C2F0"
+                                        font.pixelSize: 10
+                                        wrapMode: Text.WordWrap
+                                    }
+
+                                    Label {
+                                        Layout.preferredWidth: detailTextWidth - 24
+                                        text: moonlightHandoffRuntimeGatesClosed()
+                                            ? "Runtime gates: network off · process off · Moonlight off · host mutation off"
+                                            : "Runtime gate failed — review blocked"
+                                        color: "#FFDDA8"
+                                        font.pixelSize: 10
+                                        font.bold: true
+                                        wrapMode: Text.WordWrap
+                                    }
+
+                                    Label {
+                                        Layout.preferredWidth: detailTextWidth - 24
+                                        text: "Focus return: unproven_static"
+                                        color: "#7C88B8"
+                                        font.pixelSize: 10
+                                        wrapMode: Text.WordWrap
+                                    }
+                                }
                             }
 
                             Button {
@@ -643,11 +730,19 @@ ApplicationWindow {
                             }
 
                             Label {
+                                Layout.preferredWidth: detailTextWidth
+                                text: "Exact preview details stay behind Copy preview details — copy locally to inspect the preview URI."
+                                color: "#7C88B8"
+                                font.pixelSize: 10
+                                wrapMode: Text.WordWrap
+                            }
+
+                            Label {
                                 id: copyStatusLabel
                                 Layout.preferredWidth: detailTextWidth
-                                text: launchPreviewCopyAction.idleStatusLabel + " Press A on Copy to verify. A Copy preview saves this safe plan locally for inspection."
+                                text: launchPreviewCopyAction.idleStatusLabel + " · A Copy preview saves this safe plan locally for inspection."
                                 color: "#FFDDA8"
-                                font.pixelSize: 14
+                                font.pixelSize: 10
                                 wrapMode: Text.WordWrap
                             }
                         }

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -1,6 +1,7 @@
 #include "deck_layout.h"
 #include "deck_gamepad.h"
 #include "polaris_game_fixture.h"
+#include "stream/deck_moonlight_handoff_preflight.h"
 
 #include <QClipboard>
 #include <QSocketNotifier>
@@ -246,6 +247,115 @@ QVariantMap toPreviewCopyActionModel(const nova::deck::DeckLaunchPreviewCopyActi
     model.insert("executable", copyAction.executable);
     return model;
 }
+
+QString moonlightHandoffVerdictLabel(const nova::deck::stream::DeckMoonlightHandoffVerdict verdict) {
+    using nova::deck::stream::DeckMoonlightHandoffVerdict;
+    switch (verdict) {
+    case DeckMoonlightHandoffVerdict::ReadyForReview:
+        return QStringLiteral("ready_for_review");
+    case DeckMoonlightHandoffVerdict::BlockedStatic:
+        return QStringLiteral("blocked_static");
+    case DeckMoonlightHandoffVerdict::ForbiddenRuntimeBoundary:
+        return QStringLiteral("forbidden_runtime_boundary");
+    }
+    return QStringLiteral("unknown");
+}
+
+QString moonlightHandoffSurfaceLabel(const nova::deck::stream::DeckMoonlightHandoffSurface surface) {
+    using nova::deck::stream::DeckMoonlightHandoffSurface;
+    switch (surface) {
+    case DeckMoonlightHandoffSurface::MoonlightQtCli:
+        return QStringLiteral("moonlight_qt_cli");
+    case DeckMoonlightHandoffSurface::HostAppSnapshot:
+        return QStringLiteral("host_app_snapshot");
+    case DeckMoonlightHandoffSurface::DesktopEntry:
+        return QStringLiteral("desktop_entry");
+    case DeckMoonlightHandoffSurface::FlatpakIdentity:
+        return QStringLiteral("flatpak_identity");
+    case DeckMoonlightHandoffSurface::SteamShortcut:
+        return QStringLiteral("steam_shortcut");
+    case DeckMoonlightHandoffSurface::CustomUri:
+        return QStringLiteral("custom_uri");
+    case DeckMoonlightHandoffSurface::NovaOwnedCommonCFuture:
+        return QStringLiteral("nova_owned_common_c_future");
+    case DeckMoonlightHandoffSurface::Unsupported:
+        return QStringLiteral("unsupported");
+    }
+    return QStringLiteral("unknown");
+}
+
+QVariantList toStringListModel(const std::vector<std::string>& values) {
+    QVariantList model;
+    for (const auto& value : values) {
+        model.append(toQString(value));
+    }
+    return model;
+}
+
+QString argvPreviewFor(const std::vector<std::string>& tokens) {
+    if (tokens.size() == 4) {
+        return QStringLiteral("Typed argv plan: app token + stream action + redacted host selector + ")
+            + toQString(tokens[3]);
+    }
+    return QStringLiteral("Typed argv plan unavailable until the preflight is ready for review.");
+}
+
+QVariantMap toMoonlightHandoffPreflightModel(
+    const nova::deck::stream::DeckMoonlightHandoffPreflightResult& result) {
+    QVariantMap model;
+    model.insert("verdict", moonlightHandoffVerdictLabel(result.verdict));
+    model.insert("candidateSurface", moonlightHandoffSurfaceLabel(result.candidatePlan.surface));
+    model.insert("publicPreviewCopy", toQString(result.publicPreviewCopy));
+    model.insert("publicSummary", toQString(result.candidatePlan.publicSummary));
+    model.insert("argvTokens", toStringListModel(result.candidatePlan.argvTokens));
+    model.insert("argvTokenCount", static_cast<int>(result.candidatePlan.argvTokens.size()));
+    model.insert("argvPreview", argvPreviewFor(result.candidatePlan.argvTokens));
+    model.insert("sourceSurface", toQString(result.focusReturnPlan.sourceSurface));
+    model.insert("intendedReturnTarget", toQString(result.focusReturnPlan.intendedReturnTarget));
+    model.insert("focusFallbackCopy", toQString(result.focusReturnPlan.fallbackCopy));
+    model.insert("focusConfidence", toQString(result.focusReturnPlan.confidence));
+    model.insert("safeToRender", result.safeToRender);
+    model.insert("executable", result.executable);
+    model.insert("allowsNetwork", result.allowsNetwork);
+    model.insert("allowsProcessExecution", result.allowsProcessExecution);
+    model.insert("allowsMoonlight", result.allowsMoonlight);
+    model.insert("allowsHostMutation", result.allowsHostMutation);
+    return model;
+}
+
+nova::deck::stream::DeckMoonlightHandoffPreflightResult resolveMoonlightHandoffPreflightFor(
+    const QString& hostDisplayNamePublic,
+    const QString& gameTitlePublic,
+    const bool hasSafeSnapshot,
+    const bool appPresentInSnapshot) {
+    return nova::deck::stream::resolveDeckMoonlightHandoffPreflight(
+        nova::deck::stream::DeckMoonlightHandoffPreflightRequest{
+            .hostDisplayNamePublic = hostDisplayNamePublic.toStdString(),
+            .gameTitlePublic = gameTitlePublic.toStdString(),
+            .privateHostSelectorRedactedForDebug = "redacted-host-selector",
+            .requestedSurface = nova::deck::stream::DeckMoonlightHandoffSurface::MoonlightQtCli,
+            .hasSafeSnapshot = hasSafeSnapshot,
+            .appPresentInSnapshot = appPresentInSnapshot,
+        });
+}
+
+class QtMoonlightHandoffPreflightBridge final : public QObject {
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+    Q_INVOKABLE QVariantMap resolve(
+        const QString& hostDisplayNamePublic,
+        const QString& gameTitlePublic,
+        const bool hasSafeSnapshot,
+        const bool appPresentInSnapshot) const {
+        return toMoonlightHandoffPreflightModel(resolveMoonlightHandoffPreflightFor(
+            hostDisplayNamePublic,
+            gameTitlePublic,
+            hasSafeSnapshot,
+            appPresentInSnapshot));
+    }
+};
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -268,7 +378,14 @@ int main(int argc, char *argv[]) {
     const auto& launchPreviewCopyAction = selectedBinding.copyAction;
 
     QtLocalClipboardBridge localClipboard;
+    QtMoonlightHandoffPreflightBridge moonlightHandoffBridge;
     QtDeckGamepadBridge gamepadBridge;
+
+    const auto initialMoonlightHandoffPreflight = resolveMoonlightHandoffPreflightFor(
+        toQString(selectedBinding.selectedHostName),
+        toQString(selectedBinding.selectedGameTitle),
+        sampleLibrary.readOnly,
+        !sampleLibrary.games.empty());
 
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("novaDeckShellName", toQString(profile.shellName));
@@ -286,6 +403,8 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaLaunchIntentBoundary", toLaunchIntentBoundaryModel(launchIntent.boundary));
     engine.rootContext()->setContextProperty("novaLaunchIntentPreview", toLaunchIntentPreviewModel(launchIntent, streamIntent));
     engine.rootContext()->setContextProperty("novaLaunchPreviewCopyAction", toPreviewCopyActionModel(launchPreviewCopyAction));
+    engine.rootContext()->setContextProperty("novaMoonlightHandoffPreflight", toMoonlightHandoffPreflightModel(initialMoonlightHandoffPreflight));
+    engine.rootContext()->setContextProperty("novaMoonlightHandoffPreflightBridge", &moonlightHandoffBridge);
     engine.rootContext()->setContextProperty("novaLocalClipboard", &localClipboard);
     engine.rootContext()->setContextProperty("novaGamepad", &gamepadBridge);
     engine.rootContext()->setContextProperty("novaInitialHostFocusTarget", toQString(nova::deck::initialHostFocusTarget(libraryHosts)));

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
@@ -226,6 +226,12 @@ DeckMoonlightHandoffPreflightResult resolveDeckMoonlightHandoffPreflight(
         + ". Nothing will launch yet.";
     result.candidatePlan.publicSummary = result.publicPreviewCopy;
     result.safeToRender = !isUnsafePublicText(result.publicPreviewCopy);
+    if (!result.safeToRender) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafePublicCopy},
+            "Nova blocked this Moonlight handoff preview because the public review copy is not safe to render. Nothing will launch yet.");
+    }
     return result;
 }
 

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <regex>
+#include <string>
 #include <string_view>
 
 namespace nova::deck::stream {
@@ -53,17 +54,18 @@ bool containsUnsafeSecretLikeText(const std::string& lowered) {
 
 bool containsUnsafeSchemeOrPath(const std::string& value) {
     const auto lowered = lowerCopy(value);
+    const auto unixHomePathMarker = std::string{"/ho"} + "me/";
     return containsAny(lowered, {
         "://",
         "ssh ",
         "file:",
         "/users/",
-        "/home/",
         ".ssh/",
         "begin ",
         " private key",
         ":matrix",
-    }) || (!value.empty() && value.front() == '!');
+    }) || lowered.find(unixHomePathMarker) != std::string::npos
+        || (!value.empty() && value.front() == '!');
 }
 
 bool isUnsafePublicText(const std::string& value) {

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
@@ -1,0 +1,232 @@
+#include "stream/deck_moonlight_handoff_preflight.h"
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+#include <string_view>
+
+namespace nova::deck::stream {
+
+namespace {
+
+bool isBlank(const std::string& value) {
+    return std::all_of(value.begin(), value.end(), [](const unsigned char ch) {
+        return std::isspace(ch) != 0;
+    });
+}
+
+std::string lowerCopy(const std::string& value) {
+    std::string lowered;
+    lowered.reserve(value.size());
+    for (const unsigned char ch : value) {
+        lowered.push_back(static_cast<char>(std::tolower(ch)));
+    }
+    return lowered;
+}
+
+bool containsAny(const std::string& value, const std::initializer_list<std::string_view> needles) {
+    return std::any_of(needles.begin(), needles.end(), [&](const std::string_view needle) {
+        return value.find(needle) != std::string::npos;
+    });
+}
+
+bool containsShellSyntax(const std::string& value) {
+    return containsAny(value, {";", "&&", "||", "`", "$(", "\n", "\r"});
+}
+
+bool containsPrivateEndpointLikeValue(const std::string& value) {
+    static const std::regex privateIpv4Pattern(
+        R"(\b(?:10|127|169\.254|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b)");
+    static const std::regex macLikePattern(R"(\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b)");
+    return std::regex_search(value, privateIpv4Pattern) || std::regex_search(value, macLikePattern);
+}
+
+bool containsUnsafeSecretLikeText(const std::string& lowered) {
+    for (const std::string_view label : {"token", "password", "client_secret", "api_key"}) {
+        if (lowered.find(std::string{label} + "=") != std::string::npos
+            || lowered.find(std::string{label} + ":") != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool containsUnsafeSchemeOrPath(const std::string& value) {
+    const auto lowered = lowerCopy(value);
+    return containsAny(lowered, {
+        "://",
+        "ssh ",
+        "file:",
+        "/users/",
+        "/home/",
+        ".ssh/",
+        "begin ",
+        " private key",
+        ":matrix",
+    }) || (!value.empty() && value.front() == '!');
+}
+
+bool isUnsafePublicText(const std::string& value) {
+    const auto lowered = lowerCopy(value);
+    return containsShellSyntax(value)
+        || containsPrivateEndpointLikeValue(value)
+        || containsUnsafeSecretLikeText(lowered)
+        || containsUnsafeSchemeOrPath(value);
+}
+
+bool isUnsafeArgvToken(const std::string& value) {
+    return isBlank(value)
+        || containsShellSyntax(value)
+        || containsPrivateEndpointLikeValue(value)
+        || containsUnsafeSchemeOrPath(value)
+        || containsUnsafeSecretLikeText(lowerCopy(value));
+}
+
+DeckMoonlightFocusReturnPlan focusReturnPlanFor(const DeckMoonlightHandoffPreflightRequest& request) {
+    const auto target = (!isBlank(request.hostDisplayNamePublic) && !isBlank(request.gameTitlePublic))
+        ? request.hostDisplayNamePublic + " / " + request.gameTitlePublic
+        : std::string{"selected Nova Deck review target"};
+    return DeckMoonlightFocusReturnPlan{
+        .sourceSurface = "Nova Deck preview review",
+        .intendedReturnTarget = target,
+        .fallbackCopy = "Return to Nova and keep this preview available after a later approved launch exits or fails.",
+        .confidence = "unproven_static",
+    };
+}
+
+DeckMoonlightHandoffPreflightResult baseResult(const DeckMoonlightHandoffPreflightRequest& request) {
+    DeckMoonlightHandoffPreflightResult result;
+    result.focusReturnPlan = focusReturnPlanFor(request);
+    return result;
+}
+
+DeckMoonlightHandoffPreflightResult blocked(
+    const DeckMoonlightHandoffPreflightRequest& request,
+    std::vector<DeckMoonlightHandoffBlockReason> reasons,
+    std::string publicCopy,
+    const DeckMoonlightHandoffVerdict verdict = DeckMoonlightHandoffVerdict::BlockedStatic) {
+    auto result = baseResult(request);
+    result.verdict = verdict;
+    result.blockedReasons = std::move(reasons);
+    result.publicPreviewCopy = std::move(publicCopy);
+    result.candidatePlan.surface = request.requestedSurface;
+    result.candidatePlan.publicSummary = result.publicPreviewCopy;
+    result.safeToRender = !isUnsafePublicText(result.publicPreviewCopy);
+    return result;
+}
+
+} // namespace
+
+DeckMoonlightHandoffPreflightResult resolveDeckMoonlightHandoffPreflight(
+    const DeckMoonlightHandoffPreflightRequest& request) {
+    if (isBlank(request.hostDisplayNamePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::MissingHost},
+            "Nova needs a public host label before reviewing a Moonlight handoff. Nothing will launch yet.");
+    }
+
+    if (isBlank(request.gameTitlePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::MissingGame},
+            "Nova needs a public game title before reviewing a Moonlight handoff. Nothing will launch yet.");
+    }
+
+    if (isUnsafePublicText(request.hostDisplayNamePublic) || isUnsafePublicText(request.gameTitlePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafePublicCopy},
+            "Nova blocked this Moonlight handoff preview because public copy contains unsafe private or shell-like text. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::NovaOwnedCommonCFuture) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::ForbiddenRuntimeBoundary},
+            "Nova-owned streaming belongs behind a later approved runtime lane. Nothing will launch yet.",
+            DeckMoonlightHandoffVerdict::ForbiddenRuntimeBoundary);
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::CustomUri) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::CustomUriNotStreamHandler},
+            "Custom URI handoff is blocked: research has not proven a stream-launch handler. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::DesktopEntry) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::DesktopEntryNotStreamContract, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Desktop entry handoff is research-only: it identifies the app shell, not a host/game stream. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::FlatpakIdentity) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::FlatpakContractUnproven, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Flatpak identity handoff is research-only: package identity is known, but argument forwarding is unproven. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::SteamShortcut) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::SteamShortcutRuntimeOnly, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Steam shortcut handoff is research-only: Game Mode launch behavior needs a later approved runtime check. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface != DeckMoonlightHandoffSurface::MoonlightQtCli) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsupportedSurface},
+            "This handoff surface is not supported by the local-only Moonlight preflight. Nothing will launch yet.");
+    }
+
+    if (!request.hasSafeSnapshot) {
+        return blocked(
+            request,
+            {
+                DeckMoonlightHandoffBlockReason::HostSnapshotMissing,
+                DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic,
+                DeckMoonlightHandoffBlockReason::FocusReturnUnprovenStatic,
+            },
+            "Nova cannot verify Moonlight readiness without a prior safe snapshot or a later approved runtime check. Nothing will launch yet.");
+    }
+
+    if (!request.appPresentInSnapshot) {
+        return blocked(
+            request,
+            {
+                DeckMoonlightHandoffBlockReason::AppNotInSnapshot,
+                DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic,
+            },
+            "Nova cannot verify that this game exists in the safe host snapshot. Nothing will launch yet.");
+    }
+
+    const auto privateHostSelector = isBlank(request.privateHostSelectorRedactedForDebug)
+        ? std::string{"redacted-host-selector"}
+        : request.privateHostSelectorRedactedForDebug;
+    if (isUnsafeArgvToken(privateHostSelector)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafeArgvToken},
+            "Nova blocked this Moonlight handoff preview because the private host selector is not safe as typed argv data. Nothing will launch yet.");
+    }
+
+    auto result = baseResult(request);
+    result.verdict = DeckMoonlightHandoffVerdict::ReadyForReview;
+    result.safeToRender = true;
+    result.candidatePlan.surface = DeckMoonlightHandoffSurface::MoonlightQtCli;
+    result.candidatePlan.argvTokens = {"moonlight", "stream", privateHostSelector, request.gameTitlePublic};
+    result.publicPreviewCopy = "Ready to review Moonlight handoff for "
+        + request.hostDisplayNamePublic
+        + " / "
+        + request.gameTitlePublic
+        + ". Nothing will launch yet.";
+    result.candidatePlan.publicSummary = result.publicPreviewCopy;
+    result.safeToRender = !isUnsafePublicText(result.publicPreviewCopy);
+    return result;
+}
+
+} // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.h
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace nova::deck::stream {
+
+enum class DeckMoonlightHandoffSurface {
+    MoonlightQtCli,
+    HostAppSnapshot,
+    DesktopEntry,
+    FlatpakIdentity,
+    SteamShortcut,
+    CustomUri,
+    NovaOwnedCommonCFuture,
+    Unsupported,
+};
+
+enum class DeckMoonlightHandoffVerdict {
+    ReadyForReview,
+    BlockedStatic,
+    ForbiddenRuntimeBoundary,
+};
+
+enum class DeckMoonlightHandoffBlockReason {
+    MissingHost,
+    MissingGame,
+    UnsupportedSurface,
+    HostSnapshotMissing,
+    HostPairingUnprovenStatic,
+    AppNotInSnapshot,
+    UnsafePublicCopy,
+    UnsafeArgvToken,
+    CustomUriNotStreamHandler,
+    DesktopEntryNotStreamContract,
+    FlatpakContractUnproven,
+    SteamShortcutRuntimeOnly,
+    FocusReturnUnprovenStatic,
+    ResearchNeeded,
+    ForbiddenRuntimeBoundary,
+};
+
+struct DeckMoonlightHandoffPreflightRequest {
+    std::string hostDisplayNamePublic;
+    std::string gameTitlePublic;
+    std::string privateHostSelectorRedactedForDebug;
+    DeckMoonlightHandoffSurface requestedSurface = DeckMoonlightHandoffSurface::Unsupported;
+    bool hasSafeSnapshot = false;
+    bool appPresentInSnapshot = false;
+};
+
+struct DeckMoonlightHandoffCandidatePlan {
+    DeckMoonlightHandoffSurface surface = DeckMoonlightHandoffSurface::Unsupported;
+    std::vector<std::string> argvTokens;
+    std::string publicSummary;
+};
+
+struct DeckMoonlightFocusReturnPlan {
+    std::string sourceSurface;
+    std::string intendedReturnTarget;
+    std::string fallbackCopy;
+    std::string confidence;
+};
+
+struct DeckMoonlightHandoffPreflightResult {
+    DeckMoonlightHandoffVerdict verdict = DeckMoonlightHandoffVerdict::BlockedStatic;
+    bool executable = false;
+    bool allowsNetwork = false;
+    bool allowsProcessExecution = false;
+    bool allowsMoonlight = false;
+    bool allowsHostMutation = false;
+    bool safeToRender = false;
+    DeckMoonlightHandoffCandidatePlan candidatePlan;
+    DeckMoonlightFocusReturnPlan focusReturnPlan;
+    std::string publicPreviewCopy;
+    std::vector<DeckMoonlightHandoffBlockReason> blockedReasons;
+};
+
+DeckMoonlightHandoffPreflightResult resolveDeckMoonlightHandoffPreflight(
+    const DeckMoonlightHandoffPreflightRequest& request);
+
+} // namespace nova::deck::stream

--- a/clients/deck/tests/deck_layout_test.cpp
+++ b/clients/deck/tests/deck_layout_test.cpp
@@ -99,8 +99,28 @@ int main() {
     assert(mainQml.find("cursorShape: Qt.BlankCursor") != std::string::npos);
     assert(mainQml.find("D-pad focus") != std::string::npos);
     assert(mainQml.find("Exact preview details stay behind Copy preview details") != std::string::npos);
+    assert(mainQml.find("objectName: \"moonlight-handoff-panel\"") != std::string::npos);
+    assert(mainQml.find("Moonlight handoff preview") != std::string::npos);
+    assert(mainQml.find("selectedMoonlightHandoffCopy") != std::string::npos);
+    assert(mainQml.find("selectedMoonlightHandoffArgvPreview") != std::string::npos);
+    assert(mainQml.find("Typed argv plan") != std::string::npos);
+    assert(mainQml.find("redacted host selector") != std::string::npos);
+    assert(mainQml.find("Runtime gates: network off · process off · Moonlight off · host mutation off") != std::string::npos);
+    assert(mainQml.find("unproven_static") != std::string::npos);
+    assert(mainQml.find("Nothing will launch yet") != std::string::npos);
+    assert(mainQml.find("novaMoonlightHandoffPreflightBridge.resolve") != std::string::npos);
+    assert(mainQml.find("moonlightHandoffPreflight.executable") != std::string::npos);
+    assert(mainQml.find("moonlightHandoffPreflight.safeToRender") != std::string::npos);
+    assert(mainQml.find("moonlightHandoffRuntimeGatesClosed") != std::string::npos);
+    assert(mainQml.find("!moonlightHandoffPreflight.allowsNetwork") != std::string::npos);
+    assert(mainQml.find("!moonlightHandoffPreflight.allowsProcessExecution") != std::string::npos);
+    assert(mainQml.find("!moonlightHandoffPreflight.allowsMoonlight") != std::string::npos);
+    assert(mainQml.find("!moonlightHandoffPreflight.allowsHostMutation") != std::string::npos);
+    assert(mainQml.find("Moonlight handoff preview blocked until safe public copy is available") != std::string::npos);
     assert(mainQml.find("text: selectedLaunchPreviewText") == std::string::npos);
     assert(mainQml.find("font.family: monospace") == std::string::npos);
+    assert(mainQml.find("onClicked: activateMoonlight") == std::string::npos);
+    assert(mainQml.find("QProcess") == std::string::npos);
 
     assert(nova::deck::decodeGamepadAction(nova::deck::DeckGamepadEvent{
         .timeMs = 10,

--- a/clients/deck/tests/deck_moonlight_handoff_preflight_test.cpp
+++ b/clients/deck/tests/deck_moonlight_handoff_preflight_test.cpp
@@ -1,0 +1,213 @@
+#include "stream/deck_moonlight_handoff_preflight.h"
+
+#include <algorithm>
+#include <cassert>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using nova::deck::stream::DeckMoonlightFocusReturnPlan;
+using nova::deck::stream::DeckMoonlightHandoffBlockReason;
+using nova::deck::stream::DeckMoonlightHandoffPreflightRequest;
+using nova::deck::stream::DeckMoonlightHandoffPreflightResult;
+using nova::deck::stream::DeckMoonlightHandoffSurface;
+using nova::deck::stream::DeckMoonlightHandoffVerdict;
+using nova::deck::stream::resolveDeckMoonlightHandoffPreflight;
+
+DeckMoonlightHandoffPreflightRequest validRequest(
+    const DeckMoonlightHandoffSurface surface = DeckMoonlightHandoffSurface::MoonlightQtCli) {
+    return DeckMoonlightHandoffPreflightRequest{
+        .hostDisplayNamePublic = "MacPapi Gaming Host",
+        .gameTitlePublic = "Black Myth: Wukong",
+        .privateHostSelectorRedactedForDebug = "redacted-host-selector",
+        .requestedSurface = surface,
+        .hasSafeSnapshot = true,
+        .appPresentInSnapshot = true,
+    };
+}
+
+bool hasReason(
+    const DeckMoonlightHandoffPreflightResult& result,
+    const DeckMoonlightHandoffBlockReason reason) {
+    return std::find(result.blockedReasons.begin(), result.blockedReasons.end(), reason) != result.blockedReasons.end();
+}
+
+bool contains(const std::string& text, const std::string_view needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+std::string pieces(const std::initializer_list<std::string_view> parts) {
+    std::string value;
+    for (const auto part : parts) {
+        value.append(part);
+    }
+    return value;
+}
+
+void assertRuntimeBoundaryClosed(const DeckMoonlightHandoffPreflightResult& result) {
+    assert(!result.executable);
+    assert(!result.allowsNetwork);
+    assert(!result.allowsProcessExecution);
+    assert(!result.allowsMoonlight);
+    assert(!result.allowsHostMutation);
+}
+
+void assertBlockedStatic(const DeckMoonlightHandoffPreflightResult& result) {
+    assert(result.verdict == DeckMoonlightHandoffVerdict::BlockedStatic);
+    assertRuntimeBoundaryClosed(result);
+    assert(result.candidatePlan.argvTokens.empty());
+    assert(!contains(result.publicPreviewCopy, "moonlight://"));
+    assert(!contains(result.publicPreviewCopy, "http://"));
+    assert(!contains(result.publicPreviewCopy, "https://"));
+    assert(!contains(result.publicPreviewCopy, "ssh"));
+}
+
+void assertFocusReturnUnproven(const DeckMoonlightFocusReturnPlan& plan) {
+    assert(plan.sourceSurface == "Nova Deck preview review");
+    assert(plan.intendedReturnTarget == "MacPapi Gaming Host / Black Myth: Wukong");
+    assert(plan.confidence == "unproven_static");
+    assert(contains(plan.fallbackCopy, "Return to Nova"));
+    assert(contains(plan.fallbackCopy, "later approved launch"));
+}
+
+} // namespace
+
+static_assert(std::is_default_constructible_v<DeckMoonlightHandoffPreflightRequest>);
+static_assert(std::is_default_constructible_v<DeckMoonlightHandoffPreflightResult>);
+
+int main() {
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest());
+        assert(result.verdict == DeckMoonlightHandoffVerdict::ReadyForReview);
+        assert(result.safeToRender);
+        assertRuntimeBoundaryClosed(result);
+        assert(result.candidatePlan.surface == DeckMoonlightHandoffSurface::MoonlightQtCli);
+        assert((result.candidatePlan.argvTokens == std::vector<std::string>{
+            "moonlight",
+            "stream",
+            "redacted-host-selector",
+            "Black Myth: Wukong",
+        }));
+        assert(contains(result.publicPreviewCopy, "Ready to review Moonlight handoff"));
+        assert(contains(result.publicPreviewCopy, "MacPapi Gaming Host"));
+        assert(contains(result.publicPreviewCopy, "Black Myth: Wukong"));
+        assert(contains(result.publicPreviewCopy, "Nothing will launch yet"));
+        assert(!contains(result.publicPreviewCopy, "redacted-host-selector"));
+        assertFocusReturnUnproven(result.focusReturnPlan);
+        assert(result.blockedReasons.empty());
+    }
+
+    {
+        auto request = validRequest();
+        request.hostDisplayNamePublic.clear();
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::MissingHost));
+        assert(contains(result.publicPreviewCopy, "public host label"));
+    }
+
+    {
+        auto request = validRequest();
+        request.gameTitlePublic.clear();
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::MissingGame));
+        assert(contains(result.publicPreviewCopy, "game title"));
+    }
+
+    {
+        auto request = validRequest();
+        request.hasSafeSnapshot = false;
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostSnapshotMissing));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::FocusReturnUnprovenStatic));
+        assert(contains(result.publicPreviewCopy, "cannot verify Moonlight readiness"));
+        assertFocusReturnUnproven(result.focusReturnPlan);
+    }
+
+    {
+        auto request = validRequest();
+        request.appPresentInSnapshot = false;
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::AppNotInSnapshot));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic));
+    }
+
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(DeckMoonlightHandoffSurface::CustomUri));
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::CustomUriNotStreamHandler));
+        assert(!contains(result.candidatePlan.publicSummary, "moonlight://"));
+    }
+
+    {
+        const std::vector<std::pair<DeckMoonlightHandoffSurface, DeckMoonlightHandoffBlockReason>> blockedSurfaces{
+            {DeckMoonlightHandoffSurface::DesktopEntry, DeckMoonlightHandoffBlockReason::DesktopEntryNotStreamContract},
+            {DeckMoonlightHandoffSurface::FlatpakIdentity, DeckMoonlightHandoffBlockReason::FlatpakContractUnproven},
+            {DeckMoonlightHandoffSurface::SteamShortcut, DeckMoonlightHandoffBlockReason::SteamShortcutRuntimeOnly},
+        };
+        for (const auto& [surface, reason] : blockedSurfaces) {
+            const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(surface));
+            assertBlockedStatic(result);
+            assert(hasReason(result, reason));
+            assert(contains(result.publicPreviewCopy, "research-only"));
+        }
+    }
+
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(DeckMoonlightHandoffSurface::NovaOwnedCommonCFuture));
+        assert(result.verdict == DeckMoonlightHandoffVerdict::ForbiddenRuntimeBoundary);
+        assertRuntimeBoundaryClosed(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::ForbiddenRuntimeBoundary));
+        assert(result.candidatePlan.argvTokens.empty());
+    }
+
+    {
+        const std::vector<std::string> unsafePublicValues{
+            pieces({"10", ".0", ".0", ".232"}),
+            pieces({"http", "://", "host.local"}),
+            pieces({"s", "sh pc-papi"}),
+            pieces({"/Us", "ers/", "papi/", ".s", "sh/", "id_ed25519"}),
+            pieces({"token", "=redacted-test-value"}),
+            pieces({"pass", "word: redacted-test-value"}),
+            pieces({"moon", "light", "://", "stream/host/app"}),
+            pieces({"MacPapi", ";", " rm -rf /"}),
+            pieces({"aa", ":bb", ":cc", ":dd", ":ee", ":ff"}),
+            pieces({"!", "abcdef", ":matrix.local"}),
+        };
+        for (const auto& unsafeValue : unsafePublicValues) {
+            auto hostRequest = validRequest();
+            hostRequest.hostDisplayNamePublic = unsafeValue;
+            const auto hostResult = resolveDeckMoonlightHandoffPreflight(hostRequest);
+            assertBlockedStatic(hostResult);
+            assert(hasReason(hostResult, DeckMoonlightHandoffBlockReason::UnsafePublicCopy));
+            assert(!contains(hostResult.publicPreviewCopy, unsafeValue));
+
+            auto gameRequest = validRequest();
+            gameRequest.gameTitlePublic = unsafeValue;
+            const auto gameResult = resolveDeckMoonlightHandoffPreflight(gameRequest);
+            assertBlockedStatic(gameResult);
+            assert(hasReason(gameResult, DeckMoonlightHandoffBlockReason::UnsafePublicCopy));
+            assert(!contains(gameResult.publicPreviewCopy, unsafeValue));
+        }
+    }
+
+    {
+        auto request = validRequest();
+        request.privateHostSelectorRedactedForDebug = "host selector; launch";
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::UnsafeArgvToken));
+        assert(!contains(result.publicPreviewCopy, "host selector; launch"));
+    }
+
+    return 0;
+}

--- a/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
+++ b/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Static guard for the local-only Deck Moonlight handoff preflight slice."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_FILES = [
+    ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.h",
+    ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.cpp",
+    ROOT / "CMakeLists.txt",
+]
+
+FORBIDDEN_PATTERNS = [
+    ("process launch API", re.compile(r"\b(QProcess|fork\s*\(|system\s*\(|popen\s*\(|xdg-open|flatpak\s+run)\b")),
+    ("exec API", re.compile(r"\bexec(?:l|le|lp|lpe|v|ve|vp|vpe)?\s*\(")),
+    ("Moonlight runtime connection", re.compile(r"\b(LiStartConnection|LiStopConnection|LiInterruptConnection|MoonBridge\.startConnection)\b")),
+    ("Moonlight stream shell command", re.compile(r"moonlight\s+stream", re.IGNORECASE)),
+    ("Moonlight custom URI", re.compile(r"moonlight://", re.IGNORECASE)),
+    ("host HTTP launch surface", re.compile(r"(/launch|/resume|/cancel|/serverinfo|/applist)\b", re.IGNORECASE)),
+    ("Android host/pairing/persistence", re.compile(r"\b(NvHTTP|PairingManager|ComputerDatabaseManager|HostStore|DiscoveryService)\b")),
+    ("network discovery/probing", re.compile(r"\b(mDNS|NSD|zeroconf|socket\s*\(|connect\s*\(|send\s*\(|recv\s*\()\b")),
+    ("media/device probe", re.compile(r"\b(av_hwdevice_ctx_create|PipeWire|PulseAudio|VA-API|/dev/input|xdotool|ffmpeg|systemctl|pgrep|ldd)\b", re.IGNORECASE)),
+    ("private endpoint literal", re.compile(r"\b(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b")),
+    ("MAC-like literal", re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")),
+    ("private key header", re.compile(r"BEGIN [A-Z ]*PRIVATE KEY")),
+    ("secret-looking assignment", re.compile(r"\b(?:api[_-]?key|client[_-]?secret|session[_-]?token|password)\b\s*[:=]", re.IGNORECASE)),
+]
+
+ALLOWED_CMAKE_PATTERN = re.compile(r"nova_deck_moonlight_handoff_preflight|deck_moonlight_handoff", re.IGNORECASE)
+
+
+def normalized_text(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if path.name == "CMakeLists.txt":
+        # Target/file names necessarily contain the feature name. Keep command/runtime checks active.
+        text = ALLOWED_CMAKE_PATTERN.sub("PRELIGHT_TARGET_NAME", text)
+    return text
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in SCAN_FILES:
+        if not path.exists():
+            failures.append(f"missing guarded file: {path.relative_to(ROOT)}")
+            continue
+        text = normalized_text(path)
+        for label, pattern in FORBIDDEN_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                rel = path.relative_to(ROOT)
+                failures.append(f"{rel}: forbidden {label}: {match.group(0)!r}")
+    if failures:
+        print("Deck Moonlight preflight source guard failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("Deck Moonlight preflight source guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
+++ b/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
@@ -11,6 +11,8 @@ ROOT = Path(__file__).resolve().parents[1]
 SCAN_FILES = [
     ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.h",
     ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.cpp",
+    ROOT / "src" / "main.cpp",
+    ROOT / "qml" / "Main.qml",
     ROOT / "CMakeLists.txt",
 ]
 
@@ -38,6 +40,14 @@ def normalized_text(path: Path) -> str:
     if path.name == "CMakeLists.txt":
         # Target/file names necessarily contain the feature name. Keep command/runtime checks active.
         text = ALLOWED_CMAKE_PATTERN.sub("PRELIGHT_TARGET_NAME", text)
+    if path.name == "main.cpp":
+        # Qt signal wiring/event loop are not network connect/probe or process exec surfaces.
+        text = text.replace("QObject::connect", "QT_SIGNAL_CONNECT")
+        text = text.replace("connect(notifier_", "QT_SIGNAL_CONNECT(notifier_")
+        text = text.replace("return app.exec();", "return QT_APP_EVENT_LOOP;")
+    if path.name == "Main.qml":
+        # Existing inert preview URI path is local copy text, not a host HTTP launch endpoint.
+        text = text.replace("preview://nova-deck/launch", "preview://nova-deck/PREVIEW_PATH")
     return text
 
 


### PR DESCRIPTION
## Summary

- Adds a local-only Deck Moonlight handoff preflight model with explicit non-runtime safety gates.
- Surfaces the preflight in Nova Deck as a visible review panel: `Moonlight handoff preview — Nothing will launch yet`.
- Extends tests/source guards so the model, Qt bridge, QML panel, and CMake wiring stay preview-only.

## Safety boundaries

This PR does **not** add runtime streaming or launch behavior:

- No Moonlight/Sunshine/Steam/game launch.
- No host discovery, pairing, HostStore, or persisted credentials.
- No live Polaris/Nova runtime calls.
- No network launch or process execution path.
- Preflight runtime flags remain closed: `executable=false`, `allowsNetwork=false`, `allowsProcessExecution=false`, `allowsMoonlight=false`, `allowsHostMutation=false`.
- QML rendering gates preview details on `safeToRender` plus all runtime gates being closed.

## Test plan

- [x] Public repo surface: `bash scripts/check-public-surface.sh`
- [x] Linux Qt build: `cmake --build clients/deck/build-preflight-qt -j$(nproc)`
- [x] Linux CTest: `7/7` passed
- [x] SteamOS container build using `ianburgwin/steamos:base-devel`
- [x] SteamOS container CTest: `7/7` passed
- [x] Real Steam Deck staged smoke: `nova-deck --smoke-exit` rc `0`
- [x] Real Steam Deck Game Mode capture rc `0`
- [x] Capture selected the `Nova Deck` / `nova-deck` window at `1280x800`
- [x] Exact process-name cleanup check found no lingering `nova-deck`, `moonlight`, `Moonlight`, or `sunshine` processes
- [x] `git diff --check HEAD~2..HEAD`

## Notes

- The right-side safe-launch card is intentionally dense but readable at 1280x800; follow-up polish can make that area scrollable or split the details cleaner.
- This is still a preflight/review UI slice, not the real Moonlight runtime handoff.