### PR TITLE
feat(ui): add Portable Chrome Nova theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Adds a Portable Chrome Nova theme matching the Polaris dim Moonlight-grey early-2000s silver palette, including settings/theme-picker entries and restrained Compose library surfaces.
+
 ## 1.1.3 - 2026-06-12
 
 Nova 1.1.3 is the public APK publishing patch for the 1.1.2 confidence build. It preserves the same handheld Library, Command Center, NovaHUD, Insert-key, stale-session recovery, input, crash, and dependency hardening work from 1.1.2, while bumping the Android package version so GitHub Releases / Obtainium installs can update cleanly.

--- a/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
@@ -19,6 +19,7 @@ object NovaThemeManager {
     const val THEME_POLARIS = "polaris"
     const val THEME_OLED = "oled"
     const val THEME_MIAMI = "miami"
+    const val THEME_PORTABLE_CHROME = "portable_chrome"
     const val THEME_HIGH_CONTRAST = "high_contrast"
     const val THEME_MATERIAL_YOU = "material_you"
 
@@ -34,6 +35,8 @@ object NovaThemeManager {
             theme == THEME_OLED -> activity.setTheme(R.style.AppTheme_OLED)
             theme == THEME_MIAMI && isSettings -> activity.setTheme(R.style.SettingsTheme_Miami)
             theme == THEME_MIAMI -> activity.setTheme(R.style.AppTheme_Miami)
+            theme == THEME_PORTABLE_CHROME && isSettings -> activity.setTheme(R.style.SettingsTheme_PortableChrome)
+            theme == THEME_PORTABLE_CHROME -> activity.setTheme(R.style.AppTheme_PortableChrome)
             theme == THEME_HIGH_CONTRAST && isSettings -> activity.setTheme(R.style.SettingsTheme_HighContrast)
             theme == THEME_HIGH_CONTRAST -> activity.setTheme(R.style.AppTheme_HighContrast)
             theme == THEME_MATERIAL_YOU && isSettings -> activity.setTheme(R.style.SettingsTheme_MaterialYou)
@@ -70,7 +73,7 @@ object NovaThemeManager {
 
     private fun normalizeTheme(theme: String?): String {
         return when (theme) {
-            THEME_POLARIS, THEME_OLED, THEME_MIAMI, THEME_HIGH_CONTRAST, THEME_MATERIAL_YOU -> theme
+            THEME_POLARIS, THEME_OLED, THEME_MIAMI, THEME_PORTABLE_CHROME, THEME_HIGH_CONTRAST, THEME_MATERIAL_YOU -> theme
             else -> THEME_POLARIS
         }
     }
@@ -86,6 +89,7 @@ object NovaThemeManager {
 
     fun isOled(context: Context): Boolean = getTheme(context) == THEME_OLED
     fun isMiami(context: Context): Boolean = getTheme(context) == THEME_MIAMI
+    fun isPortableChrome(context: Context): Boolean = getTheme(context) == THEME_PORTABLE_CHROME
     fun isHighContrast(context: Context): Boolean = getTheme(context) == THEME_HIGH_CONTRAST
     fun isMaterialYou(context: Context): Boolean = getTheme(context) == THEME_MATERIAL_YOU
 
@@ -93,7 +97,8 @@ object NovaThemeManager {
         val next = when (getTheme(context)) {
             THEME_POLARIS -> THEME_OLED
             THEME_OLED -> THEME_MIAMI
-            THEME_MIAMI -> THEME_HIGH_CONTRAST
+            THEME_MIAMI -> THEME_PORTABLE_CHROME
+            THEME_PORTABLE_CHROME -> THEME_HIGH_CONTRAST
             THEME_HIGH_CONTRAST -> if (isMaterialYouAvailable()) THEME_MATERIAL_YOU else THEME_POLARIS
             THEME_MATERIAL_YOU -> THEME_POLARIS
             else -> THEME_POLARIS
@@ -106,6 +111,7 @@ object NovaThemeManager {
         return when (theme) {
             THEME_OLED -> context.getString(R.string.nova_theme_oled_label)
             THEME_MIAMI -> context.getString(R.string.nova_theme_miami_label)
+            THEME_PORTABLE_CHROME -> context.getString(R.string.nova_theme_portable_chrome_label)
             THEME_HIGH_CONTRAST -> context.getString(R.string.nova_theme_high_contrast_label)
             THEME_MATERIAL_YOU -> context.getString(R.string.nova_theme_material_you_label)
             else -> context.getString(R.string.nova_theme_polaris_label)
@@ -130,6 +136,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> Color.BLACK
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_window)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_window)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_window)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.colorBackground, ContextCompat.getColor(context, R.color.nova_bg_window))
@@ -160,6 +167,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_bg_card)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_card)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_card)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_card)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_bg_card))
@@ -172,6 +180,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_dialog_bg)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_dialog_bg)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_dialog_bg)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_dialog_bg)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_dialog_bg))
@@ -196,6 +205,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_accent)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_accent)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_accent)
             else -> ContextCompat.getColor(context, R.color.nova_accent)
         }
@@ -206,6 +216,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_accent_surface)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_accent_surface)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent_surface)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_accent_surface)
             else -> ContextCompat.getColor(context, R.color.nova_accent_surface)
         }
@@ -216,6 +227,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_divider)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_divider)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_divider)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_divider)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorOutline, ContextCompat.getColor(context, R.color.nova_divider))
@@ -228,6 +240,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_primary)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_primary)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_primary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_primary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorPrimary, ContextCompat.getColor(context, R.color.nova_text_primary))
@@ -240,6 +253,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_secondary)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_secondary)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_secondary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_secondary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_secondary))
@@ -252,6 +266,7 @@ object NovaThemeManager {
         return when {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_muted)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_muted)
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_muted)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_muted)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_muted))

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -77,12 +77,14 @@ val LocalNovaLibrarySurfaces = staticCompositionLocalOf {
 fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
     val isOled = theme == NovaThemeManager.THEME_OLED
     val isMiami = theme == NovaThemeManager.THEME_MIAMI
+    val isPortableChrome = theme == NovaThemeManager.THEME_PORTABLE_CHROME
     val isHighContrast = theme == NovaThemeManager.THEME_HIGH_CONTRAST
     val isMaterialYou = theme == NovaThemeManager.THEME_MATERIAL_YOU
     return NovaLibrarySurfaces(
         backgroundScrim = when {
             isOled -> Color.Transparent
             isMiami -> window.copy(alpha = 0.60f)
+            isPortableChrome -> Color.Black.copy(alpha = 0.20f)
             isHighContrast -> Color.Black.copy(alpha = 0.72f)
             isMaterialYou -> window.copy(alpha = 0.28f)
             else -> window.copy(alpha = 0.56f)
@@ -90,6 +92,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         panel = when {
             isOled -> dialog.copy(alpha = 0.88f)
             isMiami -> dialog.copy(alpha = 0.82f)
+            isPortableChrome -> dialog.copy(alpha = 0.90f)
             isHighContrast -> dialog.copy(alpha = 0.96f)
             isMaterialYou -> card.copy(alpha = 0.76f)
             else -> dialog.copy(alpha = 0.64f)
@@ -97,6 +100,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         panelBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> accent.copy(alpha = 0.18f)
+            isPortableChrome -> divider.copy(alpha = 0.62f)
             isHighContrast -> divider.copy(alpha = 0.92f)
             isMaterialYou -> divider.copy(alpha = 0.46f)
             else -> divider.copy(alpha = 0.44f)
@@ -104,6 +108,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         tile = when {
             isOled -> card.copy(alpha = 0.90f)
             isMiami -> card.copy(alpha = 0.82f)
+            isPortableChrome -> card.copy(alpha = 0.88f)
             isHighContrast -> card.copy(alpha = 0.98f)
             isMaterialYou -> card.copy(alpha = 0.78f)
             else -> card.copy(alpha = 0.74f)
@@ -111,12 +116,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         tileBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> divider.copy(alpha = 0.58f)
+            isPortableChrome -> divider.copy(alpha = 0.62f)
             isHighContrast -> divider.copy(alpha = 0.90f)
             else -> divider.copy(alpha = 0.50f)
         },
         control = when {
             isOled -> card.copy(alpha = 0.78f)
             isMiami -> card.copy(alpha = 0.76f)
+            isPortableChrome -> card.copy(alpha = 0.84f)
             isHighContrast -> card.copy(alpha = 1f)
             isMaterialYou -> card.copy(alpha = 0.70f)
             else -> card.copy(alpha = 0.72f)
@@ -124,6 +131,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         selectedControl = accent.copy(alpha = when {
             isHighContrast -> 0.34f
             isMiami -> 0.22f
+            isPortableChrome -> 0.20f
             isOled -> 0.22f
             else -> 0.18f
         }),
@@ -131,12 +139,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusHalo = accent.copy(alpha = when {
             isHighContrast -> 0.36f
             isMiami -> 0.28f
+            isPortableChrome -> 0.20f
             isOled -> 0.24f
             else -> 0.18f
         }),
         mediaPlaceholder = when {
             isOled -> Color(0xFF08080C)
             isMiami -> Color(0xFF2C1734)
+            isPortableChrome -> Color(0xFFB8C1CC)
             isHighContrast -> Color(0xFF111827)
             isMaterialYou -> card.copy(alpha = 1f)
             else -> divider.copy(alpha = 1f)
@@ -152,12 +162,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusedArtworkAlpha = when {
             isOled -> 0.10f
             isMiami -> 0.26f
+            isPortableChrome -> 0.16f
             isMaterialYou -> 0.18f
             else -> 0.24f
         },
         focusedArtworkScrim = Color.Black.copy(alpha = when {
             isOled -> 0.82f
             isMiami -> 0.76f
+            isPortableChrome -> 0.64f
             else -> 0.72f
         }),
         particlesEnabled = !isOled,
@@ -165,6 +177,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
             isOled -> 0f
             isHighContrast -> 0.28f
             isMiami -> 0.68f
+            isPortableChrome -> 0.32f
             isMaterialYou -> 0.42f
             else -> 1f
         }
@@ -190,7 +203,11 @@ fun NovaComposeTheme(content: @Composable () -> Unit) {
         onAccent = Color(
             ContextCompat.getColor(
                 context,
-                if (theme == NovaThemeManager.THEME_MIAMI) R.color.nova_miami_void else R.color.nova_ice
+                when (theme) {
+                    NovaThemeManager.THEME_MIAMI -> R.color.nova_miami_void
+                    NovaThemeManager.THEME_PORTABLE_CHROME -> R.color.nova_portable_on_accent
+                    else -> R.color.nova_ice
+                }
             )
         )
     )

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -27,4 +27,10 @@
         <item name="android:windowSplashScreenBackground">@color/nova_miami_bg_window</item>
         <item name="android:windowSplashScreenIconBackgroundColor">@color/nova_miami_bg_window</item>
     </style>
+    <style name="AppTheme.PortableChrome">
+        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowSplashScreenBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@color/nova_portable_bg_window</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -4,6 +4,7 @@
         <item>Polaris Aurora</item>
         <item>Console OLED</item>
         <item>Miami Nebula</item>
+        <item>Portable Chrome</item>
         <item>High Contrast</item>
         <item>Material You</item>
     </string-array>
@@ -11,6 +12,7 @@
         <item>polaris</item>
         <item>oled</item>
         <item>miami</item>
+        <item>portable_chrome</item>
         <item>high_contrast</item>
         <item>material_you</item>
     </string-array>

--- a/app/src/main/res/values/colors_nova.xml
+++ b/app/src/main/res/values/colors_nova.xml
@@ -55,6 +55,32 @@
     <color name="nova_miami_accent_glow">#73FF5CAB</color>
     <color name="nova_miami_ripple">#22FF5CAB</color>
 
+    <!-- Portable Chrome - Moonlight-grey early-2000s silver with restrained status accents. -->
+    <color name="nova_portable_void">#FF98A6B5</color>
+    <color name="nova_portable_deep">#FFB8C1CC</color>
+    <color name="nova_portable_twilight">#FFA7B2BE</color>
+    <color name="nova_portable_storm">#FF7F8C9A</color>
+    <color name="nova_portable_silver">#FFD6DDE5</color>
+    <color name="nova_portable_ice">#FFEAF0F5</color>
+    <color name="nova_portable_bg_primary">#FFB8C1CC</color>
+    <color name="nova_portable_bg_window">#FFB8C1CC</color>
+    <color name="nova_portable_bg_card">#E6D6DDE5</color>
+    <color name="nova_portable_bg_elevated">#FFE0E6EC</color>
+    <color name="nova_portable_bg_input">#FFC8D1DC</color>
+    <color name="nova_portable_dialog_bg">#FFD6DDE5</color>
+    <color name="nova_portable_context_bg">#FFC7D1DD</color>
+    <color name="nova_portable_divider">#FF7F8C9A</color>
+    <color name="nova_portable_text_primary">#FF25313D</color>
+    <color name="nova_portable_text_secondary">#FF4F5D6B</color>
+    <color name="nova_portable_text_muted">#FF667584</color>
+    <color name="nova_portable_accent">#FF557395</color>
+    <color name="nova_portable_accent_surface">#22557395</color>
+    <color name="nova_portable_accent_glow">#33557395</color>
+    <color name="nova_portable_ripple">#22557395</color>
+    <color name="nova_portable_success">#FF315B45</color>
+    <color name="nova_portable_streaming">#FF315B45</color>
+    <color name="nova_portable_online">#FF557395</color>
+    <color name="nova_portable_on_accent">#FFFFFFFF</color>
     <!-- High Contrast — brighter copy, firm outlines, and blue focus for readability. -->
     <color name="nova_hc_bg_primary">#FF05070c</color>
     <color name="nova_hc_bg_card">#F00f172a</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="nova_theme_polaris_label">Polaris Aurora</string>
     <string name="nova_theme_oled_label">Console OLED</string>
     <string name="nova_theme_miami_label">Miami Nebula</string>
+    <string name="nova_theme_portable_chrome_label">Portable Chrome</string>
     <string name="nova_theme_high_contrast_label">High Contrast</string>
     <string name="nova_theme_material_you_label">Material You</string>
     <string name="pcview_quick_library">Open Nova Library</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -55,6 +55,20 @@
         <item name="colorOnSurface">@color/nova_miami_text_primary</item>
     </style>
 
+    <!-- Portable Chrome - dim Moonlight-grey silver shell matching Polaris Portable Chrome. -->
+    <style name="AppTheme.PortableChrome">
+        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
+        <item name="android:textColor">@color/nova_portable_text_primary</item>
+        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
+        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
+        <item name="android:navigationBarColor">@color/nova_portable_deep</item>
+        <item name="android:statusBarColor">@color/nova_portable_deep</item>
+        <item name="colorPrimary">@color/nova_portable_accent</item>
+        <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
+        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
+    </style>
     <!-- High Contrast — firm outlines and bright copy without abandoning Nova's dark UI. -->
     <style name="AppTheme.HighContrast">
         <item name="android:colorBackground">@color/nova_hc_bg_window</item>
@@ -126,6 +140,18 @@
         <item name="android:statusBarColor">@color/nova_miami_void</item>
     </style>
 
+    <style name="SettingsTheme.PortableChrome" parent="SettingsTheme">
+        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
+        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
+        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
+        <item name="colorPrimary">@color/nova_portable_accent</item>
+        <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
+        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
+        <item name="android:navigationBarColor">@color/nova_portable_deep</item>
+        <item name="android:statusBarColor">@color/nova_portable_deep</item>
+    </style>
     <style name="SettingsTheme.HighContrast" parent="SettingsTheme">
         <item name="android:colorBackground">@color/nova_hc_bg_window</item>
         <item name="android:windowBackground">@color/nova_hc_bg_window</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -608,7 +608,7 @@
         <ListPreference
             android:key="nova_theme"
             android:title="Theme"
-            android:summary="Polaris Aurora, Console OLED, Miami Nebula, High Contrast, or Material You"
+            android:summary="Polaris Aurora, Console OLED, Miami Nebula, Portable Chrome, High Contrast, or Material You"
             android:entries="@array/nova_theme_names"
             android:entryValues="@array/nova_theme_values"
             android:defaultValue="polaris"

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
@@ -31,6 +31,14 @@ class NovaThemeManagerTest {
     }
 
     @Test
+    fun portableChromeThemeIsRecognizedStoredAndLabeled() {
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
+
+        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.getTheme(context))
+        assertEquals("Portable Chrome", NovaThemeManager.getThemeLabel(context))
+    }
+
+    @Test
     fun unknownThemeFallsBackToPolaris() {
         NovaThemeManager.setTheme(context, "south_beach_laser_flamingo")
 
@@ -44,6 +52,7 @@ class NovaThemeManagerTest {
 
         assertEquals(NovaThemeManager.THEME_OLED, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_MIAMI, NovaThemeManager.cycleTheme(context))
+        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_HIGH_CONTRAST, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_POLARIS, NovaThemeManager.cycleTheme(context))
     }
@@ -55,6 +64,21 @@ class NovaThemeManagerTest {
 
         assertEquals(NovaThemeManager.THEME_MATERIAL_YOU, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_POLARIS, NovaThemeManager.cycleTheme(context))
+    }
+
+    @Test
+    fun portableChromeThemeResolvesSemanticColors() {
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
+
+        assertEquals(context.getColor(R.color.nova_portable_bg_window), NovaThemeManager.getWindowBackgroundColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_bg_card), NovaThemeManager.getCardBackgroundColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_dialog_bg), NovaThemeManager.getDialogBackgroundColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_accent), NovaThemeManager.getAccentColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_accent_surface), NovaThemeManager.getAccentSurfaceColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_text_primary), NovaThemeManager.getTextPrimaryColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_text_secondary), NovaThemeManager.getTextSecondaryColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_text_muted), NovaThemeManager.getTextMutedColor(context))
+        assertEquals(context.getColor(R.color.nova_portable_divider), NovaThemeManager.getDividerColor(context))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -13,24 +13,25 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NovaThemeResourcesTest {
     @Test
-    fun themeArraysExposeMiamiInPredictableOrder() {
+    fun themeArraysExposePortableChromeInPredictableOrder() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val names = context.resources.getStringArray(R.array.nova_theme_names).toList()
         val values = context.resources.getStringArray(R.array.nova_theme_values).toList()
 
         assertEquals(names.size, values.size)
         assertEquals(
-            listOf("polaris", "oled", "miami", "high_contrast", "material_you"),
+            listOf("polaris", "oled", "miami", "portable_chrome", "high_contrast", "material_you"),
             values
         )
         assertEquals("Miami Nebula", names[values.indexOf("miami")])
+        assertEquals("Portable Chrome", names[values.indexOf("portable_chrome")])
     }
 
     @Test
-    fun preferencesThemeSummaryMentionsMiami() {
+    fun preferencesThemeSummaryMentionsPortableChrome() {
         val preferencesXml = File("src/main/res/xml/preferences.xml").readText()
 
         assertTrue(preferencesXml.contains("android:key=\"nova_theme\""))
-        assertTrue(preferencesXml.contains("Miami Nebula"))
+        assertTrue(preferencesXml.contains("Portable Chrome"))
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
@@ -45,6 +45,25 @@ class NovaLibrarySurfacesTest {
     }
 
     @Test
+    fun portableChromeLibrarySurfacesUseDimSilverPanelsAndSubduedParticles() {
+        val portableColors = portableChromeColors()
+
+        val portableChrome = portableColors.librarySurfaces(NovaThemeManager.THEME_PORTABLE_CHROME)
+
+        assertTrue(portableChrome.particlesEnabled)
+        assertEquals(portableColors.accent, portableChrome.focusRing)
+        assertTrue(portableChrome.panel.alpha >= 0.86f)
+        assertTrue(portableChrome.panelBorder.alpha >= 0.56f)
+        assertTrue(portableChrome.particleAlpha in 0.20f..0.45f)
+        assertTrue(portableChrome.focusHalo.alpha < 0.24f)
+        assertEquals(Color(0xFFB8C1CC), portableChrome.mediaPlaceholder)
+    }
+
+    @Test
+    fun portableChromeOnAccentUsesWhiteForReadableBlueControls() {
+        assertEquals(Color.White, portableChromeColors().onAccent)
+    }
+    @Test
     fun miamiLibrarySurfacesUsePlumGlassMagentaFocusAndParticles() {
         val miamiColors = miamiColors()
 
@@ -75,6 +94,20 @@ class NovaLibrarySurfacesTest {
         assertEquals(Color(0xFF130817), miamiColors().onAccent)
     }
 
+    private fun portableChromeColors(): NovaComposeColors = NovaComposeColors(
+        window = Color(0xFFB8C1CC),
+        card = Color(0xE6D6DDE5),
+        dialog = Color(0xFFD6DDE5),
+        badge = Color(0x33557395),
+        divider = Color(0xFF7F8C9A),
+        accent = Color(0xFF557395),
+        accentSurface = Color(0x22557395),
+        warning = Color(0xFFFBBF24),
+        textPrimary = Color(0xFF25313D),
+        textSecondary = Color(0xFF4F5D6B),
+        textMuted = Color(0xFF667584),
+        onAccent = Color.White
+    )
     private fun miamiColors(): NovaComposeColors = NovaComposeColors(
         window = Color(0xFF130817),
         card = Color(0xE6241429),


### PR DESCRIPTION
## Summary
- Adds a Portable Chrome theme to Nova matching the Polaris dim Moonlight-grey early-2000s silver palette
- Wires the theme into settings, theme cycling, app/settings styles, Android 12 splash colors, and Compose library surfaces
- Keeps status/silver readability restrained with dark text and muted blue/green accents

## Test Plan
- RED: ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaThemeManagerTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.compose.NovaLibrarySurfacesTest failed before implementation with missing THEME_PORTABLE_CHROME/resources
- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaThemeManagerTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.compose.NovaLibrarySurfacesTest
- git submodule update --init --recursive app/src/main/jni/moonlight-core/moonlight-common-c
- ./gradlew testDebugUnitTest assembleRootDebug lintRootDebug