### PR TITLE
fix(ui): label Portable Chrome as PSP theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Adds a Portable Chrome Nova theme matching the Polaris dim Moonlight-grey early-2000s silver palette, including settings/theme-picker entries and restrained Compose library surfaces.
+- Adds a PSP / Portable Chrome Nova theme matching the Polaris dim Moonlight-grey early-2000s silver palette, including settings/theme-picker entries and restrained Compose library surfaces.
 
 ## 1.1.3 - 2026-06-12
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -4,7 +4,7 @@
         <item>Polaris Aurora</item>
         <item>Console OLED</item>
         <item>Miami Nebula</item>
-        <item>Portable Chrome</item>
+        <item>PSP / Portable Chrome</item>
         <item>High Contrast</item>
         <item>Material You</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="nova_theme_polaris_label">Polaris Aurora</string>
     <string name="nova_theme_oled_label">Console OLED</string>
     <string name="nova_theme_miami_label">Miami Nebula</string>
-    <string name="nova_theme_portable_chrome_label">Portable Chrome</string>
+    <string name="nova_theme_portable_chrome_label">PSP / Portable Chrome</string>
     <string name="nova_theme_high_contrast_label">High Contrast</string>
     <string name="nova_theme_material_you_label">Material You</string>
     <string name="pcview_quick_library">Open Nova Library</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -608,7 +608,7 @@
         <ListPreference
             android:key="nova_theme"
             android:title="Theme"
-            android:summary="Polaris Aurora, Console OLED, Miami Nebula, Portable Chrome, High Contrast, or Material You"
+            android:summary="Polaris Aurora, Console OLED, Miami Nebula, PSP / Portable Chrome, High Contrast, or Material You"
             android:entries="@array/nova_theme_names"
             android:entryValues="@array/nova_theme_values"
             android:defaultValue="polaris"

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
@@ -35,7 +35,7 @@ class NovaThemeManagerTest {
         NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
 
         assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.getTheme(context))
-        assertEquals("Portable Chrome", NovaThemeManager.getThemeLabel(context))
+        assertEquals("PSP / Portable Chrome", NovaThemeManager.getThemeLabel(context))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -24,7 +24,7 @@ class NovaThemeResourcesTest {
             values
         )
         assertEquals("Miami Nebula", names[values.indexOf("miami")])
-        assertEquals("Portable Chrome", names[values.indexOf("portable_chrome")])
+        assertEquals("PSP / Portable Chrome", names[values.indexOf("portable_chrome")])
     }
 
     @Test
@@ -32,6 +32,6 @@ class NovaThemeResourcesTest {
         val preferencesXml = File("src/main/res/xml/preferences.xml").readText()
 
         assertTrue(preferencesXml.contains("android:key=\"nova_theme\""))
-        assertTrue(preferencesXml.contains("Portable Chrome"))
+        assertTrue(preferencesXml.contains("PSP / Portable Chrome"))
     }
 }


### PR DESCRIPTION
## Summary
- Renames the visible Nova theme option from Portable Chrome to PSP / Portable Chrome
- Keeps the stable stored value portable_chrome so existing installs and tests remain compatible
- Updates settings summary, label resources, changelog, and regression tests

## Test Plan
- RED: theme label tests failed while resources still said Portable Chrome
- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaThemeManagerTest --tests com.papi.nova.ui.NovaThemeResourcesTest
- ./gradlew testDebugUnitTest assembleRootDebug lintRootDebug
- aapt dump --values resources app/build/outputs/apk/root/debug/app-root-arm64-v8a-debug.apk confirmed PSP / Portable Chrome in nova_theme_names and nova_theme_portable_chrome_label
- adb install -r -d -g app/build/outputs/apk/root/debug/app-root-arm64-v8a-debug.apk on Retroid Pocket 6
- run-as prefs verify nova_theme=portable_chrome
- monkey launch confirmed com.papi.nova.root.debug/com.papi.nova.ui.NovaLibraryActivity resumed