### PR TITLE
fix(ui): remove PSP purple accent leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Removes hardcoded Polaris-purple accents from legacy Nova XML/views so PSP / Portable Chrome uses theme-aware steel highlights.
 - Deepens the PSP / Portable Chrome theme into a sleeker smoked-graphite handheld shell with less washed-out white.
 - Adds a PSP / Portable Chrome Nova theme matching the Polaris dim Moonlight-grey early-2000s silver palette, including settings/theme-picker entries and restrained Compose library surfaces.
 

--- a/app/src/main/java/com/papi/nova/AppView.kt
+++ b/app/src/main/java/com/papi/nova/AppView.kt
@@ -278,7 +278,7 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
             if (UiHelper.isTvDevice(this)) {
                 swipeRefresh.isEnabled = false
             }
-            swipeRefresh.setColorSchemeColors(ContextCompat.getColor(this, R.color.nova_accent))
+            swipeRefresh.setColorSchemeColors(NovaThemeManager.getAccentColor(this))
             swipeRefresh.setProgressBackgroundColorSchemeColor(
                 ContextCompat.getColor(this, R.color.nova_bg_elevated),
             )

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -313,7 +313,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         spaceParticleView = findViewById(R.id.space_particles)
         val swipeRefresh = findViewById<SwipeRefreshLayout>(R.id.swipe_refresh)
         if (swipeRefresh != null) {
-            swipeRefresh.setColorSchemeColors(ContextCompat.getColor(this, R.color.nova_accent))
+            swipeRefresh.setColorSchemeColors(NovaThemeManager.getAccentColor(this))
             swipeRefresh.setProgressBackgroundColorSchemeColor(
                 ContextCompat.getColor(this, R.color.nova_bg_elevated),
             )
@@ -433,6 +433,8 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
             swipeRefresh.setColorSchemeColors(accent)
             swipeRefresh.setProgressBackgroundColorSchemeColor(surface)
         }
+        findViewById<android.widget.ProgressBar>(R.id.pcs_loading)?.indeterminateTintList =
+            ColorStateList.valueOf(accent)
 
         findViewById<TextView>(R.id.pcViewTitle)?.setTextColor(textPrimary)
         findViewById<TextView>(R.id.pcViewSectionLabel)?.setTextColor(textMuted)

--- a/app/src/main/java/com/papi/nova/service/NovaStreamNotification.kt
+++ b/app/src/main/java/com/papi/nova/service/NovaStreamNotification.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.papi.nova.R
+import com.papi.nova.ui.NovaThemeManager
 
 /**
  * Manages the persistent streaming notification.
@@ -52,7 +53,7 @@ object NovaStreamNotification {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setContentIntent(returnPending)
             .addAction(0, "Disconnect", disconnectPending)
-            .setColor(context.getColor(R.color.nova_accent))
+            .setColor(NovaThemeManager.getAccentColor(context))
             .build()
 
         val mgr = context.getSystemService(NotificationManager::class.java)

--- a/app/src/main/java/com/papi/nova/ui/NovaSnackbar.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSnackbar.kt
@@ -17,7 +17,7 @@ object NovaSnackbar {
         val snackbar = Snackbar.make(rootView, message, duration)
         snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
         snackbar.setTextColor(activity.getColor(R.color.nova_text_primary))
-        snackbar.setActionTextColor(activity.getColor(R.color.nova_accent))
+        snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
         snackbar.show()
     }
 
@@ -26,7 +26,7 @@ object NovaSnackbar {
         val snackbar = Snackbar.make(rootView, message, Snackbar.LENGTH_LONG)
         snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
         snackbar.setTextColor(activity.getColor(R.color.nova_error))
-        snackbar.setActionTextColor(activity.getColor(R.color.nova_accent))
+        snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
         snackbar.show()
     }
 
@@ -35,7 +35,7 @@ object NovaSnackbar {
         val snackbar = Snackbar.make(rootView, message, Snackbar.LENGTH_SHORT)
         snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
         snackbar.setTextColor(activity.getColor(R.color.nova_success))
-        snackbar.setActionTextColor(activity.getColor(R.color.nova_accent))
+        snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
         snackbar.show()
     }
 }

--- a/app/src/main/res/color/nova_chip_bg_selector.xml
+++ b/app/src/main/res/color/nova_chip_bg_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/nova_accent" android:state_checked="true" />
+    <item android:color="?attr/colorAccent" android:state_checked="true" />
     <item android:color="#33687b81" /> <!-- match nova_badge_bg solid color -->
 </selector>

--- a/app/src/main/res/color/nova_focus_stroke_selector.xml
+++ b/app/src/main/res/color/nova_focus_stroke_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@color/nova_ice" android:state_focused="true" />
-    <item android:color="@color/nova_accent" android:state_pressed="true" />
+    <item android:color="?attr/colorAccent" android:state_pressed="true" />
     <item android:color="@android:color/transparent" />
 </selector>

--- a/app/src/main/res/drawable/ic_nova_star_foreground.xml
+++ b/app/src/main/res/drawable/ic_nova_star_foreground.xml
@@ -12,7 +12,7 @@
 
     <!-- Inner accent — small 4-pointed sparkle -->
     <path
-        android:fillColor="#FF7c73ff"
+        android:fillColor="?attr/colorAccent"
         android:pathData="M54,42 Q55.5,52.5 64,54 Q55.5,55.5 54,66 Q52.5,55.5 44,54 Q52.5,52.5 54,42 Z" />
 
     <!-- Center dot -->

--- a/app/src/main/res/drawable/nova_atv_banner.xml
+++ b/app/src/main/res/drawable/nova_atv_banner.xml
@@ -20,7 +20,7 @@
             android:pathData="M60,10 Q63,52 100,60 Q63,68 60,110 Q57,68 20,60 Q57,52 60,10 Z" />
         <!-- Inner accent -->
         <path
-            android:fillColor="#7c73ff"
+            android:fillColor="?attr/colorAccent"
             android:pathData="M60,40 Q62,57 75,60 Q62,63 60,80 Q58,63 45,60 Q58,57 60,40 Z" />
         <!-- Center dot -->
         <path

--- a/app/src/main/res/drawable/nova_card_bg_focusable.xml
+++ b/app/src/main/res/drawable/nova_card_bg_focusable.xml
@@ -5,7 +5,7 @@
             <solid android:color="#3Ac8d6e5" />
             <stroke
                 android:width="2dp"
-                android:color="@color/nova_accent" />
+                android:color="?attr/colorAccent" />
             <corners android:radius="16dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/nova_card_focus_ring.xml
+++ b/app/src/main/res/drawable/nova_card_focus_ring.xml
@@ -4,6 +4,6 @@
     <solid android:color="@android:color/transparent" />
     <stroke
         android:width="3dp"
-        android:color="@color/nova_accent" />
+        android:color="?attr/colorAccent" />
     <corners android:radius="18dp" />
 </shape>

--- a/app/src/main/res/drawable/nova_chip_default.xml
+++ b/app/src/main/res/drawable/nova_chip_default.xml
@@ -5,16 +5,16 @@
             <solid android:color="@color/nova_badge_bg" />
             <stroke
                 android:width="3dp"
-                android:color="@color/nova_accent" />
+                android:color="?attr/colorAccent" />
             <corners android:radius="12dp" />
         </shape>
     </item>
     <item android:state_selected="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent_surface" />
+            <solid android:color="?attr/colorControlHighlight" />
             <stroke
                 android:width="2dp"
-                android:color="@color/nova_accent" />
+                android:color="?attr/colorAccent" />
             <corners android:radius="12dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/nova_chip_selected.xml
+++ b/app/src/main/res/drawable/nova_chip_selected.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
+            <solid android:color="?attr/colorAccent" />
             <stroke
                 android:width="3dp"
                 android:color="@color/nova_ice" />
@@ -11,7 +11,7 @@
     </item>
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/nova_accent" />
+            <solid android:color="?attr/colorAccent" />
             <corners android:radius="12dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/nova_dialog_choice_bg.xml
+++ b/app/src/main/res/drawable/nova_dialog_choice_bg.xml
@@ -3,28 +3,28 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:radius="4dp" />
-            <solid android:color="#407C73FF" />
-            <stroke android:width="2dp" android:color="@color/nova_accent" />
+            <solid android:color="?attr/colorControlHighlight" />
+            <stroke android:width="2dp" android:color="?attr/colorAccent" />
         </shape>
     </item>
     <item android:state_selected="true">
         <shape android:shape="rectangle">
             <corners android:radius="4dp" />
-            <solid android:color="#337C73FF" />
-            <stroke android:width="2dp" android:color="@color/nova_accent" />
+            <solid android:color="?attr/colorControlHighlight" />
+            <stroke android:width="2dp" android:color="?attr/colorAccent" />
         </shape>
     </item>
     <item android:state_focused="true">
         <shape android:shape="rectangle">
             <corners android:radius="4dp" />
-            <solid android:color="#337C73FF" />
-            <stroke android:width="2dp" android:color="@color/nova_accent" />
+            <solid android:color="?attr/colorControlHighlight" />
+            <stroke android:width="2dp" android:color="?attr/colorAccent" />
         </shape>
     </item>
     <item android:state_activated="true">
         <shape android:shape="rectangle">
             <corners android:radius="4dp" />
-            <solid android:color="#247C73FF" />
+            <solid android:color="?attr/colorControlHighlight" />
         </shape>
     </item>
     <item android:drawable="@android:color/transparent" />

--- a/app/src/main/res/drawable/nova_featured_action_bg.xml
+++ b/app/src/main/res/drawable/nova_featured_action_bg.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/nova_accent_surface" />
+    <solid android:color="?attr/colorControlHighlight" />
     <corners android:radius="14dp" />
     <stroke
         android:width="1dp"
-        android:color="@color/nova_accent_glow" />
+        android:color="?attr/colorControlHighlight" />
 </shape>

--- a/app/src/main/res/drawable/nova_ripple_accent.xml
+++ b/app/src/main/res/drawable/nova_ripple_accent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Branded ripple using Nova accent color instead of default gray -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/nova_ripple">
+    android:color="?attr/colorControlHighlight">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@android:color/white" />

--- a/app/src/main/res/drawable/nova_server_row_focus_ring.xml
+++ b/app/src/main/res/drawable/nova_server_row_focus_ring.xml
@@ -4,6 +4,6 @@
     <solid android:color="@color/nova_bg_elevated" />
     <stroke
         android:width="2dp"
-        android:color="@color/nova_accent" />
+        android:color="?attr/colorAccent" />
     <corners android:radius="18dp" />
 </shape>

--- a/app/src/main/res/drawable/nova_tv_banner.xml
+++ b/app/src/main/res/drawable/nova_tv_banner.xml
@@ -20,7 +20,7 @@
         android:fillColor="@android:color/transparent"
         android:pathData="M54,138 C96,116 128,106 160,104 C192,102 224,92 266,70"
         android:strokeAlpha="0.3"
-        android:strokeColor="#7c73ff"
+        android:strokeColor="?attr/colorAccent"
         android:strokeLineCap="round"
         android:strokeWidth="2" />
 
@@ -31,7 +31,7 @@
             android:fillColor="#d4dde8"
             android:pathData="M60,10 Q63,52 100,60 Q63,68 60,110 Q57,68 20,60 Q57,52 60,10 Z" />
         <path
-            android:fillColor="#7c73ff"
+            android:fillColor="?attr/colorAccent"
             android:pathData="M60,40 Q62,57 75,60 Q62,63 60,80 Q58,63 45,60 Q58,57 60,40 Z" />
         <path
             android:fillColor="#d4dde8"

--- a/app/src/main/res/layout-land/activity_nova_welcome.xml
+++ b/app/src/main/res/layout-land/activity_nova_welcome.xml
@@ -76,7 +76,7 @@
                     android:letterSpacing="0.08"
                     android:text="01  Find your host"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="10sp" />
 
                 <TextView
@@ -102,7 +102,7 @@
                     android:letterSpacing="0.08"
                     android:text="02  Pair with confidence"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="10sp" />
 
                 <TextView
@@ -128,7 +128,7 @@
                     android:letterSpacing="0.08"
                     android:text="03  Built for handhelds and TV"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="10sp" />
 
                 <TextView
@@ -158,7 +158,7 @@
                     android:textColor="@android:color/white"
                     android:textSize="15sp"
                     android:textStyle="bold"
-                    app:backgroundTint="@color/nova_accent"
+                    app:backgroundTint="?attr/colorAccent"
                     app:cornerRadius="25dp"
                     app:strokeColor="@color/nova_focus_stroke_selector"
                     app:strokeWidth="2dp" />

--- a/app/src/main/res/layout-land/activity_pc_view.xml
+++ b/app/src/main/res/layout-land/activity_pc_view.xml
@@ -147,7 +147,7 @@
                     app:cardBackgroundColor="@color/nova_bg_elevated"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
-                    app:strokeColor="@color/nova_accent"
+                    app:strokeColor="?attr/colorAccent"
                     app:strokeWidth="1dp">
 
                     <LinearLayout
@@ -163,7 +163,7 @@
                             android:letterSpacing="0.04"
                             android:text="@string/pcview_destination_current"
                             android:textAllCaps="true"
-                            android:textColor="@color/nova_accent"
+                            android:textColor="?attr/colorAccent"
                             android:textSize="10sp" />
 
                         <TextView
@@ -298,7 +298,7 @@
                     android:layout_weight="1"
                     android:text="@string/pcview_quick_add_server"
                     android:textAllCaps="false"
-                    app:backgroundTint="@color/nova_accent_surface"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_add"
@@ -461,8 +461,7 @@
                         android:layout_width="32dp"
                         android:layout_height="32dp"
                         android:layout_marginTop="20dp"
-                        android:indeterminate="true"
-                        android:indeterminateTint="@color/nova_accent" />
+                        android:indeterminate="true" />
 
                     <TextView
                         android:id="@+id/pcViewEmptyTitle"

--- a/app/src/main/res/layout/activity_app_view.xml
+++ b/app/src/main/res/layout/activity_app_view.xml
@@ -119,7 +119,7 @@
                     android:layout_height="wrap_content"
                     android:text="@string/applist_hero_continue"
                     android:textSize="10sp"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:fontFamily="sans-serif-medium"
                     android:letterSpacing="0.1" />
 
@@ -273,7 +273,7 @@
         android:layout_marginEnd="24dp"
         android:contentDescription="@string/profile_manager_choose_profile"
         app:icon="@drawable/ic_profiles"
-        app:backgroundTint="@color/nova_accent"
+        app:backgroundTint="?attr/colorAccent"
         app:iconTint="@color/nova_ice" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/activity_nova_welcome.xml
+++ b/app/src/main/res/layout/activity_nova_welcome.xml
@@ -67,7 +67,7 @@
                     android:letterSpacing="0.08"
                     android:text="01  Find your host"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="11sp" />
 
                 <TextView
@@ -93,7 +93,7 @@
                     android:letterSpacing="0.08"
                     android:text="02  Pair with confidence"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="11sp" />
 
                 <TextView
@@ -119,7 +119,7 @@
                     android:letterSpacing="0.08"
                     android:text="03  Built for the screen in your hands"
                     android:textAllCaps="true"
-                    android:textColor="@color/nova_accent"
+                    android:textColor="?attr/colorAccent"
                     android:textSize="11sp" />
 
                 <TextView
@@ -142,7 +142,7 @@
                 android:textColor="@android:color/white"
                 android:textSize="17sp"
                 android:textStyle="bold"
-                app:backgroundTint="@color/nova_accent"
+                app:backgroundTint="?attr/colorAccent"
                 app:cornerRadius="26dp"
                 app:strokeColor="@color/nova_focus_stroke_selector"
                 app:strokeWidth="2dp" />

--- a/app/src/main/res/layout/activity_pc_view.xml
+++ b/app/src/main/res/layout/activity_pc_view.xml
@@ -147,7 +147,7 @@
                     app:cardBackgroundColor="@color/nova_bg_elevated"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
-                    app:strokeColor="@color/nova_accent"
+                    app:strokeColor="?attr/colorAccent"
                     app:strokeWidth="1dp">
 
                     <LinearLayout
@@ -163,7 +163,7 @@
                             android:letterSpacing="0.04"
                             android:text="@string/pcview_destination_current"
                             android:textAllCaps="true"
-                            android:textColor="@color/nova_accent"
+                            android:textColor="?attr/colorAccent"
                             android:textSize="10sp" />
 
                         <TextView
@@ -296,7 +296,7 @@
                     android:layout_weight="1"
                     android:text="@string/pcview_quick_add_server"
                     android:textAllCaps="false"
-                    app:backgroundTint="@color/nova_accent_surface"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_add"
@@ -459,8 +459,7 @@
                         android:layout_width="32dp"
                         android:layout_height="32dp"
                         android:layout_marginTop="20dp"
-                        android:indeterminate="true"
-                        android:indeterminateTint="@color/nova_accent" />
+                        android:indeterminate="true" />
 
                     <TextView
                         android:id="@+id/pcViewEmptyTitle"

--- a/app/src/main/res/layout/activity_profiles.xml
+++ b/app/src/main/res/layout/activity_profiles.xml
@@ -66,7 +66,7 @@
         android:layout_marginBottom="24dp"
         android:contentDescription="@string/profile_manager_new_profile"
         android:src="@drawable/ic_add_base"
-        app:backgroundTint="@color/nova_accent"
+        app:backgroundTint="?attr/colorAccent"
         xmlns:app="http://schemas.android.com/apk/res-auto" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/nova_qr_viewfinder.xml
+++ b/app/src/main/res/layout/nova_qr_viewfinder.xml
@@ -11,8 +11,8 @@
         android:id="@+id/zxing_viewfinder_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:zxing_viewfinder_laser="@color/nova_accent"
+        app:zxing_viewfinder_laser="?attr/colorAccent"
         app:zxing_viewfinder_mask="@color/nova_overlay_dark"
-        app:zxing_possible_result_points="@color/nova_accent" />
+        app:zxing_possible_result_points="?attr/colorAccent" />
 
 </merge>

--- a/app/src/main/res/layout/nova_spinner_dialog.xml
+++ b/app/src/main/res/layout/nova_spinner_dialog.xml
@@ -9,8 +9,7 @@
     <ProgressBar
         android:layout_width="32dp"
         android:layout_height="32dp"
-        android:indeterminate="true"
-        android:indeterminateTint="@color/nova_accent" />
+        android:indeterminate="true" />
 
     <TextView
         android:id="@+id/spinner_message"

--- a/app/src/main/res/layout/pc_grid_item.xml
+++ b/app/src/main/res/layout/pc_grid_item.xml
@@ -47,8 +47,7 @@
                     android:layout_width="26dp"
                     android:layout_height="26dp"
                     android:layout_centerInParent="true"
-                    android:indeterminate="true"
-                    android:indeterminateTint="@color/nova_accent" />
+                    android:indeterminate="true" />
             </RelativeLayout>
         </FrameLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,7 @@
         <item name="colorPrimary">@color/nova_accent</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
         <item name="colorAccent">@color/nova_accent</item>
+        <item name="colorControlHighlight">@color/nova_accent_surface</item>
         <item name="colorSurface">@color/nova_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_text_primary</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
@@ -38,6 +39,7 @@
         <item name="android:statusBarColor">@android:color/black</item>
         <item name="colorPrimary">@color/nova_oled_accent</item>
         <item name="colorAccent">@color/nova_oled_accent</item>
+        <item name="colorControlHighlight">@color/nova_oled_accent_surface</item>
     </style>
 
     <!-- Miami Nebula — deep plum shell with neon flamingo accent. -->
@@ -51,6 +53,7 @@
         <item name="android:statusBarColor">@color/nova_miami_void</item>
         <item name="colorPrimary">@color/nova_miami_accent</item>
         <item name="colorAccent">@color/nova_miami_accent</item>
+        <item name="colorControlHighlight">@color/nova_miami_accent_surface</item>
         <item name="colorSurface">@color/nova_miami_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_miami_text_primary</item>
     </style>
@@ -66,6 +69,7 @@
         <item name="android:statusBarColor">@color/nova_portable_deep</item>
         <item name="colorPrimary">@color/nova_portable_accent</item>
         <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
         <item name="colorSurface">@color/nova_portable_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_portable_text_primary</item>
     </style>
@@ -78,6 +82,7 @@
         <item name="android:textColorSecondary">@color/nova_hc_text_secondary</item>
         <item name="colorPrimary">@color/nova_hc_accent</item>
         <item name="colorAccent">@color/nova_hc_accent</item>
+        <item name="colorControlHighlight">@color/nova_hc_accent_surface</item>
         <item name="colorSurface">@color/nova_hc_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_hc_text_primary</item>
     </style>
@@ -121,6 +126,7 @@
         <item name="android:textColorSecondary">@color/nova_oled_text_secondary</item>
         <item name="colorPrimary">@color/nova_oled_accent</item>
         <item name="colorAccent">@color/nova_oled_accent</item>
+        <item name="colorControlHighlight">@color/nova_oled_accent_surface</item>
         <item name="colorSurface">@color/nova_oled_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_oled_text_primary</item>
         <item name="android:navigationBarColor">@android:color/black</item>
@@ -134,6 +140,7 @@
         <item name="android:textColorSecondary">@color/nova_miami_text_secondary</item>
         <item name="colorPrimary">@color/nova_miami_accent</item>
         <item name="colorAccent">@color/nova_miami_accent</item>
+        <item name="colorControlHighlight">@color/nova_miami_accent_surface</item>
         <item name="colorSurface">@color/nova_miami_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_miami_text_primary</item>
         <item name="android:navigationBarColor">@color/nova_miami_void</item>
@@ -147,6 +154,7 @@
         <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
         <item name="colorPrimary">@color/nova_portable_accent</item>
         <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
         <item name="colorSurface">@color/nova_portable_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_portable_text_primary</item>
         <item name="android:navigationBarColor">@color/nova_portable_deep</item>
@@ -159,6 +167,7 @@
         <item name="android:textColorSecondary">@color/nova_hc_text_secondary</item>
         <item name="colorPrimary">@color/nova_hc_accent</item>
         <item name="colorAccent">@color/nova_hc_accent</item>
+        <item name="colorControlHighlight">@color/nova_hc_accent_surface</item>
         <item name="colorSurface">@color/nova_hc_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_hc_text_primary</item>
     </style>
@@ -170,6 +179,7 @@
         <item name="android:windowBackground">@color/nova_bg_window</item>
         <item name="colorPrimary">@color/nova_accent</item>
         <item name="colorAccent">@color/nova_accent</item>
+        <item name="colorControlHighlight">@color/nova_accent_surface</item>
         <item name="colorSurface">@color/nova_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_text_primary</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
@@ -187,7 +197,7 @@
     </style>
 
     <style name="NovaPrefCategory" parent="Preference.Category">
-        <item name="android:textColor">@color/nova_accent</item>
+        <item name="android:textColor">?attr/colorAccent</item>
     </style>
 
     <style name="ExternalDisplayControllerTheme" parent="AppTheme">
@@ -203,14 +213,15 @@
         <item name="android:windowBackground">@color/nova_dialog_bg</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
         <item name="android:textColorSecondary">@color/nova_text_secondary</item>
-        <item name="colorAccent">@color/nova_accent</item>
+        <item name="colorAccent">?attr/colorAccent</item>
+        <item name="colorControlHighlight">?attr/colorControlHighlight</item>
         <item name="buttonBarPositiveButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/NovaDialogButton</item>
     </style>
 
     <style name="NovaDialogButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
-        <item name="android:textColor">@color/nova_accent</item>
+        <item name="android:textColor">?attr/colorAccent</item>
     </style>
 
     <!-- Nova popup/context menu -->

--- a/app/src/test/java/com/papi/nova/ui/NovaFocusDrawableTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaFocusDrawableTest.kt
@@ -21,14 +21,14 @@ class NovaFocusDrawableTest {
             doc.documentElement.tagName == "shape"
         )
         assertTrue(
-            "focus ring should include a clear nova_accent stroke",
-            hasStroke(doc, "3dp", "@color/nova_accent")
+            "focus ring should follow the active theme accent instead of hardcoding Polaris violet",
+            hasStroke(doc, "3dp", "?attr/colorAccent")
         )
     }
 
     @Test
-    fun chipFocusedStatesUseCleanHighContrastStroke() {
-        assertFocusedStroke("src/main/res/drawable/nova_chip_default.xml", "3dp", "@color/nova_accent")
+    fun chipFocusedStatesUseCleanThemeAwareStroke() {
+        assertFocusedStroke("src/main/res/drawable/nova_chip_default.xml", "3dp", "?attr/colorAccent")
         assertFocusedStroke("src/main/res/drawable/nova_chip_selected.xml", "3dp", "@color/nova_ice")
     }
 
@@ -50,7 +50,7 @@ class NovaFocusDrawableTest {
         val rowRing = parseXml("src/main/res/drawable/nova_server_row_focus_ring.xml")
         assertTrue(
             "server row focus ring should use a slimmer accent stroke",
-            hasStroke(rowRing, "2dp", "@color/nova_accent")
+            hasStroke(rowRing, "2dp", "?attr/colorAccent")
         )
     }
 


### PR DESCRIPTION
## Summary
- Routes legacy XML drawable/layout accent colors through the active theme instead of hardcoded Polaris violet
- Tints refresh spinners, snackbars, notifications, chips, focus rings, banners, and the Nova star through PSP steel-blue accents
- Removes ProgressBar XML theme-attr tints that crash inflate and applies the empty-state spinner tint at runtime

## Test Plan
- RED: NovaFocusDrawableTest failed while focus/chip/server-row drawables still used @color/nova_accent
- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaFocusDrawableTest --tests com.papi.nova.grid.KotlinGridAdaptersMigrationTest
- ./gradlew testDebugUnitTest assembleRootDebug lintRootDebug
- grep scan over drawable/color/layout/layout-land/java shows remaining default violet hits only in NovaThemeManager/Compose default Polaris fallback paths
- adb install -r -d -g app/build/outputs/apk/root/debug/app-root-arm64-v8a-debug.apk on Retroid Pocket 6
- forced com.papi.nova.root.debug prefs to nova_theme=portable_chrome
- launched Nova Debug (Root) and verified package version/update time/activity via adb