### PR TITLE
feat(ui): add themed glass drawer chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ app/.externalNativeBuild/
 .cxx/
 
 # agent files
+.hermes/
 AGENTS.md
 CLAUDE.md
 .githooks/

--- a/app/src/main/java/com/papi/nova/AppView.kt
+++ b/app/src/main/java/com/papi/nova/AppView.kt
@@ -44,6 +44,7 @@ import com.papi.nova.profiles.ProfilesManager
 import com.papi.nova.runtime.NovaRuntimeTasks
 import com.papi.nova.ui.AdapterFragment
 import com.papi.nova.ui.AdapterFragmentCallbacks
+import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.utils.CacheHelper
 import com.papi.nova.utils.Dialog
@@ -732,8 +733,11 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
     private fun showAppBottomSheet(selectedApp: AppObject) {
         val sheet = BottomSheetDialog(this, R.style.NovaBottomSheet)
         sheet.setContentView(R.layout.nova_app_context_sheet)
-        sheet.behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        sheet.behavior.skipCollapsed = true
+        val sheetRoot = sheet.findViewById<View>(R.id.nova_sheet_root)
+        sheet.setOnShowListener {
+            NovaSheetChrome.applyBottomSheetChrome(sheet, sheetRoot)
+            sheet.findViewById<TextView>(R.id.sheet_app_name)?.let(NovaSheetChrome::styleSheetTitle)
+        }
 
         val titleView = sheet.findViewById<TextView>(R.id.sheet_app_name)
         titleView?.text = selectedApp.app.appName
@@ -869,15 +873,11 @@ class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
         val item = TextView(this)
         item.text = label
         item.textSize = 15f
-        item.setTextColor(ContextCompat.getColor(this, R.color.nova_text_primary))
+        NovaSheetChrome.styleSheetAction(item)
         item.typeface = android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.NORMAL)
         val pad = UiHelper.dpToPx(this, 24f).toInt()
         val padV = UiHelper.dpToPx(this, 14f).toInt()
         item.setPadding(pad, padV, pad, padV)
-
-        val outValue = android.util.TypedValue()
-        theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
-        item.setBackgroundResource(outValue.resourceId)
 
         item.setOnClickListener { action.run() }
         container.addView(item)

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.content.res.ColorStateList
 import android.content.res.Configuration
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.opengl.GLSurfaceView
 import android.os.Build
@@ -18,6 +20,7 @@ import android.os.Looper
 import android.os.SystemClock
 import android.text.InputFilter
 import android.text.InputType
+import android.view.Gravity
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
@@ -67,6 +70,7 @@ import com.papi.nova.ui.AdapterFragment
 import com.papi.nova.ui.AdapterFragmentCallbacks
 import com.papi.nova.ui.NovaLibraryActivity
 import com.papi.nova.ui.NovaQrScanActivity
+import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.NovaSnackbar
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.NovaWelcomeActivity
@@ -87,6 +91,7 @@ import javax.microedition.khronos.opengles.GL10
 import org.xmlpull.v1.XmlPullParserException
 
 class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
+    private val THEME_PICKER_GRID_GAP_DP = 12
     private var noPcFoundLayout: View? = null
     private lateinit var pcGridAdapter: PcGridAdapter
     private lateinit var shortcutHelper: ShortcutHelper
@@ -433,8 +438,6 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
             swipeRefresh.setColorSchemeColors(accent)
             swipeRefresh.setProgressBackgroundColorSchemeColor(surface)
         }
-        findViewById<android.widget.ProgressBar>(R.id.pcs_loading)?.indeterminateTintList =
-            ColorStateList.valueOf(accent)
 
         findViewById<TextView>(R.id.pcViewTitle)?.setTextColor(textPrimary)
         findViewById<TextView>(R.id.pcViewSectionLabel)?.setTextColor(textMuted)
@@ -541,8 +544,99 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
     }
 
     private fun showThemePicker(anchor: View?) {
+        val themes = buildThemePickerThemes()
+        val currentTheme = NovaThemeManager.getTheme(this)
+        val surface = NovaThemeManager.getCardBackgroundColor(this)
+        val textPrimary = NovaThemeManager.getTextPrimaryColor(this)
+        val textSecondary = NovaThemeManager.getTextSecondaryColor(this)
+        val textMuted = NovaThemeManager.getTextMutedColor(this)
+
+        val dialog = BottomSheetDialog(this, R.style.NovaBottomSheet)
+        var focusTarget: View? = null
+        lateinit var themePickerFocusLabel: TextView
+
+        val content = NovaSheetChrome.createSheetContainer(this)
+
+        content.addView(
+            TextView(this).apply {
+                text = getString(R.string.pcview_theme_picker_title)
+                setTextColor(textPrimary)
+                textSize = 22f
+                typeface = Typeface.DEFAULT_BOLD
+                includeFontPadding = false
+            },
+        )
+        content.addView(
+            TextView(this).apply {
+                text = getString(R.string.pcview_theme_picker_hint)
+                setTextColor(textMuted)
+                textSize = 12f
+                setPadding(0, dp(6), 0, dp(14))
+            },
+        )
+
+        themePickerFocusLabel = TextView(this).apply {
+            text = getString(
+                R.string.pcview_theme_picker_focus_format,
+                NovaThemeManager.getThemeLabel(this@PcView, currentTheme),
+                getThemePickerSubtitle(currentTheme),
+            )
+            setTextColor(NovaThemeManager.getAccentColor(this@PcView))
+            textSize = 12f
+            typeface = Typeface.DEFAULT_BOLD
+            setPadding(0, 0, 0, dp(12))
+        }
+        content.addView(themePickerFocusLabel)
+
+        val themeGrid = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            val gridGap = dp(THEME_PICKER_GRID_GAP_DP)
+            setPadding(gridGap, 0, gridGap, gridGap)
+        }
+        content.addView(themeGrid)
+        themes.chunked(2).forEach { themePair ->
+            val gridRow = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+            }
+            themePair.forEachIndexed { index, theme ->
+                val row = createThemePickerRow(theme, currentTheme, themePickerFocusLabel, surface, textPrimary, textSecondary, dialog)
+                row.layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
+                    if (index == 0) {
+                        marginEnd = dp(THEME_PICKER_GRID_GAP_DP)
+                    }
+                    bottomMargin = dp(THEME_PICKER_GRID_GAP_DP)
+                }
+                if (focusTarget == null || theme == currentTheme) {
+                    focusTarget = row
+                }
+                gridRow.addView(row)
+            }
+            if (themePair.size == 1) {
+                gridRow.addView(
+                    View(this).apply {
+                        layoutParams = LinearLayout.LayoutParams(0, 1, 1f)
+                    },
+                )
+            }
+            themeGrid.addView(gridRow)
+        }
+
+        dialog.setContentView(content)
+        dialog.setOnShowListener {
+            NovaSheetChrome.applyBottomSheetChrome(dialog, content)
+            content.post {
+                focusTarget?.requestFocus()
+            }
+        }
+        dialog.show()
+        anchor?.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+    }
+
+    private fun buildThemePickerThemes(): List<String> {
         val themes = mutableListOf(
             NovaThemeManager.THEME_POLARIS,
+            NovaThemeManager.THEME_PORTABLE_CHROME,
             NovaThemeManager.THEME_OLED,
             NovaThemeManager.THEME_MIAMI,
             NovaThemeManager.THEME_HIGH_CONTRAST,
@@ -550,19 +644,173 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         if (NovaThemeManager.isMaterialYouAvailable()) {
             themes.add(NovaThemeManager.THEME_MATERIAL_YOU)
         }
-        val labels = themes.map { NovaThemeManager.getThemeLabel(this, it) }.toTypedArray()
-        val currentTheme = NovaThemeManager.getTheme(this)
-        val checkedIndex = themes.indexOf(currentTheme).coerceAtLeast(0)
-
-        AlertDialog.Builder(this)
-            .setTitle(R.string.pcview_theme_picker_title)
-            .setSingleChoiceItems(labels, checkedIndex) { dialog, which ->
-                applyThemeSelection(themes[which])
-                dialog.dismiss()
-            }
-            .show()
-        anchor?.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+        return themes
     }
+
+    private fun createThemePickerRow(
+        theme: String,
+        currentTheme: String,
+        themePickerFocusLabel: TextView,
+        surface: Int,
+        textPrimary: Int,
+        textSecondary: Int,
+        dialog: BottomSheetDialog,
+    ): MaterialCardView {
+        val label = NovaThemeManager.getThemeLabel(this, theme)
+        val subtitle = getThemePickerSubtitle(theme)
+        val rowAccent = getThemePickerPreviewAccent(theme)
+        val divider = NovaThemeManager.getDividerColor(this)
+        val selected = theme == currentTheme
+
+        val card = MaterialCardView(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                bottomMargin = dp(10)
+            }
+            radius = dp(18).toFloat()
+            isClickable = true
+            isFocusable = true
+            setOnClickListener {
+                dialog.dismiss()
+                applyThemeSelection(theme)
+            }
+            setOnKeyListener { _, keyCode, event ->
+                if (event.action == KeyEvent.ACTION_UP &&
+                    (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_BUTTON_A)
+                ) {
+                    performClick()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+        }
+        row.addView(
+            View(this).apply {
+                background = GradientDrawable().apply {
+                    shape = GradientDrawable.OVAL
+                    setColor(rowAccent)
+                    setStroke(dp(2), ColorUtils.blendARGB(rowAccent, textPrimary, 0.32f))
+                }
+                layoutParams = LinearLayout.LayoutParams(dp(18), dp(18)).apply {
+                    marginEnd = dp(14)
+                }
+            },
+        )
+        row.addView(
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                addView(
+                    TextView(this@PcView).apply {
+                        text = label
+                        setTextColor(textPrimary)
+                        textSize = 17f
+                        typeface = Typeface.DEFAULT_BOLD
+                        includeFontPadding = false
+                    },
+                )
+                addView(
+                    TextView(this@PcView).apply {
+                        text = subtitle
+                        setTextColor(textSecondary)
+                        textSize = 12f
+                        setPadding(0, dp(5), dp(8), 0)
+                    },
+                )
+            },
+        )
+        if (selected) {
+            row.addView(
+                TextView(this).apply {
+                    text = getString(R.string.pcview_theme_picker_current_badge)
+                    setTextColor(textPrimary)
+                    textSize = 11f
+                    typeface = Typeface.DEFAULT_BOLD
+                    gravity = Gravity.CENTER
+                    includeFontPadding = false
+                    background = GradientDrawable().apply {
+                        setColor(ColorUtils.blendARGB(surface, rowAccent, 0.30f))
+                        setStroke(dp(1), rowAccent)
+                        cornerRadius = dp(999).toFloat()
+                    }
+                    setPadding(dp(12), dp(7), dp(12), dp(7))
+                },
+            )
+        }
+        card.addView(row)
+        updateThemePickerRowState(card, selected, false, rowAccent, surface, divider, themePickerFocusLabel, label, subtitle)
+        card.setOnFocusChangeListener { _, hasFocus ->
+            updateThemePickerRowState(card, selected, hasFocus, rowAccent, surface, divider, themePickerFocusLabel, label, subtitle)
+        }
+        return card
+    }
+
+    private fun updateThemePickerRowState(
+        card: MaterialCardView,
+        selected: Boolean,
+        focused: Boolean,
+        rowAccent: Int,
+        surface: Int,
+        divider: Int,
+        themePickerFocusLabel: TextView,
+        label: String,
+        subtitle: String,
+    ) {
+        card.setCardBackgroundColor(
+            when {
+                focused -> ColorUtils.blendARGB(surface, rowAccent, 0.18f)
+                selected -> ColorUtils.blendARGB(surface, rowAccent, 0.14f)
+                else -> surface
+            },
+        )
+        card.strokeColor = if (focused || selected) rowAccent else divider
+        card.strokeWidth = dp(
+            when {
+                focused -> 4
+                selected -> 3
+                else -> 1
+            },
+        )
+        if (focused) {
+            themePickerFocusLabel.text = getString(R.string.pcview_theme_picker_focus_format, label, subtitle)
+            themePickerFocusLabel.setTextColor(rowAccent)
+        }
+    }
+
+    private fun getThemePickerSubtitle(theme: String): String {
+        return when (theme) {
+            NovaThemeManager.THEME_PORTABLE_CHROME -> getString(R.string.pcview_theme_portable_chrome_subtitle)
+            NovaThemeManager.THEME_OLED -> getString(R.string.pcview_theme_oled_subtitle)
+            NovaThemeManager.THEME_MIAMI -> getString(R.string.pcview_theme_miami_subtitle)
+            NovaThemeManager.THEME_HIGH_CONTRAST -> getString(R.string.pcview_theme_high_contrast_subtitle)
+            NovaThemeManager.THEME_MATERIAL_YOU -> getString(R.string.pcview_theme_material_you_subtitle)
+            else -> getString(R.string.pcview_theme_polaris_subtitle)
+        }
+    }
+
+    private fun getThemePickerPreviewAccent(theme: String): Int {
+        return ContextCompat.getColor(
+            this,
+            when (theme) {
+                NovaThemeManager.THEME_PORTABLE_CHROME -> R.color.nova_portable_accent
+                NovaThemeManager.THEME_OLED -> R.color.nova_oled_accent
+                NovaThemeManager.THEME_MIAMI -> R.color.nova_miami_accent
+                NovaThemeManager.THEME_HIGH_CONTRAST -> R.color.nova_hc_accent
+                else -> R.color.nova_polaris_accent
+            },
+        )
+    }
+
+    private fun dp(value: Int): Int = UiHelper.dpToPx(this, value.toFloat()).toInt()
 
     private fun applyThemeSelection(theme: String) {
         if (theme == NovaThemeManager.getTheme(this)) {
@@ -1198,8 +1446,11 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
 
         val sheet = BottomSheetDialog(this, R.style.NovaBottomSheet)
         sheet.setContentView(R.layout.nova_app_context_sheet)
-        sheet.behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        sheet.behavior.skipCollapsed = true
+        val sheetRoot = sheet.findViewById<View>(R.id.nova_sheet_root)
+        sheet.setOnShowListener {
+            NovaSheetChrome.applyBottomSheetChrome(sheet, sheetRoot)
+            sheet.findViewById<TextView>(R.id.sheet_app_name)?.let(NovaSheetChrome::styleSheetTitle)
+        }
         sheet.setOnDismissListener { startComputerUpdates() }
 
         val titleView = sheet.findViewById<TextView>(R.id.sheet_app_name)
@@ -1329,11 +1580,10 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         val deleteItem = TextView(this)
         deleteItem.text = getString(R.string.pcview_menu_delete_pc)
         deleteItem.textSize = 15f
-        deleteItem.setTextColor(ContextCompat.getColor(this, R.color.nova_error))
+        NovaSheetChrome.styleSheetAction(deleteItem, destructive = true)
         val pad = UiHelper.dpToPx(this, 24f).toInt()
         val padV = UiHelper.dpToPx(this, 14f).toInt()
         deleteItem.setPadding(pad, padV, pad, padV)
-        deleteItem.setBackgroundResource(R.drawable.nova_dialog_choice_bg)
         UiHelper.applyTvFocusStyle(deleteItem)
         deleteItem.setOnClickListener {
             sheet.dismiss()
@@ -1378,11 +1628,10 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         val item = TextView(this)
         item.text = label
         item.textSize = 15f
-        item.setTextColor(ContextCompat.getColor(this, R.color.nova_text_primary))
+        NovaSheetChrome.styleSheetAction(item)
         val pad = UiHelper.dpToPx(this, 24f).toInt()
         val padV = UiHelper.dpToPx(this, 14f).toInt()
         item.setPadding(pad, padV, pad, padV)
-        item.setBackgroundResource(R.drawable.nova_dialog_choice_bg)
         UiHelper.applyTvFocusStyle(item)
         item.setOnClickListener { action.run() }
         container.addView(item)

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -2,14 +2,12 @@ package com.papi.nova.ui
 
 import android.app.Dialog
 import android.content.Context
-import android.content.res.Configuration
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.ScrollView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.background
@@ -55,9 +53,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.papi.nova.LimeLog
@@ -117,7 +113,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setBackgroundResource(sheetBackgroundRes())
+            background = NovaSheetChrome.createSheetBackground(requireContext())
         }
     }
 
@@ -820,65 +816,14 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         ).filterNotNull().joinToString(" · ")
     }
 
-    private fun sheetBackgroundRes(): Int {
-        return if (NovaThemeManager.isOled(requireContext())) {
-            R.drawable.nova_sheet_bg_oled
-        } else {
-            R.drawable.nova_sheet_bg
-        }
-    }
-
     private fun expandBottomSheet(bottomSheetDialog: BottomSheetDialog?) {
-        val sheet = bottomSheetDialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
+        bottomSheetDialog ?: return
         val contentView = view ?: return
-        sheet.setBackgroundResource(sheetBackgroundRes())
-        contentView.post {
-            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-            val maxHeightRatio = if (isLandscape) 0.96f else 0.90f
-            val maxHeight = (resources.displayMetrics.heightPixels * maxHeightRatio).toInt()
-            val contentHeight = contentView.measuredHeight.takeIf { it > 0 } ?: return@post
-            val desiredHeight = contentHeight.coerceAtMost(maxHeight)
-            val displayWidth = resources.displayMetrics.widthPixels
-            val density = resources.displayMetrics.density
-            val desiredWidth = if (isLandscape) {
-                val minWidth = (720 * density).toInt()
-                val maxWidth = (1260 * density).toInt()
-                (displayWidth * 0.7f).toInt().coerceIn(minWidth, maxWidth)
-            } else {
-                displayWidth
-            }
-            val horizontalMargin = if (isLandscape) {
-                ((displayWidth - desiredWidth) / 2).coerceAtLeast((18 * density).toInt())
-            } else {
-                0
-            }
-
-            contentView.layoutParams = contentView.layoutParams.apply {
-                height = if (contentHeight > maxHeight) desiredHeight else ViewGroup.LayoutParams.WRAP_CONTENT
-            }
-            sheet.layoutParams = sheet.layoutParams.apply {
-                width = if (isLandscape) displayWidth - (horizontalMargin * 2) else ViewGroup.LayoutParams.MATCH_PARENT
-                height = desiredHeight
-            }
-            (sheet.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
-                lp.marginStart = horizontalMargin
-                lp.marginEnd = horizontalMargin
-                sheet.layoutParams = lp
-            }
-            sheet.minimumHeight = 0
-            sheet.requestLayout()
-
-            val behavior = BottomSheetBehavior.from(sheet)
-            behavior.isFitToContents = true
-            behavior.skipCollapsed = true
-            behavior.peekHeight = desiredHeight
-            behavior.state = BottomSheetBehavior.STATE_EXPANDED
-
-            when (contentView) {
-                is NestedScrollView -> contentView.post { contentView.scrollTo(0, 0) }
-                is ScrollView -> contentView.post { contentView.scrollTo(0, 0) }
-            }
-        }
+        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog,
+            contentView,
+            minLandscapeWidthDp = 720,
+            maxLandscapeWidthDp = 1260
+        )
     }
 }
 
@@ -939,7 +884,10 @@ fun NovaGameDetailSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .clip(RoundedCornerShape(
+                topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp,
+                topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp
+            ))
             .background(surfaces.panel)
             .verticalScroll(verticalScroll)
             .padding(bottom = 16.dp)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -3248,10 +3248,13 @@ class NovaLibraryActivity : AppCompatActivity() {
         ModalBottomSheet(
             onDismissRequest = onDismiss,
             sheetState = sheetState,
-            shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+            shape = RoundedCornerShape(
+                topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp,
+                topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp
+            ),
             containerColor = surfaces.panel,
             contentColor = colors.textPrimary,
-            scrimColor = surfaces.backgroundScrim.copy(alpha = 0.30f)
+            scrimColor = surfaces.backgroundScrim.copy(alpha = NovaSheetChrome.SCRIM_ALPHA)
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
@@ -1,7 +1,6 @@
 package com.papi.nova.ui
 
 import android.app.Dialog
-import android.content.res.Configuration
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.LayoutInflater
@@ -16,7 +15,6 @@ import androidx.compose.runtime.key
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.papi.nova.LimeLog
@@ -326,52 +324,13 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
     }
 
     private fun expandBottomSheet(bottomSheetDialog: BottomSheetDialog?) {
-        val sheet = bottomSheetDialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
+        bottomSheetDialog ?: return
         val contentView = view ?: return
-        sheet.setBackgroundResource(
-            if (NovaThemeManager.isOled(requireContext())) {
-                R.drawable.nova_sheet_bg_oled
-            } else {
-                R.drawable.nova_sheet_bg
-            }
+        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog,
+            contentView,
+            widthFraction = 0.62f,
+            minLandscapeWidthDp = 700,
+            maxLandscapeWidthDp = 980
         )
-        contentView.post {
-            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-            val maxHeightRatio = if (isLandscape) 0.96f else 0.90f
-            val maxHeight = (resources.displayMetrics.heightPixels * maxHeightRatio).toInt()
-            val contentHeight = contentView.measuredHeight.takeIf { it > 0 } ?: return@post
-            val desiredHeight = contentHeight.coerceAtMost(maxHeight)
-            val displayWidth = resources.displayMetrics.widthPixels
-            val density = resources.displayMetrics.density
-            val desiredWidth = if (isLandscape) {
-                val minWidth = (700 * density).toInt()
-                val maxWidth = (980 * density).toInt()
-                (displayWidth * 0.62f).toInt().coerceIn(minWidth, maxWidth)
-            } else {
-                displayWidth
-            }
-            val horizontalMargin = if (isLandscape) {
-                ((displayWidth - desiredWidth) / 2).coerceAtLeast((18 * density).toInt())
-            } else {
-                0
-            }
-
-            sheet.layoutParams = sheet.layoutParams.apply {
-                width = if (isLandscape) desiredWidth else ViewGroup.LayoutParams.MATCH_PARENT
-                height = desiredHeight
-            }
-            (sheet.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
-                lp.marginStart = horizontalMargin
-                lp.marginEnd = horizontalMargin
-                sheet.layoutParams = lp
-            }
-            sheet.setPadding(0, 0, 0, 0)
-            sheet.requestLayout()
-            BottomSheetBehavior.from(sheet).apply {
-                peekHeight = desiredHeight
-                state = BottomSheetBehavior.STATE_EXPANDED
-                skipCollapsed = true
-            }
-        }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -10,6 +10,7 @@ import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.setPadding
 import androidx.core.widget.NestedScrollView
@@ -134,7 +135,7 @@ object NovaSheetChrome {
     fun styleSheetAction(action: TextView, destructive: Boolean = false) {
         val context = action.context
         action.setTextColor(
-            if (destructive) context.getColor(R.color.nova_error) else NovaThemeManager.getTextPrimaryColor(context)
+            if (destructive) ContextCompat.getColor(context, R.color.nova_error) else NovaThemeManager.getTextPrimaryColor(context)
         )
         action.background = createActionBackground(context)
         action.isClickable = true

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -1,0 +1,199 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.core.graphics.ColorUtils
+import androidx.core.view.setPadding
+import androidx.core.widget.NestedScrollView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.papi.nova.R
+
+/**
+ * Shared Nova bottom-sheet chrome.
+ *
+ * Keep drawer/sheet surfaces here so theme palettes stay distinct while sheet
+ * geometry, scrim, radius, stroke, and D-pad action rows feel like one app.
+ */
+object NovaSheetChrome {
+    const val SHEET_CORNER_RADIUS_DP = 26
+    const val LANDSCAPE_WIDTH_FRACTION = 0.70f
+    const val SCRIM_ALPHA = 0.22f
+
+    /** Default glass opacity for NovaHUD-friendly drawer overlays. */
+    const val SHEET_GLASS_ALPHA = 0.62f
+    const val PORTABLE_CHROME_SHEET_GLASS_ALPHA = 0.58f
+    const val MIAMI_SHEET_GLASS_ALPHA = 0.64f
+    const val OLED_SHEET_GLASS_ALPHA = 0.70f
+    const val MATERIAL_YOU_SHEET_GLASS_ALPHA = 0.60f
+    const val HIGH_CONTRAST_SHEET_GLASS_ALPHA = 0.94f
+
+    fun createSheetContainer(
+        context: Context,
+        horizontalPaddingDp: Int = 22,
+        topPaddingDp: Int = 18,
+        bottomPaddingDp: Int = 26
+    ): LinearLayout {
+        return LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(
+                dp(context, horizontalPaddingDp),
+                dp(context, topPaddingDp),
+                dp(context, horizontalPaddingDp),
+                dp(context, bottomPaddingDp)
+            )
+            background = createSheetBackground(context)
+            clipToOutline = true
+        }
+    }
+
+    fun applyBottomSheetChrome(
+        dialog: BottomSheetDialog,
+        contentView: View? = null,
+        widthFraction: Float = LANDSCAPE_WIDTH_FRACTION,
+        minLandscapeWidthDp: Int = 660,
+        maxLandscapeWidthDp: Int = 1120,
+        maxHeightLandscape: Float = 0.94f,
+        maxHeightPortrait: Float = 0.90f
+    ) {
+        val context = dialog.context
+        dialog.window?.let { window ->
+            window.setDimAmount(SCRIM_ALPHA)
+            window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+        }
+
+        val sheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
+        sheet.background = createSheetBackground(context)
+        sheet.clipToOutline = true
+        sheet.setPadding(0, 0, 0, 0)
+        contentView?.clipToOutline = true
+
+        val measuredView = contentView ?: sheet
+        measuredView.post {
+            val resources = context.resources
+            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val density = resources.displayMetrics.density
+            val displayWidth = resources.displayMetrics.widthPixels
+            val displayHeight = resources.displayMetrics.heightPixels
+            val maxHeight = (displayHeight * if (isLandscape) maxHeightLandscape else maxHeightPortrait).toInt()
+            val measuredHeight = measuredView.measuredHeight.takeIf { it > 0 } ?: sheet.measuredHeight
+            val desiredHeight = measuredHeight.takeIf { it > 0 }?.coerceAtMost(maxHeight) ?: maxHeight
+            val minWidth = dp(context, minLandscapeWidthDp)
+            val maxWidth = dp(context, maxLandscapeWidthDp)
+            val landscapeWidth = (displayWidth * widthFraction).toInt()
+                .coerceIn(minWidth.coerceAtMost(displayWidth), maxWidth.coerceAtMost(displayWidth))
+                .coerceAtMost(displayWidth - dp(context, 36))
+            val desiredWidth = if (isLandscape) landscapeWidth else ViewGroup.LayoutParams.MATCH_PARENT
+            val horizontalMargin = if (isLandscape) {
+                ((displayWidth - landscapeWidth) / 2).coerceAtLeast(dp(context, 18))
+            } else {
+                0
+            }
+
+            contentView?.layoutParams = contentView.layoutParams?.apply {
+                height = if (measuredHeight > maxHeight) desiredHeight else ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+            sheet.layoutParams = sheet.layoutParams.apply {
+                width = desiredWidth
+                height = if (measuredHeight > maxHeight) desiredHeight else ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+            (sheet.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                lp.marginStart = horizontalMargin
+                lp.marginEnd = horizontalMargin
+                sheet.layoutParams = lp
+            }
+            sheet.minimumHeight = 0
+            sheet.requestLayout()
+
+            BottomSheetBehavior.from(sheet).apply {
+                isFitToContents = true
+                skipCollapsed = true
+                peekHeight = desiredHeight
+                state = BottomSheetBehavior.STATE_EXPANDED
+            }
+
+            when (contentView) {
+                is NestedScrollView -> contentView.post { contentView.scrollTo(0, 0) }
+                is ScrollView -> contentView.post { contentView.scrollTo(0, 0) }
+            }
+        }
+    }
+
+    fun styleSheetTitle(title: TextView) {
+        title.setTextColor(NovaThemeManager.getTextPrimaryColor(title.context))
+    }
+
+    fun styleSheetAction(action: TextView, destructive: Boolean = false) {
+        val context = action.context
+        action.setTextColor(
+            if (destructive) context.getColor(R.color.nova_error) else NovaThemeManager.getTextPrimaryColor(context)
+        )
+        action.background = createActionBackground(context)
+        action.isClickable = true
+        action.isFocusable = true
+    }
+
+    fun createSheetBackground(context: Context): GradientDrawable {
+        val radius = dp(context, SHEET_CORNER_RADIUS_DP).toFloat()
+        return GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(createSheetSurfaceColor(context))
+            cornerRadii = floatArrayOf(radius, radius, radius, radius, 0f, 0f, 0f, 0f)
+            setStroke(dp(context, 1), getSheetStrokeColor(context))
+        }
+    }
+
+    fun createSheetSurfaceColor(context: Context): Int {
+        val baseSurface = NovaThemeManager.getDialogBackgroundColor(context)
+        val alpha = (getSheetGlassAlpha(context) * 255).toInt().coerceIn(0, 255)
+        return ColorUtils.setAlphaComponent(baseSurface, alpha)
+    }
+
+    fun getSheetGlassAlpha(context: Context): Float {
+        return when {
+            NovaThemeManager.isHighContrast(context) -> HIGH_CONTRAST_SHEET_GLASS_ALPHA
+            NovaThemeManager.isPortableChrome(context) -> PORTABLE_CHROME_SHEET_GLASS_ALPHA
+            NovaThemeManager.isMiami(context) -> MIAMI_SHEET_GLASS_ALPHA
+            NovaThemeManager.isOled(context) -> OLED_SHEET_GLASS_ALPHA
+            NovaThemeManager.isMaterialYou(context) -> MATERIAL_YOU_SHEET_GLASS_ALPHA
+            else -> SHEET_GLASS_ALPHA
+        }
+    }
+
+    fun getSheetStrokeColor(context: Context): Int {
+        val surface = NovaThemeManager.getDialogBackgroundColor(context)
+        val accent = NovaThemeManager.getAccentColor(context)
+        return when {
+            NovaThemeManager.isHighContrast(context) -> NovaThemeManager.getDividerColor(context)
+            NovaThemeManager.isPortableChrome(context) -> ColorUtils.blendARGB(surface, accent, 0.46f)
+            NovaThemeManager.isOled(context) -> ColorUtils.blendARGB(surface, Color.WHITE, 0.12f)
+            else -> ColorUtils.blendARGB(surface, accent, 0.32f)
+        }
+    }
+
+    private fun createActionBackground(context: Context): GradientDrawable {
+        val radius = dp(context, 16).toFloat()
+        return GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(Color.TRANSPARENT)
+            cornerRadius = radius
+            setStroke(dp(context, 1), ColorUtils.blendARGB(
+                NovaThemeManager.getDialogBackgroundColor(context),
+                NovaThemeManager.getAccentColor(context),
+                0.18f
+            ))
+        }
+    }
+
+    private fun dp(context: Context, value: Int): Int {
+        return (value * context.resources.displayMetrics.density).toInt()
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
@@ -17,9 +17,10 @@ object NovaThemeManager {
     private const val KEY_THEME = "nova_theme"
 
     const val THEME_POLARIS = "polaris"
+    const val THEME_PORTABLE_CHROME = "portable_chrome"
+    private const val THEME_PSP = "psp"
     const val THEME_OLED = "oled"
     const val THEME_MIAMI = "miami"
-    const val THEME_PORTABLE_CHROME = "portable_chrome"
     const val THEME_HIGH_CONTRAST = "high_contrast"
     const val THEME_MATERIAL_YOU = "material_you"
 
@@ -31,12 +32,12 @@ object NovaThemeManager {
         val isSettings = activity is com.papi.nova.preferences.StreamSettings
 
         when {
+            theme == THEME_PORTABLE_CHROME && isSettings -> activity.setTheme(R.style.SettingsTheme_PortableChrome)
+            theme == THEME_PORTABLE_CHROME -> activity.setTheme(R.style.AppTheme_PortableChrome)
             theme == THEME_OLED && isSettings -> activity.setTheme(R.style.SettingsTheme_OLED)
             theme == THEME_OLED -> activity.setTheme(R.style.AppTheme_OLED)
             theme == THEME_MIAMI && isSettings -> activity.setTheme(R.style.SettingsTheme_Miami)
             theme == THEME_MIAMI -> activity.setTheme(R.style.AppTheme_Miami)
-            theme == THEME_PORTABLE_CHROME && isSettings -> activity.setTheme(R.style.SettingsTheme_PortableChrome)
-            theme == THEME_PORTABLE_CHROME -> activity.setTheme(R.style.AppTheme_PortableChrome)
             theme == THEME_HIGH_CONTRAST && isSettings -> activity.setTheme(R.style.SettingsTheme_HighContrast)
             theme == THEME_HIGH_CONTRAST -> activity.setTheme(R.style.AppTheme_HighContrast)
             theme == THEME_MATERIAL_YOU && isSettings -> activity.setTheme(R.style.SettingsTheme_MaterialYou)
@@ -73,7 +74,8 @@ object NovaThemeManager {
 
     private fun normalizeTheme(theme: String?): String {
         return when (theme) {
-            THEME_POLARIS, THEME_OLED, THEME_MIAMI, THEME_PORTABLE_CHROME, THEME_HIGH_CONTRAST, THEME_MATERIAL_YOU -> theme
+            THEME_POLARIS, THEME_PORTABLE_CHROME, THEME_OLED, THEME_MIAMI, THEME_HIGH_CONTRAST, THEME_MATERIAL_YOU -> theme
+            THEME_PSP -> THEME_PORTABLE_CHROME
             else -> THEME_POLARIS
         }
     }
@@ -87,18 +89,18 @@ object NovaThemeManager {
             .edit().putString(KEY_THEME, normalizedTheme).apply()
     }
 
+    fun isPortableChrome(context: Context): Boolean = getTheme(context) == THEME_PORTABLE_CHROME
     fun isOled(context: Context): Boolean = getTheme(context) == THEME_OLED
     fun isMiami(context: Context): Boolean = getTheme(context) == THEME_MIAMI
-    fun isPortableChrome(context: Context): Boolean = getTheme(context) == THEME_PORTABLE_CHROME
     fun isHighContrast(context: Context): Boolean = getTheme(context) == THEME_HIGH_CONTRAST
     fun isMaterialYou(context: Context): Boolean = getTheme(context) == THEME_MATERIAL_YOU
 
     fun cycleTheme(context: Context): String {
         val next = when (getTheme(context)) {
-            THEME_POLARIS -> THEME_OLED
+            THEME_POLARIS -> THEME_PORTABLE_CHROME
+            THEME_PORTABLE_CHROME -> THEME_OLED
             THEME_OLED -> THEME_MIAMI
-            THEME_MIAMI -> THEME_PORTABLE_CHROME
-            THEME_PORTABLE_CHROME -> THEME_HIGH_CONTRAST
+            THEME_MIAMI -> THEME_HIGH_CONTRAST
             THEME_HIGH_CONTRAST -> if (isMaterialYouAvailable()) THEME_MATERIAL_YOU else THEME_POLARIS
             THEME_MATERIAL_YOU -> THEME_POLARIS
             else -> THEME_POLARIS
@@ -109,9 +111,9 @@ object NovaThemeManager {
 
     fun getThemeLabel(context: Context, theme: String = getTheme(context)): String {
         return when (theme) {
+            THEME_PORTABLE_CHROME -> context.getString(R.string.nova_theme_portable_chrome_label)
             THEME_OLED -> context.getString(R.string.nova_theme_oled_label)
             THEME_MIAMI -> context.getString(R.string.nova_theme_miami_label)
-            THEME_PORTABLE_CHROME -> context.getString(R.string.nova_theme_portable_chrome_label)
             THEME_HIGH_CONTRAST -> context.getString(R.string.nova_theme_high_contrast_label)
             THEME_MATERIAL_YOU -> context.getString(R.string.nova_theme_material_you_label)
             else -> context.getString(R.string.nova_theme_polaris_label)
@@ -134,9 +136,9 @@ object NovaThemeManager {
     /** Returns the correct window background color for the current theme */
     fun getWindowBackgroundColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_window)
             isOled(context) -> Color.BLACK
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_window)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_window)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_window)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.colorBackground, ContextCompat.getColor(context, R.color.nova_bg_window))
@@ -165,9 +167,9 @@ object NovaThemeManager {
     /** Returns the correct card background color for the current theme */
     fun getCardBackgroundColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_card)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_bg_card)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_card)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_bg_card)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_card)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_bg_card))
@@ -178,9 +180,9 @@ object NovaThemeManager {
     /** Returns the correct dialog background color for the current theme */
     fun getDialogBackgroundColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_dialog_bg)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_dialog_bg)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_dialog_bg)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_dialog_bg)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_dialog_bg)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_dialog_bg))
@@ -203,31 +205,31 @@ object NovaThemeManager {
             }
         }
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_accent)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_accent)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_accent)
-            else -> ContextCompat.getColor(context, R.color.nova_accent)
+            else -> ContextCompat.getColor(context, R.color.nova_polaris_accent)
         }
     }
 
     /** Returns the correct low-emphasis accent surface for the current theme */
     fun getAccentSurfaceColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent_surface)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_accent_surface)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_accent_surface)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent_surface)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_accent_surface)
-            else -> ContextCompat.getColor(context, R.color.nova_accent_surface)
+            else -> ContextCompat.getColor(context, R.color.nova_polaris_accent_surface)
         }
     }
 
     /** Returns the correct divider color for the current theme */
     fun getDividerColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_divider)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_divider)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_divider)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_divider)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_divider)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, com.google.android.material.R.attr.colorOutline, ContextCompat.getColor(context, R.color.nova_divider))
@@ -238,9 +240,9 @@ object NovaThemeManager {
     /** Returns the correct text primary color for the current theme */
     fun getTextPrimaryColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_primary)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_primary)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_primary)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_primary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_primary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorPrimary, ContextCompat.getColor(context, R.color.nova_text_primary))
@@ -251,9 +253,9 @@ object NovaThemeManager {
     /** Returns the correct text secondary color for the current theme */
     fun getTextSecondaryColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_secondary)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_secondary)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_secondary)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_secondary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_secondary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_secondary))
@@ -264,9 +266,9 @@ object NovaThemeManager {
     /** Returns the correct text muted color for the current theme */
     fun getTextMutedColor(context: Context): Int {
         return when {
+            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_muted)
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_text_muted)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_muted)
-            isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_text_muted)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_muted)
             isMaterialYou(context) && isMaterialYouAvailable() ->
                 resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_muted))

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -78,12 +78,14 @@ val LocalNovaLibrarySurfaces = staticCompositionLocalOf {
 fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
     val isOled = theme == NovaThemeManager.THEME_OLED
     val isMiami = theme == NovaThemeManager.THEME_MIAMI
+    val isPortableChrome = theme == NovaThemeManager.THEME_PORTABLE_CHROME
     val isHighContrast = theme == NovaThemeManager.THEME_HIGH_CONTRAST
     val isMaterialYou = theme == NovaThemeManager.THEME_MATERIAL_YOU
     return NovaLibrarySurfaces(
         backgroundScrim = when {
             isOled -> Color.Transparent
             isMiami -> window.copy(alpha = 0.60f)
+            isPortableChrome -> window.copy(alpha = 0.34f)
             isHighContrast -> Color.Black.copy(alpha = 0.72f)
             isMaterialYou -> window.copy(alpha = 0.28f)
             else -> window.copy(alpha = 0.56f)
@@ -91,6 +93,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         panel = when {
             isOled -> dialog.copy(alpha = NovaSheetChrome.OLED_SHEET_GLASS_ALPHA)
             isMiami -> dialog.copy(alpha = NovaSheetChrome.MIAMI_SHEET_GLASS_ALPHA)
+            isPortableChrome -> dialog.copy(alpha = NovaSheetChrome.PORTABLE_CHROME_SHEET_GLASS_ALPHA)
             isHighContrast -> dialog.copy(alpha = NovaSheetChrome.HIGH_CONTRAST_SHEET_GLASS_ALPHA)
             isMaterialYou -> card.copy(alpha = NovaSheetChrome.MATERIAL_YOU_SHEET_GLASS_ALPHA)
             else -> dialog.copy(alpha = NovaSheetChrome.SHEET_GLASS_ALPHA)
@@ -98,6 +101,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         panelBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> accent.copy(alpha = 0.18f)
+            isPortableChrome -> divider.copy(alpha = 0.46f)
             isHighContrast -> divider.copy(alpha = 0.92f)
             isMaterialYou -> divider.copy(alpha = 0.46f)
             else -> divider.copy(alpha = 0.44f)
@@ -105,6 +109,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         tile = when {
             isOled -> card.copy(alpha = 0.82f)
             isMiami -> card.copy(alpha = 0.70f)
+            isPortableChrome -> card.copy(alpha = 0.62f)
             isHighContrast -> card.copy(alpha = 0.98f)
             isMaterialYou -> card.copy(alpha = 0.68f)
             else -> card.copy(alpha = 0.66f)
@@ -112,12 +117,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         tileBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> divider.copy(alpha = 0.58f)
+            isPortableChrome -> divider.copy(alpha = 0.46f)
             isHighContrast -> divider.copy(alpha = 0.90f)
             else -> divider.copy(alpha = 0.50f)
         },
         control = when {
             isOled -> card.copy(alpha = 0.74f)
             isMiami -> card.copy(alpha = 0.64f)
+            isPortableChrome -> card.copy(alpha = 0.58f)
             isHighContrast -> card.copy(alpha = 1f)
             isMaterialYou -> card.copy(alpha = 0.62f)
             else -> card.copy(alpha = 0.60f)
@@ -125,6 +132,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         selectedControl = accent.copy(alpha = when {
             isHighContrast -> 0.34f
             isMiami -> 0.22f
+            isPortableChrome -> 0.16f
             isOled -> 0.22f
             else -> 0.18f
         }),
@@ -132,12 +140,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusHalo = accent.copy(alpha = when {
             isHighContrast -> 0.36f
             isMiami -> 0.28f
+            isPortableChrome -> 0.14f
             isOled -> 0.24f
             else -> 0.18f
         }),
         mediaPlaceholder = when {
             isOled -> Color(0xFF08080C)
             isMiami -> Color(0xFF2C1734)
+            isPortableChrome -> window.copy(alpha = 1f)
             isHighContrast -> Color(0xFF111827)
             isMaterialYou -> card.copy(alpha = 1f)
             else -> divider.copy(alpha = 1f)
@@ -153,12 +163,14 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusedArtworkAlpha = when {
             isOled -> 0.10f
             isMiami -> 0.26f
+            isPortableChrome -> 0.18f
             isMaterialYou -> 0.18f
             else -> 0.24f
         },
         focusedArtworkScrim = Color.Black.copy(alpha = when {
             isOled -> 0.82f
             isMiami -> 0.76f
+            isPortableChrome -> 0.66f
             else -> 0.72f
         }),
         particlesEnabled = !isOled,
@@ -166,6 +178,7 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
             isOled -> 0f
             isHighContrast -> 0.28f
             isMiami -> 0.68f
+            isPortableChrome -> 0.22f
             isMaterialYou -> 0.42f
             else -> 1f
         }

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import com.papi.nova.R
 import com.papi.nova.ui.NovaThemeManager
+import com.papi.nova.ui.NovaSheetChrome
 
 @Immutable
 data class NovaComposeColors(
@@ -56,8 +57,8 @@ private fun defaultNovaComposeColors(): NovaComposeColors {
         dialog = Color(0xFF232340),
         badge = Color(0x33687B81),
         divider = Color(0xFF393C51),
-        accent = Color(0xFF7C73FF),
-        accentSurface = Color(0x1A7C73FF),
+        accent = Color(0xFF78A6FF),
+        accentSurface = Color(0x1A78A6FF),
         warning = Color(0xFFFBBF24),
         textPrimary = Color(0xFFD4DDE8),
         textSecondary = Color(0xFFA8B0B8),
@@ -77,61 +78,53 @@ val LocalNovaLibrarySurfaces = staticCompositionLocalOf {
 fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
     val isOled = theme == NovaThemeManager.THEME_OLED
     val isMiami = theme == NovaThemeManager.THEME_MIAMI
-    val isPortableChrome = theme == NovaThemeManager.THEME_PORTABLE_CHROME
     val isHighContrast = theme == NovaThemeManager.THEME_HIGH_CONTRAST
     val isMaterialYou = theme == NovaThemeManager.THEME_MATERIAL_YOU
     return NovaLibrarySurfaces(
         backgroundScrim = when {
             isOled -> Color.Transparent
             isMiami -> window.copy(alpha = 0.60f)
-            isPortableChrome -> Color.Black.copy(alpha = 0.28f)
             isHighContrast -> Color.Black.copy(alpha = 0.72f)
             isMaterialYou -> window.copy(alpha = 0.28f)
             else -> window.copy(alpha = 0.56f)
         },
         panel = when {
-            isOled -> dialog.copy(alpha = 0.88f)
-            isMiami -> dialog.copy(alpha = 0.82f)
-            isPortableChrome -> dialog.copy(alpha = 0.94f)
-            isHighContrast -> dialog.copy(alpha = 0.96f)
-            isMaterialYou -> card.copy(alpha = 0.76f)
-            else -> dialog.copy(alpha = 0.64f)
+            isOled -> dialog.copy(alpha = NovaSheetChrome.OLED_SHEET_GLASS_ALPHA)
+            isMiami -> dialog.copy(alpha = NovaSheetChrome.MIAMI_SHEET_GLASS_ALPHA)
+            isHighContrast -> dialog.copy(alpha = NovaSheetChrome.HIGH_CONTRAST_SHEET_GLASS_ALPHA)
+            isMaterialYou -> card.copy(alpha = NovaSheetChrome.MATERIAL_YOU_SHEET_GLASS_ALPHA)
+            else -> dialog.copy(alpha = NovaSheetChrome.SHEET_GLASS_ALPHA)
         },
         panelBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> accent.copy(alpha = 0.18f)
-            isPortableChrome -> divider.copy(alpha = 0.70f)
             isHighContrast -> divider.copy(alpha = 0.92f)
             isMaterialYou -> divider.copy(alpha = 0.46f)
             else -> divider.copy(alpha = 0.44f)
         },
         tile = when {
-            isOled -> card.copy(alpha = 0.90f)
-            isMiami -> card.copy(alpha = 0.82f)
-            isPortableChrome -> card.copy(alpha = 0.92f)
+            isOled -> card.copy(alpha = 0.82f)
+            isMiami -> card.copy(alpha = 0.70f)
             isHighContrast -> card.copy(alpha = 0.98f)
-            isMaterialYou -> card.copy(alpha = 0.78f)
-            else -> card.copy(alpha = 0.74f)
+            isMaterialYou -> card.copy(alpha = 0.68f)
+            else -> card.copy(alpha = 0.66f)
         },
         tileBorder = when {
             isOled -> divider.copy(alpha = 0.78f)
             isMiami -> divider.copy(alpha = 0.58f)
-            isPortableChrome -> divider.copy(alpha = 0.62f)
             isHighContrast -> divider.copy(alpha = 0.90f)
             else -> divider.copy(alpha = 0.50f)
         },
         control = when {
-            isOled -> card.copy(alpha = 0.78f)
-            isMiami -> card.copy(alpha = 0.76f)
-            isPortableChrome -> card.copy(alpha = 0.88f)
+            isOled -> card.copy(alpha = 0.74f)
+            isMiami -> card.copy(alpha = 0.64f)
             isHighContrast -> card.copy(alpha = 1f)
-            isMaterialYou -> card.copy(alpha = 0.70f)
-            else -> card.copy(alpha = 0.72f)
+            isMaterialYou -> card.copy(alpha = 0.62f)
+            else -> card.copy(alpha = 0.60f)
         },
         selectedControl = accent.copy(alpha = when {
             isHighContrast -> 0.34f
             isMiami -> 0.22f
-            isPortableChrome -> 0.18f
             isOled -> 0.22f
             else -> 0.18f
         }),
@@ -139,14 +132,12 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusHalo = accent.copy(alpha = when {
             isHighContrast -> 0.36f
             isMiami -> 0.28f
-            isPortableChrome -> 0.16f
             isOled -> 0.24f
             else -> 0.18f
         }),
         mediaPlaceholder = when {
             isOled -> Color(0xFF08080C)
             isMiami -> Color(0xFF2C1734)
-            isPortableChrome -> Color(0xFFA2ADBA)
             isHighContrast -> Color(0xFF111827)
             isMaterialYou -> card.copy(alpha = 1f)
             else -> divider.copy(alpha = 1f)
@@ -162,14 +153,12 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
         focusedArtworkAlpha = when {
             isOled -> 0.10f
             isMiami -> 0.26f
-            isPortableChrome -> 0.12f
             isMaterialYou -> 0.18f
             else -> 0.24f
         },
         focusedArtworkScrim = Color.Black.copy(alpha = when {
             isOled -> 0.82f
             isMiami -> 0.76f
-            isPortableChrome -> 0.70f
             else -> 0.72f
         }),
         particlesEnabled = !isOled,
@@ -177,7 +166,6 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
             isOled -> 0f
             isHighContrast -> 0.28f
             isMiami -> 0.68f
-            isPortableChrome -> 0.24f
             isMaterialYou -> 0.42f
             else -> 1f
         }
@@ -203,11 +191,7 @@ fun NovaComposeTheme(content: @Composable () -> Unit) {
         onAccent = Color(
             ContextCompat.getColor(
                 context,
-                when (theme) {
-                    NovaThemeManager.THEME_MIAMI -> R.color.nova_miami_void
-                    NovaThemeManager.THEME_PORTABLE_CHROME -> R.color.nova_portable_on_accent
-                    else -> R.color.nova_ice
-                }
+                if (theme == NovaThemeManager.THEME_MIAMI) R.color.nova_miami_void else R.color.nova_ice
             )
         )
     )

--- a/app/src/main/res/color/nova_chip_bg_selector.xml
+++ b/app/src/main/res/color/nova_chip_bg_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="?attr/colorAccent" android:state_checked="true" />
+    <item android:color="?attr/colorControlHighlight" android:state_checked="true" />
     <item android:color="#33687b81" /> <!-- match nova_badge_bg solid color -->
 </selector>

--- a/app/src/main/res/color/nova_focus_stroke_selector.xml
+++ b/app/src/main/res/color/nova_focus_stroke_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/nova_ice" android:state_focused="true" />
+    <item android:color="?attr/colorAccent" android:state_focused="true" />
     <item android:color="?attr/colorAccent" android:state_pressed="true" />
     <item android:color="@android:color/transparent" />
 </selector>

--- a/app/src/main/res/drawable/nova_chip_selected.xml
+++ b/app/src/main/res/drawable/nova_chip_selected.xml
@@ -5,7 +5,7 @@
             <solid android:color="?attr/colorAccent" />
             <stroke
                 android:width="3dp"
-                android:color="@color/nova_ice" />
+                android:color="?attr/colorOnSurface" />
             <corners android:radius="12dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/nova_featured_action_bg.xml
+++ b/app/src/main/res/drawable/nova_featured_action_bg.xml
@@ -5,5 +5,5 @@
     <corners android:radius="14dp" />
     <stroke
         android:width="1dp"
-        android:color="?attr/colorControlHighlight" />
+        android:color="?attr/colorAccent" />
 </shape>

--- a/app/src/main/res/drawable/nova_server_row_focus_ring.xml
+++ b/app/src/main/res/drawable/nova_server_row_focus_ring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/nova_bg_elevated" />
+    <solid android:color="?attr/colorSurface" />
     <stroke
         android:width="2dp"
         android:color="?attr/colorAccent" />

--- a/app/src/main/res/layout-land/activity_pc_view.xml
+++ b/app/src/main/res/layout-land/activity_pc_view.xml
@@ -461,7 +461,8 @@
                         android:layout_width="32dp"
                         android:layout_height="32dp"
                         android:layout_marginTop="20dp"
-                        android:indeterminate="true" />
+                        android:indeterminate="true"
+                        android:indeterminateTint="@color/nova_accent" />
 
                     <TextView
                         android:id="@+id/pcViewEmptyTitle"

--- a/app/src/main/res/layout/activity_pc_view.xml
+++ b/app/src/main/res/layout/activity_pc_view.xml
@@ -459,7 +459,8 @@
                         android:layout_width="32dp"
                         android:layout_height="32dp"
                         android:layout_marginTop="20dp"
-                        android:indeterminate="true" />
+                        android:indeterminate="true"
+                        android:indeterminateTint="@color/nova_accent" />
 
                     <TextView
                         android:id="@+id/pcViewEmptyTitle"

--- a/app/src/main/res/layout/nova_app_context_sheet.xml
+++ b/app/src/main/res/layout/nova_app_context_sheet.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/nova_sheet_root"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="@drawable/nova_sheet_bg"
     android:paddingBottom="32dp">
 
     <!-- Drag handle -->
@@ -22,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textSize="18sp"
-        android:textColor="@color/nova_ice"
+        android:textColor="?android:textColorPrimary"
         android:fontFamily="sans-serif-medium"
         android:paddingStart="24dp"
         android:paddingEnd="24dp"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,17 +2,17 @@
 <resources>
     <string-array name="nova_theme_names">
         <item>Polaris Aurora</item>
+        <item>PSP Chrome / Portable Chrome</item>
         <item>Console OLED</item>
         <item>Miami Nebula</item>
-        <item>PSP / Portable Chrome</item>
         <item>High Contrast</item>
         <item>Material You</item>
     </string-array>
     <string-array name="nova_theme_values">
         <item>polaris</item>
+        <item>portable_chrome</item>
         <item>oled</item>
         <item>miami</item>
-        <item>portable_chrome</item>
         <item>high_contrast</item>
         <item>material_you</item>
     </string-array>

--- a/app/src/main/res/values/colors_nova.xml
+++ b/app/src/main/res/values/colors_nova.xml
@@ -55,32 +55,6 @@
     <color name="nova_miami_accent_glow">#73FF5CAB</color>
     <color name="nova_miami_ripple">#22FF5CAB</color>
 
-    <!-- Portable Chrome / PSP - smoked graphite handheld chrome with restrained status accents. -->
-    <color name="nova_portable_void">#FF7C8998</color>
-    <color name="nova_portable_deep">#FFA2ADBA</color>
-    <color name="nova_portable_twilight">#FF8E9BAA</color>
-    <color name="nova_portable_storm">#FF667484</color>
-    <color name="nova_portable_silver">#FFC4CDD8</color>
-    <color name="nova_portable_ice">#FFD7DEE7</color>
-    <color name="nova_portable_bg_primary">#FFA2ADBA</color>
-    <color name="nova_portable_bg_window">#FFA2ADBA</color>
-    <color name="nova_portable_bg_card">#E6C4CDD8</color>
-    <color name="nova_portable_bg_elevated">#FFCBD3DD</color>
-    <color name="nova_portable_bg_input">#FFB1BCC9</color>
-    <color name="nova_portable_dialog_bg">#FFC0CAD5</color>
-    <color name="nova_portable_context_bg">#FFAFBAC7</color>
-    <color name="nova_portable_divider">#FF667484</color>
-    <color name="nova_portable_text_primary">#FF1F2A35</color>
-    <color name="nova_portable_text_secondary">#FF465464</color>
-    <color name="nova_portable_text_muted">#FF5A6877</color>
-    <color name="nova_portable_accent">#FF4B6686</color>
-    <color name="nova_portable_accent_surface">#264B6686</color>
-    <color name="nova_portable_accent_glow">#334B6686</color>
-    <color name="nova_portable_ripple">#244B6686</color>
-    <color name="nova_portable_success">#FF294F3D</color>
-    <color name="nova_portable_streaming">#FF294F3D</color>
-    <color name="nova_portable_online">#FF4B6686</color>
-    <color name="nova_portable_on_accent">#FFFFFFFF</color>
     <!-- High Contrast — brighter copy, firm outlines, and blue focus for readability. -->
     <color name="nova_hc_bg_primary">#FF05070c</color>
     <color name="nova_hc_bg_card">#F00f172a</color>
@@ -100,15 +74,34 @@
     <color name="nova_text_secondary">#FFa8b0b8</color>
     <color name="nova_text_muted">#FF7a8e95</color>
 
-    <color name="nova_accent">#FF7c73ff</color>
-    <color name="nova_accent_glow">#336c63ff</color>
-    <color name="nova_accent_surface">#1A7c73ff</color>
+    <color name="nova_polaris_accent">#FF78A6FF</color>
+    <color name="nova_polaris_accent_glow">#3378A6FF</color>
+    <color name="nova_polaris_accent_surface">#1A78A6FF</color>
+    <color name="nova_polaris_ripple">#2278A6FF</color>
+
+    <color name="nova_portable_bg_window">#FFA2ADBA</color>
+    <color name="nova_portable_bg_card">#FFC4CDD8</color>
+    <color name="nova_portable_bg_elevated">#FFCBD3DD</color>
+    <color name="nova_portable_bg_input">#FFB1BCC9</color>
+    <color name="nova_portable_dialog_bg">#FFC4CDD8</color>
+    <color name="nova_portable_divider">#FF83909F</color>
+    <color name="nova_portable_text_primary">#FF1F2A35</color>
+    <color name="nova_portable_text_secondary">#FF3B4856</color>
+    <color name="nova_portable_text_muted">#FF5E6B79</color>
+    <color name="nova_portable_accent">#FF7FA38D</color>
+    <color name="nova_portable_accent_glow">#337FA38D</color>
+    <color name="nova_portable_accent_surface">#1A7FA38D</color>
+    <color name="nova_portable_ripple">#227FA38D</color>
+
+    <color name="nova_accent">@color/nova_polaris_accent</color>
+    <color name="nova_accent_glow">@color/nova_polaris_accent_glow</color>
+    <color name="nova_accent_surface">@color/nova_polaris_accent_surface</color>
     <color name="nova_success">#FF4ade80</color>
     <color name="nova_warning">#FFfbbf24</color>
     <color name="nova_error">#FFf87171</color>
 
     <color name="nova_divider">#FF393c51</color>
-    <color name="nova_ripple">#226c63ff</color>
+    <color name="nova_ripple">@color/nova_polaris_ripple</color>
 
     <!-- Dialog / popup colors -->
     <color name="nova_dialog_bg">#FF252545</color>
@@ -121,5 +114,5 @@
     <color name="nova_streaming">#FF4ade80</color>
     <color name="nova_connecting">#FFfbbf24</color>
     <color name="nova_offline">#FFf87171</color>
-    <color name="nova_online">#FF7c73ff</color>
+    <color name="nova_online">#FF7FA38D</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,9 +48,9 @@
     <string name="nova_theme_cycle">Cycle theme</string>
     <string name="nova_theme_switched_to">Theme: %1$s</string>
     <string name="nova_theme_polaris_label">Polaris Aurora</string>
+    <string name="nova_theme_portable_chrome_label">PSP Chrome / Portable Chrome</string>
     <string name="nova_theme_oled_label">Console OLED</string>
     <string name="nova_theme_miami_label">Miami Nebula</string>
-    <string name="nova_theme_portable_chrome_label">PSP / Portable Chrome</string>
     <string name="nova_theme_high_contrast_label">High Contrast</string>
     <string name="nova_theme_material_you_label">Material You</string>
     <string name="pcview_quick_library">Open Nova Library</string>
@@ -78,6 +78,15 @@
     <string name="pcview_quick_github">GitHub</string>
     <string name="pcview_quick_settings">Settings</string>
     <string name="pcview_theme_picker_title">Choose theme</string>
+    <string name="pcview_theme_picker_hint">D-pad moves focus. Select a theme to apply.</string>
+    <string name="pcview_theme_picker_focus_format">Focused: %1$s · %2$s</string>
+    <string name="pcview_theme_picker_current_badge">Current</string>
+    <string name="pcview_theme_polaris_subtitle">Polaris blue cockpit · balanced dark streaming shell</string>
+    <string name="pcview_theme_portable_chrome_subtitle">PSP / Portable Chrome profile · smoked graphite, dim silver, muted green accents</string>
+    <string name="pcview_theme_oled_subtitle">OLED black · high contrast console glow</string>
+    <string name="pcview_theme_miami_subtitle">Miami neon · warm rose and cyan night drive</string>
+    <string name="pcview_theme_high_contrast_subtitle">Maximum contrast · accessibility-first focus states</string>
+    <string name="pcview_theme_material_you_subtitle">System dynamic colors when Android supports them</string>
     <string name="pcview_filter_all">All</string>
     <string name="pcview_filter_online">Online</string>
     <string name="pcview_filter_streaming">Streaming</string>
@@ -1167,4 +1176,5 @@
 
     <string name="title_checkbox_full_screen">Enable Full Screen</string>
     <string name="summary_checkbox_full_screen">Hide system bars with immersive mode</string>
+    <string name="nova_stream_surface_accessibility_label">Nova game stream surface</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,10 +6,10 @@
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
     <style name="AppBaseTheme" parent="Theme.MaterialComponents.NoActionBar">
-        <item name="colorPrimary">@color/nova_accent</item>
+        <item name="colorPrimary">@color/nova_polaris_accent</item>
         <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorAccent">@color/nova_accent</item>
-        <item name="colorControlHighlight">@color/nova_accent_surface</item>
+        <item name="colorAccent">@color/nova_polaris_accent</item>
+        <item name="colorControlHighlight">@color/nova_polaris_accent_surface</item>
         <item name="colorSurface">@color/nova_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_text_primary</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
@@ -30,6 +30,22 @@
         <item name="android:textColor">@color/nova_text_primary</item>
     </style>
 
+    <!-- PSP / Portable Chrome — smoked graphite/silver shell with restrained green status accent. -->
+    <style name="AppTheme.PortableChrome" parent="AppBaseTheme">
+        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
+        <item name="android:textColor">@color/nova_portable_text_primary</item>
+        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
+        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
+        <item name="android:navigationBarColor">@color/nova_portable_bg_window</item>
+        <item name="android:statusBarColor">@color/nova_portable_bg_window</item>
+        <item name="colorPrimary">@color/nova_portable_accent</item>
+        <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
+        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
+        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
+    </style>
+
     <!-- Console OLED — pure black surfaces and dim accents for low-emission handheld play. -->
     <style name="AppTheme.OLED">
         <item name="android:colorBackground">@color/nova_oled_bg_window</item>
@@ -37,9 +53,13 @@
         <item name="android:textColor">@color/nova_oled_text_primary</item>
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:textColorPrimary">@color/nova_oled_text_primary</item>
+        <item name="android:textColorSecondary">@color/nova_oled_text_secondary</item>
         <item name="colorPrimary">@color/nova_oled_accent</item>
         <item name="colorAccent">@color/nova_oled_accent</item>
         <item name="colorControlHighlight">@color/nova_oled_accent_surface</item>
+        <item name="colorSurface">@color/nova_oled_bg_elevated</item>
+        <item name="colorOnSurface">@color/nova_oled_text_primary</item>
     </style>
 
     <!-- Miami Nebula — deep plum shell with neon flamingo accent. -->
@@ -58,21 +78,6 @@
         <item name="colorOnSurface">@color/nova_miami_text_primary</item>
     </style>
 
-    <!-- Portable Chrome - dim Moonlight-grey silver shell matching Polaris Portable Chrome. -->
-    <style name="AppTheme.PortableChrome">
-        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
-        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
-        <item name="android:textColor">@color/nova_portable_text_primary</item>
-        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
-        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
-        <item name="android:navigationBarColor">@color/nova_portable_deep</item>
-        <item name="android:statusBarColor">@color/nova_portable_deep</item>
-        <item name="colorPrimary">@color/nova_portable_accent</item>
-        <item name="colorAccent">@color/nova_portable_accent</item>
-        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
-        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
-        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
-    </style>
     <!-- High Contrast — firm outlines and bright copy without abandoning Nova's dark UI. -->
     <style name="AppTheme.HighContrast">
         <item name="android:colorBackground">@color/nova_hc_bg_window</item>
@@ -118,6 +123,20 @@
         <item name="colorButtonNormal">@android:color/white</item>
     </style>
 
+    <style name="SettingsTheme.PortableChrome" parent="SettingsTheme">
+        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
+        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
+        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
+        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
+        <item name="colorPrimary">@color/nova_portable_accent</item>
+        <item name="colorAccent">@color/nova_portable_accent</item>
+        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
+        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
+        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
+        <item name="android:navigationBarColor">@color/nova_portable_bg_window</item>
+        <item name="android:statusBarColor">@color/nova_portable_bg_window</item>
+    </style>
+
     <!-- Settings OLED variant -->
     <style name="SettingsTheme.OLED" parent="SettingsTheme">
         <item name="android:colorBackground">@color/nova_oled_bg_window</item>
@@ -126,7 +145,6 @@
         <item name="android:textColorSecondary">@color/nova_oled_text_secondary</item>
         <item name="colorPrimary">@color/nova_oled_accent</item>
         <item name="colorAccent">@color/nova_oled_accent</item>
-        <item name="colorControlHighlight">@color/nova_oled_accent_surface</item>
         <item name="colorSurface">@color/nova_oled_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_oled_text_primary</item>
         <item name="android:navigationBarColor">@android:color/black</item>
@@ -147,19 +165,6 @@
         <item name="android:statusBarColor">@color/nova_miami_void</item>
     </style>
 
-    <style name="SettingsTheme.PortableChrome" parent="SettingsTheme">
-        <item name="android:colorBackground">@color/nova_portable_bg_window</item>
-        <item name="android:windowBackground">@color/nova_portable_bg_window</item>
-        <item name="android:textColorPrimary">@color/nova_portable_text_primary</item>
-        <item name="android:textColorSecondary">@color/nova_portable_text_secondary</item>
-        <item name="colorPrimary">@color/nova_portable_accent</item>
-        <item name="colorAccent">@color/nova_portable_accent</item>
-        <item name="colorControlHighlight">@color/nova_portable_accent_surface</item>
-        <item name="colorSurface">@color/nova_portable_bg_elevated</item>
-        <item name="colorOnSurface">@color/nova_portable_text_primary</item>
-        <item name="android:navigationBarColor">@color/nova_portable_deep</item>
-        <item name="android:statusBarColor">@color/nova_portable_deep</item>
-    </style>
     <style name="SettingsTheme.HighContrast" parent="SettingsTheme">
         <item name="android:colorBackground">@color/nova_hc_bg_window</item>
         <item name="android:windowBackground">@color/nova_hc_bg_window</item>
@@ -177,9 +182,9 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:colorBackground">@color/nova_bg_window</item>
         <item name="android:windowBackground">@color/nova_bg_window</item>
-        <item name="colorPrimary">@color/nova_accent</item>
-        <item name="colorAccent">@color/nova_accent</item>
-        <item name="colorControlHighlight">@color/nova_accent_surface</item>
+        <item name="colorPrimary">@color/nova_polaris_accent</item>
+        <item name="colorAccent">@color/nova_polaris_accent</item>
+        <item name="colorControlHighlight">@color/nova_polaris_accent_surface</item>
         <item name="colorSurface">@color/nova_bg_elevated</item>
         <item name="colorOnSurface">@color/nova_text_primary</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
@@ -214,7 +219,6 @@
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
         <item name="android:textColorSecondary">@color/nova_text_secondary</item>
         <item name="colorAccent">?attr/colorAccent</item>
-        <item name="colorControlHighlight">?attr/colorControlHighlight</item>
         <item name="buttonBarPositiveButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/NovaDialogButton</item>

--- a/app/src/test/java/com/papi/nova/ui/NovaFocusDrawableTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaFocusDrawableTest.kt
@@ -21,15 +21,15 @@ class NovaFocusDrawableTest {
             doc.documentElement.tagName == "shape"
         )
         assertTrue(
-            "focus ring should follow the active theme accent instead of hardcoding Polaris violet",
+            "focus ring should include a clear themed accent stroke",
             hasStroke(doc, "3dp", "?attr/colorAccent")
         )
     }
 
     @Test
-    fun chipFocusedStatesUseCleanThemeAwareStroke() {
+    fun chipFocusedStatesUseCleanHighContrastStroke() {
         assertFocusedStroke("src/main/res/drawable/nova_chip_default.xml", "3dp", "?attr/colorAccent")
-        assertFocusedStroke("src/main/res/drawable/nova_chip_selected.xml", "3dp", "@color/nova_ice")
+        assertFocusedStroke("src/main/res/drawable/nova_chip_selected.xml", "3dp", "?attr/colorOnSurface")
     }
 
     @Test
@@ -49,7 +49,7 @@ class NovaFocusDrawableTest {
 
         val rowRing = parseXml("src/main/res/drawable/nova_server_row_focus_ring.xml")
         assertTrue(
-            "server row focus ring should use a slimmer accent stroke",
+            "server row focus ring should use a slimmer themed accent stroke",
             hasStroke(rowRing, "2dp", "?attr/colorAccent")
         )
     }
@@ -59,6 +59,7 @@ class NovaFocusDrawableTest {
         val dimens = parseXml("src/main/res/values/dimens.xml")
         val landDimens = parseXml("src/main/res/values-land/dimens.xml")
         val ripple = parseXml("src/main/res/drawable/nova_ripple_accent.xml")
+        val legacyFocusableCard = parseXml("src/main/res/drawable/nova_card_bg_focusable.xml")
 
         assertTrue(
             "AppView search height should keep the established portrait height",
@@ -79,6 +80,10 @@ class NovaFocusDrawableTest {
         assertTrue(
             "server card ripple should continue to follow the shared card radius",
             hasCorners(ripple, "@dimen/nova_card_corner_radius")
+        )
+        assertTrue(
+            "legacy XML focusable cards should use the active theme accent instead of a static global accent",
+            hasStroke(legacyFocusableCard, "2dp", "?attr/colorAccent")
         )
     }
 
@@ -241,12 +246,15 @@ class NovaFocusDrawableTest {
         val picker = source.substringAfter("private fun showThemePicker(")
             .substringBefore("private fun applyThemeSelection")
 
+        assertTrue(picker.contains("NovaThemeManager.THEME_PORTABLE_CHROME"))
         assertTrue(picker.contains("NovaThemeManager.THEME_OLED"))
         assertTrue(picker.contains("NovaThemeManager.THEME_MIAMI"))
         assertTrue(picker.contains("NovaThemeManager.THEME_HIGH_CONTRAST"))
         assertTrue(
-            "Miami should sit between OLED and High Contrast in the dashboard picker",
-            picker.indexOf("NovaThemeManager.THEME_OLED") < picker.indexOf("NovaThemeManager.THEME_MIAMI") &&
+            "Portable Chrome should be selectable before OLED, with Miami between OLED and High Contrast",
+            picker.indexOf("NovaThemeManager.THEME_POLARIS") < picker.indexOf("NovaThemeManager.THEME_PORTABLE_CHROME") &&
+                picker.indexOf("NovaThemeManager.THEME_PORTABLE_CHROME") < picker.indexOf("NovaThemeManager.THEME_OLED") &&
+                picker.indexOf("NovaThemeManager.THEME_OLED") < picker.indexOf("NovaThemeManager.THEME_MIAMI") &&
                 picker.indexOf("NovaThemeManager.THEME_MIAMI") < picker.indexOf("NovaThemeManager.THEME_HIGH_CONTRAST")
         )
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.R
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,14 +32,6 @@ class NovaThemeManagerTest {
     }
 
     @Test
-    fun portableChromeThemeIsRecognizedStoredAndLabeled() {
-        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
-
-        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.getTheme(context))
-        assertEquals("PSP / Portable Chrome", NovaThemeManager.getThemeLabel(context))
-    }
-
-    @Test
     fun unknownThemeFallsBackToPolaris() {
         NovaThemeManager.setTheme(context, "south_beach_laser_flamingo")
 
@@ -47,12 +40,12 @@ class NovaThemeManagerTest {
 
     @Test
     @Config(sdk = [30])
-    fun cycleThemeIncludesMiamiAndSkipsUnavailableMaterialYou() {
+    fun cycleThemeIncludesPortableChromeMiamiAndSkipsUnavailableMaterialYou() {
         NovaThemeManager.setTheme(context, NovaThemeManager.THEME_POLARIS)
 
+        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_OLED, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_MIAMI, NovaThemeManager.cycleTheme(context))
-        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_HIGH_CONTRAST, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_POLARIS, NovaThemeManager.cycleTheme(context))
     }
@@ -64,34 +57,6 @@ class NovaThemeManagerTest {
 
         assertEquals(NovaThemeManager.THEME_MATERIAL_YOU, NovaThemeManager.cycleTheme(context))
         assertEquals(NovaThemeManager.THEME_POLARIS, NovaThemeManager.cycleTheme(context))
-    }
-
-    @Test
-    fun portableChromeThemeResolvesSemanticColors() {
-        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
-
-        assertEquals(context.getColor(R.color.nova_portable_bg_window), NovaThemeManager.getWindowBackgroundColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_bg_card), NovaThemeManager.getCardBackgroundColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_dialog_bg), NovaThemeManager.getDialogBackgroundColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_accent), NovaThemeManager.getAccentColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_accent_surface), NovaThemeManager.getAccentSurfaceColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_text_primary), NovaThemeManager.getTextPrimaryColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_text_secondary), NovaThemeManager.getTextSecondaryColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_text_muted), NovaThemeManager.getTextMutedColor(context))
-        assertEquals(context.getColor(R.color.nova_portable_divider), NovaThemeManager.getDividerColor(context))
-    }
-
-    @Test
-    fun portableChromePaletteUsesSmokedPspGraphiteInsteadOfWashedSilver() {
-        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
-
-        assertEquals(0xFFA2ADBA.toInt(), context.getColor(R.color.nova_portable_bg_window))
-        assertEquals(0xE6C4CDD8.toInt(), context.getColor(R.color.nova_portable_bg_card))
-        assertEquals(0xFFC0CAD5.toInt(), context.getColor(R.color.nova_portable_dialog_bg))
-        assertEquals(0xFF667484.toInt(), context.getColor(R.color.nova_portable_divider))
-        assertEquals(0xFF1F2A35.toInt(), context.getColor(R.color.nova_portable_text_primary))
-        assertEquals(0xFF4B6686.toInt(), NovaThemeManager.getAccentColor(context))
-        assertEquals(0xFF294F3D.toInt(), context.getColor(R.color.nova_portable_success))
     }
 
     @Test
@@ -108,4 +73,22 @@ class NovaThemeManagerTest {
         assertEquals(context.getColor(R.color.nova_miami_text_muted), NovaThemeManager.getTextMutedColor(context))
         assertEquals(context.getColor(R.color.nova_miami_divider), NovaThemeManager.getDividerColor(context))
     }
+
+    @Test
+    fun portableChromeAndPolarisHaveSeparateAccentTokens() {
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
+        val portableAccent = NovaThemeManager.getAccentColor(context)
+        val portableSurface = NovaThemeManager.getAccentSurfaceColor(context)
+
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_POLARIS)
+        val polarisAccent = NovaThemeManager.getAccentColor(context)
+        val polarisSurface = NovaThemeManager.getAccentSurfaceColor(context)
+
+        assertEquals(context.getColor(R.color.nova_portable_accent), portableAccent)
+        assertEquals(context.getColor(R.color.nova_portable_accent_surface), portableSurface)
+        assertEquals(context.getColor(R.color.nova_polaris_accent), polarisAccent)
+        assertEquals(context.getColor(R.color.nova_polaris_accent_surface), polarisSurface)
+        assertTrue("Polaris Aurora must not inherit PSP green", polarisAccent != portableAccent)
+    }
+
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.R
 import java.io.File
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,25 +14,194 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NovaThemeResourcesTest {
     @Test
-    fun themeArraysExposePortableChromeInPredictableOrder() {
+    fun themeArraysExposeMiamiInPredictableOrder() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val names = context.resources.getStringArray(R.array.nova_theme_names).toList()
         val values = context.resources.getStringArray(R.array.nova_theme_values).toList()
 
         assertEquals(names.size, values.size)
         assertEquals(
-            listOf("polaris", "oled", "miami", "portable_chrome", "high_contrast", "material_you"),
+            listOf("polaris", "portable_chrome", "oled", "miami", "high_contrast", "material_you"),
             values
         )
+        assertEquals("PSP Chrome / Portable Chrome", names[values.indexOf("portable_chrome")])
         assertEquals("Miami Nebula", names[values.indexOf("miami")])
-        assertEquals("PSP / Portable Chrome", names[values.indexOf("portable_chrome")])
     }
 
     @Test
-    fun preferencesThemeSummaryMentionsPortableChrome() {
+    fun preferencesThemeSummaryMentionsMiami() {
         val preferencesXml = File("src/main/res/xml/preferences.xml").readText()
 
         assertTrue(preferencesXml.contains("android:key=\"nova_theme\""))
-        assertTrue(preferencesXml.contains("PSP / Portable Chrome"))
+        assertTrue(preferencesXml.contains("Miami Nebula"))
     }
+
+    @Test
+    fun pspPortableChromeIsASelectableThemeValueAndLabel() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
+
+        assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.getTheme(context))
+        assertEquals("PSP Chrome / Portable Chrome", NovaThemeManager.getThemeLabel(context))
+    }
+
+    @Test
+    fun portableChromeAliasesToDefaultThemeAndBaseAccentAvoidsPurpleTaskMetadata() {
+        val colors = File("src/main/res/values/colors_nova.xml").readText()
+        val manager = File("src/main/java/com/papi/nova/ui/NovaThemeManager.kt").readText()
+
+        assertTrue(manager.contains("THEME_PORTABLE_CHROME"))
+        assertTrue(manager.contains("portable_chrome"))
+        assertTrue(manager.contains("psp"))
+        assertTrue(colors.contains("<color name=\"nova_portable_accent\">#FF7FA38D</color>"))
+        assertTrue(colors.contains("<color name=\"nova_accent\">@color/nova_polaris_accent</color>"))
+        assertTrue(!colors.lowercase().contains("7c73ff"))
+    }
+
+
+    @Test
+    fun portableChromeHasDedicatedThemeStylesAndAccentTokens() {
+        val colors = File("src/main/res/values/colors_nova.xml").readText()
+        val styles = File("src/main/res/values/styles.xml").readText()
+
+        assertTrue(colors.contains("<color name=\"nova_portable_accent\">#FF7FA38D</color>"))
+        assertTrue(colors.contains("<color name=\"nova_polaris_accent\">"))
+        assertTrue(styles.contains("AppTheme.PortableChrome"))
+        assertTrue(styles.contains("SettingsTheme.PortableChrome"))
+        assertTrue(styles.contains("@color/nova_portable_accent"))
+    }
+
+    @Test
+    fun pcViewThemePickerExposesPspPortableChrome() {
+        val source = File("src/main/java/com/papi/nova/PcView.kt").readText()
+        val picker = source.substringAfter("private fun showThemePicker(")
+            .substringBefore("private fun applyThemeSelection")
+
+        assertTrue(picker.contains("NovaThemeManager.THEME_PORTABLE_CHROME"))
+        assertTrue(
+            "Portable Chrome should sit between Polaris and OLED in the dashboard picker",
+            picker.indexOf("NovaThemeManager.THEME_POLARIS") < picker.indexOf("NovaThemeManager.THEME_PORTABLE_CHROME") &&
+                picker.indexOf("NovaThemeManager.THEME_PORTABLE_CHROME") < picker.indexOf("NovaThemeManager.THEME_OLED")
+        )
+    }
+
+
+    @Test
+    fun pcViewThemePickerUsesCustomDpadFocusedRows() {
+        val source = File("src/main/java/com/papi/nova/PcView.kt").readText()
+        val picker = source.substringAfter("private fun showThemePicker(")
+            .substringBefore("private fun applyThemeSelection")
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertFalse("D-pad users need a custom focusable sheet, not Android's square single-choice list", picker.contains("setSingleChoiceItems"))
+        assertTrue("theme picker should be rendered as a custom bottom sheet", picker.contains("BottomSheetDialog"))
+        assertTrue("theme picker rows must be explicit focusable views", source.contains("createThemePickerRow("))
+        assertTrue("theme picker should expose a focused-row helper label", source.contains("themePickerFocusLabel"))
+        assertTrue("theme picker rows must update visible state on D-pad focus", source.contains("setOnFocusChangeListener"))
+        assertTrue("theme picker should use a compact two-column grid so Material You is not pushed below the Retroid landscape fold", picker.contains("themes.chunked(2)"))
+        assertTrue("Material You should remain part of the dashboard picker when the device supports it", picker.contains("NovaThemeManager.THEME_MATERIAL_YOU"))
+        assertFalse("theme picker rows must not use the solid server-card foreground that obscures focused text", picker.contains("nova_card_focus_frame"))
+        assertFalse("non-selected theme rows should not repeat an obvious Press A badge", picker.contains("pcview_theme_picker_apply_badge"))
+        assertTrue("theme picker should request focus for the current/first row", source.contains("requestFocus()"))
+        assertTrue("Chrome needs to be eye-scan visible in the picker title", strings.contains("PSP Chrome / Portable Chrome"))
+        assertTrue("the exact old alias should remain visible as a subtitle", strings.contains("PSP / Portable Chrome profile"))
+        assertTrue("the picker should tell handheld users that D-pad focus is live", strings.contains("D-pad"))
+        assertFalse("the picker copy should not repeat Press A after removing per-row action badges", strings.contains("Press A"))
+    }
+
+    @Test
+    fun serverSelectionAccentsUseThemeAttributesInsteadOfGlobalGreenResource() {
+        val portrait = File("src/main/res/layout/activity_pc_view.xml").readText()
+        val landscape = File("src/main/res/layout-land/activity_pc_view.xml").readText()
+        val styles = File("src/main/res/values/styles.xml").readText()
+
+        assertTrue(portrait.contains("app:strokeColor=\"?attr/colorAccent\""))
+        assertTrue(portrait.contains("android:textColor=\"?attr/colorAccent\""))
+        assertTrue(landscape.contains("app:strokeColor=\"?attr/colorAccent\""))
+        assertTrue(landscape.contains("android:textColor=\"?attr/colorAccent\""))
+        assertTrue(styles.contains("<item name=\"chipBackgroundColor\">@color/nova_chip_bg_selector</item>"))
+        assertTrue(styles.contains("<item name=\"chipStrokeColor\">@color/nova_focus_stroke_selector</item>"))
+        assertTrue(File("src/main/res/color/nova_focus_stroke_selector.xml").readText().contains("?attr/colorAccent"))
+        assertTrue(File("src/main/res/color/nova_chip_bg_selector.xml").readText().contains("?attr/colorControlHighlight"))
+    }
+
+
+    @Test
+    fun bottomSheetsShareNovaSheetChromeInsteadOfOneOffSurfaces() {
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val pcView = File("src/main/java/com/papi/nova/PcView.kt").readText()
+        val appView = File("src/main/java/com/papi/nova/AppView.kt").readText()
+        val gameDetail = File("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt").readText()
+        val polarisSync = File("src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt").readText()
+        val library = File("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt").readText()
+        val contextSheet = File("src/main/res/layout/nova_app_context_sheet.xml").readText()
+
+        assertTrue("native sheets should use a single chrome helper", sheetChrome.contains("object NovaSheetChrome"))
+        assertTrue("sheet chrome should use theme-specific dialog surface colors", sheetChrome.contains("NovaThemeManager.getDialogBackgroundColor"))
+        assertTrue("sheet chrome should use theme-specific accents for the handle/stroke", sheetChrome.contains("NovaThemeManager.getAccentColor"))
+        assertTrue("sheet chrome should expose shared top corner radius", sheetChrome.contains("SHEET_CORNER_RADIUS_DP"))
+        assertTrue("sheet chrome should expose shared landscape width policy", sheetChrome.contains("LANDSCAPE_WIDTH_FRACTION"))
+        assertTrue("theme picker should use shared sheet chrome", pcView.contains("NovaSheetChrome.applyBottomSheetChrome(dialog"))
+        assertTrue("pc context menu should use shared sheet chrome", pcView.contains("NovaSheetChrome.applyBottomSheetChrome(sheet"))
+        assertTrue("app context menu should use shared sheet chrome", appView.contains("NovaSheetChrome.applyBottomSheetChrome(sheet"))
+        assertTrue("game detail sheet should use shared sheet chrome", gameDetail.contains("NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog"))
+        assertTrue("Polaris sync sheet should use shared sheet chrome", polarisSync.contains("NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog"))
+        assertTrue("Compose library sheets should use the same shared radius token", library.contains("NovaSheetChrome.SHEET_CORNER_RADIUS_DP"))
+        assertTrue("Compose library sheets should use a common themed scrim alpha", library.contains("NovaSheetChrome.SCRIM_ALPHA"))
+        assertFalse("context sheet XML must not hardcode the Polaris sheet drawable", contextSheet.contains("@drawable/nova_sheet_bg"))
+        assertFalse("context sheet title must not hardcode Polaris ice text", contextSheet.contains("@color/nova_ice"))
+    }
+
+    @Test
+    fun sheetChromeContractPreventsClippedOrStaticThemePickerSurfaces() {
+        val pcView = File("src/main/java/com/papi/nova/PcView.kt").readText()
+        val picker = pcView.substringAfter("private fun showThemePicker(")
+            .substringBefore("private fun buildThemePickerThemes")
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+
+        assertTrue("theme picker content should be wrapped in a themed rounded sheet container", picker.contains("NovaSheetChrome.createSheetContainer"))
+        assertFalse("theme picker must not draw a square setBackgroundColor surface inside a rounded sheet", picker.contains("setBackgroundColor(dialogSurface)"))
+        assertTrue("theme picker rows need inset margins so focus strokes cannot look clipped", picker.contains("THEME_PICKER_GRID_GAP_DP"))
+        assertTrue("sheet chrome must draw a stroke around sheet surfaces for clean themed edges", sheetChrome.contains("setStroke"))
+        assertTrue("sheet chrome should include theme-specific light/dark stroke blending", sheetChrome.contains("getSheetStrokeColor"))
+    }
+
+
+    @Test
+    fun legacyFocusableDrawablesUseThemeAttrsInsteadOfStaticPolarisAccent() {
+        val drawableFiles = listOf(
+            "src/main/res/drawable/nova_dialog_choice_bg.xml",
+            "src/main/res/drawable/nova_chip_default.xml",
+            "src/main/res/drawable/nova_chip_selected.xml",
+            "src/main/res/drawable/nova_featured_action_bg.xml",
+            "src/main/res/drawable/nova_card_focus_ring.xml",
+            "src/main/res/drawable/nova_server_row_focus_ring.xml"
+        )
+        drawableFiles.forEach { path ->
+            val xml = File(path).readText()
+            assertFalse("$path must not hardcode old Polaris violet", xml.contains("7C73FF", ignoreCase = true))
+            assertFalse("$path must not bind reusable focus chrome to global nova_accent", xml.contains("@color/nova_accent"))
+        }
+        assertTrue(File("src/main/res/drawable/nova_dialog_choice_bg.xml").readText().contains("?attr/colorAccent"))
+        assertTrue(File("src/main/res/drawable/nova_dialog_choice_bg.xml").readText().contains("?attr/colorControlHighlight"))
+        assertTrue(File("src/main/res/drawable/nova_server_row_focus_ring.xml").readText().contains("?attr/colorSurface"))
+    }
+
+
+    @Test
+    fun sheetChromeUsesSharedTranslucentGlassForNovaHudFriendlyDrawers() {
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val composeTheme = File("src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt").readText()
+        val gameDetail = File("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt").readText()
+
+        assertTrue("native sheet chrome must expose a named glass alpha contract", sheetChrome.contains("SHEET_GLASS_ALPHA"))
+        assertTrue("native sheet backgrounds should alpha the active theme surface instead of using opaque slabs", sheetChrome.contains("ColorUtils.setAlphaComponent") && sheetChrome.contains("getSheetGlassAlpha"))
+        assertTrue("high contrast can remain more opaque for readability", sheetChrome.contains("HIGH_CONTRAST_SHEET_GLASS_ALPHA"))
+        assertTrue("shared scrim should be light enough for NovaHUD/game context to remain visible", sheetChrome.contains("const val SCRIM_ALPHA = 0.22f"))
+        assertTrue("action rows should remain transparent glass rows, not opaque mini slabs", sheetChrome.contains("setColor(Color.TRANSPARENT)"))
+        assertTrue("Compose library surfaces should reuse shared glass alpha language", composeTheme.contains("NovaSheetChrome.SHEET_GLASS_ALPHA"))
+        assertTrue("game detail Compose drawer should reuse the shared native sheet radius token", gameDetail.contains("NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp"))
+    }
+
 }

--- a/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui.compose
 
 import androidx.compose.ui.graphics.Color
+import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.NovaThemeManager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -53,8 +54,8 @@ class NovaLibrarySurfacesTest {
         assertTrue(portableChrome.particlesEnabled)
         assertEquals(portableColors.accent, portableChrome.focusRing)
         assertTrue(portableChrome.backgroundScrim.alpha >= 0.24f)
-        assertTrue(portableChrome.panel.alpha >= 0.92f)
-        assertTrue(portableChrome.panelBorder.alpha >= 0.68f)
+        assertEquals(NovaSheetChrome.PORTABLE_CHROME_SHEET_GLASS_ALPHA, portableChrome.panel.alpha, 0.001f)
+        assertTrue(portableChrome.panelBorder.alpha in 0.40f..0.52f)
         assertTrue(portableChrome.particleAlpha in 0.16f..0.28f)
         assertTrue(portableChrome.focusHalo.alpha < 0.18f)
         assertEquals(Color(0xFFA2ADBA), portableChrome.mediaPlaceholder)
@@ -76,9 +77,11 @@ class NovaLibrarySurfacesTest {
             "Miami halo should be stronger than default but not a hot pink foghorn",
             miami.focusHalo.alpha in 0.24f..0.34f
         )
-        assertTrue(
-            "Miami panels should keep readable plum glass",
-            miami.panel.alpha >= 0.78f
+        assertEquals(
+            "Miami panels should use shared readable plum glass alpha",
+            NovaSheetChrome.MIAMI_SHEET_GLASS_ALPHA,
+            miami.panel.alpha,
+            0.001f
         )
         assertTrue(
             "Miami focused artwork needs enough scrim for rose text",


### PR DESCRIPTION
## Summary
- Adds shared NovaSheetChrome glass/chrome helper for native and Compose bottom sheets.
- Updates Portable Chrome/PSP theme picker, themed focus/accent resources, and sheet transparency contracts.
- Keeps the branch Android-only; Deck client/docs/spike changes from local master are excluded.

## Test plan
- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaFocusDrawableTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.NovaThemeManagerTest
- ./gradlew :app:assembleNonRoot_gameDebug :app:assembleRootDebug -PnovaAbis=arm64-v8a
- git diff --check && git diff --cached --check before commit

## Notes
- Branch was created from origin/master in isolated worktree /home/papi/.config/superpowers/worktrees/nova/feat-android-themed-glass-drawer.
- The isolated worktree required git submodule update --init --recursive for moonlight-core before the APK assemble gate could run.
