### PR TITLE
fix(ui): exit stream activity on terminal events

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5233,6 +5233,10 @@ object : com.papi.nova.api.PolarisEventSource.EventListener {
 override fun onSessionEvent(event:String, state:String, message:String) {
 LimeLog.info("Nova SSE: " + event + " [" + state + "] " + message)
 novaProgressOverlay!!.updateState(state, message)
+                if (com.papi.nova.api.PolarisSessionEvents.shouldFinishGameActivity(event, state)) {
+                    LimeLog.info("Nova SSE: terminal session event received; ending local stream activity")
+                    runOnUiThread { finishAfterRemotePolarisSessionEnd() }
+                }
 }
 override fun onStateUpdate(sessionState:String, cageRunning:Boolean, screenLocked:Boolean) {
 novaProgressOverlay!!.updateState(sessionState, "")
@@ -5820,6 +5824,22 @@ this@Game.getIntent().getStringExtra(EXTRA_PC_UUID),
 host ?: this@Game.getIntent().getStringExtra(EXTRA_HOST)
 )
 }
+
+private fun finishAfterRemotePolarisSessionEnd() {
+        if (isFinishing || isDestroyed) {
+            return
+        }
+        markLocalSessionEnd()
+        stopBackgroundResumeWindow()
+        stopPolarisLiveSessionStatusRefresh()
+        if (novaReconnectOverlay != null) {
+            novaReconnectOverlay!!.dismiss()
+        }
+        if (novaProgressOverlay != null) {
+            novaProgressOverlay!!.dismiss()
+        }
+        finish()
+    }
 
  fun disconnect() {
 prepareBackgroundResumeWindow()

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionEvents.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionEvents.kt
@@ -1,0 +1,19 @@
+package com.papi.nova.api
+
+object PolarisSessionEvents {
+    private val terminalEvents = setOf(
+        "stream_ended",
+        "session_ended",
+        "stream_resume_timeout",
+    )
+
+    @JvmStatic
+    fun shouldFinishGameActivity(event: String?, state: String?): Boolean {
+        val normalizedEvent = event?.trim()?.lowercase().orEmpty()
+        val normalizedState = state?.trim()?.lowercase().orEmpty()
+        if (terminalEvents.contains(normalizedEvent)) {
+            return true
+        }
+        return normalizedState == "idle" && normalizedEvent == "stream_ended"
+    }
+}

--- a/app/src/test/java/com/papi/nova/api/PolarisSessionEventsTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisSessionEventsTest.kt
@@ -1,0 +1,23 @@
+package com.papi.nova.api
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolarisSessionEventsTest {
+    @Test
+    fun terminalStreamEndedFinishesGameActivity() {
+        assertTrue(PolarisSessionEvents.shouldFinishGameActivity("stream_ended", "idle"))
+    }
+
+    @Test
+    fun streamResumeTimeoutFinishesGameActivity() {
+        assertTrue(PolarisSessionEvents.shouldFinishGameActivity("stream_resume_timeout", "idle"))
+    }
+
+    @Test
+    fun activeStreamingEventsDoNotFinishGameActivity() {
+        assertFalse(PolarisSessionEvents.shouldFinishGameActivity("stream_active", "streaming"))
+        assertFalse(PolarisSessionEvents.shouldFinishGameActivity("cage_starting", "cage_starting"))
+    }
+}


### PR DESCRIPTION
Summary: add a Polaris terminal session event classifier and close Nova Game activity when Polaris reports terminal stream or session end events. The activity now dismisses overlays, stops local session polling, and finishes instead of leaving stale stream UI. Test Plan: focused PolarisSessionEvents unit tests; Nova nonRoot game debug lint; Nova arm64 debug APK assemble and adb install; live Retroid host cancel smoke confirmed stream ended event, Nova terminal event log, and launcher return instead of stale Game UI.