### PR TITLE
fix: add explicit desktop Steam launch choice

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
@@ -79,6 +79,7 @@ class NovaGameDetailSheetComposeTest {
                         headlessModeLabel = "Headless",
                         virtualDisplayModeLabel = "Virtual Display",
                         coverContentDescription = "Game cover art",
+                        onSheetHandleDismiss = {},
                         onPrimaryLaunch = {},
                         onLaunchOptions = {},
                         onLaunchModeSelected = {},

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -492,9 +492,10 @@ getWindow().addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
 
 clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
- // Start the spinner
-        spinner = SpinnerDialog.displayDialog(this, getResources().getString(R.string.conn_establishing_title),
-getResources().getString(R.string.conn_establishing_msg), true)
+ // Show the verbose Nova session progress overlay immediately; keep spinner nullable for legacy cleanup paths.
+        novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)
+        novaProgressOverlay?.show()
+        novaProgressOverlay?.updateState("conn_establishing", getResources().getString(R.string.conn_establishing_msg))
 
 
 var currentDisplay:Display? = null
@@ -1183,6 +1184,7 @@ initKeyboardController()
 
 if (!decoderRenderer!!.isAvcSupported)
 {
+novaProgressOverlay?.dismiss()
 if (spinner != null)
 {
 spinner!!.dismiss()
@@ -4432,7 +4434,7 @@ override fun stageFailed(stage:String, portFlags:Int, errorCode:Int):Boolean {
 
 if (errorCode == 0 && portFlags != 0 && (portTestResult == MoonBridge.ML_TEST_RESULT_INCONCLUSIVE || portTestResult == 0))
 {
-spinner!!.setMessage(getResources().getString(R.string.unlocking_or_starting))
+novaProgressOverlay?.updateState("unlocking_or_starting", getResources().getString(R.string.unlocking_or_starting))
 return true
 }
 
@@ -5959,29 +5961,60 @@ Handler(Looper.getMainLooper()).postDelayed({ getApplicationContext().startActiv
 overridePendingTransition(0, 0) }, 900)
 }
  fun quit() {
-var context:Context?
-if (isOnExternalDisplay && ExternalDisplayControlActivity.instance != null)
+val context:Context = if (isOnExternalDisplay && ExternalDisplayControlActivity.instance != null)
 {
-context = ExternalDisplayControlActivity.instance
+ExternalDisplayControlActivity.instance ?: this
 }
 else
 {
-context = this
+this
 }
-var builder:AlertDialog.Builder = AlertDialog.Builder(context)
-builder.setTitle(R.string.game_dialog_title_quit_confirm)
-builder.setMessage(R.string.game_dialog_message_quit_confirm)
 
-builder.setPositiveButton(getString(R.string.yes), { dialog, which->
+val sheet = BottomSheetDialog(context)
+val container = NovaSheetChrome.createSheetContainer(context)
+
+val title = TextView(context).apply {
+setText(R.string.game_dialog_title_quit_confirm)
+textSize = 20f
+NovaSheetChrome.styleSheetTitle(this)
+}
+container.addView(title, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+
+val message = TextView(context).apply {
+setText(R.string.game_dialog_message_quit_confirm)
+textSize = 15f
+setPadding(0, UiHelper.dpToPx(context, 10f).toInt(), 0, UiHelper.dpToPx(context, 18f).toInt())
+setTextColor(com.papi.nova.ui.NovaThemeManager.getTextSecondaryColor(context))
+}
+container.addView(message, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+
+val stay = TextView(context).apply {
+text = getString(R.string.game_dialog_action_stay_in_game)
+gravity = Gravity.CENTER
+NovaSheetChrome.styleSheetAction(this)
+setOnClickListener { sheet.dismiss() }
+}
+container.addView(stay, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, UiHelper.dpToPx(context, 48f).toInt()))
+
+val endSession = TextView(context).apply {
+text = getString(R.string.game_dialog_action_end_session)
+gravity = Gravity.CENTER
+NovaSheetChrome.styleSheetAction(this, destructive = true)
+setOnClickListener {
 quitOnStop = true
 markLocalSessionEnd()
-dialog!!.dismiss()
-finish() })
+sheet.dismiss()
+finish()
+}
+}
+container.addView(endSession, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, UiHelper.dpToPx(context, 48f).toInt()).apply {
+topMargin = UiHelper.dpToPx(context, 10f).toInt()
+})
 
-builder.setNegativeButton(getString(R.string.no), { dialog, which-> dialog!!.dismiss() })
-
-var dialog:AlertDialog? = builder.create()
-dialog!!.show()
+sheet.setContentView(container)
+sheet.setOnShowListener { NovaSheetChrome.applyBottomSheetChrome(sheet, container) }
+sheet.show()
+NovaSheetChrome.applyBottomSheetChrome(sheet, container)
 }
 override fun showGameMenu(device:GameInputDevice?) {
 if (isOnExternalDisplay)

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -44,7 +44,11 @@ import com.papi.nova.runtime.NovaRuntimeTasks
 import com.papi.nova.ui.ExternalControllerView
 import com.papi.nova.ui.GameGestures
 import com.papi.nova.ui.NovaHudSessionSummaryLog
+import com.papi.nova.ui.NovaSnackbar
+import com.papi.nova.ui.NovaThemeManager
+import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.StreamContainer
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
 import com.papi.nova.utils.ExternalDisplayControlActivity
@@ -54,10 +58,7 @@ import com.papi.nova.utils.PerformanceDataTracker
 import com.papi.nova.utils.ServerHelper
 import com.papi.nova.utils.ShortcutHelper
 import com.papi.nova.utils.SpinnerDialog
-import com.papi.nova.ui.NovaSheetChrome
-import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.utils.UiHelper
-import com.google.android.material.bottomsheet.BottomSheetDialog
 
 import org.json.JSONObject
 
@@ -77,10 +78,10 @@ import android.content.SharedPreferences
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.graphics.Color
 import android.graphics.Outline
 import android.graphics.Point
 import android.graphics.Rect
-import android.graphics.Typeface
 import android.hardware.display.DisplayManager
 import android.hardware.input.InputManager
 import android.media.AudioManager
@@ -110,8 +111,10 @@ import android.view.ViewOutlineProvider
 import android.view.ViewParent
 import android.view.Window
 import android.view.WindowManager
+import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import android.widget.Toast
@@ -225,6 +228,8 @@ private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
 com.papi.nova.manager.ClientProfileProvenance(com.papi.nova.manager.ClientProfileSource.LOCAL_DEFAULT)
 private var launchProfilePreference:String = "auto"
 private var launchOptimizationJson:String? = null
+private var mirrorDesktop:Boolean = false
+private var forcePrivateAfterSteamClose:Boolean = false
 private var clientPresentationReportInFlight:AtomicBoolean = AtomicBoolean(false)
 private var cursorVisibilitySyncLock:Any = Any()
 private var pendingHostCursorVisible:Boolean = false
@@ -262,6 +267,7 @@ private var lastAbsTouchDownY:Float = 0.toFloat()
 
 private var quitOnStop:Boolean = false
 private var localSessionEndMarked:Boolean = false
+@Volatile private var hostSessionEnded:Boolean = false
 private var isHidingOverlays:Boolean = false
 private var floatingButtonShown:Boolean = false
 private var overlayToggleZoomButtonShown:Boolean = false
@@ -486,31 +492,9 @@ getWindow().addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
 
 clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
- // Show Nova verbose session progress overlay immediately. The legacy spinner overlaps it.
-        novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)
-        novaProgressOverlay?.show()
-
-appName = this@Game.getIntent().getStringExtra(EXTRA_APP_NAME)
-pcName = this@Game.getIntent().getStringExtra(EXTRA_PC_NAME)
-
-host = this@Game.getIntent().getStringExtra(EXTRA_HOST)
-port = this@Game.getIntent().getIntExtra(EXTRA_PORT, NvHTTP.DEFAULT_HTTP_PORT)
-httpsPort = this@Game.getIntent().getIntExtra(EXTRA_HTTPS_PORT, 0) // 0 is treated as unknown
-appUUID = this@Game.getIntent().getStringExtra(EXTRA_APP_UUID)
-appId = this@Game.getIntent().getIntExtra(EXTRA_APP_ID, StreamConfiguration.INVALID_APP_ID)
-uniqueId = this@Game.getIntent().getStringExtra(EXTRA_UNIQUEID)
-vDisplay = this@Game.getIntent().getBooleanExtra(EXTRA_VDISPLAY, false)
-var displayModeExplicit:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_DISPLAY_MODE_EXPLICIT, false)
-watchOnlyRequested = this@Game.getIntent().getBooleanExtra(EXTRA_WATCH_ONLY, false)
-watchStreamWidth = this@Game.getIntent().getIntExtra(EXTRA_STREAM_WIDTH, 0)
-watchStreamHeight = this@Game.getIntent().getIntExtra(EXTRA_STREAM_HEIGHT, 0)
-watchStreamFps = this@Game.getIntent().getFloatExtra(EXTRA_STREAM_FPS, 0f)
-launchProfilePreference = this@Game.getIntent().getStringExtra(EXTRA_AI_PROFILE_PREFERENCE) ?: ""
-launchOptimizationJson = this@Game.getIntent().getStringExtra(EXTRA_LAUNCH_OPTIMIZATION)
-serverCmds = this@Game.getIntent().getStringArrayListExtra(EXTRA_SERVER_COMMANDS) ?: ArrayList()
-var appSupportsHdr:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_APP_HDR, false)
-var derCertData:ByteArray? = this@Game.getIntent().getByteArrayExtra(EXTRA_SERVER_CERT)
-
+ // Start the spinner
+        spinner = SpinnerDialog.displayDialog(this, getResources().getString(R.string.conn_establishing_title),
+getResources().getString(R.string.conn_establishing_msg), true)
 
 
 var currentDisplay:Display? = null
@@ -566,16 +550,9 @@ displayHeight = if (shouldInvertDecoderResolution) prefConfig!!.width else prefC
 	            setPreferredOrientationForActivity()
 	}
 
-if (watchStreamWidth > 0 && watchStreamHeight > 0)
-{
-if (watchOnlyRequested)
+if (watchOnlyRequested && watchStreamWidth > 0 && watchStreamHeight > 0)
 {
 LimeLog.info("Nova: Watch mode using active stream resolution " + watchStreamWidth + "x" + watchStreamHeight)
-}
-else
-{
-LimeLog.info("Nova: Launch using explicit stream resolution " + watchStreamWidth + "x" + watchStreamHeight)
-}
 displayWidth = watchStreamWidth
 displayHeight = watchStreamHeight
 }
@@ -718,6 +695,28 @@ catch (e:SecurityException) {
             e!!.printStackTrace()
 }
 
+appName = this@Game.getIntent().getStringExtra(EXTRA_APP_NAME)
+pcName = this@Game.getIntent().getStringExtra(EXTRA_PC_NAME)
+
+host = this@Game.getIntent().getStringExtra(EXTRA_HOST)
+port = this@Game.getIntent().getIntExtra(EXTRA_PORT, NvHTTP.DEFAULT_HTTP_PORT)
+httpsPort = this@Game.getIntent().getIntExtra(EXTRA_HTTPS_PORT, 0) // 0 is treated as unknown
+appUUID = this@Game.getIntent().getStringExtra(EXTRA_APP_UUID)
+appId = this@Game.getIntent().getIntExtra(EXTRA_APP_ID, StreamConfiguration.INVALID_APP_ID)
+uniqueId = this@Game.getIntent().getStringExtra(EXTRA_UNIQUEID)
+vDisplay = this@Game.getIntent().getBooleanExtra(EXTRA_VDISPLAY, false)
+var displayModeExplicit:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_DISPLAY_MODE_EXPLICIT, false)
+mirrorDesktop = this@Game.getIntent().getBooleanExtra(EXTRA_MIRROR_DESKTOP, false)
+forcePrivateAfterSteamClose = this@Game.getIntent().getBooleanExtra(EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, false)
+watchOnlyRequested = this@Game.getIntent().getBooleanExtra(EXTRA_WATCH_ONLY, false)
+watchStreamWidth = this@Game.getIntent().getIntExtra(EXTRA_STREAM_WIDTH, 0)
+watchStreamHeight = this@Game.getIntent().getIntExtra(EXTRA_STREAM_HEIGHT, 0)
+watchStreamFps = this@Game.getIntent().getFloatExtra(EXTRA_STREAM_FPS, 0f)
+launchProfilePreference = this@Game.getIntent().getStringExtra(EXTRA_AI_PROFILE_PREFERENCE) ?: ""
+launchOptimizationJson = this@Game.getIntent().getStringExtra(EXTRA_LAUNCH_OPTIMIZATION)
+serverCmds = this@Game.getIntent().getStringArrayListExtra(EXTRA_SERVER_COMMANDS) ?: ArrayList()
+var appSupportsHdr:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_APP_HDR, false)
+var derCertData:ByteArray? = this@Game.getIntent().getByteArrayExtra(EXTRA_SERVER_CERT)
 
 app = NvApp(if (appName != null) appName else "app", appUUID, appId, appSupportsHdr)
 
@@ -738,14 +737,13 @@ e!!.printStackTrace()
  // Nova: set up Polaris integration without blocking stream startup on REST probes.
         com.papi.nova.manager.FeatureFlagManager.reset()
 novaApiClient = com.papi.nova.api.PolarisApiClient(this, host ?: "", httpsPort, serverCert)
-if (novaProgressOverlay == null)
-{
 novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)
-}
 novaLockScreenOverlay = com.papi.nova.ui.LockScreenOverlay(this, novaApiClient!!)
 novaReconnectOverlay = com.papi.nova.ui.ReconnectOverlay(this)
 novaResilienceManager = com.papi.nova.manager.ConnectionResilienceManager(
-novaApiClient!!, { LimeLog.info("Nova: Attempting reconnect...") }
+novaApiClient!!,
+{ LimeLog.info("Nova: Attempting reconnect...") },
+{ handlePolarisHostSessionEnded() }
 )
 com.papi.nova.jni.PolarisNativeHook.register(novaResilienceManager!!)
 syncDisconnectResumeTimeoutPolicy()
@@ -951,25 +949,18 @@ if (prefConfig!!.onscreenController)
             gamepadMask = gamepadMask or 1
 }
 
-var explicitStreamFpsOverride:Boolean = watchStreamFps > 0f
-var launchRefreshRate:Float = if (explicitStreamFpsOverride) watchStreamFps else prefConfig!!.fps
+var watchStreamFpsOverride:Boolean = watchOnlyRequested && watchStreamFps > 0f
+var launchRefreshRate:Float = if (watchStreamFpsOverride) watchStreamFps else prefConfig!!.fps
 var maxSupportedLaunchRefreshRate:Float = getMaxSupportedRefreshRate(currentDisplay)
-if (!explicitStreamFpsOverride && (maxSupportedLaunchRefreshRate > 0 && launchRefreshRate > maxSupportedLaunchRefreshRate + 0.5f))
+if (!watchStreamFpsOverride && (maxSupportedLaunchRefreshRate > 0 && launchRefreshRate > maxSupportedLaunchRefreshRate + 0.5f))
 {
 LimeLog.info(("Clamping launch refresh rate from " + launchRefreshRate +
 " to display max " + maxSupportedLaunchRefreshRate))
 launchRefreshRate = maxSupportedLaunchRefreshRate
 }
-if (explicitStreamFpsOverride)
-{
-if (watchOnlyRequested)
+if (watchStreamFpsOverride)
 {
 LimeLog.info("Nova: Watch mode using active stream FPS " + watchStreamFps)
-}
-else
-{
-LimeLog.info("Nova: Launch using explicit stream FPS " + watchStreamFps)
-}
 }
 var autoSafeTargetFps:Float = com.papi.nova.manager.StreamSyncManager.resolveAutoSafeTargetFps(
 launchRefreshRate,
@@ -1106,6 +1097,8 @@ displayHeight
 .setRefreshRate(chosenFrameRate)
 .setVirtualDisplay(vDisplay)
 .setDisplayModeExplicit(displayModeExplicit)
+.setMirrorDesktop(mirrorDesktop)
+.setForcePrivateAfterSteamClose(forcePrivateAfterSteamClose)
 .setResolutionScaleFactor(prefConfig!!.resolutionScaleFactor)
 .setApp(app)
 .setEnableUltraLowLatency(prefConfig!!.enableUltraLowLatency)
@@ -1197,7 +1190,6 @@ spinner = null
 }
 
  // If we can't find an AVC decoder, we can't proceed
-novaProgressOverlay?.dismiss()
             Dialog.displayDialog(this, getResources().getString(R.string.conn_error_title),
 "This device or ROM doesn't support hardware accelerated H.264 playback.", true)
 return
@@ -2392,6 +2384,7 @@ novaLockScreenOverlay!!.dismiss()
 novaLockScreenOverlay!!.destroy()
 }
 if (novaReconnectOverlay != null) novaReconnectOverlay!!.dismiss()
+novaResilienceManager?.shutdown()
 com.papi.nova.jni.PolarisNativeHook.unregister()
 com.papi.nova.manager.FeatureFlagManager.reset()
 
@@ -2510,7 +2503,10 @@ if (conn != null)
 var videoFormat:Int = decoderRenderer!!.activeVideoFormat
 
 displayedFailureDialog = true
+if (!hostSessionEnded)
+{
 prepareBackgroundResumeWindow()
+}
 stopConnection()
 var message:String? = null
 var selectedVideoFormat:String = ""
@@ -4436,9 +4432,7 @@ override fun stageFailed(stage:String, portFlags:Int, errorCode:Int):Boolean {
 
 if (errorCode == 0 && portFlags != 0 && (portTestResult == MoonBridge.ML_TEST_RESULT_INCONCLUSIVE || portTestResult == 0))
 {
-runOnUiThread {
-novaProgressOverlay?.updateState("unlocking_or_starting", getResources().getString(R.string.unlocking_or_starting))
-}
+spinner!!.setMessage(getResources().getString(R.string.unlocking_or_starting))
 return true
 }
 
@@ -4449,7 +4443,6 @@ if (spinner != null)
 spinner!!.dismiss()
 spinner = null
 }
-novaProgressOverlay?.dismiss()
 
 if (!displayedFailureDialog)
 {
@@ -4488,13 +4481,71 @@ if (portTestResult != MoonBridge.ML_TEST_RESULT_INCONCLUSIVE && portTestResult !
 dialogText += "\n\n" + getResources().getString(R.string.nettest_text_blocked)
 }
 
-Dialog.displayDialog(this@Game, getResources().getString(R.string.conn_error_title), dialogText, true)
+showNovaLaunchIssueSheet(dialogText)
 finishSecondScreen()
 }
 }
 })
 
 return false
+}
+
+private fun showNovaLaunchIssueSheet(message: String) {
+runOnUiThread {
+if (isFinishing || isDestroyed) return@runOnUiThread
+if (spinner != null) {
+spinner!!.dismiss()
+spinner = null
+}
+val sheet = BottomSheetDialog(this@Game)
+val density = resources.displayMetrics.density
+fun dp(value: Int): Int = (value * density).toInt()
+val container = LinearLayout(this@Game).apply {
+orientation = LinearLayout.VERTICAL
+setPadding(dp(18), dp(14), dp(18), dp(18))
+background = NovaSheetChrome.createSheetBackground(this@Game)
+}
+val handle = View(this@Game).apply {
+background = NovaSheetChrome.createHandleBackground(this@Game)
+}
+NovaSheetChrome.attachHandleDragToDismiss(handle, sheet)
+container.addView(handle, LinearLayout.LayoutParams(dp(42), dp(4)).apply {
+gravity = Gravity.CENTER_HORIZONTAL
+bottomMargin = dp(14)
+})
+val title = TextView(this@Game).apply {
+text = getString(R.string.nova_launch_issue_title)
+setTextColor(NovaThemeManager.getTextPrimaryColor(this@Game))
+textSize = 20f
+}
+container.addView(title)
+val body = TextView(this@Game).apply {
+text = message
+setTextColor(NovaThemeManager.getTextSecondaryColor(this@Game))
+textSize = 14f
+setPadding(0, dp(10), 0, dp(12))
+}
+val scroll = ScrollView(this@Game).apply {
+addView(body)
+}
+container.addView(scroll, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+val dismiss = Button(this@Game).apply {
+text = getString(R.string.nova_launch_issue_dismiss)
+isAllCaps = false
+setTextColor(NovaThemeManager.getTextPrimaryColor(this@Game))
+background = NovaSheetChrome.createActionBackground(this@Game)
+setOnClickListener {
+sheet.dismiss()
+finish()
+}
+}
+container.addView(dismiss, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(48)))
+sheet.setContentView(container)
+sheet.setOnShowListener { NovaSheetChrome.applyBottomSheetChrome(sheet, container) }
+sheet.setOnDismissListener { finish() }
+sheet.show()
+NovaSheetChrome.applyBottomSheetChrome(sheet, container)
+}
 }
 
 private fun finishSecondScreen() {
@@ -4737,12 +4788,19 @@ Toast.makeText(this@Game, message, Toast.LENGTH_LONG).show()
 override fun displayTransientMessage(message:String) {
 if (!prefConfig!!.disableWarnings)
 {
+showQuietStreamTransientMessage(message)
+}
+}
+private fun showQuietStreamTransientMessage(message: String) {
 runOnUiThread(object : Runnable {
 override fun run() {
-Toast.makeText(this@Game, message, Toast.LENGTH_LONG).show()
+if (connecting || !connected || spinner != null) {
+LimeLog.info("Nova: quiet stream transient during setup: ")
+return
+}
+NovaSnackbar.showQuiet(this@Game, message)
 }
 })
-}
 }
 override fun rumble(controllerNumber:Short, lowFreqMotor:Short, highFreqMotor:Short) {
 if (prefConfig!!.enableRumble)
@@ -5261,16 +5319,20 @@ object : com.papi.nova.api.PolarisEventSource.EventListener {
 override fun onSessionEvent(event:String, state:String, message:String) {
 LimeLog.info("Nova SSE: " + event + " [" + state + "] " + message)
 novaProgressOverlay!!.updateState(state, message)
-                if (com.papi.nova.api.PolarisSessionEvents.shouldFinishGameActivity(event, state)) {
-                    LimeLog.info("Nova SSE: terminal session event received; ending local stream activity")
-                    runOnUiThread { finishAfterRemotePolarisSessionEnd() }
-                }
+if (event == "stream_ended" || (state == "idle" && (connected || isStreamActive)))
+{
+handlePolarisHostSessionEnded()
+}
 }
 override fun onStateUpdate(sessionState:String, cageRunning:Boolean, screenLocked:Boolean) {
 novaProgressOverlay!!.updateState(sessionState, "")
 if ("streaming".equals(sessionState))
 {
 schedulePolarisLiveSessionStatusRefresh(true)
+}
+else if (sessionState == "idle" && (connected || isStreamActive))
+{
+handlePolarisHostSessionEnded()
 }
 if (com.papi.nova.manager.FeatureFlagManager.hasLockScreenControl)
 {
@@ -5853,24 +5915,31 @@ host ?: this@Game.getIntent().getStringExtra(EXTRA_HOST)
 )
 }
 
-private fun finishAfterRemotePolarisSessionEnd() {
-        if (isFinishing || isDestroyed) {
-            return
-        }
-        markLocalSessionEnd()
-        stopBackgroundResumeWindow()
-        stopPolarisLiveSessionStatusRefresh()
-        if (novaReconnectOverlay != null) {
-            novaReconnectOverlay!!.dismiss()
-        }
-        if (novaProgressOverlay != null) {
-            novaProgressOverlay!!.dismiss()
-        }
-        finish()
-    }
+private fun handlePolarisHostSessionEnded() {
+if (hostSessionEnded)
+{
+return
+}
+hostSessionEnded = true
+markLocalSessionEnd()
+LimeLog.info("Nova: Polaris host session ended; returning to library")
+runOnUiThread {
+if (!isFinishing && !isDestroyed)
+{
+stopPolarisLiveSessionStatusRefresh()
+novaReconnectOverlay?.dismiss()
+novaProgressOverlay?.dismiss()
+stopBackgroundResumeWindow()
+finish()
+}
+}
+}
 
  fun disconnect() {
+if (!hostSessionEnded)
+{
 prepareBackgroundResumeWindow()
+}
 if (prefConfig!!.smartClipboardSync)
 {
 getClipboard(-1)
@@ -5890,76 +5959,29 @@ Handler(Looper.getMainLooper()).postDelayed({ getApplicationContext().startActiv
 overridePendingTransition(0, 0) }, 900)
 }
  fun quit() {
-val dialogContext:Context = if (isOnExternalDisplay && ExternalDisplayControlActivity.instance != null)
+var context:Context?
+if (isOnExternalDisplay && ExternalDisplayControlActivity.instance != null)
 {
-ExternalDisplayControlActivity.instance!!
+context = ExternalDisplayControlActivity.instance
 }
 else
 {
-this
+context = this
 }
-fun dp(value:Float):Int = UiHelper.dpToPx(dialogContext, value).toInt()
+var builder:AlertDialog.Builder = AlertDialog.Builder(context)
+builder.setTitle(R.string.game_dialog_title_quit_confirm)
+builder.setMessage(R.string.game_dialog_message_quit_confirm)
 
-val sheet = BottomSheetDialog(dialogContext, R.style.NovaBottomSheet)
-val content = NovaSheetChrome.createSheetContainer(dialogContext, horizontalPaddingDp = 24, topPaddingDp = 22, bottomPaddingDp = 24)
-
-content.addView(TextView(dialogContext).apply {
-text = getString(R.string.game_dialog_title_quit_confirm)
-setTextColor(NovaThemeManager.getTextPrimaryColor(dialogContext))
-textSize = 22f
-typeface = Typeface.DEFAULT_BOLD
-includeFontPadding = false
-setPadding(0, 0, 0, dp(10f))
-NovaSheetChrome.styleSheetTitle(this)
-})
-
-content.addView(TextView(dialogContext).apply {
-text = getString(R.string.game_dialog_message_quit_confirm)
-setTextColor(NovaThemeManager.getTextSecondaryColor(dialogContext))
-textSize = 14f
-setLineSpacing(0f, 1.08f)
-setPadding(0, 0, 0, dp(20f))
-})
-
-val actions = LinearLayout(dialogContext).apply {
-orientation = LinearLayout.HORIZONTAL
-gravity = Gravity.CENTER_VERTICAL
-}
-val stayAction = TextView(dialogContext).apply {
-text = getString(R.string.game_dialog_action_stay_in_game)
-gravity = Gravity.CENTER
-textSize = 15f
-setPadding(dp(16f), dp(14f), dp(16f), dp(14f))
-NovaSheetChrome.styleSheetAction(this)
-setOnClickListener { sheet.dismiss() }
-layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
-marginEnd = dp(12f)
-}
-}
-val endAction = TextView(dialogContext).apply {
-text = getString(R.string.game_dialog_action_end_session)
-gravity = Gravity.CENTER
-textSize = 15f
-setPadding(dp(16f), dp(14f), dp(16f), dp(14f))
-NovaSheetChrome.styleSheetAction(this, destructive = true)
-setOnClickListener {
-sheet.dismiss()
+builder.setPositiveButton(getString(R.string.yes), { dialog, which->
 quitOnStop = true
 markLocalSessionEnd()
-finish()
-}
-layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-}
-actions.addView(stayAction)
-actions.addView(endAction)
-content.addView(actions)
+dialog!!.dismiss()
+finish() })
 
-sheet.setContentView(content)
-sheet.setOnShowListener {
-NovaSheetChrome.applyBottomSheetChrome(sheet, content, widthFraction = 0.52f, minLandscapeWidthDp = 520, maxLandscapeWidthDp = 760, maxHeightLandscape = 0.82f, maxHeightPortrait = 0.70f)
-content.post { stayAction.requestFocus() }
-}
-sheet.show()
+builder.setNegativeButton(getString(R.string.no), { dialog, which-> dialog!!.dismiss() })
+
+var dialog:AlertDialog? = builder.create()
+dialog!!.show()
 }
 override fun showGameMenu(device:GameInputDevice?) {
 if (isOnExternalDisplay)
@@ -6105,6 +6127,8 @@ companion object {
  const val EXTRA_SERVER_CERT:String = "ServerCert"
  const val EXTRA_VDISPLAY:String = "VirtualDisplay"
  const val EXTRA_DISPLAY_MODE_EXPLICIT:String = "DisplayModeExplicit"
+ const val EXTRA_MIRROR_DESKTOP:String = "MirrorDesktop"
+const val EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE:String = "ForcePrivateAfterSteamClose"
  const val EXTRA_WATCH_ONLY:String = "WatchOnly"
  const val EXTRA_STREAM_WIDTH:String = "StreamWidth"
  const val EXTRA_STREAM_HEIGHT:String = "StreamHeight"

--- a/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
@@ -28,6 +28,8 @@ class StreamConfiguration private constructor() {
     private var enableUltraLowLatency = false
     private var forceFreshLaunch = false
     private var profilePreference = "auto"
+    private var mirrorDesktop = false
+    private var forcePrivateAfterSteamClose = false
 
     class Builder {
         private val config = StreamConfiguration()
@@ -158,6 +160,16 @@ class StreamConfiguration private constructor() {
             return this
         }
 
+        fun setMirrorDesktop(enable: Boolean): Builder {
+            config.mirrorDesktop = enable
+            return this
+        }
+
+        fun setForcePrivateAfterSteamClose(enable: Boolean): Builder {
+            config.forcePrivateAfterSteamClose = enable
+            return this
+        }
+
         fun build(): StreamConfiguration = config
     }
 
@@ -220,6 +232,10 @@ class StreamConfiguration private constructor() {
     fun getForceFreshLaunch(): Boolean = forceFreshLaunch
 
     fun getProfilePreference(): String = profilePreference
+
+    fun getMirrorDesktop(): Boolean = mirrorDesktop
+
+    fun getForcePrivateAfterSteamClose(): Boolean = forcePrivateAfterSteamClose
 
     companion object {
         const val INVALID_APP_ID = 0

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -694,6 +694,8 @@ class NvHTTP @Throws(IOException::class) constructor(
             .takeIf { it.isNotBlank() }
             ?.let { "&profilePreference=" + URLEncoder.encode(it, "UTF-8") }
             ?: ""
+        val mirrorDesktop = streamConfig.getMirrorDesktop()
+        val forcePrivateAfterSteamClose = streamConfig.getForcePrivateAfterSteamClose()
 
         val xmlStr = openHttpConnectionToString(
             httpClientLongConnectNoReadTimeout,
@@ -711,6 +713,9 @@ class NvHTTP @Throws(IOException::class) constructor(
                 (if (watchOnly) "&watch=1" else "") +
                 "&virtualDisplay=" + (if (streamConfig.getVirtualDisplay()) 1 else 0) +
                 "&displayModeExplicit=" + (if (streamConfig.getDisplayModeExplicit()) 1 else 0) +
+                "&mirrorDesktop=" + (if (mirrorDesktop) 1 else 0) +
+                (if (mirrorDesktop) "&launchMode=mirror_desktop" else "") +
+                (if (forcePrivateAfterSteamClose) "&closeDesktopSteamForPrivate=1&launchMode=force_private_stream" else "") +
                 profilePreference +
                 "&localAudioPlayMode=" + (if (streamConfig.getPlayLocalAudio()) 1 else 0) +
                 "&surroundAudioInfo=" + streamConfig.getAudioConfiguration()!!.getSurroundAudioInfo() +

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -491,16 +491,35 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
 
         AlertDialog.Builder(requireContext())
             .setTitle(R.string.nova_library_launch_options_title)
-            .setItems(options.map { it.first }.toTypedArray()) { _, which ->
-                onLaunch?.invoke(
-                    game.copy(mangohud = mangoHudEnabled),
-                    options[which].second,
-                    false,
-                    false,
-                    profilePreference,
-                    rawOptimization
+            .setItems(options.map { it.first }.toTypedArray()) { dialog, which ->
+                val selectedUsesVirtualDisplay = options[which].second
+                fun launchSelected(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
+                    onLaunch?.invoke(
+                        game.copy(mangohud = mangoHudEnabled),
+                        selectedUsesVirtualDisplay,
+                        mirrorDesktop,
+                        forcePrivateAfterSteamClose,
+                        profilePreference,
+                        rawOptimization
+                    )
+                    dismiss()
+                }
+                val desktopSteamDecision = NovaDesktopSteamLaunchDecision.from(
+                    uiState,
+                    rawOptimization,
+                    usesVirtualDisplay = selectedUsesVirtualDisplay
                 )
-                dismiss()
+                dialog.dismiss()
+                if (desktopSteamDecision.required) {
+                    showDesktopSteamLaunchDecision(
+                        decision = desktopSteamDecision,
+                        onPrivateStream = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = false) },
+                        onMirrorDesktop = { launchSelected(mirrorDesktop = true, forcePrivateAfterSteamClose = false) },
+                        onForcePrivateAfterSteamClose = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }
+                    )
+                } else {
+                    launchSelected(mirrorDesktop = false)
+                }
             }
             .show()
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -2,16 +2,19 @@ package com.papi.nova.ui
 
 import android.app.Dialog
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ScrollView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
@@ -53,7 +57,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.papi.nova.LimeLog
@@ -90,7 +96,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
     private var apiClient: PolarisApiClient? = null
     private var defaultToVirtualDisplay: Boolean = false
     private var clientSettings: PolarisClientSettings? = null
-    private var onLaunch: ((PolarisGame, Boolean, String, JSONObject?) -> Unit)? = null
+    private var onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, JSONObject?) -> Unit)? = null
 
     companion object {
         fun newInstance(
@@ -98,7 +104,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
             apiClient: PolarisApiClient,
             defaultToVirtualDisplay: Boolean,
             clientSettings: PolarisClientSettings?,
-            onLaunch: (PolarisGame, Boolean, String, JSONObject?) -> Unit
+            onLaunch: (PolarisGame, Boolean, Boolean, Boolean, String, JSONObject?) -> Unit
         ): NovaGameDetailSheet {
             return NovaGameDetailSheet().apply {
                 this.game = game
@@ -258,21 +264,35 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                     headlessModeLabel = modeBadgeLabel("headless"),
                     virtualDisplayModeLabel = modeBadgeLabel("virtual_display"),
                     coverContentDescription = getString(R.string.nova_a11y_game_cover),
+                    onSheetHandleDismiss = { dismiss() },
                     onPrimaryLaunch = {
                         if (!uiState.playEnabled) return@NovaGameDetailSheetContent
-                        val launchConfirmed = {
+                        fun launchConfirmed(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
                             onLaunch?.invoke(
                                 currentGame.copy(mangohud = mangoHudEnabled),
                                 uiState.playUsesVirtualDisplay,
+                                mirrorDesktop,
+                                forcePrivateAfterSteamClose,
                                 profilePreference,
                                 optimizationState.rawOptimization
                             )
                             dismiss()
                         }
-                        if (optimizationState.reviewRequired) {
+                        val desktopSteamDecision = NovaDesktopSteamLaunchDecision.from(
+                            uiState,
+                            optimizationState.rawOptimization
+                        )
+                        if (desktopSteamDecision.required) {
+                            showDesktopSteamLaunchDecision(
+                                decision = desktopSteamDecision,
+                                onPrivateStream = { launchConfirmed(mirrorDesktop = false, forcePrivateAfterSteamClose = false) },
+                                onMirrorDesktop = { launchConfirmed(mirrorDesktop = true, forcePrivateAfterSteamClose = false) },
+                                onForcePrivateAfterSteamClose = { launchConfirmed(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }
+                            )
+                        } else if (optimizationState.reviewRequired) {
                             showPreflightReview(
                                 optimizationState = optimizationState,
-                                onLaunchConfirmed = launchConfirmed,
+                                onLaunchConfirmed = { launchConfirmed(false) },
                                 onRetryHighFps = { retryHighFpsTrial() },
                                 onResetProfile = {
                                     resetWorking = true
@@ -287,7 +307,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                                 }
                             )
                         } else {
-                            launchConfirmed()
+                            launchConfirmed(false)
                         }
                     },
                     onLaunchOptions = {
@@ -475,6 +495,8 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                 onLaunch?.invoke(
                     game.copy(mangohud = mangoHudEnabled),
                     options[which].second,
+                    false,
+                    false,
                     profilePreference,
                     rawOptimization
                 )
@@ -523,6 +545,56 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
             .setNeutralButton(R.string.nova_library_retry_high_fps) { _, _ -> onRetryHighFps() }
             .setNegativeButton(R.string.nova_library_reset_game_profile) { _, _ -> onResetProfile() }
             .show()
+    }
+
+    private fun showDesktopSteamLaunchDecision(
+        decision: NovaDesktopSteamLaunchDecision,
+        onPrivateStream: () -> Unit,
+        onMirrorDesktop: () -> Unit,
+        onForcePrivateAfterSteamClose: () -> Unit
+    ) {
+        val sheet = BottomSheetDialog(requireContext(), theme)
+        val composeView = ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                NovaComposeTheme {
+                    NovaDesktopSteamLaunchDecisionContent(
+                        title = stringResource(R.string.nova_desktop_steam_title),
+                        message = decision.reason.ifBlank {
+                            stringResource(R.string.nova_desktop_steam_message)
+                        },
+                        privateStreamLabel = stringResource(R.string.nova_desktop_steam_private_stream),
+                        privateStreamUnavailableReason = decision.privateStreamUnavailableReason,
+                        privateStreamEnabled = decision.privateStreamEnabled,
+                        mirrorDesktopLabel = stringResource(R.string.nova_desktop_steam_mirror_desktop),
+                        mirrorDesktopEnabled = decision.mirrorDesktopEnabled,
+                        mirrorDesktopCaption = stringResource(R.string.nova_desktop_steam_mirror_caption),
+                        forcePrivateLabel = decision.forcePrivateAfterSteamCloseLabel.ifBlank {
+                            stringResource(R.string.nova_desktop_steam_force_private)
+                        },
+                        forcePrivateEnabled = decision.forcePrivateAfterSteamCloseEnabled,
+                        forcePrivateCaption = stringResource(R.string.nova_desktop_steam_force_private_caption),
+                        cancelLabel = stringResource(R.string.nova_desktop_steam_cancel),
+                        onPrivateStream = {
+                            sheet.dismiss()
+                            onPrivateStream()
+                        },
+                        onMirrorDesktop = {
+                            sheet.dismiss()
+                            onMirrorDesktop()
+                        },
+                        onForcePrivateAfterSteamClose = {
+                            sheet.dismiss()
+                            onForcePrivateAfterSteamClose()
+                        },
+                        onCancel = { sheet.dismiss() }
+                    )
+                }
+            }
+        }
+        sheet.setContentView(composeView)
+        sheet.setOnShowListener { expandBottomSheet(sheet) }
+        sheet.show()
     }
 
     private fun modeLabel(mode: String): String {
@@ -816,15 +888,111 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         ).filterNotNull().joinToString(" · ")
     }
 
+    private fun sheetBackgroundRes(): Int {
+        return if (NovaThemeManager.isOled(requireContext())) {
+            R.drawable.nova_sheet_bg_oled
+        } else {
+            R.drawable.nova_sheet_bg
+        }
+    }
+
     private fun expandBottomSheet(bottomSheetDialog: BottomSheetDialog?) {
-        bottomSheetDialog ?: return
+        val sheet = bottomSheetDialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
         val contentView = view ?: return
-        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog,
-            contentView,
-            minLandscapeWidthDp = 720,
-            maxLandscapeWidthDp = 1260
+        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog, contentView)
+        contentView.post {
+            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val maxHeightRatio = if (isLandscape) 0.96f else 0.90f
+            val maxHeight = (resources.displayMetrics.heightPixels * maxHeightRatio).toInt()
+            val contentHeight = contentView.measuredHeight.takeIf { it > 0 } ?: return@post
+            val desiredHeight = contentHeight.coerceAtMost(maxHeight)
+            val displayWidth = resources.displayMetrics.widthPixels
+            val density = resources.displayMetrics.density
+            val desiredWidth = if (isLandscape) {
+                val minWidth = (720 * density).toInt()
+                val maxWidth = (1260 * density).toInt()
+                (displayWidth * 0.7f).toInt().coerceIn(minWidth, maxWidth)
+            } else {
+                displayWidth
+            }
+            val horizontalMargin = if (isLandscape) {
+                ((displayWidth - desiredWidth) / 2).coerceAtLeast((18 * density).toInt())
+            } else {
+                0
+            }
+
+            contentView.layoutParams = contentView.layoutParams.apply {
+                height = if (contentHeight > maxHeight) desiredHeight else ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+            sheet.layoutParams = sheet.layoutParams.apply {
+                width = if (isLandscape) displayWidth - (horizontalMargin * 2) else ViewGroup.LayoutParams.MATCH_PARENT
+                height = desiredHeight
+            }
+            (sheet.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                lp.marginStart = horizontalMargin
+                lp.marginEnd = horizontalMargin
+                sheet.layoutParams = lp
+            }
+            sheet.minimumHeight = 0
+            sheet.requestLayout()
+
+            val behavior = BottomSheetBehavior.from(sheet)
+            behavior.isFitToContents = true
+            behavior.isDraggable = false
+            behavior.skipCollapsed = true
+            behavior.peekHeight = desiredHeight
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+            when (contentView) {
+                is NestedScrollView -> contentView.post { contentView.scrollTo(0, 0) }
+                is ScrollView -> contentView.post { contentView.scrollTo(0, 0) }
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun NovaSheetDragHandle(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalNovaComposeColors.current
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .size(height = 28.dp, width = 1.dp)
+            .novaSheetHandleDrag(onDismiss),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 42.dp, height = 4.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(colors.divider)
         )
     }
+}
+
+private fun Modifier.novaSheetHandleDrag(onDismiss: () -> Unit): Modifier = pointerInput(onDismiss) {
+    val dismissThreshold = 42.dp.toPx()
+    var draggedDown = 0f
+    detectVerticalDragGestures(
+        onDragStart = { draggedDown = 0f },
+        onDragCancel = { draggedDown = 0f },
+        onDragEnd = {
+            if (draggedDown >= dismissThreshold) {
+                onDismiss()
+            }
+            draggedDown = 0f
+        },
+        onVerticalDrag = { change, dragAmount ->
+            if (dragAmount > 0f) {
+                draggedDown += dragAmount
+                change.consume()
+            }
+        }
+    )
 }
 
 data class NovaGameDetailOptimizationState(
@@ -867,6 +1035,7 @@ fun NovaGameDetailSheetContent(
     headlessModeLabel: String,
     virtualDisplayModeLabel: String,
     coverContentDescription: String,
+    onSheetHandleDismiss: () -> Unit,
     onPrimaryLaunch: () -> Unit,
     onLaunchOptions: () -> Unit,
     onLaunchModeSelected: (String) -> Unit,
@@ -884,22 +1053,12 @@ fun NovaGameDetailSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(
-                topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp,
-                topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp
-            ))
+            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
             .background(surfaces.panel)
             .verticalScroll(verticalScroll)
             .padding(bottom = 16.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .padding(top = 6.dp, bottom = 6.dp)
-                .size(width = 36.dp, height = 4.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(colors.divider)
-                .align(Alignment.CenterHorizontally)
-        )
+        NovaSheetDragHandle(onDismiss = onSheetHandleDismiss)
 
         GameDetailsPanel(
             uiState = uiState,
@@ -1022,6 +1181,132 @@ private fun NovaDetailPanel(
             .padding(contentPadding)
     ) {
         content()
+    }
+}
+
+@Composable
+private fun NovaDesktopSteamLaunchDecisionContent(
+    title: String,
+    message: String,
+    privateStreamLabel: String,
+    privateStreamUnavailableReason: String,
+    privateStreamEnabled: Boolean,
+    mirrorDesktopLabel: String,
+    mirrorDesktopEnabled: Boolean,
+    mirrorDesktopCaption: String,
+    forcePrivateLabel: String,
+    forcePrivateEnabled: Boolean,
+    forcePrivateCaption: String,
+    cancelLabel: String,
+    onPrivateStream: () -> Unit,
+    onMirrorDesktop: () -> Unit,
+    onForcePrivateAfterSteamClose: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val colors = LocalNovaComposeColors.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .background(LocalNovaLibrarySurfaces.current.panel)
+            .padding(start = 14.dp, top = 12.dp, end = 14.dp, bottom = 16.dp)
+    ) {
+        NovaSheetDragHandle(
+            onDismiss = onCancel,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        NovaDetailPanel(
+            modifier = Modifier.fillMaxWidth(),
+            accent = true,
+            warning = true,
+            contentPadding = PaddingValues(14.dp)
+        ) {
+            Text(
+                text = title,
+                color = colors.textPrimary,
+                fontSize = 19.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = message,
+                modifier = Modifier.padding(top = 8.dp),
+                color = colors.textSecondary,
+                fontSize = 12.sp,
+                lineHeight = 15.sp
+            )
+            if (privateStreamUnavailableReason.isNotBlank()) {
+                Text(
+                    text = privateStreamUnavailableReason,
+                    modifier = Modifier.padding(top = 8.dp),
+                    color = colors.warning,
+                    fontSize = 11.sp,
+                    lineHeight = 14.sp
+                )
+            }
+            Text(
+                text = mirrorDesktopCaption,
+                modifier = Modifier.padding(top = 8.dp),
+                color = colors.textMuted,
+                fontSize = 11.sp,
+                lineHeight = 14.sp
+            )
+        }
+        NovaActionButton(
+            text = privateStreamLabel,
+            onClick = onPrivateStream,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+            enabled = privateStreamEnabled,
+            contentDescription = privateStreamLabel,
+            minHeight = 46.dp,
+            cornerRadius = 12.dp,
+            fontSize = 14.sp
+        )
+        NovaActionButton(
+            text = forcePrivateLabel,
+            onClick = onForcePrivateAfterSteamClose,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            enabled = forcePrivateEnabled,
+            primary = false,
+            contentDescription = forcePrivateLabel,
+            minHeight = 46.dp,
+            cornerRadius = 12.dp,
+            fontSize = 14.sp
+        )
+        Text(
+            text = forcePrivateCaption,
+            modifier = Modifier.padding(top = 5.dp),
+            color = colors.textMuted,
+            fontSize = 11.sp,
+            lineHeight = 14.sp
+        )
+        NovaActionButton(
+            text = mirrorDesktopLabel,
+            onClick = onMirrorDesktop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            enabled = mirrorDesktopEnabled,
+            primary = true,
+            contentDescription = mirrorDesktopLabel,
+            minHeight = 48.dp,
+            cornerRadius = 12.dp,
+            fontSize = 15.sp
+        )
+        NovaActionButton(
+            text = cancelLabel,
+            onClick = onCancel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            contentDescription = cancelLabel,
+            minHeight = 42.dp,
+            cornerRadius = 10.dp,
+            fontSize = 13.sp
+        )
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -1072,7 +1072,7 @@ fun NovaGameDetailSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .clip(RoundedCornerShape(topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp, topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp))
             .background(surfaces.panel)
             .verticalScroll(verticalScroll)
             .padding(bottom = 16.dp)
@@ -1226,7 +1226,7 @@ private fun NovaDesktopSteamLaunchDecisionContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .clip(RoundedCornerShape(topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp, topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp))
             .background(LocalNovaLibrarySurfaces.current.panel)
             .padding(start = 14.dp, top = 12.dp, end = 14.dp, bottom = 16.dp)
     ) {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
@@ -3,6 +3,7 @@ package com.papi.nova.ui
 import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.api.resolveLaunchModeChoice
 import com.papi.nova.shared.polaris.model.PolarisGame
+import org.json.JSONObject
 
 data class NovaGameDetailUiState(
     val game: PolarisGame,
@@ -78,6 +79,87 @@ data class NovaGameDetailUiState(
                 steamLaunchMode = steamLaunchMode,
                 steamLaunchWarning = steamLaunchWarning
             )
+        }
+    }
+}
+
+data class NovaDesktopSteamLaunchDecision(
+    val required: Boolean = false,
+    val privateStreamEnabled: Boolean = true,
+    val mirrorDesktopEnabled: Boolean = true,
+    val forcePrivateAfterSteamCloseEnabled: Boolean = false,
+    val forcePrivateAfterSteamCloseLabel: String = "Close desktop Steam and start private stream",
+    val reason: String = "",
+    val privateStreamUnavailableReason: String = ""
+) {
+    companion object {
+        fun from(uiState: NovaGameDetailUiState, optimization: JSONObject?): NovaDesktopSteamLaunchDecision {
+            val policy = optimization?.optJSONObject("launch_policy")
+                ?: optimization?.optJSONObject("launchPolicy")
+                ?: return NovaDesktopSteamLaunchDecision()
+            if (uiState.playUsesVirtualDisplay) return NovaDesktopSteamLaunchDecision()
+
+            val desktopSteamActive = policy.optPolicyBoolean("desktop_steam_active", "desktopSteamActive")
+            val physicalDisplayRisk = policy.optPolicyBoolean("physical_display_risk", "physicalDisplayRisk")
+            if (!desktopSteamActive && !physicalDisplayRisk) return NovaDesktopSteamLaunchDecision()
+
+            val privateSupported = policy.optPolicyBoolean(
+                "canLaunchPrivateStream",
+                "private_stream_supported",
+                "privateStreamSupported",
+                default = true
+            )
+            val mirrorSupported = policy.optPolicyBoolean(
+                "canMirrorDesktop",
+                "mirror_desktop_supported",
+                "mirrorDesktopSupported",
+                default = true
+            )
+            val forcePrivateSupported = policy.optPolicyBoolean(
+                "canForceCloseDesktopSteamForPrivateStream",
+                "force_private_after_steam_close_supported",
+                "forcePrivateAfterSteamCloseSupported",
+                default = false
+            )
+            val forcePrivateLabel = policy.optPolicyString(
+                "forcePrivateStreamLabel",
+                "force_private_stream_label"
+            ).ifBlank { "Close desktop Steam and start private stream" }
+            val reason = policy.optPolicyString("reason", "message")
+            val privateReason = policy.optPolicyString(
+                "private_stream_unavailable_reason",
+                "privateStreamUnavailableReason"
+            ).ifBlank {
+                if (privateSupported) "" else reason.ifBlank { "Private stream is unavailable while desktop Steam is active." }
+            }
+
+            return NovaDesktopSteamLaunchDecision(
+                required = true,
+                privateStreamEnabled = privateSupported,
+                mirrorDesktopEnabled = mirrorSupported,
+                forcePrivateAfterSteamCloseEnabled = forcePrivateSupported,
+                forcePrivateAfterSteamCloseLabel = forcePrivateLabel,
+                reason = reason,
+                privateStreamUnavailableReason = privateReason
+            )
+        }
+
+        private fun JSONObject.optPolicyBoolean(
+            vararg names: String,
+            default: Boolean = false
+        ): Boolean {
+            for (name in names) {
+                if (has(name)) return optBoolean(name, default)
+            }
+            return default
+        }
+
+        private fun JSONObject.optPolicyString(vararg names: String): String {
+            for (name in names) {
+                val value = optString(name, "")
+                if (value.isNotBlank()) return value
+            }
+            return ""
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
@@ -93,11 +93,15 @@ data class NovaDesktopSteamLaunchDecision(
     val privateStreamUnavailableReason: String = ""
 ) {
     companion object {
-        fun from(uiState: NovaGameDetailUiState, optimization: JSONObject?): NovaDesktopSteamLaunchDecision {
+        fun from(
+            uiState: NovaGameDetailUiState,
+            optimization: JSONObject?,
+            usesVirtualDisplay: Boolean = uiState.playUsesVirtualDisplay
+        ): NovaDesktopSteamLaunchDecision {
             val policy = optimization?.optJSONObject("launch_policy")
                 ?: optimization?.optJSONObject("launchPolicy")
                 ?: return NovaDesktopSteamLaunchDecision()
-            if (uiState.playUsesVirtualDisplay) return NovaDesktopSteamLaunchDecision()
+            if (usesVirtualDisplay) return NovaDesktopSteamLaunchDecision()
 
             val desktopSteamActive = policy.optPolicyBoolean("desktop_steam_active", "desktopSteamActive")
             val physicalDisplayRisk = policy.optPolicyBoolean("physical_display_risk", "physicalDisplayRisk")

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -553,8 +553,8 @@ class NovaLibraryActivity : AppCompatActivity() {
             apiClient = apiClient,
             defaultToVirtualDisplay = defaultToVirtualDisplay,
             clientSettings = clientSettings
-        ) { selectedGame, withVirtualDisplay, profilePreference, preflightOptimization ->
-            launchGame(selectedGame, withVirtualDisplay, profilePreference, preflightOptimization)
+        ) { selectedGame, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, preflightOptimization ->
+            launchGame(selectedGame, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, preflightOptimization)
         }
         detailSheet?.show(supportFragmentManager, "game_detail")
     }
@@ -562,6 +562,8 @@ class NovaLibraryActivity : AppCompatActivity() {
     private fun launchGame(
         game: PolarisGame,
         withVirtualDisplay: Boolean,
+        mirrorDesktop: Boolean = false,
+        forcePrivateAfterSteamClose: Boolean = false,
         profilePreference: String = "auto",
         preflightOptimization: org.json.JSONObject? = null
     ) {
@@ -588,8 +590,12 @@ class NovaLibraryActivity : AppCompatActivity() {
             getString(
                 R.string.nova_library_launching_mode,
                 game.name,
-                if (withVirtualDisplay) getString(R.string.nova_library_launch_virtual_display)
-                else getString(R.string.nova_library_launch_headless)
+                when {
+                    withVirtualDisplay -> getString(R.string.nova_library_launch_virtual_display)
+                    mirrorDesktop -> getString(R.string.nova_desktop_steam_mirror_desktop)
+                    forcePrivateAfterSteamClose -> getString(R.string.nova_desktop_steam_force_private)
+                    else -> getString(R.string.nova_library_launch_headless)
+                }
             ),
             Toast.LENGTH_SHORT
         ).show()
@@ -605,7 +611,11 @@ class NovaLibraryActivity : AppCompatActivity() {
                 val preferences = com.papi.nova.preferences.PreferenceConfiguration.readPreferences(this@NovaLibraryActivity)
                 val syncedSettings = withContext(Dispatchers.IO) {
                     apiClient.updateClientSettings(
-                        streamDisplayMode = if (withVirtualDisplay) "host_virtual_display" else "headless_stream",
+                        streamDisplayMode = when {
+                            withVirtualDisplay -> "host_virtual_display"
+                            mirrorDesktop -> "desktop_display"
+                            else -> "headless_stream"
+                        },
                         displayMode = com.papi.nova.preferences.PreferenceConfiguration.formatStreamingDisplayMode(
                             preferences.width,
                             preferences.height,
@@ -634,7 +644,9 @@ class NovaLibraryActivity : AppCompatActivity() {
                     false,
                     serverCert,
                     aiProfilePreference = profilePreference,
-                    launchOptimizationJson = preflightOptimization?.toString()
+                    launchOptimizationJson = preflightOptimization?.toString(),
+                    mirrorDesktop = mirrorDesktop,
+                    forcePrivateAfterSteamClose = forcePrivateAfterSteamClose
                 )
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui
 
 import android.app.Dialog
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.LayoutInflater
@@ -15,6 +16,7 @@ import androidx.compose.runtime.key
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.papi.nova.LimeLog
@@ -324,13 +326,47 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
     }
 
     private fun expandBottomSheet(bottomSheetDialog: BottomSheetDialog?) {
-        bottomSheetDialog ?: return
+        val sheet = bottomSheetDialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
         val contentView = view ?: return
-        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog,
-            contentView,
-            widthFraction = 0.62f,
-            minLandscapeWidthDp = 700,
-            maxLandscapeWidthDp = 980
-        )
+        NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog, contentView)
+        contentView.post {
+            val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val maxHeightRatio = if (isLandscape) 0.96f else 0.90f
+            val maxHeight = (resources.displayMetrics.heightPixels * maxHeightRatio).toInt()
+            val contentHeight = contentView.measuredHeight.takeIf { it > 0 } ?: return@post
+            val desiredHeight = contentHeight.coerceAtMost(maxHeight)
+            val displayWidth = resources.displayMetrics.widthPixels
+            val density = resources.displayMetrics.density
+            val desiredWidth = if (isLandscape) {
+                val minWidth = (700 * density).toInt()
+                val maxWidth = (980 * density).toInt()
+                (displayWidth * 0.62f).toInt().coerceIn(minWidth, maxWidth)
+            } else {
+                displayWidth
+            }
+            val horizontalMargin = if (isLandscape) {
+                ((displayWidth - desiredWidth) / 2).coerceAtLeast((18 * density).toInt())
+            } else {
+                0
+            }
+
+            sheet.layoutParams = sheet.layoutParams.apply {
+                width = if (isLandscape) desiredWidth else ViewGroup.LayoutParams.MATCH_PARENT
+                height = desiredHeight
+            }
+            (sheet.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                lp.marginStart = horizontalMargin
+                lp.marginEnd = horizontalMargin
+                sheet.layoutParams = lp
+            }
+            sheet.setPadding(0, 0, 0, 0)
+            sheet.requestLayout()
+            BottomSheetBehavior.from(sheet).apply {
+                peekHeight = desiredHeight
+                isDraggable = false
+                state = BottomSheetBehavior.STATE_EXPANDED
+                skipCollapsed = true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -3,6 +3,8 @@ package com.papi.nova.ui
 import android.app.AlertDialog
 import android.content.Context
 import android.content.res.Configuration
+import android.view.MotionEvent
+import android.view.ViewConfiguration
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.StateListDrawable
@@ -116,6 +118,7 @@ object NovaSheetChrome {
             sheet.requestLayout()
 
             BottomSheetBehavior.from(sheet).apply {
+                isDraggable = false
                 isFitToContents = true
                 skipCollapsed = true
                 peekHeight = desiredHeight
@@ -212,7 +215,7 @@ object NovaSheetChrome {
         }
     }
 
-    private fun createActionBackground(context: Context): StateListDrawable {
+    fun createActionBackground(context: Context): StateListDrawable {
         return StateListDrawable().apply {
             addState(
                 intArrayOf(android.R.attr.state_pressed),
@@ -226,6 +229,55 @@ object NovaSheetChrome {
                 intArrayOf(),
                 createActionStateBackground(context, fillAccentBlend = 0f, strokeAccentBlend = 0.18f)
             )
+        }
+    }
+
+    fun createHandleBackground(context: Context): GradientDrawable {
+        val radius = dp(context, 4).toFloat()
+        return GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(ColorUtils.setAlphaComponent(NovaThemeManager.getAccentColor(context), 0xA8))
+            cornerRadius = radius
+        }
+    }
+
+    fun attachHandleDragToDismiss(handle: View, dialog: BottomSheetDialog) {
+        val touchSlop = ViewConfiguration.get(handle.context).scaledTouchSlop
+        val dismissThreshold = dp(handle.context, 42).toFloat()
+        var downY = 0f
+        var consumedDrag = false
+        handle.setOnTouchListener { view, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    downY = event.rawY
+                    consumedDrag = false
+                    view.parent?.requestDisallowInterceptTouchEvent(true)
+                    true
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val dragDistance = event.rawY - downY
+                    if (dragDistance > touchSlop) {
+                        consumedDrag = true
+                        view.parent?.requestDisallowInterceptTouchEvent(true)
+                    }
+                    true
+                }
+                MotionEvent.ACTION_UP -> {
+                    val dragDistance = event.rawY - downY
+                    view.parent?.requestDisallowInterceptTouchEvent(false)
+                    if (dragDistance >= dismissThreshold) {
+                        dialog.dismiss()
+                    } else if (!consumedDrag) {
+                        view.performClick()
+                    }
+                    true
+                }
+                MotionEvent.ACTION_CANCEL -> {
+                    view.parent?.requestDisallowInterceptTouchEvent(false)
+                    true
+                }
+                else -> true
+            }
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaSnackbar.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSnackbar.kt
@@ -1,41 +1,92 @@
 package com.papi.nova.ui
 
 import android.app.Activity
+import android.graphics.Color
 import android.view.View
+import androidx.core.graphics.ColorUtils
 import com.google.android.material.snackbar.Snackbar
 import com.papi.nova.R
 
 /**
  * Nova-themed Snackbar helper.
- * Shows messages with consistent Nova styling.
+ *
+ * Keep transient status lightweight and theme-aware. These are not drawers, so
+ * they must not show up as hardcoded purple cards layered over Nova glass sheets
+ * or the stream setup overlay.
  */
 object NovaSnackbar {
+    private const val SurfaceAlpha = 0xDC
+    private const val QuietSurfaceAlpha = 0xB8
+    private var activeSnackbar: Snackbar? = null
 
     @JvmOverloads
     fun show(activity: Activity, message: String, duration: Int = Snackbar.LENGTH_SHORT) {
-        val rootView = activity.findViewById<View>(android.R.id.content) ?: return
-        val snackbar = Snackbar.make(rootView, message, duration)
-        snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
-        snackbar.setTextColor(activity.getColor(R.color.nova_text_primary))
-        snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
-        snackbar.show()
+        showStyled(
+            activity = activity,
+            message = message,
+            duration = duration,
+            textColor = NovaThemeManager.getTextPrimaryColor(activity),
+            surfaceAlpha = SurfaceAlpha
+        )
+    }
+
+    fun showQuiet(activity: Activity, message: String) {
+        showStyled(
+            activity = activity,
+            message = message,
+            duration = Snackbar.LENGTH_SHORT,
+            textColor = NovaThemeManager.getTextSecondaryColor(activity),
+            surfaceAlpha = QuietSurfaceAlpha
+        )
     }
 
     fun showError(activity: Activity, message: String) {
-        val rootView = activity.findViewById<View>(android.R.id.content) ?: return
-        val snackbar = Snackbar.make(rootView, message, Snackbar.LENGTH_LONG)
-        snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
-        snackbar.setTextColor(activity.getColor(R.color.nova_error))
-        snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
-        snackbar.show()
+        showStyled(
+            activity = activity,
+            message = message,
+            duration = Snackbar.LENGTH_LONG,
+            textColor = activity.getColor(R.color.nova_error),
+            surfaceAlpha = SurfaceAlpha
+        )
     }
 
     fun showSuccess(activity: Activity, message: String) {
+        showStyled(
+            activity = activity,
+            message = message,
+            duration = Snackbar.LENGTH_SHORT,
+            textColor = activity.getColor(R.color.nova_success),
+            surfaceAlpha = SurfaceAlpha
+        )
+    }
+
+    private fun showStyled(
+        activity: Activity,
+        message: String,
+        duration: Int,
+        textColor: Int,
+        surfaceAlpha: Int
+    ) {
         val rootView = activity.findViewById<View>(android.R.id.content) ?: return
-        val snackbar = Snackbar.make(rootView, message, Snackbar.LENGTH_SHORT)
-        snackbar.setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))
-        snackbar.setTextColor(activity.getColor(R.color.nova_success))
+        activeSnackbar?.dismiss()
+        val snackbar = Snackbar.make(rootView, message, duration)
+        activeSnackbar = snackbar
+        snackbar.setBackgroundTint(
+            ColorUtils.setAlphaComponent(
+                NovaThemeManager.getDialogBackgroundColor(activity),
+                surfaceAlpha
+            )
+        )
+        snackbar.setTextColor(textColor)
         snackbar.setActionTextColor(NovaThemeManager.getAccentColor(activity))
+        snackbar.view.alpha = if (surfaceAlpha < SurfaceAlpha) 0.88f else 0.94f
+        snackbar.addCallback(object : Snackbar.Callback() {
+            override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                if (activeSnackbar === transientBottomBar) {
+                    activeSnackbar = null
+                }
+            }
+        })
         snackbar.show()
     }
 }

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -114,6 +114,8 @@ object ServerHelper {
         streamFps: Float = 0f,
         aiProfilePreference: String = "auto",
         launchOptimizationJson: String? = null,
+        mirrorDesktop: Boolean = false,
+        forcePrivateAfterSteamClose: Boolean = false,
     ): Intent {
         val prefConfig = PreferenceConfiguration.readPreferences(parent)
         val gameIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && prefConfig.enableFullExDisplay) {
@@ -141,6 +143,8 @@ object ServerHelper {
         gameIntent.putExtra(Game.EXTRA_PC_NAME, pcName)
         gameIntent.putExtra(Game.EXTRA_VDISPLAY, withVDisplay)
         gameIntent.putExtra(Game.EXTRA_DISPLAY_MODE_EXPLICIT, displayModeExplicit)
+        gameIntent.putExtra(Game.EXTRA_MIRROR_DESKTOP, mirrorDesktop)
+        gameIntent.putExtra(Game.EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, forcePrivateAfterSteamClose)
         gameIntent.putExtra(Game.EXTRA_WATCH_ONLY, watchOnly)
         if (streamWidth > 0 && streamHeight > 0) {
             gameIntent.putExtra(Game.EXTRA_STREAM_WIDTH, streamWidth)
@@ -219,6 +223,8 @@ object ServerHelper {
         watchOnly: Boolean,
         profilePreference: String = "auto",
         launchOptimizationJson: String? = null,
+        mirrorDesktop: Boolean = false,
+        forcePrivateAfterSteamClose: Boolean = false,
     ): Intent {
         var serverCert: ByteArray? = null
         try {
@@ -249,6 +255,8 @@ object ServerHelper {
             serverCert,
             aiProfilePreference = profilePreference,
             launchOptimizationJson = launchOptimizationJson,
+            mirrorDesktop = mirrorDesktop,
+            forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
         )
     }
 
@@ -315,6 +323,8 @@ object ServerHelper {
         streamFps: Float,
         aiProfilePreference: String = "auto",
         launchOptimizationJson: String? = null,
+        mirrorDesktop: Boolean = false,
+        forcePrivateAfterSteamClose: Boolean = false,
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -339,6 +349,7 @@ object ServerHelper {
             streamFps,
             aiProfilePreference,
             launchOptimizationJson,
+            mirrorDesktop,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)
@@ -402,6 +413,8 @@ object ServerHelper {
         serverCert: ByteArray?,
         aiProfilePreference: String = "auto",
         launchOptimizationJson: String? = null,
+        mirrorDesktop: Boolean = false,
+        forcePrivateAfterSteamClose: Boolean = false,
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -423,6 +436,8 @@ object ServerHelper {
             serverCert,
             aiProfilePreference = aiProfilePreference,
             launchOptimizationJson = launchOptimizationJson,
+            mirrorDesktop = mirrorDesktop,
+            forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -350,6 +350,7 @@ object ServerHelper {
             aiProfilePreference,
             launchOptimizationJson,
             mirrorDesktop,
+            forcePrivateAfterSteamClose,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,6 +308,14 @@
     <string name="nova_library_launch_intro_virtual_unavailable">Virtual display is not available on this host. Nova will use a private stream for this launch.</string>
     <string name="nova_library_launch_mode_note">Private stream uses Nova\'s headless path when available. Virtual display creates a separate display for the session.</string>
     <string name="nova_library_launch_default_mode_badge">Default: %1$s</string>
+    <string name="nova_desktop_steam_title">Desktop Steam is active</string>
+    <string name="nova_desktop_steam_message">Polaris detected that this launch may appear on the host\'s physical display. Choose a safe private stream or explicitly mirror the desktop.</string>
+    <string name="nova_desktop_steam_private_stream">Private Stream</string>
+    <string name="nova_desktop_steam_mirror_desktop">Mirror Desktop</string>
+    <string name="nova_desktop_steam_mirror_caption">Explicitly stream the host desktop. People near the PC may see this session.</string>
+    <string name="nova_desktop_steam_force_private">Close desktop Steam and start private stream</string>
+    <string name="nova_desktop_steam_force_private_caption">Nova will ask Polaris to close desktop Steam first, then reopen the game inside the private handheld stream.</string>
+    <string name="nova_desktop_steam_cancel">Cancel</string>
     <string name="nova_library_launch_mode_default_format">%1$s · Default</string>
     <string name="nova_library_launch_recommended_mode_badge">Rec. %1$s</string>
     <string name="nova_library_launch_preferred_mode_format">App default: %1$s.</string>
@@ -454,6 +462,8 @@
     <string name="conn_terminated_title">Connection Terminated</string>
     <string name="conn_terminated_msg">The connection was terminated.</string>
     <string name="error_code_prefix">Error code:</string>
+    <string name="nova_launch_issue_title">Launch needs attention</string>
+    <string name="nova_launch_issue_dismiss">Back to Nova</string>
 
     <!-- General strings -->
     <string name="ip_hint">IP address of host PC</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
@@ -2,11 +2,17 @@ package com.papi.nova.ui
 
 import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.shared.polaris.model.PolarisGame
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
 class NovaGameDetailUiStateTest {
     @Test
     fun virtualRecommendedModeUsesVirtualPlayMode() {
@@ -192,6 +198,83 @@ class NovaGameDetailUiStateTest {
         assertFalse(nonSteam.showSteamLaunchMode)
         assertTrue(bigPicture.showSteamLaunchMode)
         assertTrue(bigPicture.steamLaunchWarning)
+    }
+
+    @Test
+    fun desktopSteamPolicyRequiresDecisionForPrivatePhysicalDisplayRisk() {
+        val state = NovaGameDetailUiState.from(
+            game = game(name = "Steam Big Picture"),
+            defaultToVirtualDisplay = false,
+            clientSettings = null,
+            profilePreference = "auto"
+        )
+        val optimization = JSONObject()
+            .put(
+                "launchPolicy",
+                JSONObject()
+                    .put("desktopSteamActive", true)
+                    .put("physicalDisplayRisk", true)
+                    .put("canLaunchPrivateStream", false)
+                    .put("canMirrorDesktop", true)
+                    .put("recommendedAction", "refuse_private_stream")
+            )
+
+        val decision = NovaDesktopSteamLaunchDecision.from(state, optimization)
+
+        assertTrue(decision.required)
+        assertFalse(decision.privateStreamEnabled)
+        assertTrue(decision.mirrorDesktopEnabled)
+        assertEquals("Private stream is unavailable while desktop Steam is active.", decision.privateStreamUnavailableReason)
+    }
+
+    @Test
+    fun desktopSteamPolicyOffersExplicitForcePrivateShutdown() {
+        val state = NovaGameDetailUiState.from(
+            game = game(name = "MOUSE:PI"),
+            defaultToVirtualDisplay = false,
+            clientSettings = null,
+            profilePreference = "auto"
+        )
+        val optimization = JSONObject()
+            .put(
+                "launchPolicy",
+                JSONObject()
+                    .put("desktopSteamActive", true)
+                    .put("physicalDisplayRisk", true)
+                    .put("canLaunchPrivateStream", false)
+                    .put("canMirrorDesktop", true)
+                    .put("canForceCloseDesktopSteamForPrivateStream", true)
+                    .put("forcePrivateStreamLabel", "Close desktop Steam and start private stream")
+            )
+
+        val decision = NovaDesktopSteamLaunchDecision.from(state, optimization)
+
+        assertTrue(decision.required)
+        assertTrue(decision.forcePrivateAfterSteamCloseEnabled)
+        assertEquals("Close desktop Steam and start private stream", decision.forcePrivateAfterSteamCloseLabel)
+    }
+
+    @Test
+    fun desktopSteamPolicyDoesNotInterruptVirtualDisplayLaunch() {
+        val state = NovaGameDetailUiState.from(
+            game = game(name = "Steam Big Picture"),
+            defaultToVirtualDisplay = true,
+            clientSettings = PolarisClientSettings(
+                desired = PolarisClientSettings.Desired(streamDisplayMode = "virtual_display")
+            ),
+            profilePreference = "auto"
+        )
+        val optimization = JSONObject()
+            .put(
+                "launchPolicy",
+                JSONObject()
+                    .put("desktopSteamActive", true)
+                    .put("physicalDisplayRisk", true)
+            )
+
+        val decision = NovaDesktopSteamLaunchDecision.from(state, optimization)
+
+        assertFalse(decision.required)
     }
 
     private fun game(

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -53,6 +53,10 @@ class NovaLaunchSourceGuardTest {
             "private fun showDesktopSteamLaunchDecision(",
             "private fun modeLabel("
         )
+        val launchOptions = detail.section(
+            "private fun showLaunchOptions(",
+            "private fun syncLaunchPreflightSettings("
+        )
 
         assertTrue(
             "desktop Steam active policy should open a Nova-themed Compose bottom sheet, not a legacy square AlertDialog",
@@ -67,6 +71,12 @@ class NovaLaunchSourceGuardTest {
                 decisionSheet.contains("nova_desktop_steam_cancel")
         )
         assertTrue(
+            "Launch Options must not bypass desktop-Steam safety for selected private headless launches",
+            launchOptions.contains("usesVirtualDisplay = selectedUsesVirtualDisplay") &&
+                launchOptions.contains("showDesktopSteamLaunchDecision(") &&
+                launchOptions.contains("onForcePrivateAfterSteamClose = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }")
+        )
+        assertTrue(
             "Mirror Desktop must be carried as an explicit launch override through the stream launch path",
             detail.contains("mirrorDesktop = true") &&
                 serverHelper.contains("Game.EXTRA_MIRROR_DESKTOP") &&
@@ -76,7 +86,8 @@ class NovaLaunchSourceGuardTest {
                 streamConfiguration.contains("fun setMirrorDesktop(enable: Boolean)") &&
                 streamConfiguration.contains("fun setForcePrivateAfterSteamClose(enable: Boolean)") &&
                 nvHttp.contains("&mirrorDesktop=") &&
-                nvHttp.contains("&launchMode=mirror_desktop")
+                nvHttp.contains("&launchMode=mirror_desktop") &&
+                serverHelper.contains("forcePrivateAfterSteamClose = forcePrivateAfterSteamClose")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -42,6 +42,128 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun desktopSteamDecisionSheetUsesNovaGlassAndExplicitMirrorDesktopPlumbing() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val serverHelper = readSource("src/main/java/com/papi/nova/utils/ServerHelper.kt")
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val streamConfiguration = readSource("src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt")
+        val nvHttp = readSource("src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt")
+        val chrome = readSource("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt")
+        val decisionSheet = detail.section(
+            "private fun showDesktopSteamLaunchDecision(",
+            "private fun modeLabel("
+        )
+
+        assertTrue(
+            "desktop Steam active policy should open a Nova-themed Compose bottom sheet, not a legacy square AlertDialog",
+            decisionSheet.contains("BottomSheetDialog(requireContext(), theme)") &&
+                decisionSheet.contains("NovaDesktopSteamLaunchDecisionContent(") &&
+                !decisionSheet.contains("AlertDialog.Builder")
+        )
+        assertTrue(
+            "decision sheet should offer explicit Private Stream, Mirror Desktop, and Cancel actions",
+            decisionSheet.contains("nova_desktop_steam_private_stream") &&
+                decisionSheet.contains("nova_desktop_steam_mirror_desktop") &&
+                decisionSheet.contains("nova_desktop_steam_cancel")
+        )
+        assertTrue(
+            "Mirror Desktop must be carried as an explicit launch override through the stream launch path",
+            detail.contains("mirrorDesktop = true") &&
+                serverHelper.contains("Game.EXTRA_MIRROR_DESKTOP") &&
+                game.contains("EXTRA_MIRROR_DESKTOP") &&
+                game.contains(".setMirrorDesktop(mirrorDesktop)") &&
+                game.contains(".setForcePrivateAfterSteamClose(forcePrivateAfterSteamClose)") &&
+                streamConfiguration.contains("fun setMirrorDesktop(enable: Boolean)") &&
+                streamConfiguration.contains("fun setForcePrivateAfterSteamClose(enable: Boolean)") &&
+                nvHttp.contains("&mirrorDesktop=") &&
+                nvHttp.contains("&launchMode=mirror_desktop")
+        )
+    }
+
+    @Test
+    fun launchFailureAndDesktopSteamActionsUseNovaThemedFlow() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val serverHelper = readSource("src/main/java/com/papi/nova/utils/ServerHelper.kt")
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val nvHttp = readSource("src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt")
+        val chrome = readSource("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt")
+        val errorSection = game.section(
+            "var dialogText:String = getResources().getString(R.string.conn_error_msg)",
+            "private fun showNovaLaunchIssueSheet"
+        )
+
+        assertTrue(
+            "desktop Steam sheet should expose an explicit force-private path that closes desktop Steam before private launch",
+            detail.contains("onForcePrivateAfterSteamClose") &&
+                detail.contains("nova_desktop_steam_force_private") &&
+                serverHelper.contains("Game.EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE") &&
+                game.contains("EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE") &&
+                nvHttp.contains("closeDesktopSteamForPrivate=1") &&
+                nvHttp.contains("launchMode=force_private_stream")
+        )
+        assertTrue(
+            "Game connection failures should route through the Nova themed launch issue drawer instead of legacy square Dialog.displayDialog",
+            game.contains("showNovaLaunchIssueSheet(") &&
+                ! errorSection.contains("Dialog.displayDialog(")
+        )
+        assertTrue(
+            "Launch issue drawer must use shared transparent Nova glass sheet chrome so the old bottom-sheet theme background cannot peek out as a clipped bump",
+            game.contains("NovaSheetChrome.applyBottomSheetChrome(") &&
+                game.contains("NovaSheetChrome.createSheetBackground(") &&
+                !game.contains("setBackgroundColor(Color.rgb(18, 22, 28))")
+        )
+        assertTrue(
+            "Nova drawers should let content scroll down without minimizing the whole sheet; only the top handle strip may drag-dismiss",
+            detail.contains("behavior.isDraggable = false") &&
+                detail.contains("novaSheetHandleDrag") &&
+                detail.contains("onSheetHandleDismiss") &&
+                syncSheetGestureIsLocked() &&
+                chrome.contains("isDraggable = false") &&
+                chrome.contains("attachHandleDragToDismiss") &&
+                game.contains("NovaSheetChrome.attachHandleDragToDismiss(handle, sheet)")
+        )
+    }
+
+
+    @Test
+    fun transientPopupsUseQuietThemeAwareChromeInsteadOfPurpleSnackbarCards() {
+        val snackbar = readSource("src/main/java/com/papi/nova/ui/NovaSnackbar.kt")
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+
+        assertTrue(
+            "Nova Snackbar should use active NovaThemeManager glass tokens, not hardcoded elevated purple card colors",
+            snackbar.contains("NovaThemeManager.getDialogBackgroundColor(activity)") &&
+                snackbar.contains("NovaThemeManager.getTextPrimaryColor(activity)") &&
+                snackbar.contains("NovaThemeManager.getAccentColor(activity)") &&
+                !snackbar.contains("setBackgroundTint(activity.getColor(R.color.nova_bg_elevated))")
+        )
+        assertTrue(
+            "Streaming transient messages should not stack Android toast/purple card popups over the launch drawer/overlay",
+            game.contains("showQuietStreamTransientMessage") &&
+                game.contains("NovaSnackbar.showQuiet") &&
+                !game.section("override fun displayTransientMessage", "override fun rumble").contains("Toast.makeText")
+        )
+    }
+
+    @Test
+    fun composeBottomSheetsUseThemeAwareGlassHostInsteadOfStaticOldThemeInset() {
+        val gameDetailSheet = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val syncSheet = readSource("src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt")
+
+        assertTrue(
+            "Game detail sheet must clear/style the Material host with shared Nova glass chrome so bottom/nav inset gaps do not show old static blue chrome",
+            gameDetailSheet.contains("NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog, contentView)") &&
+                gameDetailSheet.contains("NovaSheetChrome.createSheetBackground(requireContext())") &&
+                !gameDetailSheet.contains("sheet.setBackgroundResource(sheetBackgroundRes())")
+        )
+        assertTrue(
+            "Polaris sync sheet must use the same theme-aware host chrome instead of static nova_sheet_bg inset background",
+            syncSheet.contains("NovaSheetChrome.applyBottomSheetChrome(bottomSheetDialog, contentView)") &&
+                !syncSheet.contains("sheet.setBackgroundResource")
+        )
+    }
+
+    @Test
     fun shortcutLaunchUsesPolarisPreflightBeforeStartingStream() {
         val trampoline = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
         val serverHelper = readSource("src/main/java/com/papi/nova/utils/ServerHelper.kt")
@@ -293,6 +415,12 @@ class NovaLaunchSourceGuardTest {
 
     private fun readSource(path: String): String =
         String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
+
+
+    private fun syncSheetGestureIsLocked(): Boolean {
+        val sync = readSource("src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt")
+        return sync.contains("isDraggable = false")
+    }
 
     private fun String.section(startMarker: String, endMarker: String): String =
         substring(indexOf(startMarker), indexOf(endMarker))


### PR DESCRIPTION
## Summary
- Show a Nova glass decision sheet when Polaris reports desktop Steam is active.
- Add explicit actions for Close desktop Steam and start private stream, Mirror Desktop, and Cancel.
- Carry force-private and mirror-desktop launch intent through ServerHelper, StreamConfiguration, and NvHTTP.
- Route launch failures and transient stream messages through themed Nova chrome, folding into the existing shared NovaSheetChrome helper.

## Verification
- ./gradlew :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaLaunchSourceGuardTest --tests com.papi.nova.ui.NovaGameDetailUiStateTest --tests com.papi.nova.KotlinGameRuntimeMigrationTest
- ./gradlew :app:assembleRootDebug
- End-to-end Retroid/Nova smoke previously verified with Polaris branch: decision sheet appears, Close desktop Steam and start private stream succeeds, stream surface appears, no 409/error drawer, and desktop Steam processes are gone afterward.

## Notes
- Companion Polaris PR: https://github.com/papi-ux/polaris/pull/153
- Remaining human-side release smoke: physical monitor confirmation for Cancel, Mirror Desktop, and Close desktop Steam paths.
