### PR TITLE
Consolidate Nova Debug dogfood fixes

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5329,7 +5329,10 @@ novaApiClient == null ||
 return
 }
 
-novaProgressOverlay!!.show()
+if (!connected && !isStreamActive)
+{
+novaProgressOverlay?.show()
+}
 novaEventSource = com.papi.nova.api.PolarisEventSource(host ?: "",
 object : com.papi.nova.api.PolarisEventSource.EventListener {
 override fun onSessionEvent(event:String, state:String, message:String) {

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5946,6 +5946,7 @@ stopPolarisLiveSessionStatusRefresh()
 novaReconnectOverlay?.dismiss()
 novaProgressOverlay?.dismiss()
 stopBackgroundResumeWindow()
+novaResilienceManager?.shutdown()
 finish()
 }
 }

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -745,7 +745,6 @@ e!!.printStackTrace()
  // Nova: set up Polaris integration without blocking stream startup on REST probes.
         com.papi.nova.manager.FeatureFlagManager.reset()
 novaApiClient = com.papi.nova.api.PolarisApiClient(this, host ?: "", httpsPort, serverCert)
-novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)
 novaLockScreenOverlay = com.papi.nova.ui.LockScreenOverlay(this, novaApiClient!!)
 novaReconnectOverlay = com.papi.nova.ui.ReconnectOverlay(this)
 novaResilienceManager = com.papi.nova.manager.ConnectionResilienceManager(

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -551,9 +551,20 @@ displayHeight = if (shouldInvertDecoderResolution) prefConfig!!.width else prefC
 	            setPreferredOrientationForActivity()
 	}
 
-if (watchOnlyRequested && watchStreamWidth > 0 && watchStreamHeight > 0)
+watchOnlyRequested = this@Game.getIntent().getBooleanExtra(EXTRA_WATCH_ONLY, false)
+watchStreamWidth = this@Game.getIntent().getIntExtra(EXTRA_STREAM_WIDTH, 0)
+watchStreamHeight = this@Game.getIntent().getIntExtra(EXTRA_STREAM_HEIGHT, 0)
+watchStreamFps = this@Game.getIntent().getFloatExtra(EXTRA_STREAM_FPS, 0f)
+if (watchStreamWidth > 0 && watchStreamHeight > 0)
+{
+if (watchOnlyRequested)
 {
 LimeLog.info("Nova: Watch mode using active stream resolution " + watchStreamWidth + "x" + watchStreamHeight)
+}
+else
+{
+LimeLog.info("Nova: Launch using explicit stream resolution " + watchStreamWidth + "x" + watchStreamHeight)
+}
 displayWidth = watchStreamWidth
 displayHeight = watchStreamHeight
 }
@@ -709,10 +720,6 @@ vDisplay = this@Game.getIntent().getBooleanExtra(EXTRA_VDISPLAY, false)
 var displayModeExplicit:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_DISPLAY_MODE_EXPLICIT, false)
 mirrorDesktop = this@Game.getIntent().getBooleanExtra(EXTRA_MIRROR_DESKTOP, false)
 forcePrivateAfterSteamClose = this@Game.getIntent().getBooleanExtra(EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, false)
-watchOnlyRequested = this@Game.getIntent().getBooleanExtra(EXTRA_WATCH_ONLY, false)
-watchStreamWidth = this@Game.getIntent().getIntExtra(EXTRA_STREAM_WIDTH, 0)
-watchStreamHeight = this@Game.getIntent().getIntExtra(EXTRA_STREAM_HEIGHT, 0)
-watchStreamFps = this@Game.getIntent().getFloatExtra(EXTRA_STREAM_FPS, 0f)
 launchProfilePreference = this@Game.getIntent().getStringExtra(EXTRA_AI_PROFILE_PREFERENCE) ?: ""
 launchOptimizationJson = this@Game.getIntent().getStringExtra(EXTRA_LAUNCH_OPTIMIZATION)
 serverCmds = this@Game.getIntent().getStringArrayListExtra(EXTRA_SERVER_COMMANDS) ?: ArrayList()
@@ -950,18 +957,25 @@ if (prefConfig!!.onscreenController)
             gamepadMask = gamepadMask or 1
 }
 
-var watchStreamFpsOverride:Boolean = watchOnlyRequested && watchStreamFps > 0f
-var launchRefreshRate:Float = if (watchStreamFpsOverride) watchStreamFps else prefConfig!!.fps
+var explicitStreamFpsOverride:Boolean = watchStreamFps > 0f
+var launchRefreshRate:Float = if (explicitStreamFpsOverride) watchStreamFps else prefConfig!!.fps
 var maxSupportedLaunchRefreshRate:Float = getMaxSupportedRefreshRate(currentDisplay)
-if (!watchStreamFpsOverride && (maxSupportedLaunchRefreshRate > 0 && launchRefreshRate > maxSupportedLaunchRefreshRate + 0.5f))
+if (!explicitStreamFpsOverride && (maxSupportedLaunchRefreshRate > 0 && launchRefreshRate > maxSupportedLaunchRefreshRate + 0.5f))
 {
 LimeLog.info(("Clamping launch refresh rate from " + launchRefreshRate +
 " to display max " + maxSupportedLaunchRefreshRate))
 launchRefreshRate = maxSupportedLaunchRefreshRate
 }
-if (watchStreamFpsOverride)
+if (explicitStreamFpsOverride)
+{
+if (watchOnlyRequested)
 {
 LimeLog.info("Nova: Watch mode using active stream FPS " + watchStreamFps)
+}
+else
+{
+LimeLog.info("Nova: Launch using explicit stream FPS " + watchStreamFps)
+}
 }
 var autoSafeTargetFps:Float = com.papi.nova.manager.StreamSyncManager.resolveAutoSafeTargetFps(
 launchRefreshRate,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -151,6 +151,8 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         var mangoHudEnabled by mutableStateOf(game.mangohud)
         var resetWorking by mutableStateOf(false)
         var optimizationState by mutableStateOf(NovaGameDetailOptimizationState())
+        var launchOptionsState by mutableStateOf<NovaLaunchOptionsState?>(null)
+        var profileOptionsState by mutableStateOf<NovaProfilePreferenceOptionsState?>(null)
 
         fun refreshUiState(preference: String = profilePreference) {
             uiState = buildUiState(currentGame, preference)
@@ -251,6 +253,8 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                     steamLaunchModeLabel = steamLaunchModeLabel(uiState.steamLaunchMode),
                     steamLaunchCaption = steamLaunchCaption(uiState),
                     optimizationState = optimizationState,
+                    launchOptionsState = launchOptionsState,
+                    profileOptionsState = profileOptionsState,
                     playLabel = if (optimizationState.reviewRequired) {
                         getString(R.string.nova_library_review_and_launch)
                     } else {
@@ -311,22 +315,61 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                         }
                     },
                     onLaunchOptions = {
-                        showLaunchOptions(
-                            currentGame,
-                            uiState,
-                            mangoHudEnabled,
-                            profilePreference,
-                            optimizationState.rawOptimization
-                        )
+                        val nextState = showLaunchOptions(currentGame, uiState)
+                        if (nextState == null) {
+                            Toast.makeText(requireContext(), R.string.nova_library_no_launch_modes, Toast.LENGTH_SHORT).show()
+                        } else {
+                            launchOptionsState = nextState
+                            profileOptionsState = null
+                        }
                     },
                     onLaunchModeSelected = ::selectLaunchMode,
-                    onProfilePreference = {
-                        showProfilePreferenceOptions(currentGame) { selected ->
-                            profilePreference = selected
-                            refreshUiState(selected)
-                            optimizationState = NovaGameDetailOptimizationState()
-                            loadOptimization(selected)
+                    onLaunchOptionSelected = { option ->
+                        fun launchSelected(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
+                            onLaunch?.invoke(
+                                currentGame.copy(mangohud = mangoHudEnabled),
+                                option.usesVirtualDisplay,
+                                mirrorDesktop,
+                                forcePrivateAfterSteamClose,
+                                profilePreference,
+                                optimizationState.rawOptimization
+                            )
+                            launchOptionsState = null
+                            dismiss()
                         }
+                        val desktopSteamDecision = NovaDesktopSteamLaunchDecision.from(
+                            uiState,
+                            optimizationState.rawOptimization,
+                            usesVirtualDisplay = option.usesVirtualDisplay
+                        )
+                        if (desktopSteamDecision.required) {
+                            showDesktopSteamLaunchDecision(
+                                decision = desktopSteamDecision,
+                                onPrivateStream = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = false) },
+                                onMirrorDesktop = { launchSelected(mirrorDesktop = true, forcePrivateAfterSteamClose = false) },
+                                onForcePrivateAfterSteamClose = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }
+                            )
+                        } else {
+                            launchSelected(mirrorDesktop = false)
+                        }
+                    },
+                    onDismissLaunchOptions = {
+                        launchOptionsState = null
+                    },
+                    onProfilePreference = {
+                        profileOptionsState = showProfilePreferenceOptions(currentGame)
+                        launchOptionsState = null
+                    },
+                    onProfilePreferenceSelected = { selected ->
+                        saveProfilePreference(currentGame, selected.value)
+                        profilePreference = selected.value
+                        refreshUiState(selected.value)
+                        optimizationState = NovaGameDetailOptimizationState()
+                        profileOptionsState = null
+                        loadOptimization(selected.value)
+                    },
+                    onDismissProfileOptions = {
+                        profileOptionsState = null
                     },
                     onRetryHighFps = { retryHighFpsTrial() },
                     onResetProfile = {
@@ -429,10 +472,10 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
     }
 
     private fun showProfilePreferenceOptions(
-        game: PolarisGame,
-        onChanged: (String) -> Unit
-    ) {
+        game: PolarisGame
+    ): NovaProfilePreferenceOptionsState {
         val values = AutoQualityProfilePreferences.values()
+        val current = loadProfilePreference(game)
         val labels = values.map {
             when (it) {
                 "quality" -> "Prefer Quality"
@@ -440,17 +483,18 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                 "stability" -> "Prefer Stability"
                 else -> "Auto"
             }
-        }.toTypedArray()
-        val checked = values.indexOf(loadProfilePreference(game)).coerceAtLeast(0)
-        AlertDialog.Builder(requireContext())
-            .setTitle(R.string.nova_library_profile_preference_title)
-            .setSingleChoiceItems(labels, checked) { dialog, which ->
-                val selected = values[which]
-                saveProfilePreference(game, selected)
-                onChanged(selected)
-                dialog.dismiss()
+        }
+        return NovaProfilePreferenceOptionsState(
+            title = getString(R.string.nova_library_profile_preference_title),
+            closeLabel = getString(R.string.nova_controller_hint_close),
+            options = values.mapIndexed { index, value ->
+                NovaProfilePreferenceItem(
+                    label = labels[index],
+                    value = value,
+                    selected = value == current
+                )
             }
-            .show()
+        )
     }
 
     private fun showSteamLaunchModeOptions(
@@ -471,57 +515,32 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
 
     private fun showLaunchOptions(
         game: PolarisGame,
-        uiState: NovaGameDetailUiState,
-        mangoHudEnabled: Boolean,
-        profilePreference: String,
-        rawOptimization: JSONObject?
-    ) {
-        val options = mutableListOf<Pair<String, Boolean>>()
+        uiState: NovaGameDetailUiState
+    ): NovaLaunchOptionsState? {
+        val options = mutableListOf<NovaLaunchOptionItem>()
         if (uiState.headlessAllowed) {
-            options += optionLabel("headless", uiState.recommendedMode) to false
+            options += NovaLaunchOptionItem(
+                label = optionLabel("headless", uiState.recommendedMode),
+                usesVirtualDisplay = false,
+                recommended = uiState.recommendedMode == "headless"
+            )
         }
         if (uiState.virtualDisplayAllowed) {
-            options += optionLabel("virtual_display", uiState.recommendedMode) to true
+            options += NovaLaunchOptionItem(
+                label = optionLabel("virtual_display", uiState.recommendedMode),
+                usesVirtualDisplay = true,
+                recommended = uiState.recommendedMode == "virtual_display"
+            )
         }
 
-        if (options.isEmpty()) {
-            Toast.makeText(requireContext(), R.string.nova_library_no_launch_modes, Toast.LENGTH_SHORT).show()
-            return
-        }
+        if (options.isEmpty()) return null
 
-        AlertDialog.Builder(requireContext())
-            .setTitle(R.string.nova_library_launch_options_title)
-            .setItems(options.map { it.first }.toTypedArray()) { dialog, which ->
-                val selectedUsesVirtualDisplay = options[which].second
-                fun launchSelected(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
-                    onLaunch?.invoke(
-                        game.copy(mangohud = mangoHudEnabled),
-                        selectedUsesVirtualDisplay,
-                        mirrorDesktop,
-                        forcePrivateAfterSteamClose,
-                        profilePreference,
-                        rawOptimization
-                    )
-                    dismiss()
-                }
-                val desktopSteamDecision = NovaDesktopSteamLaunchDecision.from(
-                    uiState,
-                    rawOptimization,
-                    usesVirtualDisplay = selectedUsesVirtualDisplay
-                )
-                dialog.dismiss()
-                if (desktopSteamDecision.required) {
-                    showDesktopSteamLaunchDecision(
-                        decision = desktopSteamDecision,
-                        onPrivateStream = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = false) },
-                        onMirrorDesktop = { launchSelected(mirrorDesktop = true, forcePrivateAfterSteamClose = false) },
-                        onForcePrivateAfterSteamClose = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }
-                    )
-                } else {
-                    launchSelected(mirrorDesktop = false)
-                }
-            }
-            .show()
+        return NovaLaunchOptionsState(
+            title = getString(R.string.nova_library_launch_options_title),
+            closeLabel = getString(R.string.nova_controller_hint_close),
+            gameName = game.name,
+            options = options
+        )
     }
 
     private fun optionLabel(mode: String, recommendedMode: String): String {
@@ -1023,6 +1042,31 @@ data class NovaGameDetailOptimizationState(
     val reviewReason: String = ""
 )
 
+data class NovaLaunchOptionsState(
+    val title: String,
+    val closeLabel: String,
+    val gameName: String,
+    val options: List<NovaLaunchOptionItem>
+)
+
+data class NovaLaunchOptionItem(
+    val label: String,
+    val usesVirtualDisplay: Boolean,
+    val recommended: Boolean
+)
+
+data class NovaProfilePreferenceOptionsState(
+    val title: String,
+    val closeLabel: String,
+    val options: List<NovaProfilePreferenceItem>
+)
+
+data class NovaProfilePreferenceItem(
+    val label: String,
+    val value: String,
+    val selected: Boolean
+)
+
 data class NovaGameDetailInsightCard(
     val label: String,
     val source: String,
@@ -1048,6 +1092,8 @@ fun NovaGameDetailSheetContent(
     steamLaunchModeLabel: String,
     steamLaunchCaption: String,
     optimizationState: NovaGameDetailOptimizationState,
+    launchOptionsState: NovaLaunchOptionsState?,
+    profileOptionsState: NovaProfilePreferenceOptionsState?,
     playLabel: String,
     launchOptionsLabel: String,
     launchModeTitle: String,
@@ -1058,7 +1104,11 @@ fun NovaGameDetailSheetContent(
     onPrimaryLaunch: () -> Unit,
     onLaunchOptions: () -> Unit,
     onLaunchModeSelected: (String) -> Unit,
+    onLaunchOptionSelected: (NovaLaunchOptionItem) -> Unit,
+    onDismissLaunchOptions: () -> Unit,
     onProfilePreference: () -> Unit,
+    onProfilePreferenceSelected: (NovaProfilePreferenceItem) -> Unit,
+    onDismissProfileOptions: () -> Unit,
     onRetryHighFps: () -> Unit,
     onResetProfile: () -> Unit,
     onSteamLaunchMode: () -> Unit,
@@ -1106,6 +1156,22 @@ fun NovaGameDetailSheetContent(
             onRetryHighFps = onRetryHighFps,
             onResetProfile = onResetProfile
         )
+
+        launchOptionsState?.let {
+            NovaLaunchOptionsSheet(
+                state = it,
+                onLaunch = onLaunchOptionSelected,
+                onDismiss = onDismissLaunchOptions
+            )
+        }
+
+        profileOptionsState?.let {
+            NovaProfilePreferenceSheet(
+                state = it,
+                onSelected = onProfilePreferenceSelected,
+                onDismiss = onDismissProfileOptions
+            )
+        }
 
         SteamLaunchModeCard(
             visible = uiState.showSteamLaunchMode,
@@ -1808,6 +1874,123 @@ private fun ProfileSummaryText(text: String, topPadding: Int = 3) {
         maxLines = 3,
         overflow = TextOverflow.Ellipsis
     )
+}
+
+
+@Composable
+private fun NovaLaunchOptionsSheet(
+    state: NovaLaunchOptionsState,
+    onLaunch: (NovaLaunchOptionItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    NovaOptionPanel(
+        title = state.title,
+        subtitle = state.gameName,
+        closeLabel = state.closeLabel,
+        onDismiss = onDismiss
+    ) {
+        state.options.forEach { option ->
+            NovaActionButton(
+                text = option.label,
+                onClick = { onLaunch(option) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                primary = option.recommended,
+                contentDescription = option.label,
+                minHeight = 44.dp,
+                cornerRadius = 10.dp,
+                fontSize = 13.sp,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 9.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun NovaProfilePreferenceSheet(
+    state: NovaProfilePreferenceOptionsState,
+    onSelected: (NovaProfilePreferenceItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    NovaOptionPanel(
+        title = state.title,
+        subtitle = "Auto Quality",
+        closeLabel = state.closeLabel,
+        onDismiss = onDismiss
+    ) {
+        state.options.forEach { option ->
+            NovaActionButton(
+                text = if (option.selected) option.label + " · Selected" else option.label,
+                onClick = { onSelected(option) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                primary = option.selected,
+                contentDescription = option.label,
+                minHeight = 44.dp,
+                cornerRadius = 10.dp,
+                fontSize = 13.sp,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 9.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun NovaOptionPanel(
+    title: String,
+    subtitle: String,
+    closeLabel: String,
+    onDismiss: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    val colors = LocalNovaComposeColors.current
+    NovaDetailPanel(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 14.dp, end = 14.dp, top = 10.dp),
+        contentDescription = title,
+        accent = true,
+        contentPadding = PaddingValues(12.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    color = colors.textPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (subtitle.isNotBlank()) {
+                    Text(
+                        text = subtitle,
+                        modifier = Modifier.padding(top = 2.dp),
+                        color = colors.textMuted,
+                        fontSize = 10.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            NovaActionButton(
+                text = closeLabel,
+                onClick = onDismiss,
+                modifier = Modifier.width(104.dp),
+                contentDescription = closeLabel,
+                minHeight = 36.dp,
+                cornerRadius = 10.dp,
+                fontSize = 11.sp,
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 7.dp)
+            )
+        }
+        content()
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/papi/nova/ui/NovaHudPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudPreferences.kt
@@ -1,0 +1,53 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.papi.nova.preferences.NovaSettingDefinition
+import com.papi.nova.preferences.NovaSettingDefinitions
+import com.papi.nova.preferences.NovaSettingValue
+import com.papi.nova.preferences.NovaSettingsRepository
+import com.papi.nova.preferences.NovaSettingsStore
+
+object NovaHudPreferences {
+    const val KEY_OPACITY = "nova_polaris_hud_opacity"
+    const val DEFAULT_OPACITY_PERCENT = 90
+    const val MIN_OPACITY_PERCENT = 25
+    const val MAX_OPACITY_PERCENT = 100
+
+    val OPACITY_PRESETS = listOf(25, 50, 75, 90, 100)
+
+    fun coerceOpacityPercent(percent: Int): Int {
+        return percent.coerceIn(MIN_OPACITY_PERCENT, MAX_OPACITY_PERCENT)
+    }
+
+    fun readOpacityPercent(prefs: SharedPreferences): Int {
+        return coerceOpacityPercent(prefs.getInt(KEY_OPACITY, DEFAULT_OPACITY_PERCENT))
+    }
+
+    fun writeOpacityPercent(prefs: SharedPreferences, percent: Int) {
+        prefs.edit()
+            .putInt(KEY_OPACITY, coerceOpacityPercent(percent))
+            .apply()
+    }
+
+    suspend fun writeOpacityPercent(context: Context, percent: Int) {
+        val definitions = NovaSettingDefinitions.load(context)
+        writeOpacityPercent(
+            store = NovaSettingsRepository.create(context),
+            definition = definitions.require(KEY_OPACITY),
+            percent = percent
+        )
+    }
+
+    suspend fun writeOpacityPercent(
+        store: NovaSettingsStore,
+        definition: NovaSettingDefinition,
+        percent: Int
+    ) {
+        store.set(definition, NovaSettingValue.IntValue(coerceOpacityPercent(percent)))
+    }
+
+    fun opacityScale(percent: Int): Float {
+        return coerceOpacityPercent(percent) / 100f
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -112,6 +112,7 @@ import com.papi.nova.NovaSessionEndSignal
 import com.papi.nova.R
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.api.PolarisClientSettings
+import com.papi.nova.manager.StreamSyncManager
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.binding.PlatformBinding
 import com.papi.nova.nvstream.http.ComputerDetails
@@ -609,6 +610,22 @@ class NovaLibraryActivity : AppCompatActivity() {
                     LimeLog.warning("Nova: MangoHUD launch state sync failed; continuing launch")
                 }
                 val preferences = com.papi.nova.preferences.PreferenceConfiguration.readPreferences(this@NovaLibraryActivity)
+                val launchResolution = StreamSyncManager.resolveAutoSafeResolution(
+                    preferences.width,
+                    preferences.height,
+                    preflightOptimization
+                )
+                val launchFps = StreamSyncManager.resolveAutoSafeTargetFps(
+                    preferences.fps,
+                    preflightOptimization
+                )
+                LimeLog.info(
+                    "Nova: Launch resolved stream mode " +
+                        launchResolution.width + "x" + launchResolution.height + "x" + launchFps + " " +
+                        "source=" + (preflightOptimization?.optString("source", "") ?: "") + " " +
+                        "effectiveFps=" + (preflightOptimization?.optDouble("effective_target_fps", 0.0) ?: 0.0) + " " +
+                        "displayMode=" + (preflightOptimization?.optString("display_mode", "") ?: "")
+                )
                 val syncedSettings = withContext(Dispatchers.IO) {
                     apiClient.updateClientSettings(
                         streamDisplayMode = when {
@@ -617,9 +634,9 @@ class NovaLibraryActivity : AppCompatActivity() {
                             else -> "headless_stream"
                         },
                         displayMode = com.papi.nova.preferences.PreferenceConfiguration.formatStreamingDisplayMode(
-                            preferences.width,
-                            preferences.height,
-                            preferences.fps
+                            launchResolution.width,
+                            launchResolution.height,
+                            launchFps
                         ),
                         targetBitrateKbps = preferences.bitrate.takeIf { it > 0 }
                     )
@@ -643,6 +660,9 @@ class NovaLibraryActivity : AppCompatActivity() {
                     true,
                     false,
                     serverCert,
+                    launchResolution.width,
+                    launchResolution.height,
+                    launchFps,
                     aiProfilePreference = profilePreference,
                     launchOptimizationJson = preflightOptimization?.toString(),
                     mirrorDesktop = mirrorDesktop,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.preference.PreferenceManager
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.papi.nova.Game
 import com.papi.nova.LimeLog
@@ -76,6 +77,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         val apiClient = game.novaApiClient ?: getServerAddress()?.let {
             PolarisApiClient(game.applicationContext, it, getHttpsPort())
         }
+        val prefs = PreferenceManager.getDefaultSharedPreferences(game)
 
         var sessionStatus: PolarisSessionStatus? = null
         var capabilities: PolarisCapabilities? = null
@@ -145,6 +147,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 currentGameUuid = currentGameUuid(),
                 profilePreference = currentProfilePreference(gameName),
                 hudShowing = game.isNovaHudShowing(),
+                hudOpacityPercent = NovaHudPreferences.readOpacityPercent(prefs),
                 perfOverlayEnabled = game.prefConfig.enablePerfOverlay,
                 onscreenControllerEnabled = game.prefConfig.onscreenController,
                 keyboardVisible = game.isKeyboardLayoutVisible,
@@ -402,6 +405,16 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                         else -> Unit
                     }
                     refreshState()
+                }
+            },
+            onHudOpacityChange = { percent ->
+                haptic {
+                    game.launchRuntimeIo("NovaQuickMenuHudOpacity") {
+                        NovaHudPreferences.writeOpacityPercent(game, percent)
+                        game.runOnMainIfRuntimeActive {
+                            refreshState()
+                        }
+                    }
                 }
             },
             onControlAction = { actionId ->

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -76,6 +76,7 @@ data class NovaQuickMenuCallbacks(
     val onProfilePreference: (String) -> Unit = {},
     val onQuickKey: (NovaQuickMenuActionId) -> Unit = {},
     val onOverlayAction: (NovaQuickMenuActionId) -> Unit = {},
+    val onHudOpacityChange: (Int) -> Unit = {},
     val onControlAction: (NovaQuickMenuActionId) -> Unit = {},
     val onSessionAction: (NovaQuickMenuActionId) -> Unit = {}
 ) {
@@ -271,6 +272,10 @@ fun NovaQuickMenuContent(
             state.overlayRows.forEach { row ->
                 NovaQuickMenuRow(action = row, callbacks = callbacks)
             }
+            NovaQuickMenuHudOpacityControl(
+                state = state,
+                callbacks = callbacks
+            )
         }
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuPanel(title = quickKeysTitle) {
@@ -673,6 +678,83 @@ private fun NovaQuickMenuRow(action: NovaQuickMenuAction, callbacks: NovaQuickMe
             action.chip?.let {
                 Spacer(Modifier.width(8.dp))
                 NovaQuickMenuChipView(it)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaQuickMenuHudOpacityControl(
+    state: NovaQuickMenuUiState,
+    callbacks: NovaQuickMenuCallbacks
+) {
+    val colors = LocalNovaComposeColors.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.nova_quick_menu_hud_opacity),
+                color = colors.textPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            NovaQuickMenuChipView(
+                NovaQuickMenuChip(
+                    label = state.hudOpacity.percent.toString() + "%",
+                    tone = if (state.hudOpacity.enabled) NovaQuickMenuTone.INFO else NovaQuickMenuTone.INACTIVE
+                )
+            )
+        }
+        Text(
+            text = stringResource(
+                if (state.hudOpacity.enabled) {
+                    R.string.nova_quick_menu_hud_opacity_caption
+                } else {
+                    R.string.nova_quick_menu_hud_opacity_disabled_caption
+                }
+            ),
+            color = colors.textMuted,
+            fontSize = 10.sp,
+            lineHeight = 13.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 5.dp)
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            state.hudOpacity.presets.forEach { percent ->
+                val selected = percent == state.hudOpacity.percent
+                NovaActionButton(
+                    text = percent.toString() + "%",
+                    onClick = { callbacks.onHudOpacityChange(percent) },
+                    modifier = Modifier.weight(1f),
+                    enabled = state.hudOpacity.enabled,
+                    primary = selected,
+                    contentDescription = stringResource(
+                        R.string.nova_quick_menu_hud_opacity_preset_cd,
+                        percent
+                    ),
+                    selected = selected,
+                    stateDescription = stringResource(
+                        if (selected) {
+                            R.string.nova_quick_menu_hud_opacity_selected
+                        } else {
+                            R.string.nova_quick_menu_hud_opacity_not_selected
+                        }
+                    ),
+                    cornerRadius = 9.dp,
+                    minHeight = 44.dp,
+                    fontSize = 10.sp,
+                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -73,6 +73,12 @@ data class NovaQuickMenuStabilityState(
     val profileOptions: List<NovaQuickMenuPreferenceOption>
 )
 
+data class NovaQuickMenuHudOpacityState(
+    val percent: Int,
+    val presets: List<Int>,
+    val enabled: Boolean
+)
+
 data class NovaQuickMenuUiState(
     val title: String,
     val subtitle: String,
@@ -87,6 +93,7 @@ data class NovaQuickMenuUiState(
     val advancedExpanded: Boolean,
     val advancedRows: List<NovaQuickMenuAction>,
     val quickKeys: List<NovaQuickMenuAction>,
+    val hudOpacity: NovaQuickMenuHudOpacityState,
     val overlayRows: List<NovaQuickMenuAction>,
     val controlRows: List<NovaQuickMenuAction>,
     val sessionRows: List<NovaQuickMenuAction>
@@ -110,6 +117,7 @@ data class NovaQuickMenuUiState(
             currentGameUuid: String?,
             profilePreference: String,
             hudShowing: Boolean,
+            hudOpacityPercent: Int = NovaHudPreferences.DEFAULT_OPACITY_PERCENT,
             perfOverlayEnabled: Boolean,
             onscreenControllerEnabled: Boolean,
             keyboardVisible: Boolean,
@@ -285,6 +293,12 @@ data class NovaQuickMenuUiState(
                 mangoRisk
             )
 
+            val hudOpacity = NovaQuickMenuHudOpacityState(
+                percent = NovaHudPreferences.coerceOpacityPercent(hudOpacityPercent),
+                presets = NovaHudPreferences.OPACITY_PRESETS,
+                enabled = hudShowing
+            )
+
             val overlays = listOf(
                 NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.NOVA_HUD,
@@ -376,6 +390,7 @@ data class NovaQuickMenuUiState(
                 advancedExpanded = advancedExpanded,
                 advancedRows = listOf(aiRow, clearRow, mangoRow),
                 quickKeys = quickKeyActions(context),
+                hudOpacity = hudOpacity,
                 overlayRows = overlays,
                 controlRows = controls,
                 sessionRows = sessionRows
@@ -424,6 +439,7 @@ data class NovaQuickMenuUiState(
                 currentGameUuid = "game-1",
                 profilePreference = "auto",
                 hudShowing = false,
+                hudOpacityPercent = NovaHudPreferences.DEFAULT_OPACITY_PERCENT,
                 perfOverlayEnabled = false,
                 onscreenControllerEnabled = false,
                 keyboardVisible = false,

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui
 
 import android.app.Activity
+import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
@@ -51,6 +52,14 @@ class NovaStreamHud(
     private var recoveredFrames = 0
     private var bitrateReduced = false
     private val sparklineData = NovaHudSparklineBuffer()
+    private val hudOpacityScale = mutableStateOf(1f)
+    private val preferenceListener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+        if (key == NovaHudPreferences.KEY_OPACITY) {
+            hudOpacityScale.value = NovaHudPreferences.opacityScale(
+                NovaHudPreferences.readOpacityPercent(prefs)
+            )
+        }
+    }
 
     var onBitrateAdjust: ((Int) -> Unit)? = null
 
@@ -70,13 +79,20 @@ class NovaStreamHud(
             resetSessionState()
             val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
             currentMode = NovaHudMode.fromPreference(prefs.getString("nova_polaris_hud_mode", "minimal"))
+            hudOpacityScale.value = NovaHudPreferences.opacityScale(
+                NovaHudPreferences.readOpacityPercent(prefs)
+            )
+            prefs.registerOnSharedPreferenceChangeListener(preferenceListener)
             publishState()
 
             val composeView = ComposeView(activity).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
                 setContent {
                     NovaComposeTheme {
-                        NovaStreamHudContent(state = hudState.value)
+                        NovaStreamHudContent(
+                            state = hudState.value,
+                            opacityScale = hudOpacityScale.value
+                        )
                     }
                 }
             }
@@ -423,6 +439,8 @@ class NovaStreamHud(
         activity.runOnUiThread {
             val view = hudView
             hudView = null
+            PreferenceManager.getDefaultSharedPreferences(activity)
+                .unregisterOnSharedPreferenceChangeListener(preferenceListener)
             sparklineData.clear()
             view?.let { safeRemoveFromParent(it) }
         }
@@ -447,7 +465,6 @@ class NovaStreamHud(
         private const val HUD_SAFE_MARGIN_DP = 12f
         private const val PREF_HUD_X = "nova_polaris_hud_x"
         private const val PREF_HUD_Y = "nova_polaris_hud_y"
-
         fun isEnabled(activity: Activity): Boolean {
             return PreferenceManager.getDefaultSharedPreferences(activity)
                 .getBoolean("nova_polaris_hud", false)

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -20,6 +20,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,13 +45,24 @@ import com.papi.nova.ui.compose.NovaInGameOverlayAlpha
 @Composable
 fun NovaStreamHudContent(
     state: NovaHudUiState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    opacityScale: Float = 1f
 ) {
-    when (state.mode) {
-        NovaHudMode.DEBUG -> NovaStreamHudDebug(state, modifier)
-        NovaHudMode.PERFORMANCE -> NovaStreamHudPerformance(state, modifier)
-        NovaHudMode.MINIMAL -> NovaStreamHudMinimal(state, modifier)
+    val hudOpacityScale = rememberHudOpacityScale(opacityScale)
+    CompositionLocalProvider(LocalNovaHudOpacityScale provides hudOpacityScale) {
+        when (state.mode) {
+            NovaHudMode.DEBUG -> NovaStreamHudDebug(state, modifier)
+            NovaHudMode.PERFORMANCE -> NovaStreamHudPerformance(state, modifier)
+            NovaHudMode.MINIMAL -> NovaStreamHudMinimal(state, modifier)
+        }
     }
+}
+
+private val LocalNovaHudOpacityScale = compositionLocalOf { 1f }
+
+@Composable
+private fun rememberHudOpacityScale(opacityScale: Float): Float {
+    return remember(opacityScale) { opacityScale.coerceIn(NovaHudPreferences.MIN_OPACITY_PERCENT / 100f, 1f) }
 }
 
 @Composable
@@ -262,13 +276,18 @@ private fun HudPanel(
     content: @Composable ColumnScope.() -> Unit
 ) {
     val surfaces = LocalNovaLibrarySurfaces.current
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     val panelShape = RoundedCornerShape(cornerRadius)
     Column(
         modifier = modifier
             .shadow(16.dp, panelShape, clip = false)
             .clip(panelShape)
-            .background(surfaces.panel.copy(alpha = NovaInGameOverlayAlpha.GlassPanel))
-            .border(1.dp, surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border), panelShape)
+            .background(surfaces.panel.copy(alpha = NovaInGameOverlayAlpha.GlassPanel * hudOpacityScale))
+            .border(
+                1.dp,
+                surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border * hudOpacityScale),
+                panelShape
+            )
             .padding(padding),
         content = content
     )
@@ -278,12 +297,13 @@ private fun HudPanel(
 private fun HudDiagnosticStrip(state: NovaHudUiState) {
     if (state.healthReasonLabel.isBlank() && state.streamTruthLabel.isBlank()) return
     val surfaces = LocalNovaLibrarySurfaces.current
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 7.dp)
             .clip(RoundedCornerShape(10.dp))
-            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl * hudOpacityScale))
             .padding(horizontal = 7.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -341,10 +361,11 @@ private fun HudLayerHealthRow(layers: List<NovaHudLayerHealth>) {
 @Composable
 private fun HudLayerChip(layer: NovaHudLayerHealth, modifier: Modifier = Modifier) {
     val surfaces = LocalNovaLibrarySurfaces.current
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(9.dp))
-            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl * hudOpacityScale))
             .padding(horizontal = 6.dp, vertical = 4.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -383,11 +404,12 @@ private fun HudMetric(
     valueTone: NovaHudTone = NovaHudTone.MUTED
 ) {
     val surfaces = LocalNovaLibrarySurfaces.current
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     Column(
         modifier = modifier
             .heightIn(min = 40.dp)
             .clip(RoundedCornerShape(10.dp))
-            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl * hudOpacityScale))
             .padding(horizontal = 7.dp, vertical = 5.dp),
         verticalArrangement = Arrangement.Center
     ) {
@@ -465,12 +487,17 @@ private fun HudStatusDot(tone: NovaHudTone, height: Dp) {
 
 @Composable
 private fun HudDivider(horizontalPadding: Dp = 8.dp) {
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     Spacer(
         modifier = Modifier
             .padding(horizontal = horizontalPadding)
             .width(1.dp)
             .height(16.dp)
-            .background(LocalNovaComposeColors.current.accent.copy(alpha = NovaInGameOverlayAlpha.AccentDivider))
+            .background(
+                LocalNovaComposeColors.current.accent.copy(
+                    alpha = NovaInGameOverlayAlpha.AccentDivider * hudOpacityScale
+                )
+            )
     )
 }
 
@@ -481,6 +508,7 @@ private fun NovaHudSparkline(
     modifier: Modifier = Modifier
 ) {
     val lineColor = tone.hudColor()
+    val hudOpacityScale = LocalNovaHudOpacityScale.current
     Canvas(modifier = modifier) {
         if (samples.size < 2 || size.width <= 0f || size.height <= 0f) {
             return@Canvas
@@ -506,18 +534,18 @@ private fun NovaHudSparkline(
         fillPath.lineTo((samples.size - 1) * stepX, size.height)
         fillPath.close()
         drawLine(
-            color = lineColor.copy(alpha = NovaInGameOverlayAlpha.SparklineGuide),
+            color = lineColor.copy(alpha = NovaInGameOverlayAlpha.SparklineGuide * hudOpacityScale),
             start = Offset(0f, size.height - 1f),
             end = Offset(size.width, size.height - 1f),
             strokeWidth = 1f
         )
         drawLine(
-            color = lineColor.copy(alpha = 0.10f),
+            color = lineColor.copy(alpha = 0.10f * hudOpacityScale),
             start = Offset(0f, 1f),
             end = Offset(size.width, 1f),
             strokeWidth = 1f
         )
-        drawPath(fillPath, lineColor.copy(alpha = NovaInGameOverlayAlpha.SparklineFill))
+        drawPath(fillPath, lineColor.copy(alpha = NovaInGameOverlayAlpha.SparklineFill * hudOpacityScale))
         drawPath(
             path = linePath,
             color = lineColor,

--- a/app/src/main/java/com/papi/nova/ui/StreamContainer.kt
+++ b/app/src/main/java/com/papi/nova/ui/StreamContainer.kt
@@ -8,11 +8,13 @@ import android.view.KeyEvent
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
+import android.view.View
 import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.widget.FrameLayout
 import com.papi.nova.Game
+import com.papi.nova.R
 import com.papi.nova.preferences.PreferenceConfiguration
 
 class StreamContainer @JvmOverloads constructor(
@@ -40,6 +42,8 @@ class StreamContainer @JvmOverloads constructor(
     init {
         isFocusable = true
         isFocusableInTouchMode = true
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+        contentDescription = context.getString(R.string.nova_stream_surface_accessibility_label)
     }
 
     fun init(game: Game, prefConfig: PreferenceConfiguration) {
@@ -53,6 +57,7 @@ class StreamContainer @JvmOverloads constructor(
 
         val childParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
         val child = SurfaceView(context)
+        child.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         surfaceView = child
         addView(child, childParams)
 

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
@@ -43,7 +43,9 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -270,6 +272,8 @@ fun NovaActionButton(
     enabled: Boolean = true,
     primary: Boolean = false,
     contentDescription: String = text,
+    selected: Boolean = false,
+    stateDescription: String? = null,
     minHeight: Dp = 38.dp,
     cornerRadius: Dp = 14.dp,
     fontSize: TextUnit = 13.sp,
@@ -335,6 +339,10 @@ fun NovaActionButton(
             .border(borderWidth, borderColor, shape)
             .semantics {
                 this.contentDescription = contentDescription
+                if (selected) {
+                    this.selected = true
+                }
+                stateDescription?.let { this.stateDescription = it }
                 role = Role.Button
             }
             .onFocusChanged { focused = it.isFocused || it.hasFocus }

--- a/app/src/main/java/com/papi/nova/utils/SpinnerDialog.kt
+++ b/app/src/main/java/com/papi/nova/utils/SpinnerDialog.kt
@@ -4,8 +4,11 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.DialogInterface
 import android.view.LayoutInflater
+import android.widget.ProgressBar
 import android.widget.TextView
 import com.papi.nova.R
+import com.papi.nova.ui.NovaSheetChrome
+import com.papi.nova.ui.NovaThemeManager
 
 class SpinnerDialog private constructor(
     private val activity: Activity,
@@ -34,6 +37,9 @@ class SpinnerDialog private constructor(
         val activeDialog = dialog
         if (activeDialog == null) {
             val content = LayoutInflater.from(activity).inflate(R.layout.nova_spinner_dialog, null)
+            content.findViewById<ProgressBar>(R.id.spinner_progress)?.indeterminateDrawable?.setTint(
+                NovaThemeManager.getAccentColor(activity)
+            )
             messageView = content.findViewById<TextView>(R.id.spinner_message).apply {
                 text = message
             }
@@ -45,6 +51,7 @@ class SpinnerDialog private constructor(
             builder.setCancelable(finish)
 
             val createdDialog = builder.create()
+            NovaSheetChrome.applyAlertDialogChrome(createdDialog)
             dialog = createdDialog
 
             synchronized(rundownDialogs) {

--- a/app/src/main/res/layout/nova_spinner_dialog.xml
+++ b/app/src/main/res/layout/nova_spinner_dialog.xml
@@ -7,6 +7,7 @@
     android:padding="24dp">
 
     <ProgressBar
+        android:id="@+id/spinner_progress"
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:indeterminate="true" />
@@ -18,7 +19,7 @@
         android:layout_weight="1"
         android:layout_marginStart="20dp"
         android:textSize="15sp"
-        android:textColor="@color/nova_text_primary"
+        android:textColor="?android:attr/textColorPrimary"
         android:fontFamily="sans-serif" />
 
 </LinearLayout>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -415,6 +415,18 @@
             android:entryValues="@array/nova_hud_position_values"
             android:defaultValue="top_left"
             app:iconSpaceReserved="false" />
+        <com.papi.nova.preferences.SeekBarPreference
+            android:key="nova_polaris_hud_opacity"
+            android:title="HUD Opacity"
+            android:summary="Adjust NovaHUD glass opacity without dimming telemetry text"
+            android:dialogMessage="Adjust NovaHUD glass opacity without dimming telemetry text"
+            android:dependency="nova_polaris_hud"
+            android:defaultValue="90"
+            android:max="100"
+            android:text="@string/suffix_osc_opacity"
+            app:iconSpaceReserved="false"
+            seekbar:min="25"
+            seekbar:step="1" />
 
         <!-- Legacy perf overlay (Moonlight-inherited) -->
         <CheckBoxPreference
@@ -608,7 +620,7 @@
         <ListPreference
             android:key="nova_theme"
             android:title="Theme"
-            android:summary="Polaris Aurora, Console OLED, Miami Nebula, PSP / Portable Chrome, High Contrast, or Material You"
+            android:summary="Polaris Aurora, PSP Chrome / Portable Chrome, Console OLED, Miami Nebula, High Contrast, or Material You"
             android:entries="@array/nova_theme_names"
             android:entryValues="@array/nova_theme_values"
             android:defaultValue="polaris"

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -110,6 +110,20 @@ class NovaSettingsDefinitionsTest {
     }
 
     @Test
+    fun hudOpacityPreferenceIsAdjustableInstantSlider() {
+        val definitions = NovaSettingDefinitions.load(context)
+        val hudOpacity = definitions.require("nova_polaris_hud_opacity")
+
+        assertEquals(NovaSettingType.Slider, hudOpacity.type)
+        assertEquals(NovaSettingValue.IntValue(90), hudOpacity.defaultValue)
+        assertEquals(25, hudOpacity.min)
+        assertEquals(100, hudOpacity.max)
+        assertEquals(1, hudOpacity.step)
+        assertEquals("%", hudOpacity.suffix)
+        assertEquals(NovaSettingApplyTiming.Instant, hudOpacity.applyTiming)
+    }
+
+    @Test
     fun upgradedBalancedInstallMigratesLegacy720Resolution() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         prefs.edit()

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2050,6 +2050,38 @@ class NovaComposeSourceGuardTest {
     private fun readNovaFocusComponents(): String =
         readSource("src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt")
 
+    @Test
+    fun gameDetailLaunchOptionsAvoidRawAppCompatAlertDialogButtons() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val launchOptions = detail.section(
+            "private fun showLaunchOptions(",
+            "private fun optionLabel("
+        )
+
+        assertTrue(
+            "Launch Options runs from the Compose game detail sheet and must not use raw AlertDialog.Builder; Retroid Portable Chrome routes this through Nova glass option panels",
+            !launchOptions.contains("AlertDialog.Builder(") &&
+                detail.contains("data class NovaLaunchOptionsState") &&
+                detail.contains("private fun NovaLaunchOptionsSheet(")
+        )
+    }
+
+    @Test
+    fun gameDetailProfilePreferenceAvoidsRawAppCompatAlertDialogButtons() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val profileOptions = detail.section(
+            "private fun showProfilePreferenceOptions(",
+            "private fun showSteamLaunchModeOptions("
+        )
+
+        assertTrue(
+            "AI Preference/Profile selector runs from the Compose game detail sheet and must not use raw AlertDialog.Builder on Retroid Portable Chrome",
+            !profileOptions.contains("AlertDialog.Builder(") &&
+                detail.contains("data class NovaProfilePreferenceOptionsState") &&
+                detail.contains("private fun NovaProfilePreferenceSheet(")
+        )
+    }
+
     private fun readSource(path: String): String =
         String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
 

--- a/app/src/test/java/com/papi/nova/ui/NovaHudPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudPreferencesTest.kt
@@ -1,0 +1,68 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.papi.nova.preferences.NovaSettingDefinitions
+import com.papi.nova.preferences.NovaSettingValue
+import com.papi.nova.preferences.NovaSettingsRepository
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaHudPreferencesTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun sharedPreferencesReadWriteClampsAndScales() {
+        val prefs = context.getSharedPreferences("nova-hud-preferences-shared", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+
+        NovaHudPreferences.writeOpacityPercent(prefs, 10)
+
+        assertEquals(25, prefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(25, NovaHudPreferences.readOpacityPercent(prefs))
+        assertEquals(0.25f, NovaHudPreferences.opacityScale(10), 0.001f)
+
+        NovaHudPreferences.writeOpacityPercent(prefs, 150)
+
+        assertEquals(100, prefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(100, NovaHudPreferences.readOpacityPercent(prefs))
+        assertEquals(0.9f, NovaHudPreferences.opacityScale(90), 0.001f)
+    }
+
+    @Test
+    fun repositoryWriteUpdatesDataStoreAndMirrorPrefs() = runBlocking {
+        val mirrorPrefs = context.getSharedPreferences("nova-hud-preferences-mirror", Context.MODE_PRIVATE)
+        mirrorPrefs.edit().clear().commit()
+        val storeFile = File(context.filesDir, "nova-hud-preferences-" + System.nanoTime() + ".preferences_pb")
+        val repository = NovaSettingsRepository.createForTest(
+            context = context,
+            mirrorPrefs = mirrorPrefs,
+            storeFile = storeFile
+        )
+        val definitions = NovaSettingDefinitions.load(context)
+        val definition = definitions.require(NovaHudPreferences.KEY_OPACITY)
+
+        NovaHudPreferences.writeOpacityPercent(repository, definition, 50)
+
+        assertEquals(50, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(
+            NovaSettingValue.IntValue(50),
+            repository.snapshot(definitions)[NovaHudPreferences.KEY_OPACITY]
+        )
+
+        NovaHudPreferences.writeOpacityPercent(repository, definition, 10)
+
+        assertEquals(25, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(
+            NovaSettingValue.IntValue(25),
+            repository.snapshot(definitions)[NovaHudPreferences.KEY_OPACITY]
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -364,6 +364,27 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun gameKeepsSingleSessionProgressOverlayInstanceForStartupLifecycle() {
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val occurrences = game.split("SessionProgressOverlay(this)").size - 1
+        val startup = game.section(
+            "setContentView(R.layout.activity_game)",
+            "appName = this@Game.getIntent().getStringExtra(EXTRA_APP_NAME)"
+        )
+        val polarisSetup = game.section(
+            "// Nova: set up Polaris integration without blocking stream startup on REST probes.",
+            "if (appId == StreamConfiguration.INVALID_APP_ID)"
+        )
+
+        assertTrue(
+            "Game should create one SessionProgressOverlay instance; replacing it later leaves the first shown overlay orphaned",
+            occurrences == 1 &&
+                startup.contains("novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)") &&
+                !polarisSetup.contains("novaProgressOverlay = com.papi.nova.ui.SessionProgressOverlay(this)")
+        )
+    }
+
+    @Test
     fun polarisEventSourceDoesNotReshowStartupOverlayAfterStreamIsActive() {
         val game = readSource("src/main/java/com/papi/nova/Game.kt")
         val eventSource = game.section(

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -425,6 +425,36 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun gameReturnsToLibraryWhenPolarisReportsHostSessionEnded() {
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val hostEnded = game.section(
+            "private fun handlePolarisHostSessionEnded(",
+            " fun disconnect() {"
+        )
+
+        assertTrue(
+            "resilience give-up should finish the Game activity when Polaris reports the host session is gone",
+            game.contains("ConnectionResilienceManager(") &&
+                game.contains("handlePolarisHostSessionEnded()") &&
+                hostEnded.contains("hostSessionEnded = true") &&
+                hostEnded.contains("markLocalSessionEnd()") &&
+                hostEnded.contains("finish()")
+        )
+        assertTrue(
+            "SSE idle/stream-ended events should use the same host-ended teardown path",
+            game.contains("event == " + 34.toChar() + "stream_ended" + 34.toChar()) &&
+                game.contains("state == " + 34.toChar() + "idle" + 34.toChar()) &&
+                game.contains("handlePolarisHostSessionEnded()")
+        )
+        assertTrue(
+            "host-ended teardown should stop background-resume state and shut down resilience executor",
+            hostEnded.contains("stopBackgroundResumeWindow()") &&
+                hostEnded.contains("novaResilienceManager?.shutdown()") &&
+                !hostEnded.contains("prepareBackgroundResumeWindow()")
+        )
+    }
+
+    @Test
     fun gameStreamSurfaceProvidesAccessibilityNodeForDeviceSmokeAutomation() {
         val container = readSource("src/main/java/com/papi/nova/ui/StreamContainer.kt")
         val strings = readSource("src/main/res/values/strings.xml")

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -364,6 +364,22 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun polarisEventSourceDoesNotReshowStartupOverlayAfterStreamIsActive() {
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val eventSource = game.section(
+            "private fun startNovaEventSourceIfSupported()",
+            "private fun schedulePolarisLiveSessionStatusRefresh"
+        )
+
+        assertTrue(
+            "Polaris SSE startup should not resurrect the session progress overlay once native connectionStarted made the stream active",
+            eventSource.contains("if (!connected && !isStreamActive)") &&
+                eventSource.indexOf("if (!connected && !isStreamActive)") < eventSource.indexOf("novaProgressOverlay") &&
+                eventSource.contains("show()")
+        )
+    }
+
+    @Test
     fun gameAcceptsSyntheticNovaControllerShortcutBeforeIgnoringAdbKeyEvents() {
         val game = readSource("src/main/java/com/papi/nova/Game.kt")
         val handleKeyDown = game.section(

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -441,6 +441,46 @@ class NovaLaunchSourceGuardTest {
         )
     }
 
+    @Test
+    fun drawerLaunchAppliesPreflightStreamModeToSettingsAndIntent() {
+        val activity = readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val launchGame = activity.section(
+            "private fun launchGame(",
+            "private fun resumeActiveSession("
+        )
+
+        assertTrue(
+            "drawer launch should derive effective stream mode from preflight optimization before syncing settings",
+            launchGame.contains("val launchResolution = StreamSyncManager.resolveAutoSafeResolution(") &&
+                launchGame.contains("val launchFps = StreamSyncManager.resolveAutoSafeTargetFps(") &&
+                launchGame.indexOf("val launchResolution") < launchGame.indexOf("apiClient.updateClientSettings(")
+        )
+        assertTrue(
+            "client settings and Game intent should use launchResolution and launchFps instead of saved fps only",
+            launchGame.contains("launchResolution.width") &&
+                launchGame.contains("launchResolution.height") &&
+                launchGame.contains("launchFps") &&
+                launchGame.contains("launchFps,")
+        )
+        val launchSetup = game.section(
+            "watchOnlyRequested = this@Game.getIntent().getBooleanExtra(EXTRA_WATCH_ONLY, false)",
+            "decoderRenderer = MediaCodecDecoderRenderer("
+        )
+        assertTrue(
+            "Game should read explicit stream dimensions before selecting the decoder resolution",
+            launchSetup.indexOf("watchStreamWidth = this@Game.getIntent().getIntExtra(EXTRA_STREAM_WIDTH, 0)") <
+                launchSetup.indexOf("if (watchStreamWidth > 0 && watchStreamHeight > 0)")
+        )
+        assertTrue(
+            "Game should honor explicit stream FPS extras for normal launch paths, not watch-only paths",
+            game.contains("var explicitStreamFpsOverride:Boolean = watchStreamFps > 0f") &&
+                game.contains("Nova: Launch using explicit stream FPS") &&
+                game.indexOf("watchStreamFps = this@Game.getIntent().getFloatExtra(EXTRA_STREAM_FPS, 0f)") <
+                    game.indexOf("var explicitStreamFpsOverride:Boolean = watchStreamFps > 0f")
+        )
+    }
+
     private fun readSource(path: String): String =
         String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -424,6 +424,23 @@ class NovaLaunchSourceGuardTest {
         )
     }
 
+    @Test
+    fun gameStreamSurfaceProvidesAccessibilityNodeForDeviceSmokeAutomation() {
+        val container = readSource("src/main/java/com/papi/nova/ui/StreamContainer.kt")
+        val strings = readSource("src/main/res/values/strings.xml")
+
+        assertTrue(
+            "Game stream should expose a stable accessibility node so adb UI automation can identify the foreground stream surface",
+            container.contains("importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES") &&
+                container.contains("contentDescription = context.getString(R.string.nova_stream_surface_accessibility_label)") &&
+                strings.contains("nova_stream_surface_accessibility_label")
+        )
+        assertTrue(
+            "StreamContainer should keep the container accessible and hide the raw SurfaceView child from traversal",
+            container.contains("child.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO")
+        )
+    }
+
     private fun readSource(path: String): String =
         String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -54,8 +54,8 @@ class NovaLaunchSourceGuardTest {
             "private fun modeLabel("
         )
         val launchOptions = detail.section(
-            "private fun showLaunchOptions(",
-            "private fun syncLaunchPreflightSettings("
+            "onLaunchOptionSelected = { option ->",
+            "onDismissLaunchOptions ="
         )
 
         assertTrue(
@@ -72,7 +72,7 @@ class NovaLaunchSourceGuardTest {
         )
         assertTrue(
             "Launch Options must not bypass desktop-Steam safety for selected private headless launches",
-            launchOptions.contains("usesVirtualDisplay = selectedUsesVirtualDisplay") &&
+            launchOptions.contains("usesVirtualDisplay = option.usesVirtualDisplay") &&
                 launchOptions.contains("showDesktopSteamLaunchDecision(") &&
                 launchOptions.contains("onForcePrivateAfterSteamClose = { launchSelected(mirrorDesktop = false, forcePrivateAfterSteamClose = true) }")
         )

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -132,6 +132,44 @@ class NovaQuickMenuUiStateTest {
         assertEquals(NovaQuickMenuTone.INFO, diagnostics.chip.tone)
     }
 
+    @Test
+    fun commandCenterStateExposesHudOpacityPresets() {
+        val state = quickState(
+            status = status(),
+            hudShowing = true,
+            hudOpacityPercent = 90
+        )
+
+        assertEquals(90, state.hudOpacity.percent)
+        assertEquals(NovaHudPreferences.OPACITY_PRESETS, state.hudOpacity.presets)
+        assertTrue(state.hudOpacity.enabled)
+    }
+
+    @Test
+    fun commandCenterStateDisablesHudOpacityWhenHudIsOff() {
+        val state = quickState(
+            status = status(),
+            hudShowing = false,
+            hudOpacityPercent = 150
+        )
+
+        assertFalse(state.hudOpacity.enabled)
+        assertEquals(100, state.hudOpacity.percent)
+    }
+
+    @Test
+    fun commandCenterStateKeepsNonPresetHudOpacityValues() {
+        val state = quickState(
+            status = status(),
+            hudShowing = true,
+            hudOpacityPercent = 87
+        )
+
+        assertTrue(state.hudOpacity.enabled)
+        assertEquals(87, state.hudOpacity.percent)
+        assertEquals(NovaHudPreferences.OPACITY_PRESETS, state.hudOpacity.presets)
+    }
+
     private fun quickState(
         status: PolarisSessionStatus?,
         apiAvailable: Boolean = true,
@@ -144,7 +182,9 @@ class NovaQuickMenuUiStateTest {
         advancedExpanded: Boolean = true,
         profileClearInProgress: Boolean = false,
         currentGameName: String? = "Portal",
-        currentGameUuid: String? = "game-1"
+        currentGameUuid: String? = "game-1",
+        hudShowing: Boolean = false,
+        hudOpacityPercent: Int = 90
     ) = NovaQuickMenuUiState.from(
         context = context,
         status = status,
@@ -160,7 +200,8 @@ class NovaQuickMenuUiStateTest {
         currentGameName = currentGameName,
         currentGameUuid = currentGameUuid,
         profilePreference = "quality",
-        hudShowing = false,
+        hudShowing = hudShowing,
+        hudOpacityPercent = hudOpacityPercent,
         perfOverlayEnabled = false,
         onscreenControllerEnabled = false,
         keyboardVisible = false,

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -29,6 +29,30 @@ class NovaThemeResourcesTest {
     }
 
     @Test
+    fun novaThemeSurfaceContractDocumentsThemeAndSmokeRequirements() {
+        val contract = File("../docs/nova-theme-surface-contract.md").readText().lowercase()
+
+        listOf(
+            "latest available debug nova apk",
+            "latest available debug polaris build",
+            "psp chrome / portable chrome",
+            "steel-blue/graphite",
+            "muted green/status accents",
+            "purple/violet accents must not",
+            "transparent/glass",
+            "novahud",
+            "drawers, sheets, dialogs",
+            "game-detail",
+            "material you",
+            "no redundant press a badges",
+            "current"
+        ).forEach { required ->
+            assertTrue("Nova theme surface contract should explicitly mention ", contract.contains(required))
+        }
+    }
+
+
+    @Test
     fun pspPortableChromeIsASelectableThemeValueAndLabel() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
@@ -202,10 +226,17 @@ class NovaThemeResourcesTest {
     @Test
     fun sessionQuitConfirmationUsesNovaGlassBottomSheetInsteadOfRawAlertDialog() {
         val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val spinnerDialog = File("src/main/java/com/papi/nova/utils/SpinnerDialog.kt").readText()
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val quitBody = game.substringAfter("fun quit() {").substringBefore("override fun showGameMenu")
+        val spinnerLayout = File("src/main/res/layout/nova_spinner_dialog.xml").readText()
 
         assertTrue("shared chrome should still expose AlertDialog styling for remaining legacy session popups", sheetChrome.contains("applyAlertDialogChrome"))
+        assertTrue("establishing-session spinner should apply Nova glass dialog chrome", spinnerDialog.contains("NovaSheetChrome.applyAlertDialogChrome(createdDialog"))
+        assertFalse("spinner progress must not hardcode the Polaris accent", spinnerLayout.contains("@color/nova_accent"))
+        assertFalse("spinner progress tint should be applied at runtime instead of risky XML attr tinting", spinnerLayout.contains("indeterminateTint"))
+        assertTrue("spinner should tint progress from the active Nova theme at runtime", spinnerDialog.contains("NovaThemeManager.getAccentColor") && spinnerDialog.contains("indeterminateDrawable"))
+        assertTrue("spinner layout should consume theme text color attrs", spinnerLayout.contains("?android:attr/textColorPrimary"))
         assertTrue("quit confirmation should be rebuilt as a Nova bottom sheet so it shares drawer/HUD glass chrome", quitBody.contains("BottomSheetDialog"))
         assertTrue("quit confirmation should build its own themed glass sheet container", quitBody.contains("NovaSheetChrome.createSheetContainer"))
         assertTrue("quit confirmation should apply shared bottom-sheet chrome", quitBody.contains("NovaSheetChrome.applyBottomSheetChrome(sheet"))

--- a/docs/nova-theme-surface-contract.md
+++ b/docs/nova-theme-surface-contract.md
@@ -1,0 +1,38 @@
+# Nova Theme Surface Contract
+
+This contract makes the Nova side of the Nova/Polaris cockpit requirements explicit. Treat it as a product guard for Android UI work, Retroid smoke runs, and Polaris pairing evidence.
+
+## Smoke build pairing
+
+- Use the latest available debug Nova APK by default for Retroid, Shield, Pixel, and paired-library smoke runs.
+- Use that Nova debug APK with the latest available debug Polaris build or live debug Polaris host unless a release, pinned, or archival build is explicitly requested.
+- Evidence must name the installed Nova package and APK hash or lastUpdateTime when available, and must not imply release coverage when the run used debug bits.
+
+## Theme picker and selectable themes
+
+- The picker must expose every selectable theme in a compact controller-friendly layout: Polaris Aurora, PSP Chrome / Portable Chrome, Console OLED, Miami Nebula, High Contrast, and Material You when the platform supports it.
+- PSP Chrome / Portable Chrome must remain eye-scan visible as the primary label, with the PSP / Portable Chrome wording still discoverable in supporting copy.
+- D-pad focus must be visible and readable, including a live focused theme label or equivalent text feedback.
+- Keep only meaningful state badges such as Current. There should be no redundant Press A badges repeated per row.
+- The compact layout must keep Material You reachable and visible instead of pushing it below the Retroid landscape fold.
+
+## Shared drawer, sheet, and dialog chrome
+
+- Drawers, sheets, dialogs, picker surfaces, host context menus, and game-detail surfaces are theme surfaces, not one-off panels.
+- The selected theme should visibly apply across the picker, host/context drawers, and game-detail surfaces with distinct palette personality.
+- Shared sheet chrome must preserve transparent/glass character for NovaHUD and gameplay-adjacent contexts.
+- High Contrast may be more opaque for readability, but PSP Chrome / Portable Chrome and Miami Nebula should keep a transparent/glass feel rather than becoming opaque slabs.
+- Avoid clipped selected strokes, square-vs-round drift, mixed purple overlays, or per-callsite sheet backgrounds that bypass shared theme tokens.
+
+## PSP Chrome / Portable Chrome palette
+
+- PSP Chrome / Portable Chrome should read as steel-blue/graphite, smoked graphite, and dim Moonlight-grey/silver shell chrome.
+- Muted green/status accents are allowed for PSP Chrome / Portable Chrome and semantic online/status states.
+- Purple/violet accents must not appear in PSP Chrome / Portable Chrome chrome, and PSP green must not leak into non-PSP selection, focus, host, or button accents.
+- Text must stay readable on all PSP panels; avoid washed-out light panels with weak dark text or bright green body text.
+
+## Regression expectations
+
+- Source guards should cover theme registry order, PSP aliasing, per-theme accent tokens, shared transparent/glass sheet chrome, picker D-pad behavior, Material You visibility, and the no redundant Press A badges rule.
+- Device evidence should include the picker, at least one host/context drawer, and a game-detail surface after applying the selected theme.
+- When validating smoke behavior, prefer the latest available debug Nova APK plus latest available debug Polaris build pairing unless Michael explicitly asks for another build lane.


### PR DESCRIPTION
Summary: consolidate the verified Nova Debug dogfood fixes onto master, including HUD opacity, stream-surface automation, Nova glass selector/spinner contracts, drawer preflight stream mode, host-session teardown, and startup overlay lifecycle fixes. Test plan: ./gradlew -PnovaAbis=arm64-v8a :app:testNonRoot_gameDebugUnitTest :app:assembleNonRoot_gameDebug; installed com.papi.nova.debug on Retroid Pocket Flip2/Fold target 10.0.0.144:40629; user dogfood confirmed the stuck startup overlay clears correctly.