### PR TITLE
fix: polish HDR downgrade command center copy

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
@@ -116,6 +116,17 @@ data class AutoQualityUiState(
             val manualOverride = status.syncStatus.isManualOverride ||
                 syncState == "manual_override"
 
+            if (status.isHdrDowngraded) {
+                return AutoQualityUiState(
+                    state = State.NEEDS_ATTENTION,
+                    label = "HDR downgraded",
+                    compactLabel = "HDR",
+                    detail = "Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.",
+                    targetSummary = streamPolicy.targetSummary,
+                    tone = Tone.WARNING,
+                    enabled = true
+                )
+            }
             if (!autoEnabled && !manualOverride) {
                 return AutoQualityUiState(
                     state = State.OFF,

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -182,7 +182,7 @@ data class NovaHudUiState(
                 autopilotCompactLabel = autoQuality.compactLabel,
                 fpsTone = toneForFps(fps, targetFps),
                 latencyTone = toneForLatency(latencyMs),
-                statusTone = autoQuality.tone.toHudTone(),
+                statusTone = if (healthReason.second == NovaHudTone.WARNING || healthReason.second == NovaHudTone.DANGER) healthReason.second else autoQuality.tone.toHudTone(),
                 healthReasonLabel = healthReason.first,
                 healthReasonTone = healthReason.second,
                 streamTruthLabel = buildStreamTruth(status, targetFps, codec, height),
@@ -279,6 +279,7 @@ data class NovaHudUiState(
             val primaryIssue = status?.health?.primaryIssue.orEmpty().lowercase()
             val issues = status?.health?.issues.orEmpty().map { it.lowercase() }
             return when {
+                status?.isHdrDowngraded == true -> "HDR downgraded" to NovaHudTone.WARNING
                 status?.isHostRenderLimited == true || primaryIssue == "host_render_limited" || issues.contains("host_render_limited") ->
                     "Host capped" to NovaHudTone.WARNING
                 primaryIssue.contains("network") || status?.health?.networkRisk?.isNotBlank() == true ->
@@ -307,6 +308,7 @@ data class NovaHudUiState(
             }
             val safeTarget = status?.health?.safeTargetFps?.takeIf { it > 0.0 }?.roundToInt()
             return when {
+                status?.isHdrDowngraded == true -> streamLabel + " • 10-bit SDR"
                 status?.isHostRenderLimited == true && safeTarget != null -> "$streamLabel • Game capped $safeTarget"
                 status?.isHostRenderLimited == true -> "$streamLabel • Host capped"
                 status?.profileState?.preferenceLabel?.isNotBlank() == true ->

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -424,15 +424,27 @@ private fun NovaQuickMenuSessionStrip(state: NovaQuickMenuUiState) {
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         NovaQuickMenuChipView(state.sessionMode)
-        Text(
-            text = state.healthSummary,
-            color = toneColor(state.healthTone),
-            fontSize = 10.sp,
-            lineHeight = 13.sp,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = state.healthSummary,
+                color = toneColor(state.healthTone),
+                fontSize = 10.sp,
+                lineHeight = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (state.healthDetail.isNotBlank()) {
+                Text(
+                    text = state.healthDetail,
+                    color = colors.textMuted,
+                    fontSize = 9.sp,
+                    lineHeight = 12.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -84,6 +84,7 @@ data class NovaQuickMenuUiState(
     val subtitle: String,
     val sessionMode: NovaQuickMenuChip,
     val healthSummary: String,
+    val healthDetail: String,
     val healthTone: NovaQuickMenuTone,
     val disconnectAction: NovaQuickMenuAction,
     val endAction: NovaQuickMenuAction,
@@ -150,6 +151,7 @@ data class NovaQuickMenuUiState(
             val mangoRisk = status?.game.equals("Steam Big Picture", ignoreCase = true)
 
             val hdrDowngradeSummary = status?.hdrDowngradeSummary(context)
+            val healthDetail = status?.hdrDowngradeDetail(context).orEmpty()
             val healthSummary = when {
                 hostStateUnavailable -> context.getString(R.string.nova_quick_menu_host_state_unavailable)
                 status == null -> context.getString(R.string.nova_quick_menu_health_checking)
@@ -371,6 +373,7 @@ data class NovaQuickMenuUiState(
                 subtitle = subtitle,
                 sessionMode = sessionMode,
                 healthSummary = healthSummary,
+                healthDetail = healthDetail,
                 healthTone = healthTone,
                 disconnectAction = NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.DISCONNECT,
@@ -683,6 +686,16 @@ data class NovaQuickMenuUiState(
             }
         }
 
+        private fun PolarisSessionStatus.hdrDowngradeDetail(context: Context): String? {
+            if (!isHdrDowngraded) {
+                return null
+            }
+            return if (isHeadlessHdrUnavailable) {
+                context.getString(R.string.nova_quick_menu_health_hdr_headless_detail)
+            } else {
+                context.getString(R.string.nova_quick_menu_health_hdr_downgrade_detail)
+            }
+        }
         private fun PolarisSessionStatus.hdrDowngradeSummary(context: Context): String? {
             if (!isHdrDowngraded) {
                 return null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,6 +792,8 @@
     <string name="nova_quick_menu_health_checking">Checking session health</string>
     <string name="nova_quick_menu_health_host_render">Host FPS is below target. Relaunch can restore full rate.</string>
     <string name="nova_quick_menu_health_hdr_downgrade">HDR requested, but Polaris is streaming 10-bit SDR.</string>
+    <string name="nova_quick_menu_health_hdr_headless_detail">Private Headless Stream does not report HDR metadata. Polaris is sending 10-bit SDR; use an HDR-capable display path for true HDR.</string>
+    <string name="nova_quick_menu_health_hdr_downgrade_detail">Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.</string>
     <string name="nova_quick_menu_health_hdr_headless_downgrade">HDR requested, but Private Headless Stream is 10-bit SDR.</string>
     <string name="nova_quick_menu_health_attention">Session needs attention.</string>
     <string name="nova_quick_menu_health_steady">Session looks steady.</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -322,6 +322,37 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun hdrDowngradeUsesExplicitWarningCopyAndTenBitSdrTruth() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.PERFORMANCE,
+            fps = 59.0,
+            targetFps = 60.0,
+            latencyMs = 18,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "watch",
+                    primaryIssue = "hdr_downgraded",
+                    issues = listOf("hdr_downgraded"),
+                    hdrEffectiveMode = "sdr_10bit",
+                    hdrDowngradeReason = "headless_hdr_unavailable",
+                    hdrDowngradeMessage = "Polaris is streaming 10-bit SDR, not HDR.",
+                    safeHdr = false,
+                    relaunchRecommended = true
+                )
+            ),
+            sparklineSamples = listOf(59f)
+        )
+
+        assertEquals("HDR downgraded", state.healthReasonLabel)
+        assertEquals(NovaHudTone.WARNING, state.healthReasonTone)
+        assertEquals("Stream 60 • 10-bit SDR", state.streamTruthLabel)
+        assertEquals(NovaHudTone.WARNING, state.statusTone)
+    }
+    @Test
     fun eventBreadcrumbTrailKeepsLatestActionableHudEvent() {
         val trail = NovaHudEventTrail(capacity = 3)
 

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -101,6 +101,8 @@ class NovaQuickMenuUiStateTest {
         )
 
         assertEquals("HDR requested, but Private Headless Stream is 10-bit SDR.", state.healthSummary)
+        assertEquals("Private Headless Stream does not report HDR metadata. Polaris is sending 10-bit SDR; use an HDR-capable display path for true HDR.", state.healthDetail)
+        assertEquals("Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.", state.stability.caption)
         assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
     }
 


### PR DESCRIPTION
## Summary
- Keeps the HDR downgrade headline short in Command Center and adds the full headless/HDR-metadata explanation below it.
- Replaces the clipped Auto Quality paragraph with concise HDR downgrade copy.
- Extracts the useful HUD truth from superseded PR #100: HDR downgraded warning state plus Stream 60 • 10-bit SDR truth.

## Test Plan
- RED: focused HDR Command Center/HUD tests failed before implementation.
- ./gradlew testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest.headlessHdrDowngradeShowsPlayerReadableCommandCenterCopy --tests com.papi.nova.ui.NovaHudUiStateTest.hdrDowngradeUsesExplicitWarningCopyAndTenBitSdrTruth
- ./gradlew testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest --tests com.papi.nova.ui.NovaHudUiStateTest --tests com.papi.nova.ui.AutoQualityUiStateTest
- git submodule update --init --recursive app/src/main/jni/moonlight-core/moonlight-common-c
- ./gradlew assembleNonRoot_gameDebug
- Installed arm64 nonRoot debug APK on Retroid Pocket 6: com.papi.nova.debug v1.1.3 versionCode 29, SHA-256 d1ef1d1479baa1af477ac6b12fd669bd984a2c2b417243f123a7159a6bebe1c9.
- Live smoke with Polaris v1.1.0.74287002 and MOUSE: P.I. For Hire: Nova sent hdrMode=1; Polaris reported dynamic_range=1, primary_issue=hdr_downgraded, hdr_effective_mode=sdr_10bit, hdr_downgrade_reason=headless_hdr_unavailable, stream_hdr_enabled=false.
- Screenshot proof copied to /tmp/nova_polish_hdr_command_center.png: session strip shows the extra HDR metadata detail and Auto Quality shows concise copy without ellipsis.
- Cleanup: paired /cancel returned status_code=200, Nova returned to launcher, no labwc/MOUSE processes remained, temp copied cert/key material removed.

Supersedes the non-conflicting useful HUD slice of #100; the rest landed in #101.
