### PR TITLE
build(deps): pin Bouncy Castle build classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,15 @@ buildscript {
             classpath('org.apache.commons:commons-lang3:3.18.0') {
                 because 'Dependabot flags the AGP toolchain transitive version'
             }
+            classpath('org.bouncycastle:bcpkix-jdk18on:1.84') {
+                because 'Keep the AGP build toolchain on a patched Bouncy Castle line'
+            }
+            classpath('org.bouncycastle:bcprov-jdk18on:1.84') {
+                because 'Fix GHSA-574f-3g2m-x479 / CVE-2025-14813 in AGP transitives'
+            }
+            classpath('org.bouncycastle:bcutil-jdk18on:1.84') {
+                because 'Align Bouncy Castle build-tool transitive modules with bcprov'
+            }
             classpath('org.apache.httpcomponents:httpclient:4.5.14') {
                 because 'Keep the AGP toolchain on a patched 4.5.x line'
             }


### PR DESCRIPTION
Summary: pin Bouncy Castle build-tool classpath modules to 1.84. This fixes the AGP 9.2.1 transitive bcprov-jdk18on 1.79 path flagged by Dependabot alert #31 / GHSA-574f-3g2m-x479 / CVE-2025-14813. Nova runtime APK dependencies were already on 1.84. Verification: git diff --check passed; Gradle buildEnvironment shows bcprov-jdk18on 1.79 resolves to 1.84 and bcpkix-jdk18on 1.79 resolves to 1.84; ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest :app:assembleNonRoot_gameDebug passed. Fixes Dependabot alert #31.