### PR TITLE
fix(nova): clarify launch modes

### DIFF
--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.computers.ComputerDatabaseManager
 import com.papi.nova.computers.ComputerManagerListener
@@ -733,7 +734,11 @@ class ShortcutTrampoline : AppCompatActivity() {
     ) {
         val preferences = PreferenceConfiguration.readPreferences(this)
         val syncedSettings = apiClient.updateClientSettings(
-            streamDisplayMode = if (withVirtualDisplay) "host_virtual_display" else "headless_stream",
+            streamDisplayMode = if (withVirtualDisplay) {
+                PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY
+            } else {
+                PolarisClientSettings.MODE_HEADLESS_STREAM
+            },
             displayMode = PreferenceConfiguration.formatStreamingDisplayMode(
                 preferences.width,
                 preferences.height,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -263,7 +263,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                             ?.takeIf { it.isNotBlank() }
                             ?: primaryPlayLabel(uiState)
                     },
-                    launchOptionsLabel = getString(R.string.nova_library_launch_options),
+                    launchOptionsLabel = getString(R.string.nova_library_launch_options_secondary),
                     launchModeTitle = getString(R.string.nova_library_launch_mode_title),
                     headlessModeLabel = modeBadgeLabel("headless"),
                     virtualDisplayModeLabel = modeBadgeLabel("virtual_display"),
@@ -1642,6 +1642,27 @@ private fun LaunchControls(
             overflow = TextOverflow.Ellipsis
         )
 
+        if (uiState.showLaunchModeSummary) {
+            val launchModeSummary = when {
+                uiState.showVirtualUnavailableHint && uiState.virtualDisplayUnavailableReason.isNotBlank() ->
+                    virtualDisplayModeLabel + " unavailable: " + uiState.virtualDisplayUnavailableReason
+                uiState.showVirtualUnavailableHint ->
+                    virtualDisplayModeLabel + " unavailable"
+                uiState.playMode == "virtual_display" -> launchModeTitle + ": " + virtualDisplayModeLabel
+                uiState.playMode == "headless" -> launchModeTitle + ": " + headlessModeLabel
+                else -> launchModeTitle
+            }
+            Text(
+                text = launchModeSummary,
+                modifier = Modifier.padding(top = 6.dp),
+                color = if (uiState.showVirtualUnavailableHint) colors.warning else colors.textMuted,
+                fontSize = 10.sp,
+                lineHeight = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
         NovaActionButton(
             text = playLabel,
             onClick = onPrimaryLaunch,
@@ -1658,41 +1679,43 @@ private fun LaunchControls(
             contentPadding = PaddingValues(horizontal = 14.dp, vertical = 12.dp)
         )
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            LaunchModeChoicePill(
-                label = headlessModeLabel,
-                status = when {
-                    uiState.playMode == "headless" -> "Selected"
-                    uiState.recommendedMode == "headless" && uiState.headlessAllowed -> "Recommended"
-                    uiState.headlessAllowed -> "Available"
-                    else -> "Unavailable"
-                },
-                recommended = uiState.recommendedMode == "headless" && uiState.headlessAllowed,
-                selected = uiState.playMode == "headless",
-                unavailable = !uiState.headlessAllowed,
-                onClick = { onLaunchModeSelected("headless") },
-                modifier = Modifier.weight(1f)
-            )
-            LaunchModeChoicePill(
-                label = virtualDisplayModeLabel,
-                status = when {
-                    uiState.virtualDisplayUnavailable -> "Unavailable"
-                    uiState.playMode == "virtual_display" -> "Selected"
-                    uiState.recommendedMode == "virtual_display" && uiState.virtualDisplayAllowed -> "Recommended"
-                    uiState.virtualDisplayAllowed -> "Available"
-                    else -> "Unavailable"
-                },
-                recommended = uiState.recommendedMode == "virtual_display" && uiState.virtualDisplayAllowed,
-                selected = uiState.playMode == "virtual_display",
-                unavailable = uiState.virtualDisplayUnavailable || !uiState.virtualDisplayAllowed,
-                onClick = { onLaunchModeSelected("virtual_display") },
-                modifier = Modifier.weight(1f)
-            )
+        if (uiState.showLaunchOptionsButton || uiState.showVirtualUnavailableHint) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                LaunchModeChoicePill(
+                    label = headlessModeLabel,
+                    status = when {
+                        uiState.playMode == "headless" -> "Selected"
+                        uiState.recommendedMode == "headless" && uiState.headlessAllowed -> "Recommended"
+                        uiState.headlessAllowed -> "Available"
+                        else -> "Unavailable"
+                    },
+                    recommended = uiState.recommendedMode == "headless" && uiState.headlessAllowed,
+                    selected = uiState.playMode == "headless",
+                    unavailable = !uiState.headlessAllowed,
+                    onClick = { onLaunchModeSelected("headless") },
+                    modifier = Modifier.weight(1f)
+                )
+                LaunchModeChoicePill(
+                    label = virtualDisplayModeLabel,
+                    status = when {
+                        uiState.virtualDisplayUnavailable -> "Unavailable"
+                        uiState.playMode == "virtual_display" -> "Selected"
+                        uiState.recommendedMode == "virtual_display" && uiState.virtualDisplayAllowed -> "Recommended"
+                        uiState.virtualDisplayAllowed -> "Available"
+                        else -> "Unavailable"
+                    },
+                    recommended = uiState.recommendedMode == "virtual_display" && uiState.virtualDisplayAllowed,
+                    selected = uiState.playMode == "virtual_display",
+                    unavailable = uiState.virtualDisplayUnavailable || !uiState.virtualDisplayAllowed,
+                    onClick = { onLaunchModeSelected("virtual_display") },
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
 
         Row(
@@ -1701,20 +1724,22 @@ private fun LaunchControls(
                 .padding(top = 9.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            NovaActionButton(
-                text = launchOptionsLabel,
-                onClick = onLaunchOptions,
-                modifier = Modifier.weight(1f),
-                contentDescription = launchOptionsLabel,
-                minHeight = 42.dp,
-                cornerRadius = 10.dp,
-                fontSize = 12.sp,
-                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp)
-            )
+            if (uiState.showLaunchOptionsButton) {
+                NovaActionButton(
+                    text = launchOptionsLabel,
+                    onClick = onLaunchOptions,
+                    modifier = Modifier.weight(1f),
+                    contentDescription = launchOptionsLabel,
+                    minHeight = 42.dp,
+                    cornerRadius = 10.dp,
+                    fontSize = 12.sp,
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp)
+                )
+            }
             NovaActionButton(
                 text = profilePreferenceLabel,
                 onClick = onProfilePreference,
-                modifier = Modifier.weight(1f),
+                modifier = if (uiState.showLaunchOptionsButton) Modifier.weight(1f) else Modifier.fillMaxWidth(),
                 contentDescription = profilePreferenceLabel,
                 minHeight = 42.dp,
                 cornerRadius = 10.dp,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -678,9 +678,20 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
             parts += getString(R.string.nova_library_launch_preferred_mode_format, modeLabel(uiState.preferredMode))
         }
         parts += when {
-            uiState.virtualDisplayUnavailable -> uiState.virtualDisplayUnavailableReason
-                .takeIf { it.isNotBlank() }
-                ?: getString(R.string.nova_library_launch_intro_virtual_unavailable)
+            uiState.virtualDisplayUnavailable -> {
+                val unavailableParts = mutableListOf(
+                    getString(R.string.nova_library_virtual_display_unavailable_body)
+                )
+                uiState.virtualDisplayUnavailableReason
+                    .takeIf { it.isNotBlank() }
+                    ?.let {
+                        unavailableParts += getString(
+                            R.string.nova_library_virtual_display_unavailable_reason_format,
+                            it
+                        )
+                    }
+                unavailableParts.joinToString(" ")
+            }
             uiState.launchChoice.hostModeReason.isNotBlank() -> uiState.launchChoice.hostModeReason
             uiState.game.launchMode?.modeReason?.isNotBlank() == true -> uiState.game.launchMode?.modeReason.orEmpty()
             uiState.recommendedMode == "virtual_display" -> getString(R.string.nova_library_launch_intro_virtual_default)

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -559,7 +559,11 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
     ): PolarisClientSettings? {
         val preferences = PreferenceConfiguration.readPreferences(context)
         return apiClient.updateClientSettings(
-            streamDisplayMode = if (usesVirtualDisplay) "host_virtual_display" else "headless_stream",
+            streamDisplayMode = if (usesVirtualDisplay) {
+                PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY
+            } else {
+                PolarisClientSettings.MODE_HEADLESS_STREAM
+            },
             displayMode = PreferenceConfiguration.formatStreamingDisplayMode(
                 preferences.width,
                 preferences.height,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
@@ -18,6 +18,10 @@ data class NovaGameDetailUiState(
     val playEnabled: Boolean,
     val playUsesVirtualDisplay: Boolean,
     val launchOptionsEnabled: Boolean,
+    val actionableLaunchModeCount: Int,
+    val showLaunchOptionsButton: Boolean,
+    val showLaunchModeSummary: Boolean,
+    val showVirtualUnavailableHint: Boolean,
     val showRecommendedModeBadge: Boolean,
     val profilePreference: String,
     val mangoHudRisk: MangoHudRisk,
@@ -46,7 +50,15 @@ data class NovaGameDetailUiState(
                 choice.virtualDisplayAllowed -> "virtual_display"
                 else -> ""
             }
-            val launchOptionsEnabled = choice.headlessAllowed || choice.virtualDisplayAllowed
+            val actionableLaunchModeCount = listOf(
+                choice.headlessAllowed,
+                choice.virtualDisplayAllowed
+            ).count { it }
+            val showVirtualUnavailableHint = choice.virtualDisplayUnavailable &&
+                choice.virtualDisplayUnavailableReason.isNotBlank()
+            val showLaunchOptionsButton = actionableLaunchModeCount > 1
+            val showLaunchModeSummary = actionableLaunchModeCount <= 1 || showVirtualUnavailableHint
+            val launchOptionsEnabled = showLaunchOptionsButton
             val mangoHudRisk = when {
                 game.isSteamBigPicture -> MangoHudRisk.BIG_PICTURE
                 game.hasMangoHudCompatibilityRisk -> MangoHudRisk.STEAM
@@ -72,6 +84,10 @@ data class NovaGameDetailUiState(
                 playEnabled = playMode.isNotBlank(),
                 playUsesVirtualDisplay = playMode == "virtual_display",
                 launchOptionsEnabled = launchOptionsEnabled,
+                actionableLaunchModeCount = actionableLaunchModeCount,
+                showLaunchOptionsButton = showLaunchOptionsButton,
+                showLaunchModeSummary = showLaunchModeSummary,
+                showVirtualUnavailableHint = showVirtualUnavailableHint,
                 showRecommendedModeBadge = launchOptionsEnabled,
                 profilePreference = AutoQualityProfilePreferences.normalize(profilePreference),
                 mangoHudRisk = mangoHudRisk,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -974,9 +974,9 @@
     <string name="summary_free_analog_stick_opacity">By default, only when the stick moves, the background is displayed. If you don\'t like it, you can adjust the opacity effect.</string>
     <string name="title_free_analog_stick_opacity">Free Analog Stick Background Opacity</string>
     <string name="title_exdisplay_mode">External Display Mode (Beta)</string>
-    <string name="title_fullexdisplay_mode">Fully External Display Mode (Beta)</string>
+    <string name="title_fullexdisplay_mode">Use Android external display</string>
     <string name="summary_exdisplay_mode">Stream display on the monitor, virtual buttons and performance information and other controls on the phone screen.</string>
-    <string name="summary_fullexdisplay_mode">Allows full immersive secondary screen mode with automatically matched refresh rate and resolution. Manual settings won\'t apply in this mode.</string>
+    <string name="summary_fullexdisplay_mode">Show the stream on an Android-connected display while keeping Nova controls on this device. This is separate from Polaris Host Virtual Display.</string>
     <string name="title_top_center_display">Display in Top Center</string>
     <string name="summary_top_center_display">Streaming picture will be aligned to the top of the screen instead of centered when resolution is not native.</string>
     <string name="title_touch_sensitivity">Touch Screen Sensitivity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,9 @@
     <string name="nova_library_launch_intro_headless_default">Nova will use a private stream for this launch.</string>
     <string name="nova_library_launch_intro_virtual_default">Nova will use a virtual display for this launch.</string>
     <string name="nova_library_launch_intro_virtual_unavailable">Virtual display is not available on this host. Nova will use a private stream for this launch.</string>
+    <string name="nova_library_virtual_display_unavailable_title">Host Virtual Display is not ready</string>
+    <string name="nova_library_virtual_display_unavailable_body">Polaris says this host cannot start a virtual-display stream right now. Nova will use Private Stream instead.</string>
+    <string name="nova_library_virtual_display_unavailable_reason_format">Reason: %1$s</string>
     <string name="nova_library_launch_mode_note">Private stream uses Nova\'s headless path when available. Virtual display creates a separate display for the session.</string>
     <string name="nova_library_launch_default_mode_badge">Default: %1$s</string>
     <string name="nova_desktop_steam_title">Desktop Steam is active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="nova_library_preflight_launch">Launch</string>
     <string name="nova_library_retry_high_fps">Retry High FPS</string>
     <string name="nova_library_launch_options">Launch Options</string>
+    <string name="nova_library_launch_options_secondary">More launch settings</string>
     <string name="nova_library_profile_preference_auto">AI Preference: Auto</string>
     <string name="nova_library_profile_preference_quality">AI Preference: Prefer Quality</string>
     <string name="nova_library_profile_preference_high_fps">AI Preference: Prefer High FPS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,8 +277,8 @@
     <string name="nova_library_meta_ready_to_play">Ready to play</string>
     <string name="nova_library_launch_mode_title">Launch Mode</string>
     <string name="nova_library_launch_headless">Private stream</string>
-    <string name="nova_library_launch_virtual_display">Virtual display</string>
-    <string name="nova_library_launch_virtual_short">Virtual</string>
+    <string name="nova_library_launch_virtual_display">Host Virtual Display</string>
+    <string name="nova_library_launch_virtual_short">Host Virtual</string>
     <string name="nova_library_launch_desktop_display">Desktop Display</string>
     <string name="nova_library_launch_gpu_native_test">GPU-Native Test</string>
     <string name="nova_library_play">Launch Recommended</string>
@@ -305,12 +305,12 @@
     <string name="nova_library_launch_recommended_format">%1$s · Recommended</string>
     <string name="nova_library_no_launch_modes">No launch modes are available for this game.</string>
     <string name="nova_library_launch_intro_headless_default">Nova will use a private stream for this launch.</string>
-    <string name="nova_library_launch_intro_virtual_default">Nova will use a virtual display for this launch.</string>
-    <string name="nova_library_launch_intro_virtual_unavailable">Virtual display is not available on this host. Nova will use a private stream for this launch.</string>
+    <string name="nova_library_launch_intro_virtual_default">Nova will use Host Virtual Display for this launch.</string>
+    <string name="nova_library_launch_intro_virtual_unavailable">Host Virtual Display is not ready on this host. Nova will use Private Stream instead.</string>
     <string name="nova_library_virtual_display_unavailable_title">Host Virtual Display is not ready</string>
     <string name="nova_library_virtual_display_unavailable_body">Polaris says this host cannot start a virtual-display stream right now. Nova will use Private Stream instead.</string>
     <string name="nova_library_virtual_display_unavailable_reason_format">Reason: %1$s</string>
-    <string name="nova_library_launch_mode_note">Private stream uses Nova\'s headless path when available. Virtual display creates a separate display for the session.</string>
+    <string name="nova_library_launch_mode_note">Private Stream keeps the launch off your physical desktop when available. Host Virtual Display creates a separate host display for the session.</string>
     <string name="nova_library_launch_default_mode_badge">Default: %1$s</string>
     <string name="nova_desktop_steam_title">Desktop Steam is active</string>
     <string name="nova_desktop_steam_message">Polaris detected that this launch may appear on the host\'s physical display. Choose a safe private stream or explicitly mirror the desktop.</string>
@@ -878,7 +878,7 @@
     <string name="nova_auto_quality_preference_high_fps">High FPS</string>
     <string name="nova_auto_quality_preference_stability">Stability</string>
     <string name="nova_session_mode_headless">Headless</string>
-    <string name="nova_session_mode_virtual_display">Virtual Display</string>
+    <string name="nova_session_mode_virtual_display">Host Virtual Display</string>
     <string name="nova_session_mode_host_display">Host Display</string>
     <string name="nova_session_mode_watch_format">Watching · %1$s</string>
     <string name="nova_session_mode_owner_format">%1$s · owner</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2051,6 +2051,18 @@ class NovaComposeSourceGuardTest {
         readSource("src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt")
 
     @Test
+    fun gameDetailLaunchOptionsUseActionableModeState() {
+        val launchControls = readNovaGameDetailSheet().section(
+            "private fun LaunchControls(",
+            "@Composable\nprivate fun LaunchModeChoicePill("
+        )
+
+        assertTrue(launchControls.contains("uiState.showLaunchOptionsButton"))
+        assertTrue(launchControls.contains("uiState.showLaunchModeSummary"))
+        assertFalse(launchControls.contains("uiState.launchOptionsEnabled"))
+    }
+
+    @Test
     fun gameDetailLaunchOptionsAvoidRawAppCompatAlertDialogButtons() {
         val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
         val launchOptions = detail.section(

--- a/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
@@ -35,6 +35,8 @@ class NovaGameDetailUiStateTest {
         assertTrue(state.playUsesVirtualDisplay)
         assertTrue(state.playEnabled)
         assertTrue(state.launchOptionsEnabled)
+        assertTrue(state.showLaunchOptionsButton)
+        assertFalse(state.showLaunchModeSummary)
         assertEquals("quality", state.profilePreference)
     }
 
@@ -87,6 +89,9 @@ class NovaGameDetailUiStateTest {
         assertEquals("headless", state.playMode)
         assertFalse(state.playUsesVirtualDisplay)
         assertTrue(state.virtualDisplayUnavailable)
+        assertTrue(state.showVirtualUnavailableHint)
+        assertFalse(state.showLaunchOptionsButton)
+        assertTrue(state.showLaunchModeSummary)
         assertEquals("Host virtual display disabled", state.virtualDisplayUnavailableReason)
         assertEquals("auto", state.profilePreference)
     }
@@ -115,6 +120,8 @@ class NovaGameDetailUiStateTest {
 
         assertFalse(state.playEnabled)
         assertFalse(state.launchOptionsEnabled)
+        assertFalse(state.showLaunchOptionsButton)
+        assertTrue(state.showLaunchModeSummary)
         assertFalse(state.showRecommendedModeBadge)
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -441,6 +441,19 @@ class NovaLaunchSourceGuardTest {
 
 
     @Test
+    fun virtualDisplayUnavailableCopyUsesHostVirtualDisplayLanguageAndReason() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val strings = readSource("src/main/res/values/strings.xml")
+
+        assertTrue(strings.contains("nova_library_virtual_display_unavailable_title") && strings.contains("Host Virtual Display is not ready"))
+        assertTrue(strings.contains("nova_library_virtual_display_unavailable_body") && strings.contains("Polaris says this host cannot start a virtual-display stream right now. Nova will use Private Stream instead."))
+        assertTrue(strings.contains("nova_library_virtual_display_unavailable_reason_format") && strings.contains("Reason: %1"))
+        assertTrue(detail.contains("nova_library_virtual_display_unavailable_body"))
+        assertTrue(detail.contains("nova_library_virtual_display_unavailable_reason_format"))
+        assertTrue(detail.contains("virtualDisplayUnavailableReason"))
+    }
+
+    @Test
     fun novaLaunchAndSessionStringsUsePlayerLifecycleLanguage() {
         val strings = readSource("src/main/res/values/strings.xml")
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -473,7 +473,7 @@ class NovaLaunchSourceGuardTest {
         assertTrue(
             "launch mode copy should explain private/headless and virtual display choices in player language",
             strings.contains("<string name=\"nova_library_launch_headless\">Private stream</string>") &&
-                strings.contains("<string name=\"nova_library_launch_virtual_display\">Virtual display</string>") &&
+                strings.contains("nova_library_launch_virtual_display" + 34.toChar() + ">Host Virtual Display</string>") &&
                 strings.contains("private stream for this launch")
         )
         assertTrue(

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -467,6 +467,17 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun androidExternalDisplayCopyIsSeparateFromHostVirtualDisplay() {
+        val preferences = readSource("src/main/res/xml/preferences.xml")
+        val strings = readSource("src/main/res/values/strings.xml")
+
+        assertTrue(preferences.contains("checkbox_enable_fullexdisplay"))
+        assertTrue(strings.contains("title_fullexdisplay_mode"))
+        assertTrue(strings.contains("Use Android external display"))
+        assertTrue(strings.contains("Show the stream on an Android-connected display while keeping Nova controls on this device. This is separate from Polaris Host Virtual Display."))
+    }
+
+    @Test
     fun novaLaunchAndSessionStringsUsePlayerLifecycleLanguage() {
         val strings = readSource("src/main/res/values/strings.xml")
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -175,6 +175,19 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun virtualLaunchPreflightUsesHostVirtualDisplayContractConstants() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val trampoline = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
+
+        assertTrue(detail.contains("PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY"))
+        assertTrue(detail.contains("PolarisClientSettings.MODE_HEADLESS_STREAM"))
+        assertTrue(trampoline.contains("PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY"))
+        assertTrue(trampoline.contains("PolarisClientSettings.MODE_HEADLESS_STREAM"))
+        assertTrue(detail.contains("streamDisplayMode = if (usesVirtualDisplay)"))
+        assertTrue(trampoline.contains("streamDisplayMode = if (withVirtualDisplay)"))
+    }
+
+    @Test
     fun shortcutLaunchUsesPolarisPreflightBeforeStartingStream() {
         val trampoline = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
         val serverHelper = readSource("src/main/java/com/papi/nova/utils/ServerHelper.kt")


### PR DESCRIPTION
## Summary
- Clarifies Nova launch-mode state so the game sheet can distinguish single-action launches from real mode selection.
- Hides noisy one-choice Launch Options, adds compact launch summaries, and explains Host Virtual Display unavailable fallbacks with the Polaris reason.
- Preserves the Host Virtual Display preflight contract with Polaris constants and separates Android external-display settings copy from Host Virtual Display.

## Verification
- git diff --check
- ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest
- ./gradlew --no-configuration-cache :app:assembleNonRoot_gameDebug

## APK artifacts from local verification
- app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-arm64-v8a-debug.apk sha256 41febb692739fa4b19c482973b1e972f06c302f65f59b1e5da730c3f5797691c
- app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-armeabi-v7a-debug.apk sha256 4412556f1eb14aec2fdd16b290106843446f8b770aaeac409d28f26ded6f68a2
- app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-x86_64-debug.apk sha256 70d33242bc6e5854e1b20d2a1c2e23974c4d7d4664e84179accc3767853151c9
