### PR TITLE
fix(nova): suppress headless host lock overlay

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -6258,7 +6258,7 @@ sdkInt < Build.VERSION_CODES.N)
 }
 
  @JvmStatic fun shouldShowPolarisLockOverlay(screenLocked:Boolean, cageRunning:Boolean):Boolean {
-return screenLocked
+return screenLocked && !cageRunning
 }
 
 private fun isDisconnectIntent(intent:Intent?):Boolean {

--- a/app/src/test/java/com/papi/nova/GameHdrDecisionTest.kt
+++ b/app/src/test/java/com/papi/nova/GameHdrDecisionTest.kt
@@ -29,4 +29,11 @@ class GameHdrDecisionTest {
         assertFalse(Game.shouldRequestHdrStream(true, false, Build.VERSION_CODES.M, false))
         assertTrue(Game.shouldShowHdrRequiresAndroidNToast(true, false, Build.VERSION_CODES.M))
     }
+
+    @Test
+    fun privateCompositorStreamSuppressesDesktopLockOverlay() {
+        assertTrue(Game.shouldShowPolarisLockOverlay(screenLocked = true, cageRunning = false))
+        assertFalse(Game.shouldShowPolarisLockOverlay(screenLocked = true, cageRunning = true))
+        assertFalse(Game.shouldShowPolarisLockOverlay(screenLocked = false, cageRunning = true))
+    }
 }

--- a/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
@@ -70,7 +70,8 @@ class KotlinGameRuntimeMigrationTest {
         assertTrue(Game.shouldRequestHdrStream(true, false, Build.VERSION_CODES.TIRAMISU, false))
         assertTrue(Game.shouldShowSdr10BitOptInToast(true, false, Build.VERSION_CODES.TIRAMISU, false))
         assertTrue(Game.shouldShowHdrRequiresAndroidNToast(true, false, Build.VERSION_CODES.M))
-        assertTrue(Game.shouldShowPolarisLockOverlay(true, true))
+        assertTrue(Game.shouldShowPolarisLockOverlay(true, false))
+        assertFalse(Game.shouldShowPolarisLockOverlay(true, true))
         assertFalse(Game.shouldShowPolarisLockOverlay(false, true))
         assertEquals(SimpleDateFormat("yyyy-MM-dd HH:mm").format(Date(0)), Game.formatCurrentTime(0))
     }


### PR DESCRIPTION
Summary: Suppress Nova Host locked overlay when Polaris reports screen_locked=true while the private headless compositor is running; preserve real locked-host prompt when no compositor is running. Tests: RED captured on GameHdrDecisionTest.privateCompositorStreamSuppressesDesktopLockOverlay; focused GameHdrDecisionTest and KotlinGameRuntimeMigrationTest passed; full :app:testNonRoot_gameDebugUnitTest passed; :app:assembleNonRoot_gameDebug passed. Retroid next: install arm64 APK sha256 1878e294d3939a71f1d1f52afb5e4846e60ecc4ee56ece1424b71e2dee705160 and verify MOUSE starts without default Host locked overlay.