### PR TITLE
feat(nova): add Android display target selector

### DIFF
--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingDefinitions.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingDefinitions.kt
@@ -203,6 +203,7 @@ object NovaSettingDefinitions {
         return when {
             this == "list_languages" -> NovaSettingApplyTiming.RestartApp
             this == "nova_theme" -> NovaSettingApplyTiming.Instant
+            this == PreferenceConfiguration.ANDROID_STREAM_DISPLAY_TARGET_PREF_STRING -> NovaSettingApplyTiming.NextStream
             categoryKey == "category_stream_quality" -> NovaSettingApplyTiming.NextStream
             categoryKey == "category_display_audio" -> NovaSettingApplyTiming.NextStream
             else -> NovaSettingApplyTiming.Instant

--- a/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
@@ -8,6 +8,7 @@ import android.view.Display
 import androidx.preference.PreferenceManager
 import com.papi.nova.nvstream.jni.MoonBridge
 import com.papi.nova.profiles.ProfilesManager
+import com.papi.nova.utils.AndroidStreamDisplayTarget
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.max
@@ -100,6 +101,7 @@ class PreferenceConfiguration {
     @JvmField var enableJoyConFix = false
     @JvmField var enableNewAnalogStick = false
     @JvmField var enableFullExDisplay = false
+    @JvmField var androidStreamDisplayTarget = AndroidStreamDisplayTarget.AUTO
     @JvmField var alignDisplayTopCenter = false
     @JvmField var touchSensitivityX = 0
     @JvmField var touchSensitivityY = 0
@@ -169,6 +171,8 @@ class PreferenceConfiguration {
         private const val ENABLE_ULTRA_LOW_LATENCY_PREF_STRING = "checkbox_ultra_low_latency"
         private const val ENFORCE_DISPLAY_MODE_PREF_STRING = "checkbox_enforce_display_mode"
         private const val USE_VIRTUAL_DISPLAY_PREF_STRING = "checkbox_use_virtual_display"
+        const val ENABLE_FULL_EXTERNAL_DISPLAY_PREF_STRING = "checkbox_enable_fullexdisplay"
+        const val ANDROID_STREAM_DISPLAY_TARGET_PREF_STRING = "android_stream_display_target"
         private const val AUTO_INVERT_VIDEO_RESOLUTION_PREF_STRING = "checkbox_auto_invert_video_resolution"
         private const val RESOLUTION_SCALE_FACTOR_PREF_STRING = "seekbar_resolution_scale_factor"
         private const val RESUME_WITHOUT_CONFIRM_PREF_STRING = "checkbox_resume_without_confirm"
@@ -255,6 +259,7 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_ULTRA_LOW_LATENCY = false
         private const val DEFAULT_ENFORCE_DISPLAY_MODE = false
         private const val DEFAULT_USE_VIRTUAL_DISPLAY = false
+        private const val DEFAULT_ANDROID_STREAM_DISPLAY_TARGET = AndroidStreamDisplayTarget.AUTO
         private const val DEFAULT_VIDEO_SCALE_MODE = "fit"
         private const val DEFAULT_AUTO_INVERT_VIDEO_RESOLUTION = true
         private const val DEFAULT_RESOLUTION_SCALE_FACTOR = 100
@@ -931,7 +936,11 @@ class PreferenceConfiguration {
             config.onscreenKeyboardAlignMode =
                 prefs.getString(LIST_ONSCREEN_KEYBOARD_ALIGN_MODE, DEFAULT_ONSCREEN_KEYBOARD_ALIGN_MODE)
             config.enableNewAnalogStick = prefs.getBoolean(CHECKBOX_CHECKBOX_ENABLE_ANALOG_STICK_NEW, false)
-            config.enableFullExDisplay = prefs.getBoolean("checkbox_enable_fullexdisplay", false)
+            config.enableFullExDisplay = prefs.getBoolean(ENABLE_FULL_EXTERNAL_DISPLAY_PREF_STRING, false)
+            config.androidStreamDisplayTarget = prefs.getString(
+                ANDROID_STREAM_DISPLAY_TARGET_PREF_STRING,
+                DEFAULT_ANDROID_STREAM_DISPLAY_TARGET,
+            ) ?: DEFAULT_ANDROID_STREAM_DISPLAY_TARGET
             config.alignDisplayTopCenter = prefs.getBoolean("checkbox_enable_view_top_center", false)
             config.touchSensitivityX = prefs.getInt(SEEKBAR_TOUCH_SENSITIVITY, 100)
             config.touchSensitivityY = prefs.getInt("seekbar_touch_sensitivity_opacity_y", 100)

--- a/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
+++ b/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
@@ -1,0 +1,31 @@
+package com.papi.nova.utils
+
+object AndroidStreamDisplayTarget {
+    const val AUTO = "auto"
+    const val PRIMARY = "primary"
+    const val EXTERNAL = "external"
+    const val LARGEST = "largest"
+
+    data class Candidate(
+        val displayId: Int,
+        val width: Int,
+        val height: Int,
+    ) {
+        val pixelArea: Long = width.toLong() * height.toLong()
+    }
+
+    fun select(displays: List<Candidate>, defaultDisplayId: Int, target: String?): Candidate? {
+        if (displays.isEmpty()) return null
+        val primary = displays.firstOrNull { it.displayId == defaultDisplayId } ?: displays.first()
+        val external = displays.firstOrNull { it.displayId != defaultDisplayId }
+        return when (target) {
+            PRIMARY -> primary
+            EXTERNAL -> external
+            LARGEST -> displays.maxWithOrNull(
+                compareBy<Candidate> { it.pixelArea }
+                    .thenByDescending { if (it.displayId == defaultDisplayId) 0 else 1 }
+            )
+            else -> external ?: primary
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
@@ -12,10 +12,12 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
+import android.hardware.display.DisplayManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.Display
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -82,7 +84,11 @@ class ExternalDisplayControlActivity :
             if (gameIntent == null) {
                 finish()
             } else {
-                val secondaryDisplay = getSecondaryDisplay(this)
+                val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+                val targetDisplayId = gameIntent.getIntExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY)
+                val secondaryDisplay = displayManager.getDisplay(targetDisplayId)
+                    ?.takeIf { it.displayId != Display.DEFAULT_DISPLAY }
+                    ?: getSecondaryDisplay(this)
                 if (secondaryDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     val options = ActivityOptions.makeBasic()
                     options.setLaunchDisplayId(secondaryDisplay.displayId)

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.hardware.display.DisplayManager
 import android.os.Build
+import android.util.DisplayMetrics
 import android.view.Display
 import android.widget.Toast
 import com.papi.nova.AppView
@@ -62,37 +63,46 @@ object ServerHelper {
 
     @JvmStatic
     fun getActiveDisplay(context: Context, prefs: PreferenceConfiguration): Display {
-        val secondary = getSecondaryDisplay(context)
-        return if (secondary != null && prefs.enableFullExDisplay) {
-            secondary
+        val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        val defaultDisplay = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            ?: throw IllegalStateException("Default display is unavailable")
+        return if (prefs.enableFullExDisplay) {
+            getAndroidStreamDisplay(context, prefs) ?: defaultDisplay
         } else {
-            val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-            displayManager.getDisplay(Display.DEFAULT_DISPLAY)
-                ?: throw IllegalStateException("Default display is unavailable")
+            defaultDisplay
         }
+    }
+
+    @JvmStatic
+    fun getAndroidStreamDisplay(context: Context, prefs: PreferenceConfiguration): Display? {
+        val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        return selectDisplay(displayManager.displays, prefs.androidStreamDisplayTarget)
     }
 
     @JvmStatic
     fun getSecondaryDisplay(context: Context): Display? {
         val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        var display: Display? = null
-        val displays = displayManager.displays
-        val mainDisplayId = Display.DEFAULT_DISPLAY
-        var secondaryDisplayId = -1
+        return selectDisplay(displayManager.displays, AndroidStreamDisplayTarget.EXTERNAL)
+    }
 
-        for (displayVariant in displays) {
-            LimeLog.info(displayVariant.toString())
-            if (displayVariant.displayId != mainDisplayId) {
-                secondaryDisplayId = displayVariant.displayId
-                break
-            }
+    private fun selectDisplay(displays: Array<Display>, target: String?): Display? {
+        val candidates = displays.map { display ->
+            LimeLog.info(display.toString())
+            val metrics = DisplayMetrics()
+            @Suppress("DEPRECATION")
+            display.getRealMetrics(metrics)
+            AndroidStreamDisplayTarget.Candidate(
+                displayId = display.displayId,
+                width = metrics.widthPixels,
+                height = metrics.heightPixels,
+            )
         }
-
-        if (secondaryDisplayId != -1) {
-            display = displayManager.getDisplay(secondaryDisplayId)
-        }
-
-        return display
+        val selected = AndroidStreamDisplayTarget.select(
+            candidates,
+            Display.DEFAULT_DISPLAY,
+            target,
+        ) ?: return null
+        return displays.firstOrNull { it.displayId == selected.displayId }
     }
 
     private fun createStartIntent(
@@ -118,14 +128,17 @@ object ServerHelper {
         forcePrivateAfterSteamClose: Boolean = false,
     ): Intent {
         val prefConfig = PreferenceConfiguration.readPreferences(parent)
-        val gameIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && prefConfig.enableFullExDisplay) {
-            val secondaryDisplay = getSecondaryDisplay(parent)
-            if (secondaryDisplay != null) {
-                Intent(parent.createDisplayContext(secondaryDisplay), Game::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            } else {
-                Intent(parent, Game::class.java)
+        val selectedAndroidDisplay = if (prefConfig.enableFullExDisplay) {
+            getAndroidStreamDisplay(parent, prefConfig)
+        } else {
+            null
+        }
+        val useAndroidExternalDisplay = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            selectedAndroidDisplay != null &&
+            selectedAndroidDisplay.displayId != Display.DEFAULT_DISPLAY
+        val gameIntent = if (useAndroidExternalDisplay) {
+            Intent(parent.createDisplayContext(selectedAndroidDisplay), Game::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
         } else {
             Intent(parent, Game::class.java)
@@ -165,13 +178,10 @@ object ServerHelper {
             gameIntent.putExtra(Game.EXTRA_SERVER_CERT, serverCert)
         }
 
-        if (prefConfig.enableFullExDisplay) {
-            val secondaryDisplay = getSecondaryDisplay(parent)
-            if (secondaryDisplay != null) {
-                gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, secondaryDisplay.displayId)
-                return Intent(parent, ExternalDisplayControlActivity::class.java).apply {
-                    putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent)
-                }
+        if (useAndroidExternalDisplay) {
+            gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, selectedAndroidDisplay.displayId)
+            return Intent(parent, ExternalDisplayControlActivity::class.java).apply {
+                putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent)
             }
         }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -56,6 +56,19 @@
         <item>bottom_right</item>
     </string-array>
 
+    <string-array name="android_stream_display_target_names">
+        <item>@string/android_stream_display_target_auto</item>
+        <item>@string/android_stream_display_target_primary</item>
+        <item>@string/android_stream_display_target_external</item>
+        <item>@string/android_stream_display_target_largest</item>
+    </string-array>
+    <string-array name="android_stream_display_target_values" translatable="false">
+        <item>auto</item>
+        <item>primary</item>
+        <item>external</item>
+        <item>largest</item>
+    </string-array>
+
     <string-array name="nova_preset_names">
         <item>Performance (720p, 10 Mbps)</item>
         <item>Balanced (1080p, 20 Mbps)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -977,6 +977,12 @@
     <string name="title_fullexdisplay_mode">Use Android external display</string>
     <string name="summary_exdisplay_mode">Stream display on the monitor, virtual buttons and performance information and other controls on the phone screen.</string>
     <string name="summary_fullexdisplay_mode">Show the stream on an Android-connected display while keeping Nova controls on this device. This is separate from Polaris Host Virtual Display.</string>
+    <string name="title_android_stream_display_target">Android stream display</string>
+    <string name="summary_android_stream_display_target">Choose which Android display shows the stream when external display mode is enabled. Auto keeps the old first-external behavior.</string>
+    <string name="android_stream_display_target_auto">Auto first external</string>
+    <string name="android_stream_display_target_primary">This device screen</string>
+    <string name="android_stream_display_target_external">First external display</string>
+    <string name="android_stream_display_target_largest">Largest display</string>
     <string name="title_top_center_display">Display in Top Center</string>
     <string name="summary_top_center_display">Streaming picture will be aligned to the top of the screen instead of centered when resolution is not native.</string>
     <string name="title_touch_sensitivity">Touch Screen Sensitivity</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -826,6 +826,16 @@
             android:title="@string/title_fullexdisplay_mode"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="auto"
+            android:dependency="checkbox_enable_fullexdisplay"
+            android:entries="@array/android_stream_display_target_names"
+            android:entryValues="@array/android_stream_display_target_values"
+            android:key="android_stream_display_target"
+            android:summary="@string/summary_android_stream_display_target"
+            android:title="@string/title_android_stream_display_target"
+            app:iconSpaceReserved="false" />
+
         <!-- Device fixes -->
         <CheckBoxPreference
             android:defaultValue="false"

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -6,6 +6,7 @@ import android.util.Xml
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.R
+import com.papi.nova.utils.AndroidStreamDisplayTarget
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -216,6 +217,28 @@ class NovaSettingsDefinitionsTest {
         assertFalse(keys.contains("checkbox_usb_driver"))
         assertFalse(keys.contains("checkbox_vibrate_fallback"))
         assertFalse(keys.contains("seekbar_vibrate_fallback_strength"))
+    }
+
+    @Test
+    fun externalDisplayTargetPreferenceOffersAutoPrimaryExternalAndLargest() {
+        val definitions = NovaSettingDefinitions.load(context)
+        val target = definitions.require(PreferenceConfiguration.ANDROID_STREAM_DISPLAY_TARGET_PREF_STRING)
+
+        assertEquals(NovaSettingType.Select, target.type)
+        assertEquals(NovaSettingValue.StringValue(AndroidStreamDisplayTarget.AUTO), target.defaultValue)
+        assertEquals(PreferenceConfiguration.ENABLE_FULL_EXTERNAL_DISPLAY_PREF_STRING, target.dependencyKey)
+        assertEquals(NovaSettingApplyTiming.NextStream, target.applyTiming)
+        assertEquals(
+            listOf(
+                AndroidStreamDisplayTarget.AUTO,
+                AndroidStreamDisplayTarget.PRIMARY,
+                AndroidStreamDisplayTarget.EXTERNAL,
+                AndroidStreamDisplayTarget.LARGEST
+            ),
+            target.options.map { it.value }
+        )
+        assertEquals(context.getString(R.string.android_stream_display_target_auto), target.options[0].label)
+        assertEquals(context.getString(R.string.android_stream_display_target_largest), target.options[3].label)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
@@ -1,0 +1,38 @@
+package com.papi.nova.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AndroidStreamDisplayTargetTest {
+    private val displays = listOf(
+        AndroidStreamDisplayTarget.Candidate(displayId = 0, width = 1920, height = 1080),
+        AndroidStreamDisplayTarget.Candidate(displayId = 2, width = 1280, height = 720),
+        AndroidStreamDisplayTarget.Candidate(displayId = 3, width = 2560, height = 1600),
+    )
+
+    @Test
+    fun autoKeepsFirstExternalDisplayForBackCompat() {
+        assertEquals(2, AndroidStreamDisplayTarget.select(displays, 0, AndroidStreamDisplayTarget.AUTO)?.displayId)
+    }
+
+    @Test
+    fun primaryChoosesDefaultDisplayEvenWhenExternalDisplaysExist() {
+        assertEquals(0, AndroidStreamDisplayTarget.select(displays, 0, AndroidStreamDisplayTarget.PRIMARY)?.displayId)
+    }
+
+    @Test
+    fun externalChoosesFirstNonDefaultDisplay() {
+        assertEquals(2, AndroidStreamDisplayTarget.select(displays, 0, AndroidStreamDisplayTarget.EXTERNAL)?.displayId)
+    }
+
+    @Test
+    fun largestChoosesDisplayWithLargestPixelArea() {
+        assertEquals(3, AndroidStreamDisplayTarget.select(displays, 0, AndroidStreamDisplayTarget.LARGEST)?.displayId)
+    }
+
+    @Test
+    fun externalReturnsNullWhenOnlyPrimaryExists() {
+        assertNull(AndroidStreamDisplayTarget.select(displays.take(1), 0, AndroidStreamDisplayTarget.EXTERNAL))
+    }
+}


### PR DESCRIPTION
## Summary
- Add an Android stream display selector for Nova external-display mode: Auto, This device screen, First external display, and Largest display.
- Route stream launch/display context through the selected target instead of always using the first secondary display.
- Keep Android external display wording separate from Polaris Host Virtual Display wording.

Closes #98

## Test Plan
- ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.utils.AndroidStreamDisplayTargetTest --tests com.papi.nova.preferences.NovaSettingsDefinitionsTest.externalDisplayTargetPreferenceOffersAutoPrimaryExternalAndLargest
- ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest :app:assembleNonRoot_gameDebug
- APK smoke: clean installed app-nonRoot_game-arm64-v8a-debug.apk on Retroid Pocket 6 and Retroid Pocket Flip2, launched com.papi.nova.debug/com.papi.nova.PcView, verified Nova process stayed running and no FATAL EXCEPTION appeared in recent logcat.

## APK Evidence
- app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-arm64-v8a-debug.apk
- sha256: e840f0494f1c375cbbfa4523a5d63c30535829955f1b1380ed48ecfcce18294d
