### PR TITLE
fix(ui): clarify host FPS recovery copy

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -155,7 +155,13 @@ data class NovaQuickMenuUiState(
             val healthSummary = when {
                 hostStateUnavailable -> context.getString(R.string.nova_quick_menu_host_state_unavailable)
                 status == null -> context.getString(R.string.nova_quick_menu_health_checking)
-                status.isHostRenderLimited -> context.getString(R.string.nova_quick_menu_health_host_render)
+                status.isHostRenderLimited -> context.getString(
+                    if (status.health.relaunchRecommended || status.autoQuality.relaunchRequired) {
+                        R.string.nova_quick_menu_health_host_render_recovery
+                    } else {
+                        R.string.nova_quick_menu_health_host_render
+                    }
+                )
                 hdrDowngradeSummary != null -> hdrDowngradeSummary
                 status.health.summary.isNotBlank() -> status.health.summary
                 status.hasHealthConcerns -> context.getString(R.string.nova_quick_menu_health_attention)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -794,7 +794,8 @@
     <string name="nova_quick_menu_virtual_subtitle">Quick keys and controls for virtual display streaming</string>
     <string name="nova_quick_menu_shutdown_subtitle">Host shutdown is in progress. Session actions are limited.</string>
     <string name="nova_quick_menu_health_checking">Checking session health</string>
-    <string name="nova_quick_menu_health_host_render">Host FPS is below target. Relaunch can restore full rate.</string>
+    <string name="nova_quick_menu_health_host_render">Host is rendering below the stream FPS target.</string>
+    <string name="nova_quick_menu_health_host_render_recovery">Host is rendering below target. Relaunch can apply the AI Recovery Profile.</string>
     <string name="nova_quick_menu_health_hdr_downgrade">HDR requested, but Polaris is streaming 10-bit SDR.</string>
     <string name="nova_quick_menu_health_hdr_headless_detail">Private Headless Stream does not report HDR metadata. Polaris is sending 10-bit SDR; use an HDR-capable display path for true HDR.</string>
     <string name="nova_quick_menu_health_hdr_downgrade_detail">Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -78,10 +78,34 @@ class NovaQuickMenuUiStateTest {
             aiEnabled = true
         )
 
-        assertEquals("Host FPS is below target. Relaunch can restore full rate.", state.healthSummary)
+        assertEquals("Host is rendering below target. Relaunch can apply the AI Recovery Profile.", state.healthSummary)
         assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
         assertEquals("AI Recovery Profile", state.stability.chip.label)
         assertEquals(NovaQuickMenuTone.WARNING, state.stability.chip.tone)
+    }
+
+    @Test
+    fun hostRenderLimitedWithoutRecoveryUsesMonitoringCopyOnly() {
+        val state = quickState(
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "watch",
+                    summary = "Host render path is missing the target frame rate",
+                    primaryIssue = "host_render_limited",
+                    hostRenderLimited = true,
+                    relaunchRecommended = false
+                ),
+                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
+                    enabled = true,
+                    state = "blocked",
+                    blockedReason = "host_render_limited",
+                    relaunchRequired = false
+                )
+            )
+        )
+
+        assertEquals("Host is rendering below the stream FPS target.", state.healthSummary)
+        assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
     }
 
     @Test


### PR DESCRIPTION
## Summary\n- split host-render-limited Command Center copy into monitoring vs recovery-queued states\n- remove the overbroad claim that relaunch can restore full rate\n- only mention relaunch when Polaris reports a recovery profile/relaunch path\n\n## Verification\n- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest.hostRenderLimitedSessionWarnsWithPlayerReadableRecoveryCopy --tests com.papi.nova.ui.NovaQuickMenuUiStateTest.hostRenderLimitedWithoutRecoveryUsesMonitoringCopyOnly --no-daemon\n- ./gradlew testDebugUnitTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest --no-daemon\n- ./gradlew testDebugUnitTest --no-daemon