### PR TITLE
fix(ui): polish Nova theme picker chrome

### DIFF
--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -91,7 +91,7 @@ import javax.microedition.khronos.opengles.GL10
 import org.xmlpull.v1.XmlPullParserException
 
 class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
-    private val THEME_PICKER_GRID_GAP_DP = 12
+    private val THEME_PICKER_GRID_GAP_DP = 8
     private var noPcFoundLayout: View? = null
     private lateinit var pcGridAdapter: PcGridAdapter
     private lateinit var shortcutHelper: ShortcutHelper
@@ -556,12 +556,14 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         lateinit var themePickerFocusLabel: TextView
 
         val content = NovaSheetChrome.createSheetContainer(this)
+        content.clipChildren = false
+        content.clipToPadding = false
 
         content.addView(
             TextView(this).apply {
                 text = getString(R.string.pcview_theme_picker_title)
                 setTextColor(textPrimary)
-                textSize = 22f
+                textSize = 20f
                 typeface = Typeface.DEFAULT_BOLD
                 includeFontPadding = false
             },
@@ -570,8 +572,8 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
             TextView(this).apply {
                 text = getString(R.string.pcview_theme_picker_hint)
                 setTextColor(textMuted)
-                textSize = 12f
-                setPadding(0, dp(6), 0, dp(14))
+                textSize = 11f
+                setPadding(0, dp(4), 0, dp(8))
             },
         )
 
@@ -582,22 +584,26 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
                 getThemePickerSubtitle(currentTheme),
             )
             setTextColor(NovaThemeManager.getAccentColor(this@PcView))
-            textSize = 12f
+            textSize = 11f
             typeface = Typeface.DEFAULT_BOLD
-            setPadding(0, 0, 0, dp(12))
+            setPadding(0, 0, 0, dp(6))
         }
         content.addView(themePickerFocusLabel)
 
         val themeGrid = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             val gridGap = dp(THEME_PICKER_GRID_GAP_DP)
-            setPadding(gridGap, 0, gridGap, gridGap)
+            setPadding(gridGap, gridGap, gridGap, gridGap)
+            clipChildren = false
+            clipToPadding = false
         }
         content.addView(themeGrid)
         themes.chunked(2).forEach { themePair ->
             val gridRow = LinearLayout(this).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
+                clipChildren = false
+                clipToPadding = false
             }
             themePair.forEachIndexed { index, theme ->
                 val row = createThemePickerRow(theme, currentTheme, themePickerFocusLabel, surface, textPrimary, textSecondary, dialog)
@@ -663,6 +669,8 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         val selected = theme == currentTheme
 
         val card = MaterialCardView(this).apply {
+            useCompatPadding = true
+            clipToOutline = false
             layoutParams = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -691,7 +699,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         val row = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
-            setPadding(dp(16), dp(14), dp(16), dp(14))
+            setPadding(dp(14), dp(9), dp(14), dp(9))
         }
         row.addView(
             View(this).apply {
@@ -713,7 +721,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
                     TextView(this@PcView).apply {
                         text = label
                         setTextColor(textPrimary)
-                        textSize = 17f
+                        textSize = 15f
                         typeface = Typeface.DEFAULT_BOLD
                         includeFontPadding = false
                     },
@@ -722,8 +730,8 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
                     TextView(this@PcView).apply {
                         text = subtitle
                         setTextColor(textSecondary)
-                        textSize = 12f
-                        setPadding(0, dp(5), dp(8), 0)
+                        textSize = 10f
+                        setPadding(0, dp(3), dp(8), 0)
                     },
                 )
             },
@@ -733,7 +741,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
                 TextView(this).apply {
                     text = getString(R.string.pcview_theme_picker_current_badge)
                     setTextColor(textPrimary)
-                    textSize = 11f
+                    textSize = 10f
                     typeface = Typeface.DEFAULT_BOLD
                     gravity = Gravity.CENTER
                     includeFontPadding = false
@@ -742,7 +750,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
                         setStroke(dp(1), rowAccent)
                         cornerRadius = dp(999).toFloat()
                     }
-                    setPadding(dp(12), dp(7), dp(12), dp(7))
+                    setPadding(dp(10), dp(5), dp(10), dp(5))
                 },
             )
         }

--- a/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
@@ -73,12 +73,12 @@ class PcGridAdapter(
         overlayView: ImageView,
         obj: PcViewModel.ComputerObject
     ) {
-        applyCardTheme(parentView, imgView, prgView!!, txtView)
+        val pcHolder = getPcHolder(parentView)
+        applyCardTheme(parentView, imgView, prgView!!, txtView, pcHolder)
 
         imgView.setImageResource(R.drawable.ic_computer)
         imgView.setColorFilter(NovaThemeManager.getTextSecondaryColor(context))
 
-        val pcHolder = getPcHolder(parentView)
         val statusDot = pcHolder.statusDot
         val statusText = pcHolder.statusText
         val statusHint = pcHolder.statusHint
@@ -205,7 +205,7 @@ class PcGridAdapter(
         statusHint.visibility = View.VISIBLE
     }
 
-    private fun applyCardTheme(parentView: View, imgView: ImageView, prgView: ProgressBar, txtView: TextView) {
+    private fun applyCardTheme(parentView: View, imgView: ImageView, prgView: ProgressBar, txtView: TextView, pcHolder: PcViewHolder) {
         val card = if (parentView is ViewGroup && parentView.childCount > 0) {
             parentView.getChildAt(0)
         } else {
@@ -227,6 +227,8 @@ class PcGridAdapter(
         if (primaryAction != null) {
             primaryAction.setTextColor(NovaThemeManager.getAccentColor(context))
         }
+        pcHolder.statusText?.setTextColor(NovaThemeManager.getTextMutedColor(context))
+        pcHolder.statusHint?.setTextColor(NovaThemeManager.getTextMutedColor(context))
     }
 
     companion object {

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.StateListDrawable
 import android.view.View
@@ -73,12 +74,14 @@ object NovaSheetChrome {
         dialog.window?.let { window ->
             window.setDimAmount(SCRIM_ALPHA)
             window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         }
 
         val sheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return
-        sheet.background = createSheetBackground(context)
+        sheet.background = ColorDrawable(Color.TRANSPARENT)
         sheet.clipToOutline = true
         sheet.setPadding(0, 0, 0, 0)
+        contentView?.background = createSheetBackground(context)
         contentView?.clipToOutline = true
 
         val measuredView = contentView ?: sheet

--- a/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
@@ -120,6 +120,9 @@ object NovaThemeManager {
         }
     }
 
+    private fun getMaterialYouSurfaceColor(context: Context): Int =
+        resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_bg_window))
+
     private fun resolveThemeColor(context: Context, attr: Int, fallback: Int): Int {
         val typedValue = TypedValue()
         if (!context.theme.resolveAttribute(attr, typedValue, true)) {
@@ -141,7 +144,7 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_window)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_window)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, android.R.attr.colorBackground, ContextCompat.getColor(context, R.color.nova_bg_window))
+                getMaterialYouSurfaceColor(context)
             else -> ContextCompat.getColor(context, R.color.nova_bg_window)
         }
     }

--- a/app/src/main/res/layout-land/activity_pc_view.xml
+++ b/app/src/main/res/layout-land/activity_pc_view.xml
@@ -45,7 +45,7 @@
                         android:fontFamily="sans-serif-light"
                         android:letterSpacing="0.04"
                         android:text="Nova"
-                        android:textColor="@color/nova_ice"
+                        android:textColor="?attr/colorOnSurface"
                         android:textSize="26sp" />
 
                     <TextView
@@ -56,7 +56,7 @@
                         android:fontFamily="sans-serif-medium"
                         android:letterSpacing="0.03"
                         android:text="@string/pcview_home_subtitle"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="11sp" />
                 </LinearLayout>
 
@@ -71,13 +71,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_profiles"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionPolarisSync"
@@ -90,13 +90,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_play"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionSettings"
@@ -108,13 +108,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_settings"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
             </LinearLayout>
 
             <TextView
@@ -124,7 +124,7 @@
                 android:layout_marginTop="2dp"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="end"
-                android:textColor="@color/nova_text_secondary"
+                android:textColor="?android:textColorSecondary"
                 android:textSize="10sp"
                 android:visibility="invisible"
                 tools:text="Settings" />
@@ -144,7 +144,7 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:foreground="?attr/selectableItemBackground"
-                    app:cardBackgroundColor="@color/nova_bg_elevated"
+                    app:cardBackgroundColor="?attr/colorSurface"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
                     app:strokeColor="?attr/colorAccent"
@@ -172,7 +172,7 @@
                             android:layout_marginTop="4dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_mode_servers"
-                            android:textColor="@color/nova_text_primary"
+                            android:textColor="?android:textColorPrimary"
                             android:textSize="18sp" />
 
                         <TextView
@@ -182,7 +182,7 @@
                             android:fontFamily="sans-serif"
                             android:lineSpacingExtra="2dp"
                             android:text="@string/pcview_destination_servers_summary"
-                            android:textColor="@color/nova_text_secondary"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="12sp" />
 
                         <TextView
@@ -192,7 +192,7 @@
                             android:layout_marginTop="6dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_destination_servers_meta_empty"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="11sp" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -206,10 +206,10 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:foreground="?attr/selectableItemBackground"
-                    app:cardBackgroundColor="@color/nova_bg_elevated"
+                    app:cardBackgroundColor="?attr/colorSurface"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
-                    app:strokeColor="@color/nova_divider"
+                    app:strokeColor="?attr/colorControlHighlight"
                     app:strokeWidth="1dp">
 
                     <LinearLayout
@@ -225,7 +225,7 @@
                             android:letterSpacing="0.04"
                             android:text="@string/pcview_destination_open"
                             android:textAllCaps="true"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="10sp" />
 
                         <TextView
@@ -234,7 +234,7 @@
                             android:layout_marginTop="4dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/nova_library_title"
-                            android:textColor="@color/nova_text_primary"
+                            android:textColor="?android:textColorPrimary"
                             android:textSize="18sp" />
 
                         <TextView
@@ -244,7 +244,7 @@
                             android:fontFamily="sans-serif"
                             android:lineSpacingExtra="2dp"
                             android:text="@string/pcview_destination_library_summary"
-                            android:textColor="@color/nova_text_secondary"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="12sp" />
 
                         <TextView
@@ -254,7 +254,7 @@
                             android:layout_marginTop="6dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_destination_library_meta_empty"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="11sp" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -268,7 +268,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.03"
                 android:text="@string/pcview_tools_label"
-                android:textColor="@color/nova_text_primary"
+                android:textColor="?android:textColorPrimary"
                 android:textSize="13sp"
                 android:visibility="gone" />
 
@@ -279,7 +279,7 @@
                 android:layout_marginTop="2dp"
                 android:fontFamily="sans-serif"
                 android:text="@string/pcview_tools_hint"
-                android:textColor="@color/nova_text_muted"
+                android:textColor="?android:textColorSecondary"
                 android:textSize="11sp"
                 android:visibility="gone" />
 
@@ -303,7 +303,7 @@
                     app:elevation="0dp"
                     app:icon="@drawable/ic_add"
                     app:iconPadding="8dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionScanPair"
@@ -314,12 +314,12 @@
                     android:layout_weight="1"
                     android:text="@string/pcview_quick_scan_pair"
                     android:textAllCaps="false"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_qr_scan"
                     app:iconPadding="8dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
             </LinearLayout>
 
             <HorizontalScrollView
@@ -363,7 +363,7 @@
                     android:fontFamily="sans-serif-medium"
                     android:letterSpacing="0.03"
                     android:text="@string/pcview_hosts_label"
-                    android:textColor="@color/nova_text_primary"
+                    android:textColor="?android:textColorPrimary"
                     android:textSize="12sp" />
 
                 <TextView
@@ -371,7 +371,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="sans-serif-medium"
-                    android:textColor="@color/nova_text_muted"
+                    android:textColor="?android:textColorSecondary"
                     android:textSize="11sp"
                     tools:text="1 visible · 3 total" />
             </LinearLayout>
@@ -471,7 +471,7 @@
                         android:layout_marginTop="12dp"
                         android:fontFamily="sans-serif"
                         android:text="@string/pcview_empty_title_searching"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="14sp" />
 
                     <TextView
@@ -483,7 +483,7 @@
                         android:fontFamily="sans-serif"
                         android:gravity="center"
                         android:text="@string/pcview_empty_hint_searching"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="12sp" />
 
                     <HorizontalScrollView

--- a/app/src/main/res/layout/activity_pc_view.xml
+++ b/app/src/main/res/layout/activity_pc_view.xml
@@ -45,7 +45,7 @@
                         android:fontFamily="sans-serif-light"
                         android:letterSpacing="0.04"
                         android:text="Nova"
-                        android:textColor="@color/nova_ice"
+                        android:textColor="?attr/colorOnSurface"
                         android:textSize="30sp" />
 
                     <TextView
@@ -56,7 +56,7 @@
                         android:fontFamily="sans-serif-medium"
                         android:letterSpacing="0.03"
                         android:text="@string/pcview_home_subtitle"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="11sp" />
                 </LinearLayout>
 
@@ -71,13 +71,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_profiles"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionPolarisSync"
@@ -90,13 +90,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_play"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionSettings"
@@ -108,13 +108,13 @@
                     android:insetBottom="0dp"
                     android:minWidth="0dp"
                     android:padding="0dp"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_settings"
                     app:iconGravity="textStart"
                     app:iconPadding="0dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
             </LinearLayout>
 
             <TextView
@@ -124,7 +124,7 @@
                 android:layout_marginTop="4dp"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="end"
-                android:textColor="@color/nova_text_secondary"
+                android:textColor="?android:textColorSecondary"
                 android:textSize="11sp"
                 android:visibility="invisible"
                 tools:text="Settings" />
@@ -144,7 +144,7 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:foreground="?attr/selectableItemBackground"
-                    app:cardBackgroundColor="@color/nova_bg_elevated"
+                    app:cardBackgroundColor="?attr/colorSurface"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
                     app:strokeColor="?attr/colorAccent"
@@ -172,7 +172,7 @@
                             android:layout_marginTop="6dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_mode_servers"
-                            android:textColor="@color/nova_text_primary"
+                            android:textColor="?android:textColorPrimary"
                             android:textSize="20sp" />
 
                         <TextView
@@ -182,7 +182,7 @@
                             android:fontFamily="sans-serif"
                             android:lineSpacingExtra="2dp"
                             android:text="@string/pcview_destination_servers_summary"
-                            android:textColor="@color/nova_text_secondary"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="12sp" />
 
                         <TextView
@@ -192,7 +192,7 @@
                             android:layout_marginTop="10dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_destination_servers_meta_empty"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="11sp" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -206,10 +206,10 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:foreground="?attr/selectableItemBackground"
-                    app:cardBackgroundColor="@color/nova_bg_elevated"
+                    app:cardBackgroundColor="?attr/colorSurface"
                     app:cardCornerRadius="18dp"
                     app:cardElevation="0dp"
-                    app:strokeColor="@color/nova_divider"
+                    app:strokeColor="?attr/colorControlHighlight"
                     app:strokeWidth="1dp">
 
                     <LinearLayout
@@ -225,7 +225,7 @@
                             android:letterSpacing="0.04"
                             android:text="@string/pcview_destination_open"
                             android:textAllCaps="true"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="10sp" />
 
                         <TextView
@@ -234,7 +234,7 @@
                             android:layout_marginTop="6dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/nova_library_title"
-                            android:textColor="@color/nova_text_primary"
+                            android:textColor="?android:textColorPrimary"
                             android:textSize="20sp" />
 
                         <TextView
@@ -244,7 +244,7 @@
                             android:fontFamily="sans-serif"
                             android:lineSpacingExtra="2dp"
                             android:text="@string/pcview_destination_library_summary"
-                            android:textColor="@color/nova_text_secondary"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="12sp" />
 
                         <TextView
@@ -254,7 +254,7 @@
                             android:layout_marginTop="10dp"
                             android:fontFamily="sans-serif-medium"
                             android:text="@string/pcview_destination_library_meta_empty"
-                            android:textColor="@color/nova_text_muted"
+                            android:textColor="?android:textColorSecondary"
                             android:textSize="11sp" />
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
@@ -268,7 +268,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.03"
                 android:text="@string/pcview_tools_label"
-                android:textColor="@color/nova_text_primary"
+                android:textColor="?android:textColorPrimary"
                 android:textSize="13sp" />
 
             <TextView
@@ -278,7 +278,7 @@
                 android:layout_marginTop="2dp"
                 android:fontFamily="sans-serif"
                 android:text="@string/pcview_tools_hint"
-                android:textColor="@color/nova_text_muted"
+                android:textColor="?android:textColorSecondary"
                 android:textSize="11sp" />
 
             <LinearLayout
@@ -301,7 +301,7 @@
                     app:elevation="0dp"
                     app:icon="@drawable/ic_add"
                     app:iconPadding="8dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/actionScanPair"
@@ -312,12 +312,12 @@
                     android:layout_weight="1"
                     android:text="@string/pcview_quick_scan_pair"
                     android:textAllCaps="false"
-                    app:backgroundTint="@color/nova_badge_bg"
+                    app:backgroundTint="?attr/colorControlHighlight"
                     app:cornerRadius="14dp"
                     app:elevation="0dp"
                     app:icon="@drawable/ic_qr_scan"
                     app:iconPadding="8dp"
-                    app:iconTint="@color/nova_ice" />
+                    app:iconTint="?attr/colorOnSurface" />
             </LinearLayout>
 
             <HorizontalScrollView
@@ -361,7 +361,7 @@
                     android:fontFamily="sans-serif-medium"
                     android:letterSpacing="0.03"
                     android:text="@string/pcview_hosts_label"
-                    android:textColor="@color/nova_text_primary"
+                    android:textColor="?android:textColorPrimary"
                     android:textSize="13sp" />
 
                 <TextView
@@ -369,7 +369,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="sans-serif-medium"
-                    android:textColor="@color/nova_text_muted"
+                    android:textColor="?android:textColorSecondary"
                     android:textSize="11sp"
                     tools:text="1 visible · 3 total" />
             </LinearLayout>
@@ -469,7 +469,7 @@
                         android:layout_marginTop="12dp"
                         android:fontFamily="sans-serif"
                         android:text="@string/pcview_empty_title_searching"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="14sp" />
 
                     <TextView
@@ -481,7 +481,7 @@
                         android:fontFamily="sans-serif"
                         android:gravity="center"
                         android:text="@string/pcview_empty_hint_searching"
-                        android:textColor="@color/nova_text_muted"
+                        android:textColor="?android:textColorSecondary"
                         android:textSize="12sp" />
 
                     <HorizontalScrollView

--- a/app/src/main/res/layout/pc_grid_item.xml
+++ b/app/src/main/res/layout/pc_grid_item.xml
@@ -64,7 +64,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textSize="@dimen/nova_text_body"
-                android:textColor="@color/nova_ice"
+                android:textColor="?android:textColorPrimary"
                 android:fontFamily="sans-serif-medium"
                 android:maxLines="1"
                 android:ellipsize="end" />
@@ -90,7 +90,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/nova_spacing_sm"
                     android:textSize="@dimen/nova_text_label"
-                    android:textColor="@color/nova_text_muted"
+                    android:textColor="?android:textColorSecondary"
                     android:fontFamily="sans-serif"
                     android:text="Connecting..." />
             </LinearLayout>
@@ -103,7 +103,7 @@
                 android:ellipsize="end"
                 android:fontFamily="sans-serif"
                 android:maxLines="1"
-                android:textColor="@color/nova_text_muted"
+                android:textColor="?android:textColorSecondary"
                 android:textSize="11sp"
                 android:visibility="gone" />
         </LinearLayout>
@@ -120,7 +120,7 @@
             android:paddingEnd="12dp"
             android:paddingBottom="8dp"
             android:text="Open Apps"
-            android:textColor="@color/nova_text_primary"
+            android:textColor="?android:textColorPrimary"
             android:textSize="12sp" />
 
     </LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,7 +2,7 @@
 <resources>
     <string-array name="nova_theme_names">
         <item>Polaris Aurora</item>
-        <item>PSP Chrome / Portable Chrome</item>
+        <item>Portable Chrome</item>
         <item>Console OLED</item>
         <item>Miami Nebula</item>
         <item>High Contrast</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="nova_theme_cycle">Cycle theme</string>
     <string name="nova_theme_switched_to">Theme: %1$s</string>
     <string name="nova_theme_polaris_label">Polaris Aurora</string>
-    <string name="nova_theme_portable_chrome_label">PSP Chrome / Portable Chrome</string>
+    <string name="nova_theme_portable_chrome_label">Portable Chrome</string>
     <string name="nova_theme_oled_label">Console OLED</string>
     <string name="nova_theme_miami_label">Miami Nebula</string>
     <string name="nova_theme_high_contrast_label">High Contrast</string>
@@ -82,7 +82,7 @@
     <string name="pcview_theme_picker_focus_format">Focused: %1$s · %2$s</string>
     <string name="pcview_theme_picker_current_badge">Current</string>
     <string name="pcview_theme_polaris_subtitle">Polaris blue cockpit · balanced dark streaming shell</string>
-    <string name="pcview_theme_portable_chrome_subtitle">PSP / Portable Chrome profile · smoked graphite, dim silver, muted green accents</string>
+    <string name="pcview_theme_portable_chrome_subtitle">Smoked graphite handheld chrome profile · dim silver shell · muted green accents</string>
     <string name="pcview_theme_oled_subtitle">OLED black · high contrast console glow</string>
     <string name="pcview_theme_miami_subtitle">Miami neon · warm rose and cyan night drive</string>
     <string name="pcview_theme_high_contrast_subtitle">Maximum contrast · accessibility-first focus states</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="android:textColor">@color/nova_text_primary</item>
     </style>
 
-    <!-- PSP / Portable Chrome — smoked graphite/silver shell with restrained green status accent. -->
+    <!-- Portable Chrome — smoked graphite/silver shell with restrained green status accent. -->
     <style name="AppTheme.PortableChrome" parent="AppBaseTheme">
         <item name="android:colorBackground">@color/nova_portable_bg_window</item>
         <item name="android:windowBackground">@color/nova_portable_bg_window</item>
@@ -94,12 +94,23 @@
 
     <!-- Material You — uses system dynamic colors on Android 12+ -->
     <style name="AppTheme.MaterialYou">
-        <item name="android:colorBackground">@color/nova_bg_window</item>
-        <item name="android:windowBackground">@color/nova_bg_window</item>
+        <item name="android:colorBackground">?attr/colorSurface</item>
+        <item name="android:windowBackground">?attr/colorSurface</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textColorPrimary">?attr/colorOnSurface</item>
+        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
         <!-- colorPrimary and colorAccent are overridden by DynamicColors.applyToActivityIfAvailable() -->
     </style>
 
     <style name="SettingsTheme.MaterialYou" parent="SettingsTheme">
+        <item name="android:colorBackground">?attr/colorSurface</item>
+        <item name="android:windowBackground">?attr/colorSurface</item>
+        <item name="android:textColorPrimary">?attr/colorOnSurface</item>
+        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
         <!-- colorPrimary and colorAccent are overridden by DynamicColors.applyToActivityIfAvailable() -->
     </style>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -620,7 +620,7 @@
         <ListPreference
             android:key="nova_theme"
             android:title="Theme"
-            android:summary="Polaris Aurora, PSP Chrome / Portable Chrome, Console OLED, Miami Nebula, High Contrast, or Material You"
+            android:summary="Polaris Aurora, Console OLED, Miami Nebula, Portable Chrome, High Contrast, or Material You"
             android:entries="@array/nova_theme_names"
             android:entryValues="@array/nova_theme_values"
             android:defaultValue="polaris"

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -24,7 +24,7 @@ class NovaThemeResourcesTest {
             listOf("polaris", "portable_chrome", "oled", "miami", "high_contrast", "material_you"),
             values
         )
-        assertEquals("PSP Chrome / Portable Chrome", names[values.indexOf("portable_chrome")])
+        assertEquals("Portable Chrome", names[values.indexOf("portable_chrome")])
         assertEquals("Miami Nebula", names[values.indexOf("miami")])
     }
 
@@ -53,13 +53,13 @@ class NovaThemeResourcesTest {
 
 
     @Test
-    fun pspPortableChromeIsASelectableThemeValueAndLabel() {
+    fun portableChromeIsASelectableThemeValueAndLabel() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
         NovaThemeManager.setTheme(context, NovaThemeManager.THEME_PORTABLE_CHROME)
 
         assertEquals(NovaThemeManager.THEME_PORTABLE_CHROME, NovaThemeManager.getTheme(context))
-        assertEquals("PSP Chrome / Portable Chrome", NovaThemeManager.getThemeLabel(context))
+        assertEquals("Portable Chrome", NovaThemeManager.getThemeLabel(context))
     }
 
     @Test
@@ -91,7 +91,7 @@ class NovaThemeResourcesTest {
     }
 
     @Test
-    fun pcViewThemePickerExposesPspPortableChrome() {
+    fun pcViewThemePickerExposesPortableChrome() {
         val source = File("src/main/java/com/papi/nova/PcView.kt").readText()
         val picker = source.substringAfter("private fun showThemePicker(")
             .substringBefore("private fun applyThemeSelection")
@@ -119,11 +119,14 @@ class NovaThemeResourcesTest {
         assertTrue("theme picker rows must update visible state on D-pad focus", source.contains("setOnFocusChangeListener"))
         assertTrue("theme picker should use a compact two-column grid so Material You is not pushed below the Retroid landscape fold", picker.contains("themes.chunked(2)"))
         assertTrue("Material You should remain part of the dashboard picker when the device supports it", picker.contains("NovaThemeManager.THEME_MATERIAL_YOU"))
+        assertTrue("theme picker sheet should disable parent clipping so rounded selected/focused strokes are not cut off", picker.contains("clipChildren = false") && picker.contains("clipToPadding = false"))
+        assertTrue("theme picker grid should reserve top padding for thick focus strokes", picker.contains("setPadding(gridGap, gridGap, gridGap, gridGap)"))
+        assertTrue("theme picker cards should reserve compat padding around rounded strokes", picker.contains("useCompatPadding = true"))
         assertFalse("theme picker rows must not use the solid server-card foreground that obscures focused text", picker.contains("nova_card_focus_frame"))
         assertFalse("non-selected theme rows should not repeat an obvious Press A badge", picker.contains("pcview_theme_picker_apply_badge"))
         assertTrue("theme picker should request focus for the current/first row", source.contains("requestFocus()"))
-        assertTrue("Chrome needs to be eye-scan visible in the picker title", strings.contains("PSP Chrome / Portable Chrome"))
-        assertTrue("the exact old alias should remain visible as a subtitle", strings.contains("PSP / Portable Chrome profile"))
+        assertTrue("Portable Chrome should be eye-scan visible as the picker title", strings.contains("Portable Chrome"))
+        assertTrue("Portable Chrome subtitle should describe the chrome profile without PSP naming", strings.contains("Smoked graphite handheld chrome profile"))
         assertTrue("the picker should tell handheld users that D-pad focus is live", strings.contains("D-pad"))
         assertFalse("the picker copy should not repeat Press A after removing per-row action badges", strings.contains("Press A"))
     }
@@ -185,6 +188,17 @@ class NovaThemeResourcesTest {
         assertTrue("sheet chrome should include theme-specific light/dark stroke blending", sheetChrome.contains("getSheetStrokeColor"))
     }
 
+
+    @Test
+    fun bottomSheetChromeClearsMaterialHostSoChildPanelDoesNotDrawABottomBump() {
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val applyBody = sheetChrome.substringAfter("fun applyBottomSheetChrome(")
+            .substringBefore("fun applyAlertDialogChrome")
+
+        assertTrue("bottom-sheet chrome must clear the Material host/window to transparent so it cannot peek out as a bottom bump", applyBody.contains("ColorDrawable(Color.TRANSPARENT)"))
+        assertTrue("bottom-sheet chrome should draw the themed glass surface on the content panel, not the Material host", applyBody.contains("contentView?.background = createSheetBackground(context)"))
+        assertFalse("Material design_bottom_sheet host must not draw the same rounded sheet background behind the content panel", applyBody.contains("sheet.background = createSheetBackground(context)"))
+    }
 
     @Test
     fun legacyFocusableDrawablesUseThemeAttrsInsteadOfStaticPolarisAccent() {


### PR DESCRIPTION
## Summary
- Renames the visible theme label from PSP Chrome / Portable Chrome to Portable Chrome across picker/settings copy.
- Tightens the Retroid landscape theme picker so all six themes fit without clipped rounded focus strokes.
- Moves dashboard and server-row chrome to active theme attrs/runtime NovaThemeManager tokens, and makes Material You use dynamic surface colors instead of old Nova background fallback.

## Test Plan
- git diff --cached --check
- ./gradlew testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.NovaFocusDrawableTest --tests com.papi.nova.ui.compose.NovaLibrarySurfacesTest
- ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug
- ./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug

## Device proof
- Installed the arm64 debug APK on Retroid Pocket 6.
- Captured live dashboard, theme picker, library, System drawer, Library Options drawer, and Material You dashboard/drawer screenshots.
- Restored debug app preference nova_theme=polaris after testing.
