### PR TITLE
style(ui): tune Nova theme accent palettes

### DIFF
--- a/app/src/main/res/values/colors_nova.xml
+++ b/app/src/main/res/values/colors_nova.xml
@@ -32,11 +32,11 @@
     <color name="nova_oled_accent">#FF8b80ff</color>
     <color name="nova_oled_accent_surface">#148b80ff</color>
 
-    <!-- Miami Nebula — Polaris plum/rose theme with neon flamingo focus. -->
+    <!-- Miami Nebula — deep plum shell with flamingo-pink hero focus and cyan/aqua neon-water support. -->
     <color name="nova_miami_void">#FF130817</color>
     <color name="nova_miami_deep">#FF241429</color>
     <color name="nova_miami_twilight">#FF3F2447</color>
-    <color name="nova_miami_storm">#FFB785A1</color>
+    <color name="nova_miami_storm">#FF85C7D4</color>
     <color name="nova_miami_silver">#FFFFD3E2</color>
     <color name="nova_miami_ice">#FFFFF1F7</color>
     <color name="nova_miami_bg_primary">#FF241429</color>
@@ -49,11 +49,14 @@
     <color name="nova_miami_divider">#FF6C3C6F</color>
     <color name="nova_miami_text_primary">#FFFFF1F7</color>
     <color name="nova_miami_text_secondary">#FFFFD3E2</color>
-    <color name="nova_miami_text_muted">#FFB785A1</color>
+    <color name="nova_miami_text_muted">#FF85C7D4</color>
     <color name="nova_miami_accent">#FFFF5CAB</color>
     <color name="nova_miami_accent_surface">#1AFF5CAB</color>
     <color name="nova_miami_accent_glow">#73FF5CAB</color>
     <color name="nova_miami_ripple">#22FF5CAB</color>
+    <color name="nova_miami_water_accent">#FF47F3FF</color>
+    <color name="nova_miami_water_accent_surface">#1A47F3FF</color>
+    <color name="nova_miami_water_accent_glow">#7347F3FF</color>
 
     <!-- High Contrast — brighter copy, firm outlines, and blue focus for readability. -->
     <color name="nova_hc_bg_primary">#FF05070c</color>
@@ -88,10 +91,14 @@
     <color name="nova_portable_text_primary">#FF1F2A35</color>
     <color name="nova_portable_text_secondary">#FF3B4856</color>
     <color name="nova_portable_text_muted">#FF5E6B79</color>
-    <color name="nova_portable_accent">#FF7FA38D</color>
-    <color name="nova_portable_accent_glow">#337FA38D</color>
-    <color name="nova_portable_accent_surface">#1A7FA38D</color>
-    <color name="nova_portable_ripple">#227FA38D</color>
+    <color name="nova_portable_accent">#FF2F64B3</color>
+    <color name="nova_portable_cross_accent">#FF2F64B3</color>
+    <color name="nova_portable_square_accent">#FF9D679D</color>
+    <color name="nova_portable_circle_accent">#FFB8575F</color>
+    <color name="nova_portable_triangle_accent">#FF4F9A67</color>
+    <color name="nova_portable_accent_glow">#332F64B3</color>
+    <color name="nova_portable_accent_surface">#1A2F64B3</color>
+    <color name="nova_portable_ripple">#222F64B3</color>
 
     <color name="nova_accent">@color/nova_polaris_accent</color>
     <color name="nova_accent_glow">@color/nova_polaris_accent_glow</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,9 +82,9 @@
     <string name="pcview_theme_picker_focus_format">Focused: %1$s · %2$s</string>
     <string name="pcview_theme_picker_current_badge">Current</string>
     <string name="pcview_theme_polaris_subtitle">Polaris blue cockpit · balanced dark streaming shell</string>
-    <string name="pcview_theme_portable_chrome_subtitle">Smoked graphite handheld chrome profile · dim silver shell · muted green accents</string>
+    <string name="pcview_theme_portable_chrome_subtitle">Smoked graphite handheld chrome profile · dim silver shell · PlayStation-symbol accents</string>
     <string name="pcview_theme_oled_subtitle">OLED black · high contrast console glow</string>
-    <string name="pcview_theme_miami_subtitle">Miami neon · warm rose and cyan night drive</string>
+    <string name="pcview_theme_miami_subtitle">Miami neon · flamingo pink glow · cyan/aqua night drive</string>
     <string name="pcview_theme_high_contrast_subtitle">Maximum contrast · accessibility-first focus states</string>
     <string name="pcview_theme_material_you_subtitle">System dynamic colors when Android supports them</string>
     <string name="pcview_filter_all">All</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="android:textColor">@color/nova_text_primary</item>
     </style>
 
-    <!-- Portable Chrome — smoked graphite/silver shell with restrained green status accent. -->
+    <!-- Portable Chrome — smoked graphite/silver shell with subtle PlayStation-symbol accents. -->
     <style name="AppTheme.PortableChrome" parent="AppBaseTheme">
         <item name="android:colorBackground">@color/nova_portable_bg_window</item>
         <item name="android:windowBackground">@color/nova_portable_bg_window</item>
@@ -62,7 +62,7 @@
         <item name="colorOnSurface">@color/nova_oled_text_primary</item>
     </style>
 
-    <!-- Miami Nebula — deep plum shell with neon flamingo accent. -->
+    <!-- Miami Nebula — deep plum shell with flamingo-pink hero accent and cyan/aqua support. -->
     <style name="AppTheme.Miami">
         <item name="android:colorBackground">@color/nova_miami_bg_window</item>
         <item name="android:windowBackground">@color/nova_miami_bg_window</item>

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -35,9 +35,9 @@ class NovaThemeResourcesTest {
         listOf(
             "latest available debug nova apk",
             "latest available debug polaris build",
-            "psp chrome / portable chrome",
-            "steel-blue/graphite",
-            "muted green/status accents",
+            "portable chrome playstation symbol accents",
+            "smoked graphite/dim moonlight grey/silver",
+            "flamingo pink as the visible hero accent",
             "purple/violet accents must not",
             "transparent/glass",
             "novahud",
@@ -72,7 +72,7 @@ class NovaThemeResourcesTest {
         assertTrue(manager.contains("THEME_PORTABLE_CHROME"))
         assertTrue(manager.contains("portable_chrome"))
         assertTrue(manager.contains("psp"))
-        assertTrue(colors.contains("<color name=\"nova_portable_accent\">#FF7FA38D</color>"))
+        assertTrue(colors.contains("nova_portable_accent") && colors.contains("#FF2F64B3"))
         assertTrue(colors.contains("<color name=\"nova_accent\">@color/nova_polaris_accent</color>"))
         assertTrue(!colors.lowercase().contains("7c73ff"))
     }
@@ -83,11 +83,41 @@ class NovaThemeResourcesTest {
         val colors = File("src/main/res/values/colors_nova.xml").readText()
         val styles = File("src/main/res/values/styles.xml").readText()
 
-        assertTrue(colors.contains("<color name=\"nova_portable_accent\">#FF7FA38D</color>"))
+        assertTrue(colors.contains("nova_portable_accent") && colors.contains("#FF2F64B3"))
         assertTrue(colors.contains("<color name=\"nova_polaris_accent\">"))
         assertTrue(styles.contains("AppTheme.PortableChrome"))
         assertTrue(styles.contains("SettingsTheme.PortableChrome"))
         assertTrue(styles.contains("@color/nova_portable_accent"))
+    }
+
+    @Test
+    fun miamiKeepsFlamingoPinkHeroAccentWithCyanAquaSupport() {
+        val colors = File("src/main/res/values/colors_nova.xml").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue(colors.contains("nova_miami_accent") && colors.contains("#FFFF5CAB"))
+        assertTrue(colors.contains("nova_miami_accent_surface") && colors.contains("#1AFF5CAB"))
+        assertTrue(colors.contains("nova_miami_accent_glow") && colors.contains("#73FF5CAB"))
+        assertTrue(colors.contains("nova_miami_water_accent") && colors.contains("#FF47F3FF"))
+        assertTrue(colors.contains("nova_miami_water_accent_surface") && colors.contains("#1A47F3FF"))
+        assertFalse("Miami must not replace flamingo pink with cyan as the primary accent", colors.lines().any { it.contains("nova_miami_accent") && it.contains("#FF47F3FF") })
+        assertTrue(strings.contains("flamingo pink"))
+        assertTrue(strings.contains("cyan/aqua"))
+    }
+
+    @Test
+    fun portableChromeUsesSubtlePlayStationSymbolAccentTokens() {
+        val colors = File("src/main/res/values/colors_nova.xml").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue(colors.contains("nova_portable_accent") && colors.contains("#FF2F64B3"))
+        assertTrue(colors.contains("nova_portable_cross_accent") && colors.contains("#FF2F64B3"))
+        assertTrue(colors.contains("nova_portable_square_accent") && colors.contains("#FF9D679D"))
+        assertTrue(colors.contains("nova_portable_circle_accent") && colors.contains("#FFB8575F"))
+        assertTrue(colors.contains("nova_portable_triangle_accent") && colors.contains("#FF4F9A67"))
+        val oldPortableAccent = "nova_portable_accent" + 34.toChar() + ">#FF7FA38D"
+        assertFalse("Portable Chrome primary accent must not stay generic muted green", colors.contains(oldPortableAccent))
+        assertTrue(strings.contains("PlayStation-symbol accents"))
     }
 
     @Test

--- a/docs/nova-theme-surface-contract.md
+++ b/docs/nova-theme-surface-contract.md
@@ -26,13 +26,14 @@ This contract makes the Nova side of the Nova/Polaris cockpit requirements expli
 
 ## PSP Chrome / Portable Chrome palette
 
-- PSP Chrome / Portable Chrome should read as steel-blue/graphite, smoked graphite, and dim Moonlight-grey/silver shell chrome.
-- Muted green/status accents are allowed for PSP Chrome / Portable Chrome and semantic online/status states.
-- Purple/violet accents must not appear in PSP Chrome / Portable Chrome chrome, and PSP green must not leak into non-PSP selection, focus, host, or button accents.
+- Portable Chrome should read as smoked graphite/dim moonlight grey/silver shell chrome, and subtle portable chrome playstation symbol accents.
+- Triangle green remains appropriate for semantic online/status states, but primary focus and selection accents should lean cross-blue with square magenta and circle coral as subtle secondary glints.
+- Purple/violet accents must not appear in PSP Chrome / Portable Chrome chrome, and Portable Chrome PlayStation-symbol accents must not leak into non-Portable selection, focus, host, or button accents.
 - Text must stay readable on all PSP panels; avoid washed-out light panels with weak dark text or bright green body text.
 
 ## Regression expectations
 
 - Source guards should cover theme registry order, PSP aliasing, per-theme accent tokens, shared transparent/glass sheet chrome, picker D-pad behavior, Material You visibility, and the no redundant Press A badges rule.
+- Miami Nebula must keep flamingo pink as the visible hero accent across focus, selected, host, and button states; cyan/aqua belongs as supporting neon-water contrast, not as a replacement for the pink personality.
 - Device evidence should include the picker, at least one host/context drawer, and a game-detail surface after applying the selected theme.
 - When validating smoke behavior, prefer the latest available debug Nova APK plus latest available debug Polaris build pairing unless Michael explicitly asks for another build lane.


### PR DESCRIPTION
## Summary
- restore Miami Nebula to flamingo pink / hot rose as the Android hero accent, with deep plum surfaces and cyan/aqua preserved as supporting neon-water tokens
- shift Portable Chrome from generic muted green primary accent to subtle PlayStation-symbol language: cross blue primary, square magenta, circle coral, triangle green/status
- update theme surface contract, reusable tests, and skill docs so Miami pink does not get replaced by cyan again

## Test Plan
- RED: NovaThemeResourcesTest.miamiKeepsFlamingoPinkHeroAccentWithCyanAquaSupport failed against the cyan-primary regression
- GREEN: ./gradlew -PnovaAbis=arm64-v8a :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaThemeResourcesTest.miamiKeepsFlamingoPinkHeroAccentWithCyanAquaSupport
- ./gradlew -PnovaAbis=arm64-v8a :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.ui.NovaThemeManagerTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.NovaFocusDrawableTest
- git diff --check
- ./gradlew -PnovaAbis=arm64-v8a :app:assembleNonRoot_gameDebug
- GitHub checks green: public-hygiene, Lint and unit test, Analyze Java/Kotlin, CodeQL, Assemble release APK

## Retroid smoke
- Device: Retroid Pocket 6, arm64-v8a, serial 98ea526f
- Clean installed verified APK: app-nonRoot_game-arm64-v8a-debug.apk
- APK SHA256: 3a52d9f069bbe0f97d402af1a103d41bb8650ec250658fab2e1c2dd997745fdd
- Package: com.papi.nova.debug, label Nova Debug, versionName 1.2.0, versionCode 30
- Installed lastUpdateTime: 2026-07-03 16:36:34
- Forced and read back nova_theme=miami and welcome_seen=true via debug package prefs
- Verified foreground: com.papi.nova.debug/com.papi.nova.PcView
- Captured local screenshot: .hermes/artifacts/nova-theme-parity/screenshots/retroid-miami-pink-restored-dashboard.png
- Pixel sanity on screenshot: pinkish_pixels=8874, plum_dark_pixels=223936
- APK resource dump proves nova_miami_accent=0xffff5cab and nova_miami_water_accent=0xff47f3ff
- Logcat check found no FATAL EXCEPTION, InflateException, or Resources.NotFoundException
