### PR TITLE
fix(tools): diagnose Retroid UI dump failures

### DIFF
--- a/tools/nova_retroid_smoke.py
+++ b/tools/nova_retroid_smoke.py
@@ -33,6 +33,11 @@ DEFAULT_REPO = Path(__file__).resolve().parents[1]
 DEFAULT_APK = Path(
     "app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-arm64-v8a-debug.apk"
 )
+DEBUG_PAIRING_CONTRACT = (
+    "Default smoke contract: use the latest available debug Nova APK from the local "
+    "debug build output with the latest available debug Polaris build or live debug "
+    "Polaris host unless a release, pinned, or archival build is explicitly requested."
+)
 NOVA_PACKAGE_PREFIX = "com.papi.nova"
 DRAWER_FIRST_LIBRARY_REQUIRED_LABELS = (
     "Library Options",
@@ -191,6 +196,10 @@ class CheckResult:
             {**self.values, **other.values},
         )
         return merged
+
+
+class UiDumpError(RuntimeError):
+    """Raised when Android UIAutomator never returns an inspectable hierarchy."""
 
 
 def parse_bounds(raw: str) -> tuple[int, int, int, int]:
@@ -794,12 +803,70 @@ def ensure_library_focused(adb: Adb, args: argparse.Namespace, reason: str, time
     )
 
 
-def dump_xml(adb: Adb, output: Path) -> str:
+def _is_inspectable_ui_hierarchy(xml_text: str) -> bool:
+    return "<hierarchy" in xml_text and "</hierarchy>" in xml_text
+
+
+def _short_output(text: str, limit: int = 240) -> str:
+    return " ".join(text.split())[:limit]
+
+
+def _ui_dump_diagnostics(adb: Adb) -> dict[str, str]:
+    commands = {
+        "focus": "dumpsys window | grep -E 'mCurrentFocus|mFocusedApp' || true",
+        "top_activity": "dumpsys activity top | grep -E 'ACTIVITY|topResumedActivity|mResumedActivity' | head -20 || true",
+        "display": "wm size; wm density; settings get system user_rotation; settings get system accelerometer_rotation",
+    }
+    diagnostics: dict[str, str] = {}
+    for name, command in commands.items():
+        try:
+            diagnostics[name] = adb.shell(command, timeout=10, check=False).strip()
+        except Exception as exc:  # diagnostics should clarify failures, never replace them
+            diagnostics[name] = f"<diagnostic command failed: {exc}>"
+    return diagnostics
+
+
+def _write_ui_dump_diagnostics(output: Path, diagnostics: dict[str, str]) -> Path:
+    diagnostic_path = output.with_suffix(output.suffix + ".diagnostics.txt")
+    diagnostic_path.write_text(
+        "\n".join([f"[{name}]\n{value}" for name, value in diagnostics.items()]) + "\n",
+        encoding="utf-8",
+    )
+    return diagnostic_path
+
+
+def dump_xml(adb: Adb, output: Path, *, attempts: int = 4, interval_s: float = 0.75) -> str:
     remote = "/sdcard/window_dump.xml"
-    adb.shell(f"uiautomator dump {remote}", timeout=20)
-    xml = adb.run(["exec-out", "cat", remote], timeout=20).stdout
-    output.write_text(xml, encoding="utf-8")
-    return xml
+    failures: list[str] = []
+    for attempt in range(1, attempts + 1):
+        try:
+            dump_output = adb.shell(f"uiautomator dump {remote}", timeout=20)
+            xml_result = adb.run(["exec-out", "cat", remote], timeout=20, check=False)
+            xml = xml_result.stdout
+            if _is_inspectable_ui_hierarchy(xml):
+                output.write_text(xml, encoding="utf-8")
+                return xml
+            details = _short_output(" ".join(part for part in (dump_output, xml_result.stdout, xml_result.stderr) if part))
+            failures.append(f"attempt {attempt}: uiautomator returned non-hierarchy output: {details or '<empty>'}")
+        except Exception as exc:
+            failures.append(f"attempt {attempt}: {exc}")
+
+        if attempt < attempts:
+            print(
+                f"uiautomator dump did not return an inspectable UI root; retrying ({attempt}/{attempts})",
+                flush=True,
+            )
+            time.sleep(interval_s)
+
+    diagnostics = _ui_dump_diagnostics(adb)
+    diagnostic_path = _write_ui_dump_diagnostics(output, diagnostics)
+    joined_failures = "; ".join(_short_output(failure, 400) for failure in failures)
+    focus = _short_output(diagnostics.get("focus", "")) or "<unknown focus>"
+    raise UiDumpError(
+        "UIAutomator did not return an inspectable UI hierarchy "
+        f"after {attempts} attempts for {output}. "
+        f"diagnostics={diagnostic_path}; focus={focus}; failures={joined_failures}"
+    )
 
 
 def wait_for_library_rail(
@@ -1324,7 +1391,10 @@ def add_common_args(parser: argparse.ArgumentParser, *, use_defaults: bool = Tru
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Nova Retroid smoke automation")
+    parser = argparse.ArgumentParser(
+        description="Nova Retroid smoke automation",
+        epilog=DEBUG_PAIRING_CONTRACT,
+    )
     add_common_args(parser)
     subparser_common = argparse.ArgumentParser(add_help=False)
     add_common_args(subparser_common, use_defaults=False)
@@ -1364,7 +1434,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    result = args.func(args)
+    try:
+        result = args.func(args)
+    except UiDumpError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
     return 0 if result.ok else 1
 
 

--- a/tools/test_nova_retroid_smoke.py
+++ b/tools/test_nova_retroid_smoke.py
@@ -1,6 +1,9 @@
 import importlib.util
+import io
+import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -605,6 +608,79 @@ class NovaRetroidSmokeHelpersTest(unittest.TestCase):
         self.assertEqual(nova_retroid_smoke.read_logcat(adb, since="05-22 20:19:00.000"), "log text")
         self.assertEqual(adb.commands, [["logcat", "-d", "-T", "05-22 20:19:00.000"]])
 
+    def test_dump_xml_retries_transient_null_root_and_returns_hierarchy(self):
+        class FakeAdb:
+            serial = "retroid"
+            dry_run = False
+
+            def __init__(self):
+                self.shell_calls = 0
+                self.run_calls = []
+
+            def shell(self, command, **kwargs):
+                self.shell_calls += 1
+                if self.shell_calls == 1:
+                    raise RuntimeError("ERROR: null root node returned by UiTestAutomationBridge")
+                return "UI hierchary dumped to: /sdcard/window_dump.xml"
+
+            def run(self, command, **kwargs):
+                self.run_calls.append((command, kwargs))
+                return type("Completed", (), {"stdout": "<hierarchy><node text=\"Library\" bounds=\"[0,0][1,1]\" /></hierarchy>", "stderr": ""})()
+
+        with tempfile.TemporaryDirectory() as tmp, patch.object(nova_retroid_smoke.time, "sleep") as sleep:
+            output = Path(tmp) / "window.xml"
+            xml = nova_retroid_smoke.dump_xml(FakeAdb(), output, attempts=2, interval_s=0.01)
+
+            self.assertIn("<hierarchy", xml)
+            self.assertIn("Library", output.read_text(encoding="utf-8"))
+        sleep.assert_called_once_with(0.01)
+
+    def test_dump_xml_fails_with_diagnostics_after_persistent_null_root(self):
+        class FakeAdb:
+            serial = "retroid"
+            dry_run = False
+
+            def shell(self, command, **kwargs):
+                if command.startswith("uiautomator dump"):
+                    raise RuntimeError("ERROR: null root node returned by UiTestAutomationBridge")
+                if "mCurrentFocus" in command:
+                    return "mCurrentFocus=Window{u0 com.papi.nova.debug/com.papi.nova.ui.NovaLibraryActivity}"
+                if "activity top" in command:
+                    return "ACTIVITY com.papi.nova.debug/com.papi.nova.ui.NovaLibraryActivity"
+                return "Physical size: 1920x1080\nPhysical density: 320\n1\n0"
+
+            def run(self, command, **kwargs):
+                raise AssertionError("persistent dump failures should not cat stale XML")
+
+        with tempfile.TemporaryDirectory() as tmp, patch.object(nova_retroid_smoke.time, "sleep"):
+            output = Path(tmp) / "window.xml"
+            with self.assertRaises(nova_retroid_smoke.UiDumpError) as raised:
+                nova_retroid_smoke.dump_xml(FakeAdb(), output, attempts=2, interval_s=0.01)
+            diagnostics = output.with_suffix(".xml.diagnostics.txt")
+
+            self.assertTrue(diagnostics.exists())
+            diagnostic_text = diagnostics.read_text(encoding="utf-8")
+
+        self.assertIn("inspectable UI hierarchy", str(raised.exception))
+        self.assertIn("diagnostics=", str(raised.exception))
+        self.assertIn("mCurrentFocus", diagnostic_text)
+        self.assertIn("Physical size", diagnostic_text)
+
+    def test_main_reports_ui_dump_error_without_traceback(self):
+        args = SimpleNamespace(
+            func=lambda _args: (_ for _ in ()).throw(nova_retroid_smoke.UiDumpError("null root diagnostics"))
+        )
+        parser = type("Parser", (), {"parse_args": lambda self, argv: args})()
+        stderr = io.StringIO()
+
+        with patch.object(nova_retroid_smoke, "build_parser", return_value=parser), \
+            patch.object(nova_retroid_smoke.sys, "stderr", stderr):
+            exit_code = nova_retroid_smoke.main(["library"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("FAIL: null root diagnostics", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
     def test_phone_surface_analysis_reports_missing_labels_by_surface(self):
         xml = """
         <hierarchy>
@@ -951,6 +1027,15 @@ class NovaRetroidSmokeHelpersTest(unittest.TestCase):
         self.assertIs(args.func, nova_retroid_smoke.run_phone)
         self.assertIn('android:name="com.papi.nova.ui.NovaLibraryActivity"', manifest_text)
         self.assertIn('android:exported="true"', manifest_text)
+
+    def test_smoke_help_documents_latest_debug_nova_polaris_pairing(self):
+        parser = nova_retroid_smoke.build_parser()
+        help_text = parser.format_help()
+
+        self.assertEqual(nova_retroid_smoke.DEFAULT_PACKAGE, "com.papi.nova.debug")
+        self.assertIn("app-nonRoot_game-arm64-v8a-debug.apk", str(nova_retroid_smoke.DEFAULT_APK))
+        self.assertIn("latest available debug Nova APK", help_text)
+        self.assertIn("latest available debug Polaris build", help_text)
 
     def test_default_repo_points_to_project_root(self):
         parser = nova_retroid_smoke.build_parser()


### PR DESCRIPTION
## Summary
- retry transient Retroid UIAutomator null-root dumps before failing smoke runs
- write focused diagnostics for persistent non-inspectable UI hierarchy failures
- document the default debug Nova + debug/live Polaris smoke pairing in helper help text

## Test Plan
- RED: copied tests first; python3 -m unittest tools.test_nova_retroid_smoke failed on missing UiDumpError / dump_xml attempts / help epilog
- python3 -m py_compile tools/nova_retroid_smoke.py tools/test_nova_retroid_smoke.py
- python3 -m unittest tools.test_nova_retroid_smoke
- git diff --check origin/master...HEAD

## Consolidation note
- Ported from dirty local master into a clean origin/master-based worktree.
- Left /home/papi/Documents/github/nova untouched; no reset/delete/cleanup performed.