### PR TITLE
fix: persist Nova library options

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudPreferences.kt
@@ -11,10 +11,10 @@ import com.papi.nova.preferences.NovaSettingsStore
 object NovaHudPreferences {
     const val KEY_OPACITY = "nova_polaris_hud_opacity"
     const val DEFAULT_OPACITY_PERCENT = 90
-    const val MIN_OPACITY_PERCENT = 25
+    const val MIN_OPACITY_PERCENT = 0
     const val MAX_OPACITY_PERCENT = 100
 
-    val OPACITY_PRESETS = listOf(25, 50, 75, 90, 100)
+    val OPACITY_PRESETS = listOf(0, 25, 64, 90, 100)
 
     fun coerceOpacityPercent(percent: Int): Int {
         return percent.coerceIn(MIN_OPACITY_PERCENT, MAX_OPACITY_PERCENT)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
@@ -196,7 +197,10 @@ class NovaLibraryActivity : AppCompatActivity() {
         }
 
         apiClient = PolarisApiClient(this, streamHost, streamHttpsPort, streamServerCert)
-        optionsState = optionsState.copy(showPosterTitles = loadPosterTitlesPreference())
+        val libraryPreferences = libraryPreferences()
+        optionsState = NovaLibraryPreferences.loadOptions(libraryPreferences)
+        filterState = NovaLibraryPreferences.loadFilterState(libraryPreferences)
+        lastFocusedPrimaryFilter = filterState.primary
 
         onBackPressedDispatcher.addCallback(
             this,
@@ -250,11 +254,14 @@ class NovaLibraryActivity : AppCompatActivity() {
                         onOpenPolarisSync = ::openPolarisSync,
                         onOpenHelpDiagnostics = ::openHelpDiagnostics,
                         onOpenAbout = ::showAboutNova,
-                        onSortMode = { sortMode -> optionsState = optionsState.copy(sortMode = sortMode) },
-                        onLayoutMode = { layoutMode -> optionsState = optionsState.copy(layoutMode = layoutMode) },
+                        onSortMode = { sortMode ->
+                            updateLibraryOptions { it.copy(sortMode = sortMode) }
+                        },
+                        onLayoutMode = { layoutMode ->
+                            updateLibraryOptions { it.copy(layoutMode = layoutMode) }
+                        },
                         onPosterTitlesVisible = { showPosterTitles ->
-                            optionsState = optionsState.copy(showPosterTitles = showPosterTitles)
-                            persistPosterTitlesPreference(showPosterTitles)
+                            updateLibraryOptions { it.copy(showPosterTitles = showPosterTitles) }
                         },
                         onDismissFilterSheet = { activeFilterSheet = null },
                         onSourceFilter = ::applySourceFilter,
@@ -310,16 +317,22 @@ class NovaLibraryActivity : AppCompatActivity() {
         }
     }
 
-    private fun loadPosterTitlesPreference(): Boolean {
-        return PreferenceManager.getDefaultSharedPreferences(this)
-            .getBoolean(POSTER_TITLES_PREF, true)
+    private fun libraryPreferences(): SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(this)
+
+    private fun updateLibraryOptions(
+        transform: (NovaLibraryOptionsState) -> NovaLibraryOptionsState
+    ) {
+        val nextState = transform(optionsState)
+        optionsState = nextState
+        NovaLibraryPreferences.persistOptions(libraryPreferences(), nextState)
     }
 
-    private fun persistPosterTitlesPreference(showPosterTitles: Boolean) {
-        PreferenceManager.getDefaultSharedPreferences(this)
-            .edit()
-            .putBoolean(POSTER_TITLES_PREF, showPosterTitles)
-            .apply()
+    private fun updateLibraryFilterState(nextState: NovaLibraryFilterState) {
+        val normalized = NovaLibraryPreferences.normalizeFilterState(nextState)
+        filterState = normalized
+        lastFocusedPrimaryFilter = normalized.primary
+        NovaLibraryPreferences.persistFilterState(libraryPreferences(), normalized)
     }
 
     override fun onResume() {
@@ -365,7 +378,7 @@ class NovaLibraryActivity : AppCompatActivity() {
             return false
         }
         val nextMode = optionsState.layoutMode.next()
-        optionsState = optionsState.copy(layoutMode = nextMode)
+        updateLibraryOptions { it.copy(layoutMode = nextMode) }
         Toast.makeText(
             this,
             getString(R.string.nova_library_layout_toast_format, getString(layoutModeLabelRes(nextMode))),
@@ -500,13 +513,17 @@ class NovaLibraryActivity : AppCompatActivity() {
 
     private fun handlePrimaryFilter(filter: NovaLibraryPrimaryFilter) {
         when (filter) {
-            NovaLibraryPrimaryFilter.ALL -> filterState = NovaLibraryFilterState()
-            NovaLibraryPrimaryFilter.RECENT -> filterState = NovaLibraryFilterState(primary = filter)
+            NovaLibraryPrimaryFilter.ALL -> updateLibraryFilterState(NovaLibraryFilterState())
+            NovaLibraryPrimaryFilter.RECENT -> updateLibraryFilterState(
+                NovaLibraryFilterState(primary = filter)
+            )
             NovaLibraryPrimaryFilter.SOURCES -> {
                 activeOptionsSheet = false
                 activeFilterSheet = LibraryFilterSheet.SOURCES
             }
-            NovaLibraryPrimaryFilter.HDR -> filterState = NovaLibraryFilterState(primary = filter)
+            NovaLibraryPrimaryFilter.HDR -> updateLibraryFilterState(
+                NovaLibraryFilterState(primary = filter)
+            )
             NovaLibraryPrimaryFilter.MORE -> {
                 activeOptionsSheet = false
                 activeFilterSheet = LibraryFilterSheet.MORE
@@ -515,26 +532,32 @@ class NovaLibraryActivity : AppCompatActivity() {
     }
 
     private fun applySourceFilter(source: String?) {
-        filterState = if (source == null) {
-            NovaLibraryFilterState()
-        } else {
-            NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.SOURCES, source = source)
-        }
+        updateLibraryFilterState(
+            if (source == null) {
+                NovaLibraryFilterState()
+            } else {
+                NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.SOURCES, source = source)
+            }
+        )
         activeFilterSheet = null
     }
 
     private fun applyCategoryFilter(category: String) {
-        filterState = NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.MORE, category = category)
+        updateLibraryFilterState(
+            NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.MORE, category = category)
+        )
         activeFilterSheet = null
     }
 
     private fun applyGenreFilter(genre: String) {
-        filterState = NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.MORE, genre = genre)
+        updateLibraryFilterState(
+            NovaLibraryFilterState(primary = NovaLibraryPrimaryFilter.MORE, genre = genre)
+        )
         activeFilterSheet = null
     }
 
     private fun clearFilters() {
-        filterState = NovaLibraryFilterState()
+        updateLibraryFilterState(NovaLibraryFilterState())
         searchQuery = ""
         activeFilterSheet = null
     }
@@ -3556,7 +3579,6 @@ class NovaLibraryActivity : AppCompatActivity() {
         const val EXTRA_PC_UUID = "pc_uuid"
         const val EXTRA_SERVER_COMMANDS = "server_commands"
         const val EXTRA_SERVER_CERT = "server_cert"
-        private const val POSTER_TITLES_PREF = "nova_library_poster_titles"
         private val ACTIVE_SESSION_RESUME_REFRESH_DELAYS_MS = longArrayOf(1500L, 2000L, 3000L, 5000L, 8000L)
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryPreferences.kt
@@ -1,0 +1,96 @@
+package com.papi.nova.ui
+
+import android.content.SharedPreferences
+
+object NovaLibraryPreferences {
+    private const val SORT_MODE_PREF = "nova_library_sort_mode"
+    private const val LAYOUT_MODE_PREF = "nova_library_layout_mode"
+    private const val POSTER_TITLES_PREF = "nova_library_poster_titles"
+    private const val FILTER_PRIMARY_PREF = "nova_library_filter_primary"
+    private const val FILTER_SOURCE_PREF = "nova_library_filter_source"
+    private const val FILTER_CATEGORY_PREF = "nova_library_filter_category"
+    private const val FILTER_GENRE_PREF = "nova_library_filter_genre"
+
+    fun loadOptions(prefs: SharedPreferences): NovaLibraryOptionsState {
+        return NovaLibraryOptionsState(
+            sortMode = prefs.enumValue(SORT_MODE_PREF, NovaLibrarySortMode.LIBRARY_ORDER),
+            layoutMode = prefs.enumValue(LAYOUT_MODE_PREF, NovaLibraryLayoutMode.GRID),
+            showPosterTitles = prefs.getBoolean(POSTER_TITLES_PREF, true)
+        )
+    }
+
+    fun persistOptions(
+        prefs: SharedPreferences,
+        optionsState: NovaLibraryOptionsState
+    ) {
+        prefs.edit()
+            .putString(SORT_MODE_PREF, optionsState.sortMode.name)
+            .putString(LAYOUT_MODE_PREF, optionsState.layoutMode.name)
+            .putBoolean(POSTER_TITLES_PREF, optionsState.showPosterTitles)
+            .apply()
+    }
+
+    fun loadFilterState(prefs: SharedPreferences): NovaLibraryFilterState {
+        return normalizeFilterState(
+            NovaLibraryFilterState(
+                primary = prefs.enumValue(FILTER_PRIMARY_PREF, NovaLibraryPrimaryFilter.ALL),
+                source = prefs.getString(FILTER_SOURCE_PREF, "").orEmpty(),
+                category = prefs.getString(FILTER_CATEGORY_PREF, "").orEmpty(),
+                genre = prefs.getString(FILTER_GENRE_PREF, "").orEmpty()
+            )
+        )
+    }
+
+    fun persistFilterState(
+        prefs: SharedPreferences,
+        filterState: NovaLibraryFilterState
+    ) {
+        val normalized = normalizeFilterState(filterState)
+        prefs.edit()
+            .putString(FILTER_PRIMARY_PREF, normalized.primary.name)
+            .putString(FILTER_SOURCE_PREF, normalized.source)
+            .putString(FILTER_CATEGORY_PREF, normalized.category)
+            .putString(FILTER_GENRE_PREF, normalized.genre)
+            .apply()
+    }
+
+    fun normalizeFilterState(filterState: NovaLibraryFilterState): NovaLibraryFilterState {
+        return when (filterState.primary) {
+            NovaLibraryPrimaryFilter.ALL -> NovaLibraryFilterState()
+            NovaLibraryPrimaryFilter.RECENT -> NovaLibraryFilterState(
+                primary = NovaLibraryPrimaryFilter.RECENT
+            )
+            NovaLibraryPrimaryFilter.SOURCES -> filterState.source.trim()
+                .takeIf { it.isNotEmpty() }
+                ?.let { source ->
+                    NovaLibraryFilterState(
+                        primary = NovaLibraryPrimaryFilter.SOURCES,
+                        source = source
+                    )
+                }
+                ?: NovaLibraryFilterState()
+            NovaLibraryPrimaryFilter.HDR -> NovaLibraryFilterState(
+                primary = NovaLibraryPrimaryFilter.HDR
+            )
+            NovaLibraryPrimaryFilter.MORE -> when {
+                filterState.category.isNotBlank() -> NovaLibraryFilterState(
+                    primary = NovaLibraryPrimaryFilter.MORE,
+                    category = filterState.category.trim()
+                )
+                filterState.genre.isNotBlank() -> NovaLibraryFilterState(
+                    primary = NovaLibraryPrimaryFilter.MORE,
+                    genre = filterState.genre.trim()
+                )
+                else -> NovaLibraryFilterState()
+            }
+        }
+    }
+
+    private inline fun <reified T : Enum<T>> SharedPreferences.enumValue(
+        key: String,
+        defaultValue: T
+    ): T {
+        val persisted = getString(key, null) ?: return defaultValue
+        return enumValues<T>().firstOrNull { it.name == persisted } ?: defaultValue
+    }
+}

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -425,7 +425,7 @@
             android:max="100"
             android:text="@string/suffix_osc_opacity"
             app:iconSpaceReserved="false"
-            seekbar:min="25"
+            seekbar:min="0"
             seekbar:step="1" />
 
         <!-- Legacy perf overlay (Moonlight-inherited) -->

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -126,7 +126,7 @@ class NovaSettingsDefinitionsTest {
 
         assertEquals(NovaSettingType.Slider, hudOpacity.type)
         assertEquals(NovaSettingValue.IntValue(90), hudOpacity.defaultValue)
-        assertEquals(25, hudOpacity.min)
+        assertEquals(0, hudOpacity.min)
         assertEquals(100, hudOpacity.max)
         assertEquals(1, hudOpacity.step)
         assertEquals("%", hudOpacity.suffix)

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -80,11 +80,15 @@ class NovaComposeSourceGuardTest {
                 optionsSheet.contains("onPosterTitlesVisible(false)")
         )
         assertTrue(
-            "poster-title visibility should be persisted from the Library drawer so users can keep plain artwork posters across launches",
-            activity.contains("POSTER_TITLES_PREF") &&
-                activity.contains("loadPosterTitlesPreference()") &&
-                activity.contains("persistPosterTitlesPreference(showPosterTitles)") &&
-                activity.contains("optionsState.copy(showPosterTitles = showPosterTitles)")
+            "library drawer options should be persisted so sort, layout, poster titles, and filters survive relaunches",
+            activity.contains("NovaLibraryPreferences.loadOptions(libraryPreferences)") &&
+                activity.contains("NovaLibraryPreferences.loadFilterState(libraryPreferences)") &&
+                activity.contains("NovaLibraryPreferences.persistOptions(libraryPreferences(), nextState)") &&
+                activity.contains("NovaLibraryPreferences.persistFilterState(libraryPreferences(), normalized)") &&
+                activity.contains("updateLibraryOptions { it.copy(sortMode = sortMode) }") &&
+                activity.contains("updateLibraryOptions { it.copy(layoutMode = layoutMode) }") &&
+                activity.contains("updateLibraryOptions { it.copy(showPosterTitles = showPosterTitles) }") &&
+                activity.contains("updateLibraryFilterState(NovaLibraryFilterState())")
         )
         assertTrue(
             "layout modes and poster-title visibility should be wired into actual library card rendering",

--- a/app/src/test/java/com/papi/nova/ui/NovaHudPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudPreferencesTest.kt
@@ -23,11 +23,14 @@ class NovaHudPreferencesTest {
         val prefs = context.getSharedPreferences("nova-hud-preferences-shared", Context.MODE_PRIVATE)
         prefs.edit().clear().commit()
 
-        NovaHudPreferences.writeOpacityPercent(prefs, 10)
+        assertEquals(listOf(0, 25, 64, 90, 100), NovaHudPreferences.OPACITY_PRESETS)
 
-        assertEquals(25, prefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
-        assertEquals(25, NovaHudPreferences.readOpacityPercent(prefs))
-        assertEquals(0.25f, NovaHudPreferences.opacityScale(10), 0.001f)
+        NovaHudPreferences.writeOpacityPercent(prefs, -10)
+
+        assertEquals(0, prefs.getInt(NovaHudPreferences.KEY_OPACITY, 25))
+        assertEquals(0, NovaHudPreferences.readOpacityPercent(prefs))
+        assertEquals(0.0f, NovaHudPreferences.opacityScale(-10), 0.001f)
+        assertEquals(0.64f, NovaHudPreferences.opacityScale(64), 0.001f)
 
         NovaHudPreferences.writeOpacityPercent(prefs, 150)
 
@@ -49,19 +52,19 @@ class NovaHudPreferencesTest {
         val definitions = NovaSettingDefinitions.load(context)
         val definition = definitions.require(NovaHudPreferences.KEY_OPACITY)
 
-        NovaHudPreferences.writeOpacityPercent(repository, definition, 50)
+        NovaHudPreferences.writeOpacityPercent(repository, definition, 64)
 
-        assertEquals(50, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(64, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
         assertEquals(
-            NovaSettingValue.IntValue(50),
+            NovaSettingValue.IntValue(64),
             repository.snapshot(definitions)[NovaHudPreferences.KEY_OPACITY]
         )
 
-        NovaHudPreferences.writeOpacityPercent(repository, definition, 10)
+        NovaHudPreferences.writeOpacityPercent(repository, definition, -10)
 
-        assertEquals(25, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 0))
+        assertEquals(0, mirrorPrefs.getInt(NovaHudPreferences.KEY_OPACITY, 25))
         assertEquals(
-            NovaSettingValue.IntValue(25),
+            NovaSettingValue.IntValue(0),
             repository.snapshot(definitions)[NovaHudPreferences.KEY_OPACITY]
         )
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
@@ -60,7 +60,7 @@ class NovaLibraryActivitySourceTest {
         assertTrue(source.contains("KeyEvent.KEYCODE_BUTTON_Y"))
         assertTrue(source.contains("cycleLibraryLayoutMode()"))
         assertTrue(source.contains("activeOptionsSheet || activeSystemMenu || activeFilterSheet != null"))
-        assertTrue(source.contains("optionsState.copy(layoutMode = nextMode)"))
+        assertTrue(source.contains("updateLibraryOptions { it.copy(layoutMode = nextMode) }"))
         assertTrue(hints.contains("R.string.nova_controller_hint_y"))
         assertTrue(hints.contains("R.string.nova_controller_hint_layout"))
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
@@ -1,0 +1,71 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NovaLibraryPreferencesTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun freshPrefs(name: String) =
+        context.getSharedPreferences(name, Context.MODE_PRIVATE).also { prefs ->
+            prefs.edit().clear().commit()
+        }
+
+    @Test
+    fun defaultsMatchFreshLibraryDrawerState() {
+        val prefs = freshPrefs("nova-library-prefs-defaults")
+
+        assertEquals(NovaLibraryOptionsState(), NovaLibraryPreferences.loadOptions(prefs))
+        assertEquals(NovaLibraryFilterState(), NovaLibraryPreferences.loadFilterState(prefs))
+    }
+
+    @Test
+    fun persistsSortLayoutPosterTitlesAndSourceFilterAcrossActivityInstances() {
+        val prefs = freshPrefs("nova-library-prefs-source")
+        val options = NovaLibraryOptionsState(
+            sortMode = NovaLibrarySortMode.HDR_FIRST,
+            layoutMode = NovaLibraryLayoutMode.LIST,
+            showPosterTitles = false
+        )
+        val filter = NovaLibraryFilterState(
+            primary = NovaLibraryPrimaryFilter.SOURCES,
+            source = "steam"
+        )
+
+        NovaLibraryPreferences.persistOptions(prefs, options)
+        NovaLibraryPreferences.persistFilterState(prefs, filter)
+
+        assertEquals(options, NovaLibraryPreferences.loadOptions(prefs))
+        assertEquals(filter, NovaLibraryPreferences.loadFilterState(prefs))
+    }
+
+    @Test
+    fun persistsMoreFiltersAndClearsThemBackToAll() {
+        val prefs = freshPrefs("nova-library-prefs-more")
+        val category = NovaLibraryFilterState(
+            primary = NovaLibraryPrimaryFilter.MORE,
+            category = "fast_action"
+        )
+        val genre = NovaLibraryFilterState(
+            primary = NovaLibraryPrimaryFilter.MORE,
+            genre = "RPG"
+        )
+
+        NovaLibraryPreferences.persistFilterState(prefs, category)
+        assertEquals(category, NovaLibraryPreferences.loadFilterState(prefs))
+
+        NovaLibraryPreferences.persistFilterState(prefs, genre)
+        assertEquals(genre, NovaLibraryPreferences.loadFilterState(prefs))
+
+        NovaLibraryPreferences.persistFilterState(prefs, NovaLibraryFilterState())
+        val cleared = NovaLibraryPreferences.loadFilterState(prefs)
+        assertEquals(NovaLibraryFilterState(), cleared)
+        assertFalse(cleared.hasActiveConstraint)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -187,7 +187,7 @@ class NovaQuickMenuUiStateTest {
         )
 
         assertEquals(90, state.hudOpacity.percent)
-        assertEquals(NovaHudPreferences.OPACITY_PRESETS, state.hudOpacity.presets)
+        assertEquals(listOf(0, 25, 64, 90, 100), state.hudOpacity.presets)
         assertTrue(state.hudOpacity.enabled)
     }
 


### PR DESCRIPTION
## Summary
- Load and persist Nova Library drawer options from default SharedPreferences
- Persist sort mode, layout mode, poster title visibility, and durable filter choices across Library relaunches
- Change NovaHUD opacity presets to 0%, 25%, 64%, 90%, and 100%, with the settings slider allowing true 0%
- Add Robolectric persistence coverage plus source guards for the Activity and HUD opacity wiring

## Test Plan
- ./gradlew :app:testDebugUnitTest --tests com.papi.nova.ui.NovaHudPreferencesTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest --tests com.papi.nova.preferences.NovaSettingsDefinitionsTest
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:lintRootDebug
- ./gradlew :app:assembleRootDebug
- ./gradlew :app:testDebugUnitTest :app:lintRootDebug :app:assembleRootDebug
