### PR TITLE
chore: prep Nova 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 1.2.1 - 2026-07-04
+
+Nova 1.2.1 is a focused post-1.2 polish patch. It keeps the Polaris 1.2 streaming contract intact while tightening the public theme language, Library option persistence, README showcase assets, and Retroid smoke diagnostics for handheld dogfooding.
+
+### Highlights
+
+- Keeps the theme picker and settings copy centered on Portable Chrome, with smoked graphite, dim silver, and PlayStation-symbol accent language instead of transitional PSP slash labels.
+- Preserves Miami Nebula as flamingo-pink first, with cyan and aqua as supporting neon-water contrast.
+- Persists Library Options choices so sorting, layout, poster-title visibility, and source filtering survive app restarts and controller shortcut changes.
+- Refreshes the GitHub README showcase media with lighter WebP/GIF assets and clearer Nova positioning.
+- Improves Retroid UI dump diagnostics so automation failures report whether the device, package, or accessibility dump path is the actual problem.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.2.1 and versionCode 31.
+- Publishes fresh release APK assets for ARM64, ARMv7, and x86_64 through the GitHub release workflow.
+- Intended as the small Nova companion patch for Polaris v1.2.x users.
+
+### Validation notes
+
+- Current master CI is green across APK build, CodeQL, public hygiene, and dependency submission before this release-prep branch.
+- Final publication should use the tagged ARM64 release APK for a fresh Retroid Pocket 6 smoke: Library, saved Library Options, preflight, live stream, Command Center, and cleanup.
+
 ## 1.2.0 - 2026-07-03
 
 Nova 1.2.0 is the matched Polaris 1.2 handheld release. It focuses on the PSP / Portable Chrome visual pass, clearer Polaris-backed launch choices, display-target handling, live-session recovery, and stream UI polish for Retroid-class handhelds and Android TV devices.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ while you play, and what is safe to do when you leave.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v120) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v121) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -105,17 +105,17 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.2.0
+## Latest release: v1.2.1
 
-Nova v1.2.0 is the matched handheld companion release for Polaris v1.2.0. It focuses on PSP / Portable Chrome polish, clearer Polaris-backed launch choices, display-target handling, host-lock/session cleanup, and stream UI refinement for Retroid-class handhelds and Android TV devices.
+Nova v1.2.1 is a small post-1.2 polish release for Polaris v1.2.x users. It keeps the streaming contract stable while tightening Portable Chrome language, Miami theme personality, Library option persistence, public showcase media, and Retroid smoke diagnostics.
 
-- **PSP / Portable Chrome**: smoked graphite, dim silver, readable text, restrained steel highlights, and no legacy Polaris-purple accent leaks.
-- **Clearer launch choices**: Private Headless Stream, Host Virtual Display, Mirror Desktop, Steam Launch, and Direct paths now explain what Nova will ask Polaris to do.
-- **Display target handling**: Android external-display selection plumbing is present while handheld-safe fallbacks remain intact.
-- **Cleaner stream recovery**: owned headless streams avoid false host-lock overlays, and terminal/session events clean up stale Game surfaces more reliably.
-- **Command Center and HUD polish**: Polaris truth, high-FPS recovery copy, session status, and in-stream controls are clearer during live play.
-- **Release packaging**: public GitHub Releases ship ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode is bumped to 30 so Obtainium/GitHub installs update cleanly.
-- **Release validation**: current master passed APK build, CodeQL, public hygiene, and dependency submission before the 1.2.0 packaging bump.
+- **Portable Chrome copy cleanup**: the public picker/settings language now centers on Portable Chrome, smoked graphite, dim silver, and PlayStation-symbol accents.
+- **Miami Nebula guardrails**: flamingo pink stays the hero accent, with cyan and aqua acting as supporting neon-water contrast.
+- **Persistent Library Options**: sorting, layout, poster-title visibility, and source filters survive restarts and controller shortcut changes.
+- **Showcase refresh**: README media and positioning were refreshed with lighter WebP/GIF assets and clearer install/readiness copy.
+- **Retroid diagnostics**: UI dump tooling now reports whether failures came from device state, package launch, or the accessibility dump path.
+- **Release packaging**: public GitHub Releases ship ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode is bumped to 31 so Obtainium/GitHub installs update cleanly.
+- **Release validation**: final publication should use the tagged ARM64 release APK for fresh Retroid Library, preflight, live stream, Command Center, and cleanup smoke evidence.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.2.0"
-        versionCode = 30
+        versionName "1.2.1"
+        versionCode = 31
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5714,12 +5714,21 @@ return novaHud?.isShowing == true
 fun toggleNovaHud() {
 if (isNovaHudShowing())
 {
+setNovaHudPreference(false)
 dismissNovaHud()
 }
 else
 {
+setNovaHudPreference(true)
 showNovaHud()
 }
+}
+
+private fun setNovaHudPreference(enabled:Boolean) {
+PreferenceManager.getDefaultSharedPreferences(this)
+.edit()
+.putBoolean("nova_polaris_hud", enabled)
+.apply()
 }
 
 fun dismissNovaHud() {

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsAvailability.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsAvailability.kt
@@ -107,6 +107,7 @@ object NovaSettingsAvailability {
         "seekbar_osc_free_analog_stick_opacity",
         "checkbox_enable_analog_stick_new",
         "option_reset_osc_preference",
+        "nova_reset_stream_ui",
         "checkbox_show_onscreen_controls",
         "keyboard_axi_list",
         "import_keyboard_file",
@@ -116,6 +117,7 @@ object NovaSettingsAvailability {
 
     private val profileEditorHiddenKeys = setOf(
         "option_reset_osc_preference",
+        "nova_reset_stream_ui",
         "import_keyboard_file",
         "export_keyboard_file",
         "import_special_button_file",

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
@@ -1,5 +1,8 @@
 package com.papi.nova.preferences
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -43,14 +46,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.papi.nova.ui.NovaHudMode
+import com.papi.nova.ui.NovaHudPreferences
+import com.papi.nova.ui.NovaHudUiState
+import com.papi.nova.ui.NovaStreamHudContent
+import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.R
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
@@ -70,6 +82,7 @@ fun NovaSettingsScreen(
     headerActions: List<NovaSettingsHeaderAction> = emptyList()
 ) {
     val state by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
     var activeDialog by remember { mutableStateOf<NovaSettingsDialog?>(null) }
 
     NovaSettingsContent(
@@ -92,7 +105,14 @@ fun NovaSettingsScreen(
                 NovaSettingType.Select -> activeDialog = NovaSettingsDialog.Select(definition)
                 NovaSettingType.Slider -> activeDialog = NovaSettingsDialog.Slider(definition)
                 NovaSettingType.Text -> activeDialog = NovaSettingsDialog.Text(definition)
-                NovaSettingType.Action -> onAction(definition)
+                NovaSettingType.Action -> {
+                    if (definition.key == RESET_STREAM_UI_DEFAULTS_KEY) {
+                        viewModel.resetStreamUiDefaults()
+                        onAction(definition)
+                    } else {
+                        onAction(definition)
+                    }
+                }
             }
         }
     )
@@ -102,9 +122,10 @@ fun NovaSettingsScreen(
             dialog = dialog,
             state = state,
             onDismiss = { activeDialog = null },
-            onSave = { definition, value ->
+            onSave = {definition, value ->
                 viewModel.setValue(definition, value)
                 activeDialog = null
+                applyThemeSelectionIfNeeded(context, definition, value)
             }
         )
     }
@@ -115,6 +136,26 @@ data class NovaSettingsHeaderAction(
     val onClick: () -> Unit
 )
 
+private const val RESET_STREAM_UI_DEFAULTS_KEY = "nova_reset_stream_ui"
+
+private fun applyThemeSelectionIfNeeded(
+    context: Context,
+    definition: NovaSettingDefinition,
+    value: NovaSettingValue
+) {
+    if (definition.key != "nova_theme" || value !is NovaSettingValue.StringValue)return
+
+    NovaThemeManager.setTheme(context, value.value)
+    val activity = context.findActivity() ?: return
+    activity.window.decorView.post {activity.recreate() }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
 private val NovaSettingsCardShape = RoundedCornerShape(14.dp)
 private val NovaSettingsChipShape = RoundedCornerShape(12.dp)
 
@@ -122,7 +163,7 @@ private object NovaSettingsMetrics {
     fun categoryRailWidthDp(): Int = 196
     fun wideColumnSpacingDp(): Int = 14
     fun quickStripHeightDp(): Int = 52
-    fun quickPillWidthDp(): Int = 144
+    fun quickPillWidthDp(): Int = 168
     fun headerToQuickStripSpacingDp(): Int = 6
     fun quickStripToContentSpacingDp(): Int = 6
     fun contentToHintSpacingDp(): Int = 4
@@ -130,7 +171,7 @@ private object NovaSettingsMetrics {
     fun categoryRowVerticalPaddingDp(): Int = 6
     fun settingsRowSpacingDp(): Int = 6
     fun settingsRowVerticalPaddingDp(): Int = 6
-    fun rowsBottomPaddingDp(): Int = 12
+    fun rowsBottomPaddingDp(): Int = 72
     fun valueChipMinHeightDp(): Int = 28
 }
 
@@ -398,20 +439,58 @@ private fun NovaSettingsQuickStrip(
     state: NovaSettingsUiState,
     onSetting: (NovaSettingDefinition) -> Unit
 ) {
-    Row(
+    val scrollState = rememberScrollState()
+    Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(NovaSettingsMetrics.quickStripHeightDp().dp)
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        for (definition in state.quickSettings) {
-            NovaSettingPill(
-                definition = definition,
-                value = state.valueLabel(definition),
-                onClick = { onSetting(definition) }
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .horizontalScroll(scrollState),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            for (definition in state.quickSettings) {
+                NovaSettingPill(
+                    definition = definition,
+                    value = state.valueLabel(definition),
+                    onClick = { onSetting(definition) }
+                )
+            }
+        }
+        if (state.quickSettings.size > 4) {
+            NovaSettingsQuickStripEdgeHint(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .fillMaxHeight()
             )
         }
+    }
+}
+
+@Composable
+private fun NovaSettingsQuickStripEdgeHint(modifier: Modifier = Modifier) {
+    val colors = LocalNovaComposeColors.current
+    Box(
+        modifier = modifier
+            .width(42.dp)
+            .background(
+                Brush.horizontalGradient(
+                    0f to Color.Transparent,
+                    0.65f to colors.window.copy(alpha = 0.78f),
+                    1f to colors.window
+                )
+            ),
+        contentAlignment = Alignment.CenterEnd
+    ) {
+        Text(
+            text = "›",
+            color = colors.textSecondary,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(end = 4.dp)
+        )
     }
 }
 
@@ -561,6 +640,11 @@ private fun NovaSettingsRows(
         verticalArrangement = Arrangement.spacedBy(NovaSettingsMetrics.settingsRowSpacingDp().dp),
         contentPadding = PaddingValues(bottom = NovaSettingsMetrics.rowsBottomPaddingDp().dp)
     ) {
+        if (state.selectedCategoryKey == "category_overlays" && !state.isSearchActive()) {
+            item(key = "nova_hud_preview", contentType = "hud_preview") {
+                NovaHudSettingsPreview(state)
+            }
+        }
         items(state.visibleSettings, key = { it.key }, contentType = { it.type }) { definition ->
             NovaSettingRow(
                 definition = definition,
@@ -574,6 +658,78 @@ private fun NovaSettingsRows(
             )
         }
     }
+}
+
+
+@Composable
+private fun NovaHudSettingsPreview(state: NovaSettingsUiState) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val enabled = state.booleanSetting("nova_polaris_hud", false)
+    val mode = NovaHudMode.fromPreference(
+        state.stringSetting("nova_polaris_hud_mode", NovaHudMode.MINIMAL.preferenceValue)
+    )
+    val opacityPercent = NovaHudPreferences.coerceOpacityPercent(
+        state.intSetting(NovaHudPreferences.KEY_OPACITY, NovaHudPreferences.DEFAULT_OPACITY_PERCENT)
+    )
+    val previewState = NovaHudUiState.preview(mode)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(NovaSettingsCardShape)
+            .background(surfaces.panel.copy(alpha = 0.86f))
+            .border(1.dp, surfaces.panelBorder, NovaSettingsCardShape)
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Live HUD preview",
+                    color = colors.textPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = if (enabled) {
+                        "Enabled · " + mode.name.lowercase().replaceFirstChar { it.uppercase() } + " · " + opacityPercent.toString() + "% glass"
+                    } else {
+                        "Previewing saved HUD mode and glass opacity"
+                    },
+                    color = colors.textMuted,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            NovaSettingValueChip(opacityPercent.toString() + "%", alpha = 1f)
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            NovaStreamHudContent(
+                state = previewState,
+                opacityScale = NovaHudPreferences.opacityScale(opacityPercent),
+                modifier = Modifier.widthIn(max = 320.dp)
+            )
+        }
+    }
+}
+
+private fun NovaSettingsUiState.booleanSetting(key: String, defaultValue: Boolean): Boolean {
+    return (values[key] as? NovaSettingValue.BooleanValue)?.value ?: defaultValue
+}
+
+private fun NovaSettingsUiState.intSetting(key: String, defaultValue: Int): Int {
+    return (values[key] as? NovaSettingValue.IntValue)?.value ?: defaultValue
+}
+
+private fun NovaSettingsUiState.stringSetting(key: String, defaultValue: String): String {
+    return (values[key] as? NovaSettingValue.StringValue)?.value ?: defaultValue
 }
 
 @Composable
@@ -756,7 +912,8 @@ private fun NovaSelectDialog(
     onDismiss: () -> Unit,
     onSave: (NovaSettingDefinition, NovaSettingValue) -> Unit
 ) {
-    AlertDialog(
+    val showThemePreview = definition.key == "nova_theme"
+    NovaSelectDialogShell(
         onDismissRequest = onDismiss,
         confirmButton = {},
         dismissButton = {
@@ -766,23 +923,202 @@ private fun NovaSelectDialog(
         text = {
             LazyColumn {
                 items(definition.options, key = { it.value }) { option ->
-                    Text(
-                        text = option.label,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                onSave(definition, NovaSettingValue.StringValue(option.value))
-                            }
-                            .padding(vertical = 12.dp),
-                        color = if (state.stringValue(definition) == option.value) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurface
-                        }
+                    val selectedOption = state.stringValue(definition) == option.value
+                    NovaSettingsSelectOptionRow(
+                        option = option,
+                        selected = selectedOption,
+                        showPreview = showThemePreview,
+                        onClick = {onSave(definition, NovaSettingValue.StringValue(option.value))}
                     )
                 }
             }
         }
+    )
+}
+
+@Composable
+private fun NovaSelectDialogShell(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit = {},
+    dismissButton: @Composable () -> Unit,
+    title: @Composable () -> Unit,
+    text: @Composable () -> Unit
+) {
+    val surfaces = LocalNovaLibrarySurfaces.current
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.72f)
+                .widthIn(max = 720.dp)
+                .clip(NovaSettingsCardShape)
+                .background(surfaces.panel.copy(alpha = 0.96f))
+                .border(1.dp, surfaces.panelBorder, NovaSettingsCardShape)
+                .padding(18.dp)
+        ) {
+            title()
+            Spacer(Modifier.height(12.dp))
+            text()
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                confirmButton()
+                dismissButton()
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaSettingsSelectOptionRow(
+    option: NovaSettingOption,
+    selected: Boolean,
+    showPreview: Boolean = false,
+    onClick: () -> Unit
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    var focused by remember {mutableStateOf(false)}
+    val shape = NovaSettingsCardShape
+    val background = when {
+        selected -> colors.accent.copy(alpha = 0.20f)
+        focused -> surfaces.selectedControl
+        else -> surfaces.control.copy(alpha = 0.74f)
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .novaFocusMotion(focused = focused, pressed = false)
+            .background(background)
+            .border(if (focused || selected)3.dp else 1.dp, if (focused || selected)surfaces.focusRing else surfaces.tileBorder, shape)
+            .onFocusChanged {focused = it.isFocused || it.hasFocus }
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (showPreview) {
+            NovaThemePreviewSwatch(option.value)
+        }
+        Text(
+            text = option.label,
+            modifier = Modifier.weight(1f),
+            color = if (selected)colors.accent else colors.textPrimary,
+            fontSize = 15.sp,
+            fontWeight = if (selected)FontWeight.SemiBold else FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        if (selected) {
+            NovaSettingCurrentBadge()
+        }
+    }
+}
+
+
+private data class NovaThemePreviewPalette(
+    val window: Color,
+    val surface: Color,
+    val accent: Color,
+    val border: Color
+)
+
+@Composable
+private fun NovaThemePreviewSwatch(themeValue: String) {
+    val palette = novaThemePreviewPalette(themeValue)
+    Row(
+        modifier = Modifier.width(72.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 30.dp, height = 22.dp)
+                .clip(RoundedCornerShape(7.dp))
+                .background(palette.window)
+                .border(1.dp, palette.border, RoundedCornerShape(7.dp))
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(width = 17.dp, height = 10.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(palette.surface)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .size(9.dp)
+                .clip(RoundedCornerShape(99.dp))
+                .background(palette.accent)
+        )
+        Box(
+            modifier = Modifier
+                .size(width = 18.dp, height = 4.dp)
+                .clip(RoundedCornerShape(99.dp))
+                .background(palette.accent.copy(alpha = 0.42f))
+        )
+    }
+}
+
+private fun novaThemePreviewPalette(themeValue: String): NovaThemePreviewPalette {
+    return when (themeValue) {
+        NovaThemeManager.THEME_PORTABLE_CHROME -> NovaThemePreviewPalette(
+            window = Color(0xFFA2ADBA),
+            surface = Color(0xFFC4CDD8),
+            accent = Color(0xFF2F64B3),
+            border = Color(0xFF83909F)
+        )
+        NovaThemeManager.THEME_OLED -> NovaThemePreviewPalette(
+            window = Color.Black,
+            surface = Color(0xFF0A0A0E),
+            accent = Color(0xFF8B80FF),
+            border = Color(0xFF1A1A22)
+        )
+        NovaThemeManager.THEME_MIAMI -> NovaThemePreviewPalette(
+            window = Color(0xFF130817),
+            surface = Color(0xFF241429),
+            accent = Color(0xFFFF5CAB),
+            border = Color(0xFF6C3C6F)
+        )
+        NovaThemeManager.THEME_HIGH_CONTRAST -> NovaThemePreviewPalette(
+            window = Color(0xFF05070C),
+            surface = Color(0xFF0F172A),
+            accent = Color(0xFF60A5FA),
+            border = Color(0xFFDBEAFE)
+        )
+        NovaThemeManager.THEME_MATERIAL_YOU -> NovaThemePreviewPalette(
+            window = Color(0xFF111318),
+            surface = Color(0xFF1D2026),
+            accent = Color(0xFFADC6FF),
+            border = Color(0xFF8E9199)
+        )
+        else -> NovaThemePreviewPalette(
+            window = Color(0xFF1A1A2E),
+            surface = Color(0xCC232340),
+            accent = Color(0xFF78A6FF),
+            border = Color(0xFF393C51)
+        )
+    }
+}
+
+@Composable
+private fun NovaSettingCurrentBadge() {
+    val colors = LocalNovaComposeColors.current
+    Text(
+        text = "Current",
+        color = colors.onAccent,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+            .clip(NovaSettingsChipShape)
+            .background(colors.accent)
+            .padding(horizontal = 10.dp, vertical = 5.dp)
     )
 }
 

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
@@ -61,6 +61,31 @@ class NovaSettingsViewModel(
         }
     }
 
+    fun resetStreamUiDefaults() {
+        viewModelScope.launch {
+            val updates = listOf(
+                "nova_polaris_hud" to NovaSettingValue.BooleanValue(false),
+                "nova_polaris_hud_mode" to NovaSettingValue.StringValue("minimal"),
+                "nova_polaris_hud_position" to NovaSettingValue.StringValue("top_left"),
+                "nova_polaris_hud_opacity" to NovaSettingValue.IntValue(90),
+                "checkbox_enable_perf_overlay" to NovaSettingValue.BooleanValue(false),
+                "checkbox_enable_perf_logging" to NovaSettingValue.BooleanValue(false),
+                "checkbox_show_onscreen_controls" to NovaSettingValue.BooleanValue(false),
+                "seekbar_osc_opacity" to NovaSettingValue.IntValue(90),
+                "checkbox_enable_keyboard" to NovaSettingValue.BooleanValue(false),
+                "checkbox_enable_floating_button" to NovaSettingValue.BooleanValue(false),
+                "checkbox_show_overlay_zoom_toggle_button" to NovaSettingValue.BooleanValue(false),
+                "checkbox_disable_warnings" to NovaSettingValue.BooleanValue(false)
+            )
+            for ((key, value) in updates) {
+                val definition = definitions.find(key) ?: continue
+                store.set(definition, value)
+            }
+            loadStoreState()
+            emit()
+        }
+    }
+
     fun refresh() {
         viewModelScope.launch {
             loadStoreState()

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -50,6 +50,7 @@ import com.papi.nova.PcView
 import com.papi.nova.R
 import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardControllerConfigurationLoader
 import com.papi.nova.binding.video.MediaCodecHelper
+import com.papi.nova.ui.NovaHudPreferences
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.compose.NovaComposeTheme
 import com.papi.nova.utils.Dialog
@@ -113,7 +114,11 @@ class StreamSettings : AppCompatActivity() {
 
     private fun showComposeSettings() {
         legacyMode = false
-        val definitions = NovaSettingsAvailability.filter(this, NovaSettingDefinitions.load(this))
+        val definitions = NovaSettingsAvailability.filter(this, NovaSettingDefinitions.load(this)).let { filtered ->
+            filtered.copy(
+                settings = filtered.settings.filterNot { it.key == NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY }
+            )
+        }
         val store = NovaSettingsRepository.create(this)
         val viewModel = ViewModelProvider(
             this,
@@ -175,6 +180,7 @@ class StreamSettings : AppCompatActivity() {
     private fun handleComposeAction(definition: NovaSettingDefinition) {
         when (definition.key) {
             "nova_app_version" -> Unit
+            "nova_reset_stream_ui" -> resetStreamUiRuntimePreferences()
             "pref_debug_info" -> startActivity(Intent(this, DebugInfoActivity::class.java))
             "option_software_release" -> HelpLauncher.launchUrl(this, "https://github.com/papi-ux/nova/releases")
             "option_follow_update" -> HelpLauncher.launchUrl(this, getString(R.string.obtainium_app_url))
@@ -187,6 +193,21 @@ class StreamSettings : AppCompatActivity() {
                 showLegacySettings()
             }
         }
+    }
+
+    private fun resetStreamUiRuntimePreferences() {
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .edit()
+            .remove("nova_polaris_hud_x")
+            .remove("nova_polaris_hud_y")
+            .putBoolean("nova_polaris_hud", false)
+            .putString("nova_polaris_hud_mode", "minimal")
+            .putString("nova_polaris_hud_position", "top_left")
+            .putInt(NovaHudPreferences.KEY_OPACITY, NovaHudPreferences.DEFAULT_OPACITY_PERCENT)
+            .putBoolean("checkbox_enable_perf_overlay", false)
+            .putBoolean("checkbox_show_onscreen_controls", false)
+            .apply()
+        Toast.makeText(this, "Stream UI defaults restored", Toast.LENGTH_SHORT).show()
     }
 
     override fun onAttachedToWindow() {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -1678,6 +1678,8 @@ private fun LaunchControls(
             )
         }
 
+        profileSummary?.let { LaunchProfilePrimaryNotice(it) }
+
         NovaActionButton(
             text = playLabel,
             onClick = onPrimaryLaunch,
@@ -1782,6 +1784,45 @@ private fun LaunchControls(
             cornerRadius = 10.dp,
             fontSize = 11.sp,
             contentPadding = PaddingValues(horizontal = 9.dp, vertical = 7.dp)
+        )
+    }
+}
+
+@Composable
+private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val notice = listOf(summary.limitingLine, summary.reasonLine)
+        .firstOrNull { it.isNotBlank() }
+        ?: summary.freshnessLine.takeIf { it.isNotBlank() }
+        ?: return
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(colors.warning.copy(alpha = 0.14f))
+            .border(1.dp, colors.warning.copy(alpha = 0.52f), RoundedCornerShape(12.dp))
+            .padding(horizontal = 12.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        NovaBadge(
+            text = "Heads up",
+            color = colors.warning,
+            backgroundColor = surfaces.control.copy(alpha = 0.72f),
+            borderColor = colors.warning.copy(alpha = 0.35f),
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = notice,
+            color = colors.textSecondary,
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -455,7 +455,7 @@ class NovaHudEventTrail(private val capacity: Int = 4) {
         if (targetFps <= 0.0) {
             return
         }
-        record("Recovery profile ready: ${targetFps.roundToInt()} FPS")
+        record("Next launch recovery: ${targetFps.roundToInt()} FPS")
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -177,9 +177,11 @@ class NovaLibraryActivity : AppCompatActivity() {
     private var lastFocusedGameId by mutableStateOf<String?>(null)
     private var lastFocusedPrimaryFilter by mutableStateOf(NovaLibraryPrimaryFilter.ALL)
     private var activeSessionRefreshJob: Job? = null
+    private var appliedTheme: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         NovaThemeManager.applyTheme(this)
+        appliedTheme = NovaThemeManager.getTheme(this)
         super.onCreate(savedInstanceState)
 
         streamHost = intent.getStringExtra(EXTRA_HOST).orEmpty()
@@ -337,6 +339,7 @@ class NovaLibraryActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (recreateForThemeChangeIfNeeded()) return
         if (::apiClient.isInitialized && !isInitialLoading) {
             if (consumeLocalSessionEndSignal()) {
                 activeSession = null
@@ -345,6 +348,14 @@ class NovaLibraryActivity : AppCompatActivity() {
                 refreshActiveSession(scheduleFollowUps = true)
             }
         }
+    }
+
+    private fun recreateForThemeChangeIfNeeded(): Boolean {
+        val currentTheme = NovaThemeManager.getTheme(this)
+        if (appliedTheme == currentTheme) return false
+        appliedTheme = currentTheme
+        recreate()
+        return true
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -642,17 +642,41 @@ private fun NovaQuickMenuPanel(
             .padding(contentPadding)
     ) {
         if (!title.isNullOrBlank()) {
-            Text(
-                text = title,
-                color = colors.textMuted,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(bottom = 6.dp)
-            )
+            NovaQuickMenuSectionHeader(title)
+            Spacer(Modifier.height(7.dp))
         }
         content()
+    }
+}
+
+
+@Composable
+private fun NovaQuickMenuSectionHeader(title: String) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(99.dp))
+            .background(colors.accent.copy(alpha = 0.14f))
+            .border(1.dp, surfaces.focusRing.copy(alpha = 0.52f), RoundedCornerShape(99.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(99.dp))
+                .background(colors.accent)
+        )
+        Text(
+            text = title.uppercase(),
+            color = colors.textSecondary,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaThemeManager.kt
@@ -7,6 +7,7 @@ import android.util.TypedValue
 import android.os.Build
 import android.view.Window
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
 import androidx.core.view.WindowCompat
 import androidx.preference.PreferenceManager
 import com.papi.nova.R
@@ -121,7 +122,37 @@ object NovaThemeManager {
     }
 
     private fun getMaterialYouSurfaceColor(context: Context): Int =
-        resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_bg_window))
+        resolveMaterialYouColor(
+            context,
+            android.R.color.system_neutral1_900,
+            com.google.android.material.R.attr.colorSurface,
+            ContextCompat.getColor(context, R.color.nova_bg_window)
+        )
+
+    private fun getMaterialYouCardColor(context: Context): Int =
+        resolveMaterialYouColor(
+            context,
+            android.R.color.system_neutral1_800,
+            com.google.android.material.R.attr.colorSurface,
+            ContextCompat.getColor(context, R.color.nova_bg_card)
+        )
+
+    private fun getMaterialYouTextPrimaryColor(context: Context): Int =
+        resolveMaterialYouColor(
+            context,
+            android.R.color.system_neutral1_50,
+            com.google.android.material.R.attr.colorOnSurface,
+            ContextCompat.getColor(context, R.color.nova_text_primary)
+        )
+
+    private fun getMaterialYouTextSecondaryColor(context: Context): Int =
+        resolveMaterialYouColor(
+            context,
+            android.R.color.system_neutral1_200,
+            com.google.android.material.R.attr.colorOnSurface,
+            ContextCompat.getColor(context, R.color.nova_text_secondary)
+        )
+
 
     private fun resolveThemeColor(context: Context, attr: Int, fallback: Int): Int {
         val typedValue = TypedValue()
@@ -134,6 +165,22 @@ object NovaThemeManager {
             typedValue.type in TypedValue.TYPE_FIRST_COLOR_INT..TypedValue.TYPE_LAST_COLOR_INT -> typedValue.data
             else -> fallback
         }
+    }
+
+    private fun resolveSystemColor(context: Context, colorRes: Int, fallback: Int): Int {
+        if (!isMaterialYouAvailable()) {
+            return fallback
+        }
+        return try {
+            ContextCompat.getColor(context, colorRes)
+        } catch (_: Exception) {
+            fallback
+        }
+    }
+
+    private fun resolveMaterialYouColor(context: Context, colorRes: Int, attr: Int, fallback: Int): Int {
+        val themedFallback = resolveThemeColor(context, attr, fallback)
+        return resolveSystemColor(context, colorRes, themedFallback)
     }
 
     /** Returns the correct window background color for the current theme */
@@ -175,7 +222,7 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_bg_card)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_bg_card)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_bg_card))
+                getMaterialYouCardColor(context)
             else -> ContextCompat.getColor(context, R.color.nova_bg_card)
         }
     }
@@ -188,7 +235,7 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_dialog_bg)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_dialog_bg)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, com.google.android.material.R.attr.colorSurface, ContextCompat.getColor(context, R.color.nova_dialog_bg))
+                getMaterialYouCardColor(context)
             else -> ContextCompat.getColor(context, R.color.nova_dialog_bg)
         }
     }
@@ -197,15 +244,12 @@ object NovaThemeManager {
     fun getAccentColor(context: Context): Int {
         val theme = getTheme(context)
         if (theme == THEME_MATERIAL_YOU && isMaterialYouAvailable()) {
-            // Use system accent (Material You primary)
-            return try {
-                val ta = context.obtainStyledAttributes(intArrayOf(android.R.attr.colorPrimary))
-                val color = ta.getColor(0, ContextCompat.getColor(context, R.color.nova_accent))
-                ta.recycle()
-                color
-            } catch (_: Exception) {
+            return resolveMaterialYouColor(
+                context,
+                android.R.color.system_accent1_500,
+                android.R.attr.colorPrimary,
                 ContextCompat.getColor(context, R.color.nova_accent)
-            }
+            )
         }
         return when {
             isPortableChrome(context) -> ContextCompat.getColor(context, R.color.nova_portable_accent)
@@ -223,6 +267,8 @@ object NovaThemeManager {
             isOled(context) -> ContextCompat.getColor(context, R.color.nova_oled_accent_surface)
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_accent_surface)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_accent_surface)
+            isMaterialYou(context) && isMaterialYouAvailable() ->
+                ColorUtils.setAlphaComponent(getAccentColor(context), 0x1A)
             else -> ContextCompat.getColor(context, R.color.nova_polaris_accent_surface)
         }
     }
@@ -235,7 +281,12 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_divider)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_divider)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, com.google.android.material.R.attr.colorOutline, ContextCompat.getColor(context, R.color.nova_divider))
+                resolveMaterialYouColor(
+                    context,
+                    android.R.color.system_neutral1_600,
+                    com.google.android.material.R.attr.colorOutline,
+                    ContextCompat.getColor(context, R.color.nova_divider)
+                )
             else -> ContextCompat.getColor(context, R.color.nova_divider)
         }
     }
@@ -248,7 +299,7 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_primary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_primary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, android.R.attr.textColorPrimary, ContextCompat.getColor(context, R.color.nova_text_primary))
+                getMaterialYouTextPrimaryColor(context)
             else -> ContextCompat.getColor(context, R.color.nova_text_primary)
         }
     }
@@ -261,7 +312,7 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_secondary)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_secondary)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_secondary))
+                getMaterialYouTextSecondaryColor(context)
             else -> ContextCompat.getColor(context, R.color.nova_text_secondary)
         }
     }
@@ -274,7 +325,12 @@ object NovaThemeManager {
             isMiami(context) -> ContextCompat.getColor(context, R.color.nova_miami_text_muted)
             isHighContrast(context) -> ContextCompat.getColor(context, R.color.nova_hc_text_muted)
             isMaterialYou(context) && isMaterialYouAvailable() ->
-                resolveThemeColor(context, android.R.attr.textColorSecondary, ContextCompat.getColor(context, R.color.nova_text_muted))
+                resolveMaterialYouColor(
+                    context,
+                    android.R.color.system_neutral1_400,
+                    com.google.android.material.R.attr.colorOnSurface,
+                    ContextCompat.getColor(context, R.color.nova_text_muted)
+                )
             else -> ContextCompat.getColor(context, R.color.nova_text_muted)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="pcview_menu_pair_pc_otp">OTP Pair</string>
     <string name="pcview_menu_scan_qr">Scan QR to Pair</string>
     <string name="nova_app_version_title">Version</string>
-    <string name="nova_settings_subtitle_with_version" translatable="false">%1$s · Streaming, input, Polaris, and device defaults</string>
+    <string name="nova_settings_subtitle_with_version" translatable="false">%1$s · Stream · input · Polaris</string>
     <string name="nova_theme_cycle">Cycle theme</string>
     <string name="nova_theme_switched_to">Theme: %1$s</string>
     <string name="nova_theme_polaris_label">Polaris Aurora</string>
@@ -795,7 +795,7 @@
     <string name="nova_quick_menu_shutdown_subtitle">Host shutdown is in progress. Session actions are limited.</string>
     <string name="nova_quick_menu_health_checking">Checking session health</string>
     <string name="nova_quick_menu_health_host_render">Host is rendering below the stream FPS target.</string>
-    <string name="nova_quick_menu_health_host_render_recovery">Host is rendering below target. Relaunch can apply the AI Recovery Profile.</string>
+    <string name="nova_quick_menu_health_host_render_recovery">AI Recovery Profile ready for next launch.</string>
     <string name="nova_quick_menu_health_hdr_downgrade">HDR requested, but Polaris is streaming 10-bit SDR.</string>
     <string name="nova_quick_menu_health_hdr_headless_detail">Private Headless Stream does not report HDR metadata. Polaris is sending 10-bit SDR; use an HDR-capable display path for true HDR.</string>
     <string name="nova_quick_menu_health_hdr_downgrade_detail">Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -427,6 +427,11 @@
             app:iconSpaceReserved="false"
             seekbar:min="0"
             seekbar:step="1" />
+        <Preference
+            android:key="nova_reset_stream_ui"
+            android:title="Reset Stream UI Defaults"
+            android:summary="Restore HUD, overlay, touch controls, and in-stream chrome defaults"
+            app:iconSpaceReserved="false" />
 
         <!-- Legacy perf overlay (Moonlight-inherited) -->
         <CheckBoxPreference
@@ -627,8 +632,8 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:key="nova_compose_settings_beta"
-            android:title="New Settings"
-            android:summary="Use Nova's controller-first Compose settings dashboard"
+            android:title="Modern Settings"
+            android:summary="Controller-first settings dashboard"
             android:defaultValue="true"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference

--- a/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceScreensMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceScreensMigrationTest.kt
@@ -70,6 +70,47 @@ class KotlinPreferenceScreensMigrationTest {
     }
 
     @Test
+    fun composeSettingsQuickStripAdvertisesHorizontalOverflow() {
+        val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+
+        assertTrue(settingsScreen.contains("NovaSettingsQuickStripEdgeHint"))
+        assertTrue(settingsScreen.contains("Brush.horizontalGradient"))
+        assertTrue(settingsScreen.contains("horizontalScroll(scrollState)"))
+        assertTrue(settingsScreen.contains("fun rowsBottomPaddingDp(): Int = 72"))
+        assertTrue(settingsScreen.contains("fun quickPillWidthDp(): Int = 168"))
+    }
+
+    @Test
+    fun composeSettingsSelectDialogShowsCurrentBadge() {
+        val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+        val selectDialog = settingsScreen.substringAfter("private fun NovaSelectDialog(")
+            .substringBefore("@Composable\nprivate fun NovaSliderDialog(")
+
+        assertTrue(selectDialog.contains("selectedOption"))
+        assertTrue(selectDialog.contains("Current"))
+        assertTrue(selectDialog.contains("NovaSettingCurrentBadge"))
+        assertFalse(selectDialog.contains("AlertDialog("))
+        assertTrue(selectDialog.contains("Dialog("))
+        assertTrue(selectDialog.contains("NovaSettingsSelectOptionRow"))
+    }
+
+    @Test
+    fun composeSettingsHidesBetaToggleAndUsesShortReleaseSubtitle() {
+        val streamSettings = File("src/main/java/com/papi/nova/preferences/StreamSettings.kt").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+        val preferences = File("src/main/res/xml/preferences.xml").readText()
+        val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+
+        assertTrue(streamSettings.contains("NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY"))
+        assertTrue(streamSettings.contains("filterNot { it.key == NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY }"))
+        assertTrue(strings.contains("%1\$s · Stream · input · Polaris"))
+        assertTrue(preferences.contains("android:title=\"Modern Settings\""))
+        assertFalse(preferences.contains("android:title=\"New Settings\""))
+        assertTrue(settingsScreen.contains("applyThemeSelectionIfNeeded"))
+        assertTrue(settingsScreen.contains("NovaThemeManager.setTheme(context, value.value)") && settingsScreen.contains("window.decorView.post") && settingsScreen.contains("activity.recreate()"))
+    }
+
+    @Test
     fun composeSettingsRowsUseDenseScanningLayout() {
         val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
 
@@ -115,5 +156,35 @@ class KotlinPreferenceScreensMigrationTest {
         val restored = GlPreferences.readPreferences(context)
         assertEquals("ANGLE", restored.glRenderer)
         assertEquals("fingerprint-1", restored.savedFingerprint)
+    }
+
+
+    @Test
+    fun composeSettingsShowsHudPreviewAndThemePreviewCards() {
+        val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+
+        assertTrue(settingsScreen.contains("NovaHudSettingsPreview"))
+        assertTrue(settingsScreen.contains("NovaStreamHudContent("))
+        assertTrue(settingsScreen.contains("NovaHudUiState.preview"))
+        assertTrue(settingsScreen.contains("category_overlays"))
+        assertTrue(settingsScreen.contains("NovaThemePreviewSwatch"))
+        assertTrue(settingsScreen.contains("definition.key == \"nova_theme\""))
+    }
+
+    @Test
+    fun composeSettingsExposesResetStreamUiDefaultsAction() {
+        val preferences = File("src/main/res/xml/preferences.xml").readText()
+        val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+        val viewModel = File("src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt").readText()
+
+        assertTrue(preferences.contains("nova_reset_stream_ui"))
+        assertTrue(settingsScreen.contains("resetStreamUiDefaults"))
+        assertTrue(settingsScreen.contains("definition.key == \"nova_theme\""))
+        assertTrue(viewModel.contains("fun resetStreamUiDefaults()"))
+        assertTrue(viewModel.contains("nova_polaris_hud"))
+        assertTrue(viewModel.contains("nova_polaris_hud_mode"))
+        assertTrue(viewModel.contains("nova_polaris_hud_opacity"))
+        assertTrue(viewModel.contains("checkbox_enable_perf_overlay"))
+        assertTrue(viewModel.contains("checkbox_show_onscreen_controls"))
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1094,6 +1094,11 @@ class NovaComposeSourceGuardTest {
             launchControls.indexOf("text = playLabel") < launchControls.indexOf("LaunchModeChoicePill(") &&
                 launchControls.indexOf("text = playLabel") < launchControls.indexOf("LaunchProfileSummaryInline(")
         )
+        assertTrue(
+            "game detail should surface host/render limits before the primary launch action",
+            launchControls.contains("LaunchProfilePrimaryNotice(") &&
+                launchControls.indexOf("LaunchProfilePrimaryNotice(") < launchControls.indexOf("text = playLabel")
+        )
     }
 
     @Test
@@ -1163,6 +1168,8 @@ class NovaComposeSourceGuardTest {
     fun libraryLoadErrorsUsePersistentRetryState() {
         val source = readNovaLibraryActivity()
         val mapper = readSource("src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt")
+        assertTrue(source.contains("private var appliedTheme"))
+        assertTrue(source.contains("recreateForThemeChangeIfNeeded()"))
         val content = source.section(
             "private fun NovaLibraryContent(",
             "private fun NovaLibraryRecentRail("
@@ -1396,7 +1403,7 @@ class NovaComposeSourceGuardTest {
                 settings.contains("fun categoryRailWidthDp(): Int = 196") &&
                 settings.contains("fun wideColumnSpacingDp(): Int = 14") &&
                 settings.contains("fun quickStripHeightDp(): Int = 52") &&
-                settings.contains("fun quickPillWidthDp(): Int = 144") &&
+                settings.contains("fun quickPillWidthDp(): Int = 168") &&
                 settings.contains("fun headerToQuickStripSpacingDp(): Int = 6") &&
                 settings.contains("fun quickStripToContentSpacingDp(): Int = 6") &&
                 settings.contains("fun contentToHintSpacingDp(): Int = 4") &&
@@ -1863,6 +1870,24 @@ class NovaComposeSourceGuardTest {
                 content.contains("contentDescription = \"Close Command Center\"") &&
                 content.contains("onClick = callbacks.onDismiss")
         )
+    }
+
+    @Test
+    fun commandCenterPanelsUseSectionHeadersForHierarchy() {
+        val content = readNovaQuickMenuContent()
+        val panel = content.section(
+            "private fun NovaQuickMenuPanel(",
+            "@Composable\nprivate fun NovaQuickMenuRow("
+        )
+
+        assertTrue(panel.contains("NovaQuickMenuSectionHeader"))
+        assertTrue(panel.contains("title.uppercase()"))
+        assertTrue(panel.contains("colors.accent.copy(alpha = 0.14f)"))
+        assertTrue(panel.contains("surfaces.focusRing.copy(alpha = 0.52f)"))
+        assertTrue(content.contains("NovaQuickMenuPanel(title = overlaysTitle)"))
+        assertTrue(content.contains("NovaQuickMenuPanel(title = quickKeysTitle)"))
+        assertTrue(content.contains("NovaQuickMenuPanel(title = controlsTitle)"))
+        assertTrue(content.contains("NovaQuickMenuPanel(title = sessionTitle)"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -374,8 +374,8 @@ class NovaHudUiStateTest {
             eventBreadcrumbLabel = trail.latestLabel
         )
 
-        assertEquals("Recovery profile ready: 60 FPS", trail.latestLabel)
-        assertEquals("Recovery profile ready: 60 FPS", state.eventBreadcrumbLabel)
+        assertEquals("Next launch recovery: 60 FPS", trail.latestLabel)
+        assertEquals("Next launch recovery: 60 FPS", state.eventBreadcrumbLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -78,7 +78,7 @@ class NovaQuickMenuUiStateTest {
             aiEnabled = true
         )
 
-        assertEquals("Host is rendering below target. Relaunch can apply the AI Recovery Profile.", state.healthSummary)
+        assertEquals("AI Recovery Profile ready for next launch.", state.healthSummary)
         assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
         assertEquals("AI Recovery Profile", state.stability.chip.label)
         assertEquals(NovaQuickMenuTone.WARNING, state.stability.chip.tone)

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeManagerTest.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.R
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -91,4 +92,18 @@ class NovaThemeManagerTest {
         assertTrue("Polaris Aurora must not inherit PSP green", polarisAccent != portableAccent)
     }
 
+
+
+    @Test
+    @Config(sdk = [31])
+    fun materialYouHudTokensDoNotFallBackToPolarisInsideStreamTheme() {
+        context.setTheme(R.style.StreamTheme)
+        NovaThemeManager.setTheme(context, NovaThemeManager.THEME_MATERIAL_YOU)
+
+        val accent = NovaThemeManager.getAccentColor(context)
+        val accentSurface = NovaThemeManager.getAccentSurfaceColor(context)
+
+        assertNotEquals(context.getColor(R.color.nova_polaris_accent), accent)
+        assertNotEquals(context.getColor(R.color.nova_polaris_accent_surface), accentSurface)
+    }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -289,6 +289,7 @@ class NovaThemeResourcesTest {
         assertFalse("quit confirmation should not use platform dialog buttons", quitBody.contains("setPositiveButton") || quitBody.contains("setNegativeButton"))
         assertTrue("quit confirmation should use Nova-themed session action copy", game.contains("R.string.game_dialog_action_end_session") && game.contains("R.string.game_dialog_action_stay_in_game"))
         assertFalse("quit confirmation should drop the old generic streaming button labels", game.contains("game_dialog_action_end_stream") || game.contains("game_dialog_action_keep_streaming"))
+        assertTrue("Command Center NovaHUD toggles should persist the next-stream preference", game.contains("setNovaHudPreference(true)") && game.contains("setNovaHudPreference(false)"))
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/31.txt
+++ b/fastlane/metadata/android/en-US/changelogs/31.txt
@@ -1,0 +1,6 @@
+Nova 1.2.1
+
+- Keeps public theme copy centered on Portable Chrome and protects Miami Nebula pink/cyan personality.
+- Persists Library Options choices across restarts.
+- Refreshes README showcase media and Retroid UI dump diagnostics.
+- Ships as a safe post-1.2 polish patch for Polaris v1.2.x users.


### PR DESCRIPTION
## Summary
- Bumps the Android package to versionName 1.2.1 and versionCode 31.
- Promotes the post-1.2 polish work into CHANGELOG and README latest-release copy.
- Adds the Fastlane changelog entry for versionCode 31.
- Fixes the stream activity theme boundary so NovaHUD and Command Center honor the saved Nova theme, including Material You.
- Adds Settings polish for NovaHUD preview, theme preview swatches, reset stream UI defaults, and clearer Command Center hierarchy.
- Keeps publication/tagging for the explicit merge and release step.

## Test Plan
- [x] `git diff --check`
- [x] `python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight`
- [x] `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug`
- [x] `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest`
- [x] `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameRelease assembleNonRoot_gameDebug`
- [x] `./gradlew -PnovaAbis=arm64-v8a :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.preferences.KotlinPreferenceScreensMigrationTest --tests com.papi.nova.preferences.NovaSettingsDefinitionsTest --tests com.papi.nova.preferences.NovaSettingsStoreTest --tests com.papi.nova.ui.NovaComposeSourceGuardTest --tests com.papi.nova.ui.NovaThemeResourcesTest --tests com.papi.nova.ui.NovaThemeManagerTest --tests com.papi.nova.ui.NovaHudUiStateTest --tests com.papi.nova.ui.NovaQuickMenuUiStateTest`
- [x] `./gradlew -PnovaAbis=arm64-v8a :app:assembleNonRoot_gameDebug`
- [x] `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true :app:lintNonRoot_gameDebug`

## Retroid smoke
- [x] Clean-installed verified `com.papi.nova.debug` arm64 APK on Retroid Pocket 6 (`versionName=1.2.1`, `versionCode=31`).
- [x] Used visible Nova flow: Welcome → Discover hosts → Trusted Pair to `pc-papi.lan` → populated Polaris Library.
- [x] Selected Material You from the public Theme picker and read back `nova_theme=material_you` from the installed debug package.
- [x] Launched MOUSE: P.I. For Hire through Library preflight; Nova `Game` foreground, HEVC decoder active, Polaris/Nova stream active.
- [x] Verified NovaHUD visible over the live stream with no host-lock overlay.
- [x] Opened Command Center over the live stream; verified Material You gray styling, Overlays section, Nova HUD on, and HUD Opacity presets `0% / 25% / 64% / 90% / 100%` with `64%` selected.
- [x] Tapped `25%`, read back persisted opacity `25`, restored `64`, and read back persisted opacity `64`.
- [x] End Session cleanup returned Nova to Library; verified no live `labwc`, no target Steam app process, and restored temporary HUD test prefs off/minimal while keeping Material You.

## Build artifacts from this branch
- Debug ARM64 APK SHA-256: `856b55b52cb987419af3907ecbe7d9451503cb8783d96544314278bd752e61bd`
- Release unsigned ARM64 APK SHA-256: `c22161b03a0535758c3be4594eaf3156957de563647d9d4f6a8985cd7766df8c`
- HUD smoke debug APK SHA-256: `285ea752ac648ab1bb9998e4dcc8ceb61d91578efbdb92aec47371d16bd518dc`

## Release hygiene
- Found and deleted a stale local `v1.2.1` tag pointing at old commit `92e761a6` before any remote tag work.
- Remote `v1.2.1` tag was absent at prep time.
- No tag was pushed by this PR.
- Pairing/certificate material from Retroid logcat was intentionally not pasted into this PR body.
