### PR TITLE
feat(deck): add Moonlight handoff preflight contract

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(nova_deck_core
     src/backend/deck_backend_interfaces.cpp
     src/stream/deck_stream_core.cpp
     src/stream/deck_stream_media_adapters.cpp
+    src/stream/deck_moonlight_handoff_preflight.cpp
 )
 
 set(NOVA_DECK_MOONLIGHT_COMMON_C_DIR
@@ -82,6 +83,12 @@ if(BUILD_TESTING)
     target_link_libraries(nova_deck_stream_media_adapters_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_stream_media_adapters_test COMMAND nova_deck_stream_media_adapters_test)
 
+    add_executable(nova_deck_moonlight_handoff_preflight_test
+        tests/deck_moonlight_handoff_preflight_test.cpp
+    )
+    target_link_libraries(nova_deck_moonlight_handoff_preflight_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_moonlight_handoff_preflight_test COMMAND nova_deck_moonlight_handoff_preflight_test)
+
     add_executable(nova_deck_backend_interfaces_test
         tests/deck_backend_interfaces_test.cpp
     )
@@ -103,6 +110,9 @@ if(BUILD_TESTING)
     )
     add_test(NAME nova_deck_media_assert_guard_test
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/deck_media_assert_guard_test.py
+    )
+    add_test(NAME nova_deck_moonlight_handoff_source_guard_test
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/deck_moonlight_handoff_source_guard_test.py
     )
     add_test(NAME nova_deck_t31_podman_validation_route_test
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/deck_t31_podman_validation_test.py

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.cpp
@@ -1,0 +1,310 @@
+#include "stream/deck_moonlight_handoff_preflight.h"
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace nova::deck::stream {
+
+namespace {
+
+bool isBlank(const std::string& value) {
+    return std::all_of(value.begin(), value.end(), [](const unsigned char ch) {
+        return std::isspace(ch) != 0;
+    });
+}
+
+std::string lowerCopy(const std::string& value) {
+    std::string lowered;
+    lowered.reserve(value.size());
+    for (const unsigned char ch : value) {
+        lowered.push_back(static_cast<char>(std::tolower(ch)));
+    }
+    return lowered;
+}
+
+bool containsAny(const std::string& value, const std::initializer_list<std::string_view> needles) {
+    return std::any_of(needles.begin(), needles.end(), [&](const std::string_view needle) {
+        return value.find(needle) != std::string::npos;
+    });
+}
+
+bool containsShellSyntax(const std::string& value) {
+    return containsAny(value, {";", "&&", "||", "`", "$(", "\n", "\r"});
+}
+
+bool containsPrivateEndpointLikeValue(const std::string& value) {
+    static const std::regex privateIpv4Pattern(
+        R"(\b(?:10|127|169\.254|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b)");
+    static const std::regex macLikePattern(R"(\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b)");
+    return std::regex_search(value, privateIpv4Pattern) || std::regex_search(value, macLikePattern);
+}
+
+bool containsUnsafeSecretLikeText(const std::string& lowered) {
+    for (const std::string_view label : {"token", "password", "client_secret", "api_key"}) {
+        if (lowered.find(std::string{label} + "=") != std::string::npos
+            || lowered.find(std::string{label} + ":") != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool containsUnsafeSchemeOrPath(const std::string& value) {
+    const auto lowered = lowerCopy(value);
+    const auto unixHomePathMarker = std::string{"/ho"} + "me/";
+    return containsAny(lowered, {
+        "://",
+        "ssh ",
+        "file:",
+        "/users/",
+        ".ssh/",
+        "begin ",
+        " private key",
+        ":matrix",
+    }) || lowered.find(unixHomePathMarker) != std::string::npos
+        || (!value.empty() && value.front() == '!');
+}
+
+bool isUnsafePublicText(const std::string& value) {
+    const auto lowered = lowerCopy(value);
+    return containsShellSyntax(value)
+        || containsPrivateEndpointLikeValue(value)
+        || containsUnsafeSecretLikeText(lowered)
+        || containsUnsafeSchemeOrPath(value);
+}
+
+bool isUnsafeArgvToken(const std::string& value) {
+    return isBlank(value)
+        || containsShellSyntax(value)
+        || containsPrivateEndpointLikeValue(value)
+        || containsUnsafeSchemeOrPath(value)
+        || containsUnsafeSecretLikeText(lowerCopy(value));
+}
+
+DeckMoonlightReadinessCheck readinessCheck(
+    std::string id,
+    std::string label,
+    DeckMoonlightReadinessCheckStatus status,
+    std::string detail) {
+    return DeckMoonlightReadinessCheck{
+        .id = std::move(id),
+        .label = std::move(label),
+        .detail = std::move(detail),
+        .status = status,
+    };
+}
+
+std::vector<DeckMoonlightReadinessCheck> readinessChecksFor(
+    const DeckMoonlightHandoffPreflightRequest& request) {
+    std::vector<DeckMoonlightReadinessCheck> checks;
+    checks.reserve(4);
+
+    checks.push_back(readinessCheck(
+        "safe-snapshot",
+        "Safe snapshot",
+        request.hasSafeSnapshot ? DeckMoonlightReadinessCheckStatus::Passed : DeckMoonlightReadinessCheckStatus::Blocked,
+        request.hasSafeSnapshot
+            ? "Read-only host snapshot is available for local review."
+            : "Needs safe host snapshot before typed handoff review."));
+
+    checks.push_back(readinessCheck(
+        "app-snapshot",
+        "App in snapshot",
+        request.appPresentInSnapshot ? DeckMoonlightReadinessCheckStatus::Passed : DeckMoonlightReadinessCheckStatus::Blocked,
+        request.appPresentInSnapshot
+            ? "Game appears in snapshot for local review."
+            : "Game missing from snapshot; review stays blocked."));
+
+    const auto privateHostSelector = isBlank(request.privateHostSelectorRedactedForDebug)
+        ? std::string{"redacted-host-selector"}
+        : request.privateHostSelectorRedactedForDebug;
+    DeckMoonlightReadinessCheckStatus argvStatus = DeckMoonlightReadinessCheckStatus::Passed;
+    std::string argvDetail = "Typed argv preview is redacted and copy-only.";
+    if (!request.hasSafeSnapshot) {
+        argvStatus = DeckMoonlightReadinessCheckStatus::Blocked;
+        argvDetail = "Snapshot gate must pass first; no typed handoff review yet.";
+    } else if (!request.appPresentInSnapshot) {
+        argvStatus = DeckMoonlightReadinessCheckStatus::Blocked;
+        argvDetail = "App snapshot gate must pass first; no typed handoff review yet.";
+    } else if (request.requestedSurface != DeckMoonlightHandoffSurface::MoonlightQtCli) {
+        argvStatus = DeckMoonlightReadinessCheckStatus::Blocked;
+        argvDetail = "Moonlight Qt CLI surface is required for typed handoff review.";
+    } else if (isUnsafePublicText(request.hostDisplayNamePublic) || isUnsafePublicText(request.gameTitlePublic)
+        || isUnsafeArgvToken(privateHostSelector)) {
+        argvStatus = DeckMoonlightReadinessCheckStatus::Blocked;
+        argvDetail = "Typed argv preview is not public-safe; review stays blocked.";
+    }
+    checks.push_back(readinessCheck(
+        "typed-argv",
+        "Typed argv",
+        argvStatus,
+        argvDetail));
+
+    checks.push_back(readinessCheck(
+        "focus-return",
+        "Focus return",
+        DeckMoonlightReadinessCheckStatus::ReviewOnly,
+        "Focus return remains unproven_static until a later approved runtime check."));
+
+    return checks;
+}
+
+DeckMoonlightFocusReturnPlan focusReturnPlanFor(const DeckMoonlightHandoffPreflightRequest& request) {
+    const auto target = (!isBlank(request.hostDisplayNamePublic) && !isBlank(request.gameTitlePublic))
+        ? request.hostDisplayNamePublic + " / " + request.gameTitlePublic
+        : std::string{"selected Nova Deck review target"};
+    return DeckMoonlightFocusReturnPlan{
+        .sourceSurface = "Nova Deck preview review",
+        .intendedReturnTarget = target,
+        .fallbackCopy = "Return to Nova and keep this preview available after a later approved launch exits or fails.",
+        .confidence = "unproven_static",
+    };
+}
+
+DeckMoonlightHandoffPreflightResult baseResult(const DeckMoonlightHandoffPreflightRequest& request) {
+    DeckMoonlightHandoffPreflightResult result;
+    result.focusReturnPlan = focusReturnPlanFor(request);
+    result.readinessChecks = readinessChecksFor(request);
+    return result;
+}
+
+DeckMoonlightHandoffPreflightResult blocked(
+    const DeckMoonlightHandoffPreflightRequest& request,
+    std::vector<DeckMoonlightHandoffBlockReason> reasons,
+    std::string publicCopy,
+    const DeckMoonlightHandoffVerdict verdict = DeckMoonlightHandoffVerdict::BlockedStatic) {
+    auto result = baseResult(request);
+    result.verdict = verdict;
+    result.blockedReasons = std::move(reasons);
+    result.publicPreviewCopy = std::move(publicCopy);
+    result.candidatePlan.surface = request.requestedSurface;
+    result.candidatePlan.publicSummary = result.publicPreviewCopy;
+    result.safeToRender = !isUnsafePublicText(result.publicPreviewCopy);
+    return result;
+}
+
+} // namespace
+
+DeckMoonlightHandoffPreflightResult resolveDeckMoonlightHandoffPreflight(
+    const DeckMoonlightHandoffPreflightRequest& request) {
+    if (isBlank(request.hostDisplayNamePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::MissingHost},
+            "Nova needs a public host label before reviewing a Moonlight handoff. Nothing will launch yet.");
+    }
+
+    if (isBlank(request.gameTitlePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::MissingGame},
+            "Nova needs a public game title before reviewing a Moonlight handoff. Nothing will launch yet.");
+    }
+
+    if (isUnsafePublicText(request.hostDisplayNamePublic) || isUnsafePublicText(request.gameTitlePublic)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafePublicCopy},
+            "Nova blocked this Moonlight handoff preview because public copy contains unsafe private or shell-like text. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::NovaOwnedCommonCFuture) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::ForbiddenRuntimeBoundary},
+            "Nova-owned streaming belongs behind a later approved runtime lane. Nothing will launch yet.",
+            DeckMoonlightHandoffVerdict::ForbiddenRuntimeBoundary);
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::CustomUri) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::CustomUriNotStreamHandler},
+            "Custom URI handoff is blocked: research has not proven a stream-launch handler. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::DesktopEntry) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::DesktopEntryNotStreamContract, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Desktop entry handoff is research-only: it identifies the app shell, not a host/game stream. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::FlatpakIdentity) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::FlatpakContractUnproven, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Flatpak identity handoff is research-only: package identity is known, but argument forwarding is unproven. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface == DeckMoonlightHandoffSurface::SteamShortcut) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::SteamShortcutRuntimeOnly, DeckMoonlightHandoffBlockReason::ResearchNeeded},
+            "Steam shortcut handoff is research-only: Game Mode launch behavior needs a later approved runtime check. Nothing will launch yet.");
+    }
+
+    if (request.requestedSurface != DeckMoonlightHandoffSurface::MoonlightQtCli) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsupportedSurface},
+            "This handoff surface is not supported by the local-only Moonlight preflight. Nothing will launch yet.");
+    }
+
+    if (!request.hasSafeSnapshot) {
+        return blocked(
+            request,
+            {
+                DeckMoonlightHandoffBlockReason::HostSnapshotMissing,
+                DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic,
+                DeckMoonlightHandoffBlockReason::FocusReturnUnprovenStatic,
+            },
+            "Nova cannot verify Moonlight readiness without a prior safe snapshot or a later approved runtime check. Nothing will launch yet.");
+    }
+
+    if (!request.appPresentInSnapshot) {
+        return blocked(
+            request,
+            {
+                DeckMoonlightHandoffBlockReason::AppNotInSnapshot,
+                DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic,
+            },
+            "Nova cannot verify that this game exists in the safe host snapshot. Nothing will launch yet.");
+    }
+
+    const auto privateHostSelector = isBlank(request.privateHostSelectorRedactedForDebug)
+        ? std::string{"redacted-host-selector"}
+        : request.privateHostSelectorRedactedForDebug;
+    if (isUnsafeArgvToken(privateHostSelector)) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafeArgvToken},
+            "Nova blocked this Moonlight handoff preview because the private host selector is not safe as typed argv data. Nothing will launch yet.");
+    }
+
+    auto result = baseResult(request);
+    result.verdict = DeckMoonlightHandoffVerdict::ReadyForReview;
+    result.safeToRender = true;
+    result.candidatePlan.surface = DeckMoonlightHandoffSurface::MoonlightQtCli;
+    result.candidatePlan.argvTokens = {"moonlight", "stream", privateHostSelector, request.gameTitlePublic};
+    result.publicPreviewCopy = "Ready to review Moonlight handoff for "
+        + request.hostDisplayNamePublic
+        + " / "
+        + request.gameTitlePublic
+        + ". Nothing will launch yet.";
+    result.candidatePlan.publicSummary = result.publicPreviewCopy;
+    result.safeToRender = !isUnsafePublicText(result.publicPreviewCopy);
+    if (!result.safeToRender) {
+        return blocked(
+            request,
+            {DeckMoonlightHandoffBlockReason::UnsafePublicCopy},
+            "Nova blocked this Moonlight handoff preview because the public review copy is not safe to render. Nothing will launch yet.");
+    }
+    return result;
+}
+
+} // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_moonlight_handoff_preflight.h
+++ b/clients/deck/src/stream/deck_moonlight_handoff_preflight.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace nova::deck::stream {
+
+enum class DeckMoonlightHandoffSurface {
+    MoonlightQtCli,
+    HostAppSnapshot,
+    DesktopEntry,
+    FlatpakIdentity,
+    SteamShortcut,
+    CustomUri,
+    NovaOwnedCommonCFuture,
+    Unsupported,
+};
+
+enum class DeckMoonlightHandoffVerdict {
+    ReadyForReview,
+    BlockedStatic,
+    ForbiddenRuntimeBoundary,
+};
+
+enum class DeckMoonlightHandoffBlockReason {
+    MissingHost,
+    MissingGame,
+    UnsupportedSurface,
+    HostSnapshotMissing,
+    HostPairingUnprovenStatic,
+    AppNotInSnapshot,
+    UnsafePublicCopy,
+    UnsafeArgvToken,
+    CustomUriNotStreamHandler,
+    DesktopEntryNotStreamContract,
+    FlatpakContractUnproven,
+    SteamShortcutRuntimeOnly,
+    FocusReturnUnprovenStatic,
+    ResearchNeeded,
+    ForbiddenRuntimeBoundary,
+};
+
+struct DeckMoonlightHandoffPreflightRequest {
+    std::string hostDisplayNamePublic;
+    std::string gameTitlePublic;
+    std::string privateHostSelectorRedactedForDebug;
+    DeckMoonlightHandoffSurface requestedSurface = DeckMoonlightHandoffSurface::Unsupported;
+    bool hasSafeSnapshot = false;
+    bool appPresentInSnapshot = false;
+};
+
+struct DeckMoonlightHandoffCandidatePlan {
+    DeckMoonlightHandoffSurface surface = DeckMoonlightHandoffSurface::Unsupported;
+    std::vector<std::string> argvTokens;
+    std::string publicSummary;
+};
+
+struct DeckMoonlightFocusReturnPlan {
+    std::string sourceSurface;
+    std::string intendedReturnTarget;
+    std::string fallbackCopy;
+    std::string confidence;
+};
+
+enum class DeckMoonlightReadinessCheckStatus {
+    Passed,
+    Blocked,
+    ReviewOnly,
+};
+
+struct DeckMoonlightReadinessCheck {
+    std::string id;
+    std::string label;
+    std::string detail;
+    DeckMoonlightReadinessCheckStatus status = DeckMoonlightReadinessCheckStatus::ReviewOnly;
+};
+
+struct DeckMoonlightHandoffPreflightResult {
+    DeckMoonlightHandoffVerdict verdict = DeckMoonlightHandoffVerdict::BlockedStatic;
+    bool executable = false;
+    bool allowsNetwork = false;
+    bool allowsProcessExecution = false;
+    bool allowsMoonlight = false;
+    bool allowsHostMutation = false;
+    bool safeToRender = false;
+    DeckMoonlightHandoffCandidatePlan candidatePlan;
+    DeckMoonlightFocusReturnPlan focusReturnPlan;
+    std::vector<DeckMoonlightReadinessCheck> readinessChecks;
+    std::string publicPreviewCopy;
+    std::vector<DeckMoonlightHandoffBlockReason> blockedReasons;
+};
+
+DeckMoonlightHandoffPreflightResult resolveDeckMoonlightHandoffPreflight(
+    const DeckMoonlightHandoffPreflightRequest& request);
+
+} // namespace nova::deck::stream

--- a/clients/deck/tests/deck_moonlight_handoff_preflight_test.cpp
+++ b/clients/deck/tests/deck_moonlight_handoff_preflight_test.cpp
@@ -1,0 +1,255 @@
+#include "stream/deck_moonlight_handoff_preflight.h"
+
+#include <algorithm>
+#include <cassert>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using nova::deck::stream::DeckMoonlightFocusReturnPlan;
+using nova::deck::stream::DeckMoonlightHandoffBlockReason;
+using nova::deck::stream::DeckMoonlightHandoffPreflightRequest;
+using nova::deck::stream::DeckMoonlightHandoffPreflightResult;
+using nova::deck::stream::DeckMoonlightHandoffSurface;
+using nova::deck::stream::DeckMoonlightHandoffVerdict;
+using nova::deck::stream::DeckMoonlightReadinessCheck;
+using nova::deck::stream::DeckMoonlightReadinessCheckStatus;
+using nova::deck::stream::resolveDeckMoonlightHandoffPreflight;
+
+DeckMoonlightHandoffPreflightRequest validRequest(
+    const DeckMoonlightHandoffSurface surface = DeckMoonlightHandoffSurface::MoonlightQtCli) {
+    return DeckMoonlightHandoffPreflightRequest{
+        .hostDisplayNamePublic = "MacPapi Gaming Host",
+        .gameTitlePublic = "Black Myth: Wukong",
+        .privateHostSelectorRedactedForDebug = "redacted-host-selector",
+        .requestedSurface = surface,
+        .hasSafeSnapshot = true,
+        .appPresentInSnapshot = true,
+    };
+}
+
+bool hasReason(
+    const DeckMoonlightHandoffPreflightResult& result,
+    const DeckMoonlightHandoffBlockReason reason) {
+    return std::find(result.blockedReasons.begin(), result.blockedReasons.end(), reason) != result.blockedReasons.end();
+}
+
+bool contains(const std::string& text, const std::string_view needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+std::string pieces(const std::initializer_list<std::string_view> parts) {
+    std::string value;
+    for (const auto part : parts) {
+        value.append(part);
+    }
+    return value;
+}
+
+void assertRuntimeBoundaryClosed(const DeckMoonlightHandoffPreflightResult& result) {
+    assert(!result.executable);
+    assert(!result.allowsNetwork);
+    assert(!result.allowsProcessExecution);
+    assert(!result.allowsMoonlight);
+    assert(!result.allowsHostMutation);
+}
+
+void assertBlockedStatic(const DeckMoonlightHandoffPreflightResult& result) {
+    assert(result.verdict == DeckMoonlightHandoffVerdict::BlockedStatic);
+    assertRuntimeBoundaryClosed(result);
+    assert(result.candidatePlan.argvTokens.empty());
+    assert(!contains(result.publicPreviewCopy, "moonlight://"));
+    assert(!contains(result.publicPreviewCopy, "http://"));
+    assert(!contains(result.publicPreviewCopy, "https://"));
+    assert(!contains(result.publicPreviewCopy, "ssh"));
+}
+
+void assertFocusReturnUnproven(const DeckMoonlightFocusReturnPlan& plan) {
+    assert(plan.sourceSurface == "Nova Deck preview review");
+    assert(plan.intendedReturnTarget == "MacPapi Gaming Host / Black Myth: Wukong");
+    assert(plan.confidence == "unproven_static");
+    assert(contains(plan.fallbackCopy, "Return to Nova"));
+    assert(contains(plan.fallbackCopy, "later approved launch"));
+}
+
+const DeckMoonlightReadinessCheck& readinessCheck(
+    const DeckMoonlightHandoffPreflightResult& result,
+    const std::string_view id) {
+    const auto match = std::find_if(
+        result.readinessChecks.begin(),
+        result.readinessChecks.end(),
+        [&](const DeckMoonlightReadinessCheck& check) {
+            return check.id == id;
+        });
+    assert(match != result.readinessChecks.end());
+    return *match;
+}
+
+void assertReadinessCheck(
+    const DeckMoonlightHandoffPreflightResult& result,
+    const std::string_view id,
+    const DeckMoonlightReadinessCheckStatus status,
+    const std::string_view detailNeedle) {
+    const auto& check = readinessCheck(result, id);
+    assert(check.status == status);
+    assert(!check.label.empty());
+    assert(contains(check.detail, detailNeedle));
+    assert(!contains(check.detail, "moonlight://"));
+    assert(!contains(check.detail, "http://"));
+    assert(!contains(check.detail, "https://"));
+    assert(!contains(check.detail, "ssh"));
+}
+
+} // namespace
+
+static_assert(std::is_default_constructible_v<DeckMoonlightHandoffPreflightRequest>);
+static_assert(std::is_default_constructible_v<DeckMoonlightHandoffPreflightResult>);
+
+int main() {
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest());
+        assert(result.verdict == DeckMoonlightHandoffVerdict::ReadyForReview);
+        assert(result.safeToRender);
+        assertRuntimeBoundaryClosed(result);
+        assert(result.candidatePlan.surface == DeckMoonlightHandoffSurface::MoonlightQtCli);
+        assert((result.candidatePlan.argvTokens == std::vector<std::string>{
+            "moonlight",
+            "stream",
+            "redacted-host-selector",
+            "Black Myth: Wukong",
+        }));
+        assert(contains(result.publicPreviewCopy, "Ready to review Moonlight handoff"));
+        assert(contains(result.publicPreviewCopy, "MacPapi Gaming Host"));
+        assert(contains(result.publicPreviewCopy, "Black Myth: Wukong"));
+        assert(contains(result.publicPreviewCopy, "Nothing will launch yet"));
+        assert(!contains(result.publicPreviewCopy, "redacted-host-selector"));
+        assertFocusReturnUnproven(result.focusReturnPlan);
+        assert(result.blockedReasons.empty());
+        assert(result.readinessChecks.size() == 4);
+        assertReadinessCheck(result, "safe-snapshot", DeckMoonlightReadinessCheckStatus::Passed, "Read-only host snapshot");
+        assertReadinessCheck(result, "app-snapshot", DeckMoonlightReadinessCheckStatus::Passed, "Game appears in snapshot");
+        assertReadinessCheck(result, "typed-argv", DeckMoonlightReadinessCheckStatus::Passed, "Typed argv preview is redacted");
+        assertReadinessCheck(result, "focus-return", DeckMoonlightReadinessCheckStatus::ReviewOnly, "Focus return remains unproven_static");
+    }
+
+    {
+        auto request = validRequest();
+        request.hostDisplayNamePublic.clear();
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::MissingHost));
+        assert(contains(result.publicPreviewCopy, "public host label"));
+    }
+
+    {
+        auto request = validRequest();
+        request.gameTitlePublic.clear();
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::MissingGame));
+        assert(contains(result.publicPreviewCopy, "game title"));
+    }
+
+    {
+        auto request = validRequest();
+        request.hasSafeSnapshot = false;
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostSnapshotMissing));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::FocusReturnUnprovenStatic));
+        assert(contains(result.publicPreviewCopy, "cannot verify Moonlight readiness"));
+        assertFocusReturnUnproven(result.focusReturnPlan);
+        assertReadinessCheck(result, "safe-snapshot", DeckMoonlightReadinessCheckStatus::Blocked, "Needs safe host snapshot");
+        assertReadinessCheck(result, "app-snapshot", DeckMoonlightReadinessCheckStatus::Passed, "Game appears in snapshot");
+        assertReadinessCheck(result, "typed-argv", DeckMoonlightReadinessCheckStatus::Blocked, "Snapshot gate must pass first");
+    }
+
+    {
+        auto request = validRequest();
+        request.appPresentInSnapshot = false;
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::AppNotInSnapshot));
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::HostPairingUnprovenStatic));
+        assertReadinessCheck(result, "safe-snapshot", DeckMoonlightReadinessCheckStatus::Passed, "Read-only host snapshot");
+        assertReadinessCheck(result, "app-snapshot", DeckMoonlightReadinessCheckStatus::Blocked, "Game missing from snapshot");
+        assertReadinessCheck(result, "typed-argv", DeckMoonlightReadinessCheckStatus::Blocked, "App snapshot gate must pass first");
+    }
+
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(DeckMoonlightHandoffSurface::CustomUri));
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::CustomUriNotStreamHandler));
+        assert(!contains(result.candidatePlan.publicSummary, "moonlight://"));
+    }
+
+    {
+        const std::vector<std::pair<DeckMoonlightHandoffSurface, DeckMoonlightHandoffBlockReason>> blockedSurfaces{
+            {DeckMoonlightHandoffSurface::DesktopEntry, DeckMoonlightHandoffBlockReason::DesktopEntryNotStreamContract},
+            {DeckMoonlightHandoffSurface::FlatpakIdentity, DeckMoonlightHandoffBlockReason::FlatpakContractUnproven},
+            {DeckMoonlightHandoffSurface::SteamShortcut, DeckMoonlightHandoffBlockReason::SteamShortcutRuntimeOnly},
+        };
+        for (const auto& [surface, reason] : blockedSurfaces) {
+            const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(surface));
+            assertBlockedStatic(result);
+            assert(hasReason(result, reason));
+            assert(contains(result.publicPreviewCopy, "research-only"));
+        }
+    }
+
+    {
+        const auto result = resolveDeckMoonlightHandoffPreflight(validRequest(DeckMoonlightHandoffSurface::NovaOwnedCommonCFuture));
+        assert(result.verdict == DeckMoonlightHandoffVerdict::ForbiddenRuntimeBoundary);
+        assertRuntimeBoundaryClosed(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::ForbiddenRuntimeBoundary));
+        assert(result.candidatePlan.argvTokens.empty());
+    }
+
+    {
+        const std::vector<std::string> unsafePublicValues{
+            pieces({"10", ".0", ".0", ".232"}),
+            pieces({"http", "://", "host.local"}),
+            pieces({"s", "sh pc-papi"}),
+            pieces({"/Us", "ers/", "papi/", ".s", "sh/", "id_ed25519"}),
+            pieces({"token", "=redacted-test-value"}),
+            pieces({"pass", "word: redacted-test-value"}),
+            pieces({"moon", "light", "://", "stream/host/app"}),
+            pieces({"MacPapi", ";", " rm -rf /"}),
+            pieces({"aa", ":bb", ":cc", ":dd", ":ee", ":ff"}),
+            pieces({"!", "abcdef", ":matrix.local"}),
+        };
+        for (const auto& unsafeValue : unsafePublicValues) {
+            auto hostRequest = validRequest();
+            hostRequest.hostDisplayNamePublic = unsafeValue;
+            const auto hostResult = resolveDeckMoonlightHandoffPreflight(hostRequest);
+            assertBlockedStatic(hostResult);
+            assert(hasReason(hostResult, DeckMoonlightHandoffBlockReason::UnsafePublicCopy));
+            assert(!contains(hostResult.publicPreviewCopy, unsafeValue));
+
+            auto gameRequest = validRequest();
+            gameRequest.gameTitlePublic = unsafeValue;
+            const auto gameResult = resolveDeckMoonlightHandoffPreflight(gameRequest);
+            assertBlockedStatic(gameResult);
+            assert(hasReason(gameResult, DeckMoonlightHandoffBlockReason::UnsafePublicCopy));
+            assert(!contains(gameResult.publicPreviewCopy, unsafeValue));
+        }
+    }
+
+    {
+        auto request = validRequest();
+        request.privateHostSelectorRedactedForDebug = "host selector; launch";
+        const auto result = resolveDeckMoonlightHandoffPreflight(request);
+        assertBlockedStatic(result);
+        assert(hasReason(result, DeckMoonlightHandoffBlockReason::UnsafeArgvToken));
+        assert(!contains(result.publicPreviewCopy, "host selector; launch"));
+        assertReadinessCheck(result, "typed-argv", DeckMoonlightReadinessCheckStatus::Blocked, "Typed argv preview is not public-safe");
+    }
+
+    return 0;
+}

--- a/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
+++ b/clients/deck/tests/deck_moonlight_handoff_source_guard_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Static guard for the local-only Deck Moonlight handoff preflight slice."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_FILES = [
+    ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.h",
+    ROOT / "src" / "stream" / "deck_moonlight_handoff_preflight.cpp",
+    ROOT / "src" / "main.cpp",
+    ROOT / "qml" / "Main.qml",
+    ROOT / "CMakeLists.txt",
+]
+
+FORBIDDEN_PATTERNS = [
+    ("process launch API", re.compile(r"\b(QProcess|fork\s*\(|system\s*\(|popen\s*\(|xdg-open|flatpak\s+run)\b")),
+    ("exec API", re.compile(r"\bexec(?:l|le|lp|lpe|v|ve|vp|vpe)?\s*\(")),
+    ("Moonlight runtime connection", re.compile(r"\b(LiStartConnection|LiStopConnection|LiInterruptConnection|MoonBridge\.startConnection)\b")),
+    ("Moonlight stream shell command", re.compile(r"moonlight\s+stream", re.IGNORECASE)),
+    ("Moonlight custom URI", re.compile(r"moonlight://", re.IGNORECASE)),
+    ("host HTTP launch surface", re.compile(r"(/launch|/resume|/cancel|/serverinfo|/applist)\b", re.IGNORECASE)),
+    ("Android host/pairing/persistence", re.compile(r"\b(NvHTTP|PairingManager|ComputerDatabaseManager|HostStore|DiscoveryService)\b")),
+    ("network discovery/probing", re.compile(r"\b(mDNS|NSD|zeroconf|socket\s*\(|connect\s*\(|send\s*\(|recv\s*\()\b")),
+    ("media/device probe", re.compile(r"\b(av_hwdevice_ctx_create|PipeWire|PulseAudio|VA-API|/dev/input|xdotool|ffmpeg|systemctl|pgrep|ldd)\b", re.IGNORECASE)),
+    ("private endpoint literal", re.compile(r"\b(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b")),
+    ("MAC-like literal", re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")),
+    ("private key header", re.compile(r"BEGIN [A-Z ]*PRIVATE KEY")),
+    ("secret-looking assignment", re.compile(r"\b(?:api[_-]?key|client[_-]?secret|session[_-]?token|password)\b\s*[:=]", re.IGNORECASE)),
+]
+
+ALLOWED_CMAKE_PATTERN = re.compile(r"nova_deck_moonlight_handoff_preflight|deck_moonlight_handoff", re.IGNORECASE)
+
+
+def normalized_text(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if path.name == "CMakeLists.txt":
+        # Target/file names necessarily contain the feature name. Keep command/runtime checks active.
+        text = ALLOWED_CMAKE_PATTERN.sub("PRELIGHT_TARGET_NAME", text)
+    if path.name == "main.cpp":
+        # Qt signal wiring/event loop are not network connect/probe or process exec surfaces.
+        text = text.replace("QObject::connect", "QT_SIGNAL_CONNECT")
+        text = text.replace("connect(notifier_", "QT_SIGNAL_CONNECT(notifier_")
+        text = text.replace("return app.exec();", "return QT_APP_EVENT_LOOP;")
+    if path.name == "Main.qml":
+        # Existing inert preview URI path is local copy text, not a host HTTP launch endpoint.
+        text = text.replace("preview://nova-deck/launch", "preview://nova-deck/PREVIEW_PATH")
+    return text
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in SCAN_FILES:
+        if not path.exists():
+            failures.append(f"missing guarded file: {path.relative_to(ROOT)}")
+            continue
+        text = normalized_text(path)
+        for label, pattern in FORBIDDEN_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                rel = path.relative_to(ROOT)
+                failures.append(f"{rel}: forbidden {label}: {match.group(0)!r}")
+    if failures:
+        print("Deck Moonlight preflight source guard failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("Deck Moonlight preflight source guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a local-only Steam Deck Moonlight handoff preflight contract.
- Blocks runtime/network/process/host mutation boundaries while still producing reviewable typed argv preview data.
- Adds C++ coverage plus a static source guard so this lane cannot quietly grow launch/network behavior.

## Verification
- RED captured: focused preflight test failed before production files existed (`stream/deck_moonlight_handoff_preflight.h` missing).
- `cmake -S clients/deck -B build/deck-final-core -DNOVA_DECK_BUILD_QT_SHELL=OFF`
- `cmake --build build/deck-final-core -- -j$(nproc)`
- `ctest --test-dir build/deck-final-core --output-on-failure` → 12/12 passed
- `cmake -S clients/deck -B build/deck-final-qt`
- `cmake --build build/deck-final-qt -- -j$(nproc)`
- `ctest --test-dir build/deck-final-qt --output-on-failure` → 13/13 passed

## Notes
- This deliberately does **not** resurrect stale QML/main bridge churn from the old branch. Current master already has the richer backend preflight DTO surface; this PR keeps the Moonlight handoff contract narrow and reviewable.