### PR TITLE
fix(nova): route dual-screen controls to companion display

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,6 +167,11 @@
             android:launchMode="singleInstance"
             android:taskAffinity=""
             android:theme="@style/ExternalDisplayControllerTheme"/>
+        <activity android:name=".utils.GameDisplayLaunchTrampolineActivity"
+            android:exported="false"
+            android:noHistory="true"
+            android:resizeableActivity="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
         <activity
             android:name=".preferences.StreamSettings"
             android:resizeableActivity="true"

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -3,7 +3,6 @@ package com.papi.nova
 
 import com.papi.nova.utils.ServerHelper.getActiveDisplay
 import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
-import com.papi.nova.utils.ServerHelper.getSecondaryDisplay
 
 import com.papi.nova.binding.PlatformBinding
 import com.papi.nova.binding.audio.AndroidAudioRenderer
@@ -219,6 +218,8 @@ private var grabbedInput:Boolean = true
 private var cursorVisible:Boolean = false
 private var currentMouseModeIndex:Int = 0
 private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
+private var companionControlDisplayId:Int = Display.INVALID_DISPLAY
+private var externalDisplayListener:DisplayManager.DisplayListener? = null
 @Volatile private var lastClientPresentationRefreshRate:Float = 0f
 @Volatile private var lastClientPresentationDisplayModeId:Int = 0
 @Volatile private var lastClientPresentationDisplayMode:String = ""
@@ -400,6 +401,16 @@ return getAndroidCompanionDisplay(this, prefConfig, streamingDisplayId)
 
 private fun shouldLaunchCompanionControls(): Boolean {
 return ::prefConfig.isInitialized && prefConfig.enableFullExDisplay && getCompanionControlDisplay() != null
+}
+
+private fun launchCompanionControlsIfAvailable() {
+val companionDisplay:Display? = getCompanionControlDisplay()
+if (::prefConfig.isInitialized && prefConfig.enableFullExDisplay && companionDisplay != null)
+{
+companionControlDisplayId = companionDisplay.getDisplayId()
+StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl(this, streamingDisplayId)
+listenForExternalDisplayRemoval()
+}
 }
 
 @SuppressLint("InlinedApi")
@@ -1177,11 +1188,7 @@ applyMouseMode(2)
 }
 else
 {
-if (shouldLaunchCompanionControls())
-{
-StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl(this, streamingDisplayId)
-listenForExternalDisplayRemoval()
-}
+launchCompanionControlsIfAvailable()
 
  // Initialize touch contexts based on preferences
             // The mouse mode preference is also read in PreferenceConfiguration to set the boolean flags
@@ -1441,23 +1448,55 @@ R.drawable.floating_menu_button)
 }
 
 private fun listenForExternalDisplayRemoval() {
-var displayManager:DisplayManager? = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-displayManager!!.registerDisplayListener(object : DisplayManager.DisplayListener {
-override fun onDisplayAdded(displayId:Int) {}
+if (externalDisplayListener != null) return
+
+val displayManager:DisplayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+val listener:DisplayManager.DisplayListener = object : DisplayManager.DisplayListener {
+override fun onDisplayAdded(displayId:Int) = Unit
+override fun onDisplayChanged(displayId:Int) = Unit
 override fun onDisplayRemoved(displayId:Int) {
-if (getSecondaryDisplay(getBaseContext()) == null)
-{
-handleDisplayRemoved()
-finish()
+handleDisplayRemoved(displayId)
 }
 }
-override fun onDisplayChanged(displayId:Int) {}
-}, null)
+externalDisplayListener = listener
+displayManager.registerDisplayListener(listener, null)
 }
 
-private fun handleDisplayRemoved() {
-NotificationManagerCompat.from(getBaseContext()).cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
+private fun stopListeningForExternalDisplayRemoval() {
+val listener:DisplayManager.DisplayListener = externalDisplayListener ?: return
+val displayManager:DisplayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+displayManager.unregisterDisplayListener(listener)
+externalDisplayListener = null
+}
+
+private fun closeCompanionControls() {
+NotificationManagerCompat.from(baseContext)
+.cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
 ExternalDisplayControlActivity.closeExternalDisplayControl()
+companionControlDisplayId = Display.INVALID_DISPLAY
+}
+
+private fun handleDisplayRemoved(removedDisplayId:Int) {
+NotificationManagerCompat.from(baseContext)
+.cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
+
+when {
+removedDisplayId == streamingDisplayId -> {
+ExternalDisplayControlActivity.closeExternalDisplayControl()
+finish()
+}
+removedDisplayId == companionControlDisplayId -> {
+ExternalDisplayControlActivity.closeExternalDisplayControl()
+companionControlDisplayId = Display.INVALID_DISPLAY
+}
+else -> {
+if (getCompanionControlDisplay() == null)
+{
+ExternalDisplayControlActivity.closeExternalDisplayControl()
+companionControlDisplayId = Display.INVALID_DISPLAY
+}
+}
+}
 }
 
 @SuppressLint("ClickableViewAccessibility")
@@ -2402,6 +2441,7 @@ decoderRenderer!!.notifyVideoForeground()
 
 override fun onDestroy() {
 super.onDestroy()
+stopListeningForExternalDisplayRemoval()
 
  // Nova: clean up Polaris integration
         stopPolarisLiveSessionStatusRefresh()
@@ -2431,7 +2471,7 @@ isStreamActive = false
 instance = null
 timerHandler!!.removeCallbacksAndMessages(null)
 
-if (prefConfig!!.enableFullExDisplay) handleDisplayRemoved()
+if (prefConfig!!.enableFullExDisplay) closeCompanionControls()
 
 if (controllerHandler != null)
 {

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -2,6 +2,7 @@ package com.papi.nova
 
 
 import com.papi.nova.utils.ServerHelper.getActiveDisplay
+import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
 import com.papi.nova.utils.ServerHelper.getSecondaryDisplay
 
 import com.papi.nova.binding.PlatformBinding
@@ -385,6 +386,20 @@ display = displayManager!!.getDisplay(streamingDisplayId)
 }
 }
 return if (display != null) display else getWindowManager().getDefaultDisplay()
+}
+
+fun streamingDisplayIdForCompanion(): Int = streamingDisplayId
+
+private fun getCompanionControlDisplay(): Display? {
+if (!::prefConfig.isInitialized)
+{
+return null
+}
+return getAndroidCompanionDisplay(this, prefConfig, streamingDisplayId)
+}
+
+private fun shouldLaunchCompanionControls(): Boolean {
+return ::prefConfig.isInitialized && prefConfig.enableFullExDisplay && getCompanionControlDisplay() != null
 }
 
 @SuppressLint("InlinedApi")
@@ -1162,9 +1177,9 @@ applyMouseMode(2)
 }
 else
 {
-if (prefConfig!!.enableFullExDisplay && isOnExternalDisplay)
+if (shouldLaunchCompanionControls())
 {
-StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl(this)
+StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl(this, streamingDisplayId)
 listenForExternalDisplayRemoval()
 }
 

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -52,6 +52,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
 import com.papi.nova.utils.ExternalDisplayControlActivity
+import com.papi.nova.utils.GameDisplayLaunchTrampolineActivity
 import com.papi.nova.utils.MouseModeOption
 import com.papi.nova.utils.PanZoomHandler
 import com.papi.nova.utils.PerformanceDataTracker
@@ -6038,7 +6039,7 @@ if (prefConfig!!.smartClipboardSync)
 getClipboard(-1)
 }
 finish()
-Handler(Looper.getMainLooper()).postDelayed({ getApplicationContext().startActivity(relaunchIntent)
+Handler(Looper.getMainLooper()).postDelayed({ GameDisplayLaunchTrampolineActivity.launchGameOnRequestedDisplay(getApplicationContext(), relaunchIntent)
 overridePendingTransition(0, 0) }, 900)
 }
  fun quit() {

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -218,7 +218,7 @@ private var grabbedInput:Boolean = true
 private var cursorVisible:Boolean = false
 private var currentMouseModeIndex:Int = 0
 private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
-private var companionControlDisplayId:Int = Display.INVALID_DISPLAY
+private var companionControlDisplayId:Int = INVALID_DISPLAY_ID
 private var externalDisplayListener:DisplayManager.DisplayListener? = null
 @Volatile private var lastClientPresentationRefreshRate:Float = 0f
 @Volatile private var lastClientPresentationDisplayModeId:Int = 0
@@ -1473,7 +1473,7 @@ private fun closeCompanionControls() {
 NotificationManagerCompat.from(baseContext)
 .cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
 ExternalDisplayControlActivity.closeExternalDisplayControl()
-companionControlDisplayId = Display.INVALID_DISPLAY
+companionControlDisplayId = INVALID_DISPLAY_ID
 }
 
 private fun handleDisplayRemoved(removedDisplayId:Int) {
@@ -1487,13 +1487,13 @@ finish()
 }
 removedDisplayId == companionControlDisplayId -> {
 ExternalDisplayControlActivity.closeExternalDisplayControl()
-companionControlDisplayId = Display.INVALID_DISPLAY
+companionControlDisplayId = INVALID_DISPLAY_ID
 }
 else -> {
 if (getCompanionControlDisplay() == null)
 {
 ExternalDisplayControlActivity.closeExternalDisplayControl()
-companionControlDisplayId = Display.INVALID_DISPLAY
+companionControlDisplayId = INVALID_DISPLAY_ID
 }
 }
 }
@@ -6227,6 +6227,7 @@ companion object {
  private const val FIVE_FINGER_TAP_THRESHOLD:Int = 300
  private const val POLARIS_SESSION_STATUS_REFRESH_MS:Long = 15000L
  private const val NOVA_PROGRESS_READY_DISMISS_DELAY_MS:Long = 350L
+ private const val INVALID_DISPLAY_ID:Int = -1
 
  const val EXTRA_HOST:String = "Host"
  const val EXTRA_PORT:String = "Port"

--- a/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
+++ b/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
@@ -11,7 +11,9 @@ import android.os.Handler
 import android.os.Looper
 import android.view.Display
 import androidx.annotation.RequiresApi
+import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.utils.ExternalDisplayControlActivity
+import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
 
 class StartExternalDisplayControlReceiver : BroadcastReceiver() {
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -33,7 +35,19 @@ class StartExternalDisplayControlReceiver : BroadcastReceiver() {
 
         @JvmStatic
         fun requestFocusToExternalDisplayControl(context: Context) {
+            requestFocusToExternalDisplayControl(
+                context,
+                Game.instance?.streamingDisplayIdForCompanion() ?: Display.DEFAULT_DISPLAY,
+            )
+        }
+
+        @JvmStatic
+        fun requestFocusToExternalDisplayControl(context: Context, streamDisplayId: Int) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val prefConfig = PreferenceConfiguration.readPreferences(context)
+                val controlsDisplay = getAndroidCompanionDisplay(context, prefConfig, streamDisplayId)
+                    ?: return
+
                 val intentTouchpad = Intent(context, ExternalDisplayControlActivity::class.java)
                 intentTouchpad.addFlags(
                     Intent.FLAG_ACTIVITY_NEW_TASK or
@@ -41,7 +55,7 @@ class StartExternalDisplayControlReceiver : BroadcastReceiver() {
                         Intent.FLAG_ACTIVITY_CLEAR_TOP,
                 )
                 val optionsDefault: Bundle = ActivityOptions.makeBasic()
-                    .setLaunchDisplayId(Display.DEFAULT_DISPLAY)
+                    .setLaunchDisplayId(controlsDisplay.displayId)
                     .toBundle()
                 context.startActivity(intentTouchpad, optionsDefault)
             }
@@ -58,7 +72,7 @@ class StartExternalDisplayControlReceiver : BroadcastReceiver() {
             val game = Game.instance
             if (game != null) {
                 if (focusExternalDisplayControl) {
-                    requestFocusToExternalDisplayControl(game)
+                    requestFocusToExternalDisplayControl(game, game.streamingDisplayIdForCompanion())
                 }
                 val activityManager = game.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
                 activityManager?.moveTaskToFront(game.taskId, 0)

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -210,6 +210,19 @@ class MediaCodecDecoderRenderer(
 
     private var targetFps = 0
 
+    private fun resetRollingPerfStatsForNewStream(reason: String) {
+        LimeLog.info("Nova: Resetting decoder perf stats for $reason")
+        activeWindowVideoStats.clear()
+        lastWindowVideoStats.clear()
+        globalVideoStats.clear()
+        lastFrameNumber = 0
+        lastTimestampUs = 0
+        lastNetDataNum = 0
+        minDecodeTime = Float.MAX_VALUE
+        minDecodeTimeFullLog = ""
+        enqueueNsByPtsUs.clear()
+    }
+
     init {
         avcDecoder = findAvcDecoder()
         if (avcDecoder != null) {
@@ -744,6 +757,7 @@ class MediaCodecDecoderRenderer(
     }
 
     override fun setup(format: Int, width: Int, height: Int, redrawRate: Int): Int {
+        resetRollingPerfStatsForNewStream("stream setup")
         targetFps = if (redrawRate > 0) redrawRate else 60
         initialWidth = if (invertResolution) height else width
         initialHeight = if (invertResolution) width else height
@@ -1426,6 +1440,9 @@ class MediaCodecDecoderRenderer(
             return MoonBridge.DR_OK
         }
         val decodeData = decodeUnitData!!
+        if (frameNumber < lastFrameNumber) {
+            resetRollingPerfStatsForNewStream("frame sequence restart")
+        }
 
         if (lastFrameNumber == 0) {
             activeWindowVideoStats.measurementStartTimestamp = SystemClock.uptimeMillis()

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -169,7 +169,7 @@ data class NovaHudUiState(
             val healthReason = buildHealthReason(status, fps, targetFps, latencyMs)
             return NovaHudUiState(
                 mode = mode,
-                fpsLabel = fps.takeIf { it > 0.0 }?.toInt()?.toString() ?: "--",
+                fpsLabel = fps.takeIf { it > 0.0 }?.roundToInt()?.toString() ?: "--",
                 targetFpsLabel = formatTargetFps(mode, targetFps),
                 latencyLabel = latencyMs.takeIf { it > 0 }?.let { "${it}ms" } ?: "--ms",
                 bitrateLabel = formatBitrate(mode, bitrateKbps),

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -50,27 +50,31 @@ data class NovaHudPerfSample(
 ) {
     companion object {
         fun fromPerfText(text: String): NovaHudPerfSample {
-            val fpsMatch = Regex("""(\d+(?:\.\d+)?)\s*(?:fps|FPS)""", RegexOption.IGNORE_CASE).find(text)
-                ?: Regex("""FPS[:\s]+(\d+(?:\.\d+)?)""", RegexOption.IGNORE_CASE).find(text)
-                ?: Regex("""(\d+\.\d)\s*$""", RegexOption.MULTILINE).find(text.lines().firstOrNull() ?: "")
+            val localizedNumber = """\d+(?:[.,]\d+)?"""
+            val fpsMatch = Regex("""(?<![\d.,])($localizedNumber)\s*(?:fps|FPS)\b""", RegexOption.IGNORE_CASE).find(text)
+                ?: Regex("""FPS[:：\s]+($localizedNumber)""", RegexOption.IGNORE_CASE).find(text)
+                ?: Regex("""($localizedNumber)\s*$""", RegexOption.MULTILINE).find(text.lines().firstOrNull() ?: "")
             val resolutionMatch = Regex("""(\d{3,4})\s*[x×]\s*(\d{3,4})""").find(text)
             val latencyMatch = Regex("""(?:RTT|latency)[^0-9]*(\d+)\s*ms""", RegexOption.IGNORE_CASE).find(text)
             val codecMatch = Regex("""(?:decoder|codec)[:\s]+(\S+)""", RegexOption.IGNORE_CASE).find(text)
             val packetLossMatch = Regex(
-                """(?:packet loss|frames dropped by your network connection|netdrops)[^0-9]*(\d+(?:\.\d+)?)\s*%""",
+                """(?:packet loss|frames dropped by your network connection|netdrops)[^0-9]*($localizedNumber)\s*%""",
                 RegexOption.IGNORE_CASE
             ).find(text)
-                ?: Regex("""(\d+(?:\.\d+)?)\s*%\s*(?:packet loss|netdrops)""", RegexOption.IGNORE_CASE).find(text)
+                ?: Regex("""($localizedNumber)\s*%\s*(?:packet loss|netdrops)""", RegexOption.IGNORE_CASE).find(text)
 
             return NovaHudPerfSample(
-                fps = fpsMatch?.groupValues?.getOrNull(1)?.toDoubleOrNull(),
+                fps = fpsMatch?.localizedDouble(),
                 width = resolutionMatch?.groupValues?.getOrNull(1)?.toIntOrNull(),
                 height = resolutionMatch?.groupValues?.getOrNull(2)?.toIntOrNull(),
                 latencyMs = latencyMatch?.groupValues?.getOrNull(1)?.toIntOrNull(),
                 codec = codecMatch?.groupValues?.getOrNull(1)?.let(NovaHudUiState::normalizeCodecLabel),
-                packetLossPct = packetLossMatch?.groupValues?.getOrNull(1)?.toDoubleOrNull()
+                packetLossPct = packetLossMatch?.localizedDouble()
             )
         }
+
+        private fun MatchResult.localizedDouble(): Double? =
+            groupValues.getOrNull(1)?.replace(',', '.')?.toDoubleOrNull()
     }
 }
 

--- a/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
+++ b/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
@@ -28,4 +28,20 @@ object AndroidStreamDisplayTarget {
             else -> external ?: primary
         }
     }
+
+    fun selectCompanion(
+        displays: List<Candidate>,
+        defaultDisplayId: Int,
+        streamDisplayId: Int?,
+    ): Candidate? {
+        if (displays.size < 2 || streamDisplayId == null) return null
+
+        val candidates = displays.filter { it.displayId != streamDisplayId }
+        if (candidates.isEmpty()) return null
+
+        return candidates.minWithOrNull(
+            compareBy<Candidate> { it.pixelArea }
+                .thenBy { if (it.displayId == defaultDisplayId) 0 else 1 }
+        )
+    }
 }

--- a/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
+++ b/app/src/main/java/com/papi/nova/utils/AndroidStreamDisplayTarget.kt
@@ -44,4 +44,13 @@ object AndroidStreamDisplayTarget {
                 .thenBy { if (it.displayId == defaultDisplayId) 0 else 1 }
         )
     }
+
+    fun shouldUseDisplayLaunchTrampoline(
+        selectedDisplayId: Int?,
+        currentDisplayId: Int?,
+        companionDisplayId: Int?,
+    ): Boolean {
+        if (selectedDisplayId == null || companionDisplayId == null) return false
+        return selectedDisplayId != currentDisplayId
+    }
 }

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
@@ -46,7 +46,6 @@ import com.papi.nova.StartExternalDisplayControlReceiver
 import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardLayoutController
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.ExternalControllerView
-import com.papi.nova.utils.ServerHelper.getSecondaryDisplay
 
 /**
  * A standalone Activity providing a full-screen touchpad controller for the secondary display.
@@ -86,22 +85,22 @@ class ExternalDisplayControlActivity :
             } else {
                 val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
                 val targetDisplayId = gameIntent.getIntExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY)
-                val secondaryDisplay = displayManager.getDisplay(targetDisplayId)
-                    ?.takeIf { it.displayId != Display.DEFAULT_DISPLAY }
-                    ?: getSecondaryDisplay(this)
-                if (secondaryDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val targetDisplay = displayManager.getDisplay(targetDisplayId)
+                if (targetDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     val options = ActivityOptions.makeBasic()
-                    options.setLaunchDisplayId(secondaryDisplay.displayId)
-                    Toast.makeText(
-                        this,
-                        getString(
-                            R.string.external_display_info,
-                            secondaryDisplay.mode.physicalWidth,
-                            secondaryDisplay.mode.physicalHeight,
-                            secondaryDisplay.mode.refreshRate,
-                        ),
-                        Toast.LENGTH_LONG,
-                    ).show()
+                    options.setLaunchDisplayId(targetDisplay.displayId)
+                    if (targetDisplay.displayId != Display.DEFAULT_DISPLAY) {
+                        Toast.makeText(
+                            this,
+                            getString(
+                                R.string.external_display_info,
+                                targetDisplay.mode.physicalWidth,
+                                targetDisplay.mode.physicalHeight,
+                                targetDisplay.mode.refreshRate,
+                            ),
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    }
 
                     startActivity(gameIntent, options.toBundle())
                 } else {

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
@@ -2,7 +2,6 @@ package com.papi.nova.utils
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.app.ActivityOptions
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -12,12 +11,10 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
-import android.hardware.display.DisplayManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.view.Display
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -76,40 +73,6 @@ class ExternalDisplayControlActivity :
 
         instance = this
         prefConfig = PreferenceConfiguration.readPreferences(this)
-
-        if (!isGameInstanceAvailable()) {
-            @Suppress("DEPRECATION")
-            val gameIntent = intent.getParcelableExtra<Intent>(EXTRA_LAUNCH_INTENT)
-            if (gameIntent == null) {
-                finish()
-            } else {
-                val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-                val targetDisplayId = gameIntent.getIntExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY)
-                val targetDisplay = displayManager.getDisplay(targetDisplayId)
-                if (targetDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val options = ActivityOptions.makeBasic()
-                    options.setLaunchDisplayId(targetDisplay.displayId)
-                    if (targetDisplay.displayId != Display.DEFAULT_DISPLAY) {
-                        Toast.makeText(
-                            this,
-                            getString(
-                                R.string.external_display_info,
-                                targetDisplay.mode.physicalWidth,
-                                targetDisplay.mode.physicalHeight,
-                                targetDisplay.mode.refreshRate,
-                            ),
-                            Toast.LENGTH_LONG,
-                        ).show()
-                    }
-
-                    startActivity(gameIntent, options.toBundle())
-                } else {
-                    LimeLog.warning(getString(R.string.no_external_display))
-                    startActivity(gameIntent)
-                    finish()
-                }
-            }
-        }
 
         initViews()
     }
@@ -500,9 +463,6 @@ class ExternalDisplayControlActivity :
     }
 
     companion object {
-        @JvmField
-        var EXTRA_LAUNCH_INTENT: String = "launchIntent"
-
         @SuppressLint("StaticFieldLeak")
         @JvmField
         var instance: ExternalDisplayControlActivity? = null

--- a/app/src/main/java/com/papi/nova/utils/GameDisplayLaunchTrampolineActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/GameDisplayLaunchTrampolineActivity.kt
@@ -1,0 +1,87 @@
+package com.papi.nova.utils
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.os.Bundle
+import android.view.Display
+import android.widget.Toast
+import com.papi.nova.Game
+import com.papi.nova.LimeLog
+import com.papi.nova.R
+
+/**
+ * One-shot activity used only to force the stream Game activity onto the selected Android display.
+ *
+ * Do not use ExternalDisplayControlActivity for this: that activity is a singleton companion/control
+ * surface. Reusing it as a bootstrap can strand Thor-style bottom-screen launches as a black
+ * control placeholder before Game owns the top display.
+ */
+class GameDisplayLaunchTrampolineActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val gameIntent = readLaunchIntent()
+        if (gameIntent == null) {
+            finish()
+            return
+        }
+
+        launchGameOnRequestedDisplay(this, gameIntent)
+        finish()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readLaunchIntent(): Intent? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(EXTRA_LAUNCH_INTENT, Intent::class.java)
+        } else {
+            intent.getParcelableExtra(EXTRA_LAUNCH_INTENT)
+        }
+    }
+
+    companion object {
+        @JvmField
+        val EXTRA_LAUNCH_INTENT: String = "launchIntent"
+
+        @JvmStatic
+        @SuppressLint("InlinedApi")
+        fun launchGameOnRequestedDisplay(context: Context, gameIntent: Intent) {
+            val launchIntent = Intent(gameIntent)
+            if (context !is Activity) {
+                launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+
+            val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            val targetDisplayId = launchIntent.getIntExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY)
+            val targetDisplay = displayManager.getDisplay(targetDisplayId)
+
+            if (targetDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                LimeLog.info("Nova: Android display launch stream id=${targetDisplay.displayId}")
+                val options = ActivityOptions.makeBasic()
+                options.setLaunchDisplayId(targetDisplay.displayId)
+                if (targetDisplay.displayId != Display.DEFAULT_DISPLAY && context is Activity) {
+                    Toast.makeText(
+                        context,
+                        context.getString(
+                            R.string.external_display_info,
+                            targetDisplay.mode.physicalWidth,
+                            targetDisplay.mode.physicalHeight,
+                            targetDisplay.mode.refreshRate,
+                        ),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                context.startActivity(launchIntent, options.toBundle())
+                return
+            }
+
+            LimeLog.warning(context.getString(R.string.no_external_display))
+            context.startActivity(launchIntent)
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -150,6 +150,15 @@ object ServerHelper {
         return candidateMap.displaysById[selected.displayId]
     }
 
+    private fun getActivityDisplayId(parent: Activity): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return parent.display?.displayId ?: Display.DEFAULT_DISPLAY
+        }
+
+        @Suppress("DEPRECATION")
+        return parent.windowManager.defaultDisplay.displayId
+    }
+
     private fun createStartIntent(
         parent: Activity,
         app: NvApp,
@@ -178,10 +187,19 @@ object ServerHelper {
         } else {
             null
         }
-        val useAndroidExternalDisplay = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-            selectedAndroidDisplay != null &&
-            selectedAndroidDisplay.displayId != Display.DEFAULT_DISPLAY
-        val gameIntent = if (useAndroidExternalDisplay) {
+        val companionAndroidDisplay = if (selectedAndroidDisplay != null) {
+            getAndroidCompanionDisplay(parent, prefConfig, selectedAndroidDisplay.displayId)
+        } else {
+            null
+        }
+        val currentDisplayId = getActivityDisplayId(parent)
+        val useAndroidDisplayLaunch = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = selectedAndroidDisplay?.displayId,
+                currentDisplayId = currentDisplayId,
+                companionDisplayId = companionAndroidDisplay?.displayId,
+            )
+        val gameIntent = if (useAndroidDisplayLaunch && selectedAndroidDisplay != null) {
             Intent(parent.createDisplayContext(selectedAndroidDisplay), Game::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
@@ -223,8 +241,11 @@ object ServerHelper {
             gameIntent.putExtra(Game.EXTRA_SERVER_CERT, serverCert)
         }
 
-        if (useAndroidExternalDisplay) {
+        if (selectedAndroidDisplay != null) {
             gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, selectedAndroidDisplay.displayId)
+        }
+
+        if (useAndroidDisplayLaunch && selectedAndroidDisplay != null) {
             return Intent(parent, ExternalDisplayControlActivity::class.java).apply {
                 putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent)
             }

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -85,9 +85,35 @@ object ServerHelper {
         return selectDisplay(displayManager.displays, AndroidStreamDisplayTarget.EXTERNAL)
     }
 
-    private fun selectDisplay(displays: Array<Display>, target: String?): Display? {
+    @JvmStatic
+    fun getAndroidCompanionDisplay(
+        context: Context,
+        prefs: PreferenceConfiguration,
+        streamDisplayId: Int,
+    ): Display? {
+        if (!prefs.enableFullExDisplay) return null
+
+        val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        val candidateMap = buildDisplayCandidateMap(displayManager.displays)
+        val selected = AndroidStreamDisplayTarget.selectCompanion(
+            candidateMap.candidates,
+            Display.DEFAULT_DISPLAY,
+            streamDisplayId,
+        ) ?: return null
+
+        return candidateMap.displaysById[selected.displayId]
+    }
+
+    private data class AndroidDisplayCandidateMap(
+        val displaysById: Map<Int, Display>,
+        val candidates: List<AndroidStreamDisplayTarget.Candidate>,
+    )
+
+    private fun buildDisplayCandidateMap(displays: Array<Display>): AndroidDisplayCandidateMap {
+        val displaysById = LinkedHashMap<Int, Display>()
         val candidates = displays.map { display ->
             LimeLog.info(display.toString())
+            displaysById[display.displayId] = display
             val metrics = DisplayMetrics()
             @Suppress("DEPRECATION")
             display.getRealMetrics(metrics)
@@ -97,12 +123,17 @@ object ServerHelper {
                 height = metrics.heightPixels,
             )
         }
+        return AndroidDisplayCandidateMap(displaysById, candidates)
+    }
+
+    private fun selectDisplay(displays: Array<Display>, target: String?): Display? {
+        val candidateMap = buildDisplayCandidateMap(displays)
         val selected = AndroidStreamDisplayTarget.select(
-            candidates,
+            candidateMap.candidates,
             Display.DEFAULT_DISPLAY,
             target,
         ) ?: return null
-        return displays.firstOrNull { it.displayId == selected.displayId }
+        return candidateMap.displaysById[selected.displayId]
     }
 
     private fun createStartIntent(

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -246,8 +246,8 @@ object ServerHelper {
         }
 
         if (useAndroidDisplayLaunch && selectedAndroidDisplay != null) {
-            return Intent(parent, ExternalDisplayControlActivity::class.java).apply {
-                putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent)
+            return Intent(parent, GameDisplayLaunchTrampolineActivity::class.java).apply {
+                putExtra(GameDisplayLaunchTrampolineActivity.EXTRA_LAUNCH_INTENT, gameIntent)
             }
         }
 

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -76,7 +76,17 @@ object ServerHelper {
     @JvmStatic
     fun getAndroidStreamDisplay(context: Context, prefs: PreferenceConfiguration): Display? {
         val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        return selectDisplay(displayManager.displays, prefs.androidStreamDisplayTarget)
+        val candidateMap = buildDisplayCandidateMap(displayManager.displays)
+        val selected = AndroidStreamDisplayTarget.select(
+            candidateMap.candidates,
+            Display.DEFAULT_DISPLAY,
+            prefs.androidStreamDisplayTarget,
+        ) ?: return null
+        LimeLog.info(
+            "Nova: Android display role stream id=${selected.displayId} " +
+                "target=${prefs.androidStreamDisplayTarget}"
+        )
+        return candidateMap.displaysById[selected.displayId]
     }
 
     @JvmStatic
@@ -100,6 +110,10 @@ object ServerHelper {
             Display.DEFAULT_DISPLAY,
             streamDisplayId,
         ) ?: return null
+        LimeLog.info(
+            "Nova: Android display role companion id=${selected.displayId} " +
+                "stream_id=$streamDisplayId"
+        )
 
         return candidateMap.displaysById[selected.displayId]
     }

--- a/app/src/test/java/com/papi/nova/binding/video/MediaCodecDecoderRendererPerfStatsSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/MediaCodecDecoderRendererPerfStatsSourceGuardTest.kt
@@ -1,0 +1,30 @@
+package com.papi.nova.binding.video
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaCodecDecoderRendererPerfStatsSourceGuardTest {
+    private val source: String
+        get() = File("src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt").readText()
+
+    @Test
+    fun streamSetupResetsRollingPerfStatsForFreshReconnectSamples() {
+        val setupBody = source.substringAfter("override fun setup(")
+            .substringBefore("return initializeDecoder(false)")
+
+        assertTrue(
+            "New stream setup/reconnect must clear rolling FPS windows so NovaHUD does not divide fresh frames by stale pre-disconnect time.",
+            setupBody.contains("resetRollingPerfStatsForNewStream(")
+        )
+    }
+
+    @Test
+    fun restartedFrameSequenceClearsStalePerfWindowsBeforeSampling() {
+        assertTrue(
+            "If a resumed stream restarts frame numbering, renderer perf stats must reset before the next HUD sample.",
+            source.contains("frameNumber < lastFrameNumber") &&
+                source.contains("resetRollingPerfStatsForNewStream(")
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/binding/video/MediaCodecDecoderRendererPerfStatsSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/MediaCodecDecoderRendererPerfStatsSourceGuardTest.kt
@@ -21,10 +21,21 @@ class MediaCodecDecoderRendererPerfStatsSourceGuardTest {
 
     @Test
     fun restartedFrameSequenceClearsStalePerfWindowsBeforeSampling() {
+        val restartBranchStart = source.indexOf("if (frameNumber < lastFrameNumber) {")
+        val restartReset = source.indexOf(
+            "resetRollingPerfStatsForNewStream(\"frame sequence restart\")",
+            restartBranchStart
+        )
+        val nextFpsSamplingBlock = source.indexOf(
+            "if (SystemClock.uptimeMillis() >= activeWindowVideoStats.measurementStartTimestamp + 1000)",
+            restartBranchStart
+        )
+
         assertTrue(
-            "If a resumed stream restarts frame numbering, renderer perf stats must reset before the next HUD sample.",
-            source.contains("frameNumber < lastFrameNumber") &&
-                source.contains("resetRollingPerfStatsForNewStream(")
+            "If a resumed stream restarts frame numbering, renderer perf stats must reset inside that branch before the next HUD FPS sample.",
+            restartBranchStart >= 0 &&
+                restartReset > restartBranchStart &&
+                nextFpsSamplingBlock > restartReset
         )
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -49,7 +49,7 @@ class NovaHudUiStateTest {
             sparklineSamples = listOf(55f, 58f, 60f)
         )
 
-        assertEquals("118", state.fpsLabel)
+        assertEquals("119", state.fpsLabel)
         assertEquals("TGT 120", state.targetFpsLabel)
         assertEquals("18ms", state.latencyLabel)
         assertEquals("24 Mbps", state.bitrateLabel)
@@ -107,6 +107,24 @@ class NovaHudUiStateTest {
         assertEquals(NovaHudMode.PERFORMANCE, NovaHudMode.MINIMAL.next())
         assertEquals(NovaHudMode.DEBUG, NovaHudMode.PERFORMANCE.next())
         assertEquals(NovaHudMode.MINIMAL, NovaHudMode.DEBUG.next())
+    }
+
+    @Test
+    fun fpsLabelRoundsNearTargetInsteadOfFlooringReconnectJitter() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.MINIMAL,
+            fps = 119.8,
+            targetFps = 120.0,
+            latencyMs = 12,
+            codec = "hevc",
+            bitrateKbps = 30000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = listOf(119.8f)
+        )
+
+        assertEquals("120", state.fpsLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -35,6 +35,23 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun performanceTextParserKeepsLocalizedCommaFpsWhole() {
+        val sample = NovaHudPerfSample.fromPerfText(
+            """
+            1920x1080 119,84 FPS
+            Avc.decoder.low_latency
+            Bildfrekvens från nätverket: 119,84 FPS
+            Renderingsfrekvens: 113,87 FPS
+            Frames dropped by your network connection: 0,00%
+            """.trimIndent()
+        )
+
+        assertEquals(119.84, sample.fps!!, 0.01)
+        assertEquals(1920, sample.width)
+        assertEquals(1080, sample.height)
+    }
+
+    @Test
     fun fullModeFormatsReadableLabelsAndTones() {
         val state = NovaHudUiState.from(
             mode = NovaHudMode.DEBUG,

--- a/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
@@ -1,7 +1,9 @@
 package com.papi.nova.utils
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AndroidStreamDisplayTargetTest {
@@ -110,5 +112,60 @@ class AndroidStreamDisplayTargetTest {
         )
 
         assertEquals(4, companion?.displayId)
+    }
+
+    @Test
+    fun displayLaunchTrampolineIsNeededForPrimaryStreamWhenCallerIsOnCompanionDisplay() {
+        assertTrue(
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = 0,
+                currentDisplayId = 4,
+                companionDisplayId = 4,
+            )
+        )
+    }
+
+    @Test
+    fun displayLaunchTrampolineIsNotNeededForPrimaryStreamWhenCallerIsAlreadyOnPrimaryDisplay() {
+        assertFalse(
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = 0,
+                currentDisplayId = 0,
+                companionDisplayId = 4,
+            )
+        )
+    }
+
+    @Test
+    fun displayLaunchTrampolineIsNotNeededForPrimaryStreamWithoutCompanionDisplay() {
+        assertFalse(
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = 0,
+                currentDisplayId = 4,
+                companionDisplayId = null,
+            )
+        )
+    }
+
+    @Test
+    fun displayLaunchTrampolineIsNeededForExternalStreamWhenCallerIsOnPrimaryDisplay() {
+        assertTrue(
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = 4,
+                currentDisplayId = 0,
+                companionDisplayId = 0,
+            )
+        )
+    }
+
+    @Test
+    fun displayLaunchTrampolineIsNotNeededForExternalStreamWhenCallerIsAlreadyOnExternalDisplay() {
+        assertFalse(
+            AndroidStreamDisplayTarget.shouldUseDisplayLaunchTrampoline(
+                selectedDisplayId = 4,
+                currentDisplayId = 4,
+                companionDisplayId = 0,
+            )
+        )
     }
 }

--- a/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/AndroidStreamDisplayTargetTest.kt
@@ -35,4 +35,80 @@ class AndroidStreamDisplayTargetTest {
     fun externalReturnsNullWhenOnlyPrimaryExists() {
         assertNull(AndroidStreamDisplayTarget.select(displays.take(1), 0, AndroidStreamDisplayTarget.EXTERNAL))
     }
+
+    @Test
+    fun companionForThorLargestStreamUsesSmallerNonStreamDisplay() {
+        val thorDisplays = listOf(
+            AndroidStreamDisplayTarget.Candidate(displayId = 0, width = 1920, height = 1080),
+            AndroidStreamDisplayTarget.Candidate(displayId = 4, width = 1240, height = 1080),
+        )
+
+        val stream = AndroidStreamDisplayTarget.select(
+            thorDisplays,
+            defaultDisplayId = 0,
+            target = AndroidStreamDisplayTarget.LARGEST,
+        )
+        val companion = AndroidStreamDisplayTarget.selectCompanion(
+            thorDisplays,
+            defaultDisplayId = 0,
+            streamDisplayId = stream?.displayId,
+        )
+
+        assertEquals(0, stream?.displayId)
+        assertEquals(4, companion?.displayId)
+    }
+
+    @Test
+    fun companionForExternalStreamUsesPrimaryDeviceDisplay() {
+        val displays = listOf(
+            AndroidStreamDisplayTarget.Candidate(displayId = 0, width = 1920, height = 1080),
+            AndroidStreamDisplayTarget.Candidate(displayId = 4, width = 1240, height = 1080),
+        )
+
+        val stream = AndroidStreamDisplayTarget.select(
+            displays,
+            defaultDisplayId = 0,
+            target = AndroidStreamDisplayTarget.EXTERNAL,
+        )
+        val companion = AndroidStreamDisplayTarget.selectCompanion(
+            displays,
+            defaultDisplayId = 0,
+            streamDisplayId = stream?.displayId,
+        )
+
+        assertEquals(4, stream?.displayId)
+        assertEquals(0, companion?.displayId)
+    }
+
+    @Test
+    fun companionIsNullWhenOnlyTheStreamDisplayExists() {
+        val displays = listOf(
+            AndroidStreamDisplayTarget.Candidate(displayId = 0, width = 1920, height = 1080),
+        )
+
+        assertNull(
+            AndroidStreamDisplayTarget.selectCompanion(
+                displays,
+                defaultDisplayId = 0,
+                streamDisplayId = 0,
+            )
+        )
+    }
+
+    @Test
+    fun companionPrefersSmallestNonStreamDisplayWhenSeveralRemain() {
+        val displays = listOf(
+            AndroidStreamDisplayTarget.Candidate(displayId = 0, width = 1920, height = 1080),
+            AndroidStreamDisplayTarget.Candidate(displayId = 4, width = 1240, height = 1080),
+            AndroidStreamDisplayTarget.Candidate(displayId = 7, width = 3840, height = 2160),
+        )
+
+        val companion = AndroidStreamDisplayTarget.selectCompanion(
+            displays,
+            defaultDisplayId = 0,
+            streamDisplayId = 0,
+        )
+
+        assertEquals(4, companion?.displayId)
+    }
 }

--- a/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
@@ -17,6 +17,7 @@ class KotlinExternalDisplayUiMigrationTest {
     fun externalDisplayUiHelpersAreKotlinSources() {
         val names = arrayOf(
             "utils/ExternalDisplayControlActivity",
+            "utils/GameDisplayLaunchTrampolineActivity",
             "utils/UiHelper"
         )
 
@@ -30,13 +31,19 @@ class KotlinExternalDisplayUiMigrationTest {
 
     @Test
     fun externalDisplayUiHelpersKeepJavaCompatibleApis() {
-        assertEquals("launchIntent", ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT)
+        assertEquals("launchIntent", GameDisplayLaunchTrampolineActivity.EXTRA_LAUNCH_INTENT)
         assertEquals(1, ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
         assertEquals(
             "com.papi.nova.action.START_EXTERNAL_DISPLAY_CONTROL",
             StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL
         )
-        assertTrue(Modifier.isStatic(ExternalDisplayControlActivity::class.java.getField("EXTRA_LAUNCH_INTENT").modifiers))
+        assertTrue(
+            Modifier.isStatic(
+                GameDisplayLaunchTrampolineActivity::class.java
+                    .getField("EXTRA_LAUNCH_INTENT")
+                    .modifiers
+            )
+        )
         assertTrue(Modifier.isStatic(ExternalDisplayControlActivity::class.java.getField("instance").modifiers))
         assertTrue(
             Modifier.isStatic(
@@ -52,6 +59,11 @@ class KotlinExternalDisplayUiMigrationTest {
         ExternalDisplayControlActivity::class.java.getMethod("toggleGameMenu")
         ExternalDisplayControlActivity::class.java.getMethod("toggleZoomMode", Boolean::class.javaPrimitiveType!!)
         ExternalDisplayControlActivity::class.java.getMethod("showGameMenu")
+        GameDisplayLaunchTrampolineActivity::class.java.getMethod(
+            "launchGameOnRequestedDisplay",
+            Context::class.java,
+            android.content.Intent::class.java
+        )
 
         UiHelper::class.java.getMethod("isTvDevice", Context::class.java)
         UiHelper::class.java.getMethod("applyTvFocusStyle", View::class.java)

--- a/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
@@ -65,6 +65,11 @@ class KotlinExternalDisplayUiMigrationTest {
         UiHelper::class.java.getMethod("applyStatusBarPadding", View::class.java)
         UiHelper::class.java.getMethod("notifyNewRootView", Activity::class.java)
         UiHelper::class.java.getMethod("showDecoderCrashDialog", Activity::class.java)
+        StartExternalDisplayControlReceiver::class.java.getMethod(
+            "requestFocusToExternalDisplayControl",
+            Context::class.java,
+            Int::class.javaPrimitiveType!!
+        )
         UiHelper::class.java.getMethod(
             "displayConfirmationDialog",
             Activity::class.java,

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -50,6 +50,18 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
+    fun externalControlBootstrapLaunchesGameOnRequestedDisplayIncludingDefault() {
+        val source = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt").readText()
+
+        assertFalse(
+            "The game bootstrap must not remap a requested primary/default stream display to the secondary display",
+            source.contains("?.takeIf { it.displayId != Display.DEFAULT_DISPLAY }")
+        )
+        assertTrue(source.contains("val targetDisplay = displayManager.getDisplay(targetDisplayId)"))
+        assertTrue(source.contains("options.setLaunchDisplayId(targetDisplay.displayId)"))
+    }
+
+    @Test
     fun gameDifferentiatesStreamAndCompanionDisplayRemoval() {
         val source = File("src/main/java/com/papi/nova/Game.kt").readText()
 

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -50,8 +50,35 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
-    fun externalControlBootstrapLaunchesGameOnRequestedDisplayIncludingDefault() {
+    fun streamLaunchUsesDedicatedTrampolineInsteadOfControlActivity() {
+        val serverHelper = File("src/main/java/com/papi/nova/utils/ServerHelper.kt").readText()
+        val manifest = File("src/main/AndroidManifest.xml").readText()
+
+        assertTrue(serverHelper.contains("GameDisplayLaunchTrampolineActivity"))
+        assertTrue(manifest.contains(".utils.GameDisplayLaunchTrampolineActivity"))
+        assertFalse(
+            "The singleton control activity must not double as the stream launch trampoline",
+            serverHelper.contains("ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT")
+        )
+    }
+
+    @Test
+    fun externalControlActivityDoesNotBootstrapGameLaunches() {
         val source = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt").readText()
+
+        assertFalse(
+            "The companion control activity should only host controls; stream bootstrapping belongs to the dedicated trampoline",
+            source.contains("EXTRA_LAUNCH_INTENT")
+        )
+        assertFalse(
+            "The companion control activity must not launch Game itself from whichever display created it",
+            source.contains("startActivity(gameIntent")
+        )
+    }
+
+    @Test
+    fun displayLaunchTrampolineLaunchesGameOnRequestedDisplayIncludingDefault() {
+        val source = File("src/main/java/com/papi/nova/utils/GameDisplayLaunchTrampolineActivity.kt").readText()
 
         assertFalse(
             "The game bootstrap must not remap a requested primary/default stream display to the secondary display",
@@ -59,6 +86,17 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         )
         assertTrue(source.contains("val targetDisplay = displayManager.getDisplay(targetDisplayId)"))
         assertTrue(source.contains("options.setLaunchDisplayId(targetDisplay.displayId)"))
+    }
+
+    @Test
+    fun gameRelaunchUsesDisplayAwareLauncher() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertTrue(source.contains("GameDisplayLaunchTrampolineActivity.launchGameOnRequestedDisplay"))
+        assertFalse(
+            "Reconnect/relaunch must not use plain application-context startActivity because it can inherit the wrong display",
+            source.contains("getApplicationContext().startActivity(relaunchIntent)")
+        )
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -1,0 +1,17 @@
+package com.papi.nova.utils
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaExternalDisplayRoutingSourceGuardTest {
+    @Test
+    fun serverHelperExposesCompanionDisplaySelectionAdapter() {
+        val source = File("src/main/java/com/papi/nova/utils/ServerHelper.kt").readText()
+
+        assertTrue(source.contains("AndroidDisplayCandidateMap"))
+        assertTrue(source.contains("buildDisplayCandidateMap"))
+        assertTrue(source.contains("getAndroidCompanionDisplay"))
+        assertTrue(source.contains("selectCompanion"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.utils
 
 import java.io.File
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -13,5 +14,30 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue(source.contains("buildDisplayCandidateMap"))
         assertTrue(source.contains("getAndroidCompanionDisplay"))
         assertTrue(source.contains("selectCompanion"))
+    }
+
+    @Test
+    fun externalControlReceiverDoesNotHardcodeDefaultDisplay() {
+        val source = File("src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt").readText()
+
+        assertFalse(
+            "External controls must launch on the derived companion display, not always Display.DEFAULT_DISPLAY",
+            source.contains("setLaunchDisplayId(Display.DEFAULT_DISPLAY)")
+        )
+        assertTrue(
+            "External controls should resolve through ServerHelper.getAndroidCompanionDisplay",
+            source.contains("getAndroidCompanionDisplay")
+        )
+    }
+
+    @Test
+    fun gameDoesNotRequireStreamToBeExternalBeforeStartingCompanionControls() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertFalse(
+            "Thor needs controls on the secondary display even when the stream is on the primary display",
+            source.contains("prefConfig!!.enableFullExDisplay && isOnExternalDisplay")
+        )
+        assertTrue(source.contains("shouldLaunchCompanionControls"))
     }
 }

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -40,4 +40,14 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         )
         assertTrue(source.contains("shouldLaunchCompanionControls"))
     }
+
+    @Test
+    fun gameDifferentiatesStreamAndCompanionDisplayRemoval() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertTrue(source.contains("companionControlDisplayId"))
+        assertTrue(source.contains("removedDisplayId == streamingDisplayId"))
+        assertTrue(source.contains("removedDisplayId == companionControlDisplayId"))
+        assertTrue(source.contains("unregisterDisplayListener"))
+    }
 }

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -50,4 +50,12 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue(source.contains("removedDisplayId == companionControlDisplayId"))
         assertTrue(source.contains("unregisterDisplayListener"))
     }
+
+    @Test
+    fun gameUsesMinSdkSafeInvalidDisplaySentinel() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertTrue(source.contains("INVALID_DISPLAY_ID"))
+        assertFalse(source.contains("Display.INVALID_DISPLAY"))
+    }
 }

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -17,6 +17,14 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
+    fun serverHelperLogsStreamAndCompanionDisplayRoles() {
+        val source = File("src/main/java/com/papi/nova/utils/ServerHelper.kt").readText()
+
+        assertTrue(source.contains("Android display role stream"))
+        assertTrue(source.contains("Android display role companion"))
+    }
+
+    @Test
     fun externalControlReceiverDoesNotHardcodeDefaultDisplay() {
         val source = File("src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt").readText()
 


### PR DESCRIPTION
## Summary

Refs papi-ux/nova#115. Builds on the display-target selector from #98/#106.

- Derives a separate companion/control display from the actual Android stream display.
- Routes `ExternalDisplayControlActivity` to the non-stream companion display instead of hard-coding `Display.DEFAULT_DISPLAY`.
- Starts companion controls even when the stream is on the primary/default display, which is the Thor `Largest` / `This device screen` path.
- Splits stream bootstrapping into a dedicated `GameDisplayLaunchTrampolineActivity` so the singleton companion-control activity no longer doubles as a launch trampoline.
- Forces stream launch/relaunch onto the requested Android display, including `Display.DEFAULT_DISPLAY`, even when Nova was opened from the Thor bottom/companion screen.
- Differentiates stream display removal from companion display removal and unregisters the display listener.
- Adds safe display-role logs for field testing:
  - `Nova: Android display role stream id=... target=...`
  - `Nova: Android display role companion id=... stream_id=...`
  - `Nova: Android display launch stream id=...`

## Field-test gate before merge

This PR should stay draft until real AYN Thor evidence confirms:

1. Enable **Use Android external display**.
2. Set **Android stream display** to **Largest display** or **This device screen**.
3. Launch Nova from the **top** screen, then launch a stream.
4. Confirm the game stays on the top/main screen.
5. Confirm the bottom screen shows Nova's touchpad/keyboard/menu controls.
6. Quit/disconnect cleanly.
7. Launch Nova from the **bottom** screen, then launch a stream.
8. Confirm the game still moves to the selected top/main stream display instead of leaving the top untouched.
9. Confirm the bottom screen shows Nova controls instead of a black placeholder.
10. Disconnect/relaunch once and confirm it does not hang at “preparing video, audio and controller input...”.
11. Open keyboard, full keyboard, menu, and zoom/pan once.
12. Attach or summarize a fresh Nova log if anything lands on the wrong screen.

Expected safe log shape:

```text
Nova: Android display role stream id=0 target=largest
Nova: Android display launch stream id=0
Nova: Android display role companion id=4 stream_id=0
```

IDs may differ by firmware/device.

## Test plan

Executed locally from an isolated worktree after initializing native submodules:

- [x] RED guard: `NovaExternalDisplayRoutingSourceGuardTest` failed before the dedicated trampoline split because `GameDisplayLaunchTrampolineActivity` did not exist, `ServerHelper` still targeted `ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT`, `ExternalDisplayControlActivity` still bootstrapped `Game`, and `Game.relaunchStream()` still used plain app-context `startActivity`.
- [x] `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew :app:testDebugUnitTest --tests com.papi.nova.utils.NovaExternalDisplayRoutingSourceGuardTest --tests com.papi.nova.utils.KotlinExternalDisplayUiMigrationTest --tests com.papi.nova.utils.AndroidStreamDisplayTargetTest --console=plain`
- [x] `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew :app:compileRootDebugKotlin :app:lintRootDebug :app:testDebugUnitTest :app:assembleDebug --console=plain`
- [x] After switching the trampoline from `AppCompatActivity` to plain `Activity` for the platform translucent theme: `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew :app:testDebugUnitTest --tests com.papi.nova.utils.NovaExternalDisplayRoutingSourceGuardTest --tests com.papi.nova.utils.KotlinExternalDisplayUiMigrationTest --tests com.papi.nova.utils.AndroidStreamDisplayTargetTest :app:compileRootDebugKotlin :app:lintRootDebug :app:assembleDebug --console=plain`
- [x] `git diff --check`
- [x] Static added-line scan for secrets/shell/eval/pickle/SQL patterns: no findings.
- [x] Lint XML changed-line scan: no findings on changed lines.

Debug APKs were produced locally for root/non-root debug flavors and arm64-v8a/armeabi-v7a/x86_64 ABIs.

## Field-test APK

Prerelease asset:
https://github.com/papi-ux/nova/releases/tag/pr117-thor-dual-screen-debug

Current arm64-v8a debug APK SHA256:
`05bbb02598c5a4c97eb4e8c6d4156f243ac9e448afda2e18370393151116e53b`

## Notes

- This is Lane A only: functional dual-display routing and lifecycle cleanup.
- It intentionally does **not** include the later companion dashboard / NovaHUD polish lane.
- No Polaris host/protocol changes are included.
- Logging is limited to display role/id/target/stream_id; no host credentials, certs, tokens, IPs, URLs, or computer names are logged by the new role lines.
- If audio still routes to the bottom/control display after this build, treat that as a separate Android audio-output routing follow-up with a fresh log and exact device-output behavior.
