### PR TITLE
feat: show AMD host capture truth in Nova

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -362,6 +362,32 @@ class PolarisApiClient @JvmOverloads constructor(
             )
         }
 
+        private fun parseLinuxGpuProfile(json: JSONObject?): PolarisSessionStatus.LinuxGpuProfile? {
+            if (json == null) return null
+            val hasAnyField = listOf(
+                "encoder_api",
+                "encoder_adapter",
+                "capture_device",
+                "adapter_matches_capture_device",
+                "gpu_native_requested",
+                "gpu_native_attempted",
+                "gpu_native_succeeded",
+                "vaapi_vendor"
+            ).any(json::has)
+            if (!hasAnyField) return null
+            return PolarisSessionStatus.LinuxGpuProfile(
+                encoderApi = json.optString("encoder_api", ""),
+                encoderAdapter = json.optString("encoder_adapter", ""),
+                captureDevice = json.optString("capture_device", ""),
+                adapterMatchesCaptureDevice = json.optBoolean("adapter_matches_capture_device", true),
+                crossGpuDmabufRisk = json.optBoolean("cross_gpu_dmabuf_risk", false),
+                gpuNativeRequested = json.optBoolean("gpu_native_requested", false),
+                gpuNativeAttempted = json.optBoolean("gpu_native_attempted", false),
+                gpuNativeSucceeded = json.optBoolean("gpu_native_succeeded", false),
+                vaapiVendor = json.optString("vaapi_vendor", "")
+            )
+        }
+
         @JvmStatic
         fun parseUnlockResponse(json: JSONObject): Boolean =
             json.optBoolean("success", false)
@@ -443,6 +469,8 @@ class PolarisApiClient @JvmOverloads constructor(
             val autoQuality = json.optJSONObject("auto_quality")
                 ?: health?.optJSONObject("recovery_policy")
             val profileState = json.optJSONObject("profile_state")
+            val linuxGpuProfile = json.optJSONObject("linux_gpu_profile")
+                ?: streamPolicy?.optJSONObject("linux_gpu_profile")
 
             return PolarisSessionStatus(
                 state = json.optString("state", "unknown"),
@@ -559,6 +587,10 @@ class PolarisApiClient @JvmOverloads constructor(
                 capture = PolarisSessionStatus.CaptureStatus(
                     backend = capture?.optString("backend", "") ?: "",
                     resolution = capture?.optString("resolution", "") ?: "",
+                    path = capture?.optString("path", json.optString("capture_path", ""))
+                        ?: json.optString("capture_path", ""),
+                    reason = capture?.optString("reason", json.optString("capture_path_reason", ""))
+                        ?: json.optString("capture_path_reason", ""),
                     transport = capture?.optString("transport", "") ?: "",
                     residency = capture?.optString("residency", "") ?: "",
                     format = capture?.optString("format", "") ?: ""
@@ -581,6 +613,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     targetResidency = encoder?.optString("target_residency", "") ?: "",
                     targetFormat = encoder?.optString("target_format", "") ?: ""
                 ),
+                linuxGpuProfile = parseLinuxGpuProfile(linuxGpuProfile),
                 autoQuality = parseAutoQualityPolicy(autoQuality),
                 profileState = parseProfileState(profileState),
                 health = PolarisSessionStatus.HealthStatus(

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -30,6 +30,7 @@ data class PolarisSessionStatus(
     val syncStatus: SyncStatus = SyncStatus(),
     val capture: CaptureStatus = CaptureStatus(),
     val encoder: EncoderStatus = EncoderStatus(),
+    val linuxGpuProfile: LinuxGpuProfile? = null,
     val autoQuality: AutoQualityPolicy = AutoQualityPolicy(),
     val profileState: ProfileState = ProfileState(),
     val health: HealthStatus = HealthStatus()
@@ -129,6 +130,8 @@ data class PolarisSessionStatus(
     data class CaptureStatus(
         val backend: String = "",
         val resolution: String = "",
+        val path: String = "",
+        val reason: String = "",
         val transport: String = "",
         val residency: String = "",
         val format: String = ""
@@ -151,6 +154,18 @@ data class PolarisSessionStatus(
         val targetDevice: String = "",
         val targetResidency: String = "",
         val targetFormat: String = ""
+    )
+
+    data class LinuxGpuProfile(
+        val encoderApi: String = "",
+        val encoderAdapter: String = "",
+        val captureDevice: String = "",
+        val adapterMatchesCaptureDevice: Boolean = true,
+        val crossGpuDmabufRisk: Boolean = false,
+        val gpuNativeRequested: Boolean = false,
+        val gpuNativeAttempted: Boolean = false,
+        val gpuNativeSucceeded: Boolean = false,
+        val vaapiVendor: String = ""
     )
 
     data class AutoQualityPolicy(
@@ -270,6 +285,29 @@ data class PolarisSessionStatus(
     val isTenBitActive get() = dynamicRange > 0 || encoder.targetFormat.equals("p010", ignoreCase = true)
     val isGpuPath get() = encoder.targetResidency.equals("gpu", ignoreCase = true) ||
         (encoder.targetResidency.isBlank() && encoder.targetDevice.isCudaGpuTarget)
+    val hostCaptureTruthLabel: String
+        get() {
+            val profile = linuxGpuProfile ?: return ""
+            val encoderApi = profile.encoderApi.ifBlank { encoder.targetDevice }
+            if (!encoderApi.equals("vaapi", ignoreCase = true)) {
+                return ""
+            }
+            if (!profile.adapterMatchesCaptureDevice || profile.crossGpuDmabufRisk) {
+                return "VAAPI render-node mismatch"
+            }
+            val captureTransport = capture.transport.lowercase().ifBlank { capture.path.lowercase() }
+            val captureResidency = capture.residency.lowercase()
+            val captureReason = capture.reason.lowercase()
+            val shmFallback = captureTransport.contains("shm") ||
+                captureResidency == "cpu" ||
+                captureReason.contains("shm_fallback")
+            return when {
+                profile.gpuNativeSucceeded || (captureTransport.contains("dmabuf") && captureResidency == "gpu") ->
+                    "VAAPI + GPU-native"
+                shmFallback -> "VAAPI + SHM fallback"
+                else -> "VAAPI host"
+            }
+        }
     val isHeadlessMode get() = displayMode.effectiveHeadless
     val isVirtualDisplayMode get() = displayMode.virtualDisplay
     val sessionModeLabel get() = when {

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -311,6 +311,8 @@ data class NovaHudUiState(
                 status?.isHdrDowngraded == true -> streamLabel + " • 10-bit SDR"
                 status?.isHostRenderLimited == true && safeTarget != null -> "$streamLabel • Game capped $safeTarget"
                 status?.isHostRenderLimited == true -> "$streamLabel • Host capped"
+                status?.hostCaptureTruthLabel?.isNotBlank() == true ->
+                    "$streamLabel • ${status.hostCaptureTruthLabel}"
                 status?.profileState?.preferenceLabel?.isNotBlank() == true ->
                     "$streamLabel • ${status.profileState.preferenceLabel} profile"
                 codec.isNotBlank() -> "$streamLabel • ${normalizeCodecLabel(codec)}"
@@ -341,8 +343,16 @@ data class NovaHudUiState(
                 status?.encoder?.targetResidency.equals("cpu", ignoreCase = true) -> NovaHudTone.WARNING
                 else -> NovaHudTone.STABLE
             }
+            val hostCaptureLabel = status?.hostCaptureTruthLabel.orEmpty()
+            val hostLabel = hostCaptureLabel.ifBlank { "HOST" }
+            val resolvedHostTone = when {
+                hostCaptureLabel.contains("SHM", ignoreCase = true) ||
+                    hostCaptureLabel.contains("mismatch", ignoreCase = true) -> NovaHudTone.WARNING
+                hostCaptureLabel.contains("GPU-native", ignoreCase = true) -> NovaHudTone.STABLE
+                else -> hostTone
+            }
             return listOf(
-                NovaHudLayerHealth("HOST", hostTone),
+                NovaHudLayerHealth(hostLabel, resolvedHostTone),
                 NovaHudLayerHealth("NET", networkTone),
                 NovaHudLayerHealth("CLIENT", clientTone)
             )

--- a/app/src/main/java/com/papi/nova/ui/StreamPolicyUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/StreamPolicyUiState.kt
@@ -11,7 +11,8 @@ data class StreamPolicyUiState(
     val adaptiveEnabled: Boolean,
     val aiEnabled: Boolean,
     val codecLabel: String,
-    val displayLabel: String
+    val displayLabel: String,
+    val hostCaptureLabel: String = ""
 ) {
     val autoQualityEnabled get() = adaptiveEnabled || aiEnabled
     val hasAdaptiveCap get() = adaptiveEnabled &&
@@ -30,7 +31,7 @@ data class StreamPolicyUiState(
         }
 
     val targetSummary: String
-        get() = listOf(displayLabel, codecLabel, bitrateSummary)
+        get() = listOf(displayLabel, codecLabel, hostCaptureLabel, bitrateSummary)
             .filter { it.isNotBlank() }
             .joinToString(" · ")
 
@@ -102,7 +103,8 @@ data class StreamPolicyUiState(
                 adaptiveEnabled = adaptiveEnabled,
                 aiEnabled = aiEnabled,
                 codecLabel = normalizeCodec(status?.encoder?.codec.orEmpty()),
-                displayLabel = display
+                displayLabel = display,
+                hostCaptureLabel = status?.hostCaptureTruthLabel.orEmpty()
             )
         }
 

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -250,6 +250,31 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
+    fun parseSessionStatusResponse_includesLinuxGpuProfile() {
+        val json = JSONObject(
+            "{\"state\":\"streaming\",\"streaming_active\":true," +
+                "\"capture\":{\"path\":\"shm_cpu_capture\",\"reason\":\"gpu_native_requested_shm_fallback\"," +
+                "\"transport\":\"shm\",\"residency\":\"cpu\",\"format\":\"bgra8\"}," +
+                "\"encoder\":{\"codec\":\"hevc\",\"target_device\":\"vaapi\",\"target_residency\":\"gpu\"}," +
+                "\"linux_gpu_profile\":{\"encoder_api\":\"vaapi\",\"encoder_adapter\":\"/dev/dri/renderD128\"," +
+                "\"capture_device\":\"/dev/dri/renderD128\",\"adapter_matches_capture_device\":true," +
+                "\"gpu_native_requested\":true,\"gpu_native_attempted\":true,\"gpu_native_succeeded\":false," +
+                "\"vaapi_vendor\":\"Mesa Gallium\"}}"
+        )
+
+        val status = PolarisApiClient.parseSessionStatusResponse(json)
+
+        assertEquals("vaapi", status.linuxGpuProfile?.encoderApi)
+        assertEquals("/dev/dri/renderD128", status.linuxGpuProfile?.encoderAdapter)
+        assertEquals("/dev/dri/renderD128", status.linuxGpuProfile?.captureDevice)
+        assertTrue(status.linuxGpuProfile?.adapterMatchesCaptureDevice == true)
+        assertTrue(status.linuxGpuProfile?.gpuNativeRequested == true)
+        assertFalse(status.linuxGpuProfile?.gpuNativeSucceeded ?: true)
+        assertEquals("Mesa Gallium", status.linuxGpuProfile?.vaapiVendor)
+        assertEquals("VAAPI + SHM fallback", status.hostCaptureTruthLabel)
+    }
+
+    @Test
     fun buildClientSettingsUpdateBody_mapsAiAutoQualityToLegacyFields() {
         val body = PolarisApiClient.buildClientSettingsUpdateBody(
             streamDisplayMode = null,

--- a/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
@@ -166,6 +166,28 @@ class AutoQualityUiStateTest {
     }
 
     @Test
+    fun streamPolicyNamesAmdVaapiHostCaptureTruthForCommandCenter() {
+        val policy = StreamPolicyUiState.from(
+            status(
+                encoder = encoder(bitrateKbps = 22000).copy(codec = "hevc", targetDevice = "vaapi"),
+                capture = capture(transport = "shm", residency = "cpu"),
+                linuxGpuProfile = PolarisSessionStatus.LinuxGpuProfile(
+                    encoderApi = "vaapi",
+                    encoderAdapter = "/dev/dri/renderD128",
+                    captureDevice = "/dev/dri/renderD128",
+                    adapterMatchesCaptureDevice = true,
+                    gpuNativeRequested = true,
+                    gpuNativeAttempted = true,
+                    gpuNativeSucceeded = false
+                )
+            )
+        )
+
+        assertEquals("VAAPI + SHM fallback", policy.hostCaptureLabel)
+        assertTrue(policy.targetSummary.contains("VAAPI + SHM fallback"))
+    }
+
+    @Test
     fun autoQualityPolicyShowsBitrateRecovery() {
         val state = AutoQualityUiState.from(
             status = status(
@@ -244,6 +266,7 @@ class AutoQualityUiStateTest {
         capture: PolarisSessionStatus.CaptureStatus = capture(),
         health: PolarisSessionStatus.HealthStatus = PolarisSessionStatus.HealthStatus(grade = "good"),
         autoQuality: PolarisSessionStatus.AutoQualityPolicy = PolarisSessionStatus.AutoQualityPolicy(),
+        linuxGpuProfile: PolarisSessionStatus.LinuxGpuProfile? = null,
         sync: PolarisSessionStatus.SyncStatus = PolarisSessionStatus.SyncStatus(
             available = true,
             state = "synced"
@@ -259,6 +282,7 @@ class AutoQualityUiStateTest {
         capture = capture,
         autoQuality = autoQuality,
         health = health,
+        linuxGpuProfile = linuxGpuProfile,
         syncStatus = sync
     )
 

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -352,6 +352,52 @@ class NovaHudUiStateTest {
         assertEquals("Stream 60 • 10-bit SDR", state.streamTruthLabel)
         assertEquals(NovaHudTone.WARNING, state.statusTone)
     }
+
+    @Test
+    fun diagnosticsExplainAmdVaapiHostCaptureTruthSeparatelyFromClientHealth() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 59.2,
+            targetFps = 120.0,
+            latencyMs = 18,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                encoder = PolarisSessionStatus.EncoderStatus(
+                    codec = "hevc",
+                    bitrateKbps = 22000,
+                    fps = 60.0,
+                    requestedClientFps = 120.0,
+                    sessionTargetFps = 120.0,
+                    encodeTargetFps = 120.0,
+                    targetDevice = "vaapi",
+                    targetResidency = "gpu"
+                ),
+                capture = PolarisSessionStatus.CaptureStatus(
+                    transport = "shm",
+                    residency = "cpu"
+                ),
+                linuxGpuProfile = PolarisSessionStatus.LinuxGpuProfile(
+                    encoderApi = "vaapi",
+                    encoderAdapter = "/dev/dri/renderD128",
+                    captureDevice = "/dev/dri/renderD128",
+                    adapterMatchesCaptureDevice = true,
+                    gpuNativeRequested = true,
+                    gpuNativeAttempted = true,
+                    gpuNativeSucceeded = false,
+                    vaapiVendor = "Mesa Gallium"
+                )
+            ),
+            sparklineSamples = listOf(58f, 60f, 59f)
+        )
+
+        assertEquals("Stream 120 • VAAPI + SHM fallback", state.streamTruthLabel)
+        assertEquals(NovaHudLayerHealth("VAAPI + SHM fallback", NovaHudTone.WARNING), state.layerHealth.first())
+        assertTrue(state.layerHealth.any { it.label == "CLIENT" && it.tone == NovaHudTone.STABLE })
+    }
+
     @Test
     fun eventBreadcrumbTrailKeepsLatestActionableHudEvent() {
         val trail = NovaHudEventTrail(capacity = 3)
@@ -441,7 +487,8 @@ class NovaHudUiStateTest {
             adaptiveTargetBitrateKbps = 30000,
             adaptiveBaseBitrateKbps = 30000,
             aiOptimizerEnabled = true
-        )
+        ),
+        linuxGpuProfile: PolarisSessionStatus.LinuxGpuProfile? = null
     ) = PolarisSessionStatus(
         state = "streaming",
         streamingActive = true,
@@ -453,6 +500,7 @@ class NovaHudUiStateTest {
         health = health,
         autoQuality = autoQuality,
         displayMode = displayMode,
+        linuxGpuProfile = linuxGpuProfile,
         syncStatus = PolarisSessionStatus.SyncStatus(
             available = true,
             state = "synced"

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -168,6 +168,41 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
+    fun commandCenterTargetSummaryIncludesAmdVaapiHostCaptureTruth() {
+        val state = quickState(
+            status = status(
+                encoder = PolarisSessionStatus.EncoderStatus(
+                    codec = "hevc",
+                    bitrateKbps = 22000,
+                    requestedClientFps = 120.0,
+                    sessionTargetFps = 120.0,
+                    encodeTargetFps = 120.0,
+                    targetDevice = "vaapi",
+                    targetResidency = "gpu"
+                ),
+                capture = PolarisSessionStatus.CaptureStatus(
+                    resolution = "1920x1080",
+                    transport = "shm",
+                    residency = "cpu"
+                ),
+                linuxGpuProfile = PolarisSessionStatus.LinuxGpuProfile(
+                    encoderApi = "vaapi",
+                    encoderAdapter = "/dev/dri/renderD128",
+                    captureDevice = "/dev/dri/renderD128",
+                    adapterMatchesCaptureDevice = true,
+                    gpuNativeRequested = true,
+                    gpuNativeAttempted = true,
+                    gpuNativeSucceeded = false
+                )
+            ),
+            fallbackTargetFps = 120.0
+        )
+
+        assertTrue(state.stability.targetSummary.contains("HEVC"))
+        assertTrue(state.stability.targetSummary.contains("VAAPI + SHM fallback"))
+    }
+
+    @Test
     fun overlayRowsExposePrivacySafeHudDiagnosticCopy() {
         val state = quickState(status = status(), currentGameName = "Portal")
         val diagnostics = state.overlayRows.first { it.id == NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS }
@@ -230,7 +265,8 @@ class NovaQuickMenuUiStateTest {
         currentGameName: String? = "Portal",
         currentGameUuid: String? = "game-1",
         hudShowing: Boolean = false,
-        hudOpacityPercent: Int = 90
+        hudOpacityPercent: Int = 90,
+        fallbackTargetFps: Double = 60.0
     ) = NovaQuickMenuUiState.from(
         context = context,
         status = status,
@@ -255,7 +291,7 @@ class NovaQuickMenuUiStateTest {
         allowChangeMouseMode = true,
         isOnExternalDisplay = false,
         fallbackBitrateKbps = 50000,
-        fallbackTargetFps = 60.0
+        fallbackTargetFps = fallbackTargetFps
     )
 
     private fun status(
@@ -278,7 +314,10 @@ class NovaQuickMenuUiStateTest {
             state = "synced"
         ),
         autoQuality: PolarisSessionStatus.AutoQualityPolicy = PolarisSessionStatus.AutoQualityPolicy(),
-        health: PolarisSessionStatus.HealthStatus = PolarisSessionStatus.HealthStatus(grade = "good")
+        health: PolarisSessionStatus.HealthStatus = PolarisSessionStatus.HealthStatus(grade = "good"),
+        encoder: PolarisSessionStatus.EncoderStatus = PolarisSessionStatus.EncoderStatus(),
+        capture: PolarisSessionStatus.CaptureStatus = PolarisSessionStatus.CaptureStatus(),
+        linuxGpuProfile: PolarisSessionStatus.LinuxGpuProfile? = null
     ) = PolarisSessionStatus(
         state = state,
         streamingActive = true,
@@ -293,6 +332,9 @@ class NovaQuickMenuUiStateTest {
         syncStatus = syncStatus,
         autoQuality = autoQuality,
         health = health,
+        encoder = encoder,
+        capture = capture,
+        linuxGpuProfile = linuxGpuProfile,
         aiOptimizerEnabled = aiOptimizerEnabled
     )
 }


### PR DESCRIPTION
## Summary
- Parse Polaris `linux_gpu_profile` and capture path/reason fields in Nova session status.
- Add `hostCaptureTruthLabel` for VAAPI GPU-native, SHM fallback, render-node mismatch, and generic VAAPI host states.
- Show host capture truth in NovaHUD stream labels and layer health.
- Include AMD/VAAPI host capture truth in Command Center stream policy summaries.

## Test Plan
- [x] `git diff --check`
- [x] `git submodule update --init --recursive`
- [x] `./gradlew :app:testDebugUnitTest --tests '*PolarisApiClientParsingTest' --tests '*NovaHudUiStateTest' --tests '*AutoQualityUiStateTest' --tests '*NovaQuickMenuUiStateTest'`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew --no-daemon -PlintFailOnError=true :app:lintRootDebug :app:lintNonRoot_gameDebug`
- [x] APK zip/content/hash checks for root + nonRoot_game across arm64-v8a, armeabi-v7a, x86_64
- [x] Installed clean `nonRoot_game` arm64 debug APK on Retroid Pocket 6
- [x] Verified `com.papi.nova.debug` launches to `NovaLibraryActivity`

## Device Smoke
- Device: Retroid Pocket 6
- Installed APK: `app/build/outputs/apk/nonRoot_game/debug/app-nonRoot_game-arm64-v8a-debug.apk`
- sha256: `45cd838bbbf9e8a5bf11663b90df98659568cb8412a177c93f477f1e4683e6bd`
- Package: `com.papi.nova.debug`
- Version: `1.2.1` / `versionCode=31`
