### PR TITLE
fix: request initial Command Center focus for DPAD

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -233,6 +235,11 @@ fun NovaQuickMenuContent(
     val overlaysTitle = stringResource(R.string.nova_quick_menu_overlays)
     val controlsTitle = stringResource(R.string.nova_quick_menu_controls)
     val sessionTitle = stringResource(R.string.nova_quick_menu_session)
+    val initialFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        initialFocusRequester.requestFocus()
+    }
 
     Column(
         modifier = modifier
@@ -257,7 +264,7 @@ fun NovaQuickMenuContent(
                 .align(Alignment.Start)
         )
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuHeader(state, callbacks)
+        NovaQuickMenuHeader(state, callbacks, initialFocusRequester)
         Spacer(Modifier.height(8.dp))
         NovaQuickMenuSessionStrip(state)
         Spacer(Modifier.height(10.dp))
@@ -310,7 +317,11 @@ fun NovaQuickMenuContent(
 }
 
 @Composable
-private fun NovaQuickMenuHeader(state: NovaQuickMenuUiState, callbacks: NovaQuickMenuCallbacks) {
+private fun NovaQuickMenuHeader(
+    state: NovaQuickMenuUiState,
+    callbacks: NovaQuickMenuCallbacks,
+    initialFocusRequester: FocusRequester
+) {
     val configuration = LocalConfiguration.current
     val compact = configuration.screenWidthDp < 430
 
@@ -322,7 +333,7 @@ private fun NovaQuickMenuHeader(state: NovaQuickMenuUiState, callbacks: NovaQuic
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     NovaQuickMenuTitleBlock(state, Modifier.weight(1f))
-                    NovaQuickMenuCloseButton(callbacks)
+                    NovaQuickMenuCloseButton(callbacks, initialFocusRequester)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     NovaQuickMenuHeaderButton(state.disconnectAction, callbacks, Modifier.weight(1f))
@@ -335,7 +346,7 @@ private fun NovaQuickMenuHeader(state: NovaQuickMenuUiState, callbacks: NovaQuic
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 NovaQuickMenuTitleBlock(state, Modifier.weight(1f))
-                NovaQuickMenuCloseButton(callbacks)
+                NovaQuickMenuCloseButton(callbacks, initialFocusRequester)
                 NovaQuickMenuHeaderButton(state.disconnectAction, callbacks)
                 NovaQuickMenuHeaderButton(state.endAction, callbacks)
             }
@@ -388,6 +399,7 @@ private fun NovaQuickMenuHeaderButton(
 @Composable
 private fun NovaQuickMenuCloseButton(
     callbacks: NovaQuickMenuCallbacks,
+    initialFocusRequester: FocusRequester,
     modifier: Modifier = Modifier
 ) {
     NovaActionButton(
@@ -395,6 +407,7 @@ private fun NovaQuickMenuCloseButton(
         onClick = callbacks.onDismiss,
         modifier = modifier
             .widthIn(min = 72.dp)
+            .focusRequester(initialFocusRequester)
             .semantics { contentDescription = "Close Command Center" },
         primary = false,
         cornerRadius = 12.dp,

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -10,6 +10,40 @@ import org.junit.Test
 
 class NovaComposeSourceGuardTest {
     @Test
+    fun commandCenterRequestsInitialFocusForDpadNavigationOnOpen() {
+        val quickMenuContent = readNovaQuickMenuContent()
+        val content = quickMenuContent.section(
+            "fun NovaQuickMenuContent(",
+            "@Composable\nprivate fun NovaQuickMenuHeader("
+        )
+        val header = quickMenuContent.section(
+            "private fun NovaQuickMenuHeader(",
+            "@Composable\nprivate fun NovaQuickMenuTitleBlock("
+        )
+        val closeButton = quickMenuContent.section(
+            "private fun NovaQuickMenuCloseButton(",
+            "@Composable\nprivate fun NovaQuickMenuSessionStrip("
+        )
+
+        assertTrue(
+            "Command Center should create a FocusRequester when opened so Android TV DPAD navigation has an initial target without requiring keyboard Tab",
+            quickMenuContent.contains("import androidx.compose.ui.focus.FocusRequester") &&
+                quickMenuContent.contains("import androidx.compose.ui.focus.focusRequester") &&
+                content.contains("val initialFocusRequester = remember { FocusRequester() }") &&
+                content.contains("LaunchedEffect(Unit)") &&
+                content.contains("initialFocusRequester.requestFocus()")
+        )
+        assertTrue(
+            "Command Center should attach that initial focus requester to the visible Close button in both compact and wide header layouts",
+            content.contains("NovaQuickMenuHeader(state, callbacks, initialFocusRequester)") &&
+                header.contains("initialFocusRequester: FocusRequester") &&
+                header.contains("NovaQuickMenuCloseButton(callbacks, initialFocusRequester)") &&
+                closeButton.contains("initialFocusRequester: FocusRequester") &&
+                closeButton.contains(".focusRequester(initialFocusRequester)")
+        )
+    }
+
+    @Test
     fun libraryFilterSheetContentIsScrollable() {
         val filterSheet = readNovaLibraryActivity().section(
             "private fun NovaLibraryFilterSheet(",


### PR DESCRIPTION
## Summary
- Request initial focus when Nova Command Center opens so Android TV/Retroid DPAD navigation starts immediately.
- Anchor the initial focus on the always-visible Close button, matching the control keyboard Tab previously landed on.
- Add a source guard covering the FocusRequester/requestFocus path so the overlay cannot regress to visible-but-unfocused.

## Test Plan
- [x] `git diff --check origin/master...HEAD`
- [x] `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew :app:testDebugUnitTest --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest.commandCenterRequestsInitialFocusForDpadNavigationOnOpen'`
- [x] `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew :app:testDebugUnitTest --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest' --tests 'com.papi.nova.ui.NovaQuickMenuUiStateTest'`
- [x] Earlier full local verification on this branch: `:app:testDebugUnitTest`, root/non-root Kotlin compile, `:app:assembleDebug`, and root/non-root lint.
- [x] Retroid field smoke: launched MOUSE: P.I. For Hire from Nova into a live Polaris stream; opened Command Center with gamepad keycodes; verified initial focus on Close and DPAD movement to Disconnect, End session, and lower Command Center controls without keyboard Tab.

## Notes
- Retroid smoke used ADB-injected gamepad keycodes for the Command Center chord/DPAD path, not a physical thumb press.
- During smoke, Polaris host config drift was corrected separately by restoring GPU-native headless capture; this PR only changes Nova focus behavior.
