### PR TITLE
fix: harden Command Center focus request

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -238,7 +239,8 @@ fun NovaQuickMenuContent(
     val initialFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
-        initialFocusRequester.requestFocus()
+        withFrameNanos { }
+        runCatching { initialFocusRequester.requestFocus() }
     }
 
     Column(

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -29,9 +29,11 @@ class NovaComposeSourceGuardTest {
             "Command Center should create a FocusRequester when opened so Android TV DPAD navigation has an initial target without requiring keyboard Tab",
             quickMenuContent.contains("import androidx.compose.ui.focus.FocusRequester") &&
                 quickMenuContent.contains("import androidx.compose.ui.focus.focusRequester") &&
+                quickMenuContent.contains("import androidx.compose.runtime.withFrameNanos") &&
                 content.contains("val initialFocusRequester = remember { FocusRequester() }") &&
                 content.contains("LaunchedEffect(Unit)") &&
-                content.contains("initialFocusRequester.requestFocus()")
+                content.contains("withFrameNanos { }") &&
+                content.contains("runCatching { initialFocusRequester.requestFocus() }")
         )
         assertTrue(
             "Command Center should attach that initial focus requester to the visible Close button in both compact and wide header layouts",


### PR DESCRIPTION
## Summary
- Harden the merged Command Center DPAD initial-focus fix by waiting one Compose frame before requesting focus.
- Wrap the focus request defensively so transient focus-owner timing does not crash or leave Android TV/DPAD users stuck needing keyboard Tab.
- Extend the existing source guard to require the one-frame delay and safe request shape.

## Test Plan
- `./gradlew --no-daemon :app:testRootDebugUnitTest --tests com.papi.nova.ui.NovaComposeSourceGuardTest :app:compileRootDebugKotlin`
- `git diff --check`

## Notes
Follow-up to the user-provided patch after PR #120 landed the core FocusRequester wiring.
