### PR TITLE
test: document Command Center focus timing

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -239,6 +239,7 @@ fun NovaQuickMenuContent(
     val initialFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
+        // Wait one Compose frame so the drawer content and Close button focus target are attached.
         withFrameNanos { }
         runCatching { initialFocusRequester.requestFocus() }
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -43,6 +43,12 @@ class NovaComposeSourceGuardTest {
                 closeButton.contains("initialFocusRequester: FocusRequester") &&
                 closeButton.contains(".focusRequester(initialFocusRequester)")
         )
+        val focusRequesterIndex = closeButton.indexOf(".focusRequester(initialFocusRequester)")
+        val semanticsIndex = closeButton.indexOf(".semantics")
+        assertTrue(
+            "Close button should attach focusRequester before later modifiers so it targets the NovaActionButton focusable node",
+            focusRequesterIndex >= 0 && semanticsIndex > focusRequesterIndex
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a comment documenting why Command Center waits one Compose frame before requesting initial focus.
- Tighten the source guard to assert the Close button keeps `focusRequester` ahead of later modifiers.

## Test Plan
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-daemon :app:testRootDebugUnitTest --tests com.papi.nova.ui.NovaComposeSourceGuardTest.commandCenterRequestsInitialFocusForDpadNavigationOnOpen :app:compileRootDebugKotlin`
- `git diff --check`

## Notes
Follow-up from independent review after #121 merged the core hardening. This PR contains only the reviewer-requested documentation/source-guard tightening on top of current `master`.
