### PR TITLE
fix(nova): preserve selected language across reconnect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,13 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
+        with:
+          # The release job only needs cmdline-tools so the following sdkmanager
+          # step can install the pinned NDK. Avoid the action's default
+          # `tools platform-tools` install, because the obsolete `tools`
+          # package currently pulls the Android Emulator and has produced
+          # transient corrupt-zip setup failures before Gradle runs.
+          packages: ''
 
       - name: Install NDK
         run: sdkmanager "ndk;27.0.12077973"

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -1304,6 +1304,7 @@ class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
         appliedTheme = NovaThemeManager.getTheme(this)
         super.onCreate(savedInstanceState)
 
+        UiHelper.setLocale(this)
         inForeground = true
 
         val glPrefs = GlPreferences.readPreferences(this)

--- a/app/src/main/java/com/papi/nova/utils/UiHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/UiHelper.kt
@@ -107,32 +107,31 @@ object UiHelper {
     }
 
     @JvmStatic
+    fun resolveLocaleForTests(language: String?, systemLocale: Locale): Locale {
+        val selectedLanguage = language ?: PreferenceConfiguration.DEFAULT_LANGUAGE
+        return if (selectedLanguage == PreferenceConfiguration.DEFAULT_LANGUAGE) {
+            systemLocale
+        } else {
+            Locale.forLanguageTag(selectedLanguage.replace('_', '-'))
+        }
+    }
+
+    @JvmStatic
     fun setLocale(activity: Activity) {
-        val locale = PreferenceConfiguration.readPreferences(activity).language
-            ?: PreferenceConfiguration.DEFAULT_LANGUAGE
-        val config = Configuration(activity.resources.configuration)
-        if (locale == PreferenceConfiguration.DEFAULT_LANGUAGE) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                // On Android 13, migrate this non-default language setting into the OS native API.
-                val localeManager = activity.getSystemService(LocaleManager::class.java)
-                val systemLocales = localeManager.systemLocales
-                if (!systemLocales.isEmpty) {
-                    config.setLocale(systemLocales[0])
-                }
+        val language = PreferenceConfiguration.readPreferences(activity).language
+        val systemLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val localeManager = activity.getSystemService(LocaleManager::class.java)
+            val systemLocales = localeManager?.systemLocales
+            if (systemLocales != null && !systemLocales.isEmpty) {
+                systemLocales[0]
+            } else {
+                Locale.getDefault()
             }
         } else {
-            // Some devices cannot set locale using system config correctly.
-            config.setLocale(
-                if (locale.contains("-")) {
-                    Locale(
-                        locale.substring(0, locale.indexOf('-')),
-                        locale.substring(locale.indexOf('-') + 1),
-                    )
-                } else {
-                    Locale(locale)
-                },
-            )
+            Locale.getDefault()
         }
+        val config = Configuration(activity.resources.configuration)
+        config.setLocale(resolveLocaleForTests(language, systemLocale))
 
         @Suppress("DEPRECATION")
         activity.resources.updateConfiguration(config, activity.resources.displayMetrics)

--- a/app/src/test/java/com/papi/nova/utils/NovaLocaleLifecycleSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaLocaleLifecycleSourceGuardTest.kt
@@ -1,0 +1,56 @@
+package com.papi.nova.utils
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaLocaleLifecycleSourceGuardTest {
+    @Test
+    fun gameAppliesLocaleBeforeInflatingContent() {
+        assertLocaleAppliedBeforeFirstContentView("Game.kt", "override fun onCreate")
+    }
+
+    @Test
+    fun appViewAppliesLocaleBeforeInflatingContent() {
+        assertLocaleAppliedBeforeFirstContentView("AppView.kt", "override fun onCreate")
+    }
+
+    @Test
+    fun pcViewAppliesLocaleBeforeInflatingContent() {
+        assertLocaleAppliedBeforeFirstContentView("PcView.kt", "override fun onCreate")
+    }
+
+    private fun assertLocaleAppliedBeforeFirstContentView(fileName: String, functionSignature: String) {
+        val body = functionBody(File("src/main/java/com/papi/nova/$fileName").readText(), functionSignature)
+        val localeIndex = body.indexOf("UiHelper.setLocale(this)")
+        val contentViewIndex = body.indexOf("setContentView(")
+
+        assertTrue("$fileName should inflate content in $functionSignature", contentViewIndex >= 0)
+        assertTrue(
+            "$fileName must call UiHelper.setLocale(this) before setContentView() so selected language survives reconnect/startup UI",
+            localeIndex >= 0 && localeIndex < contentViewIndex,
+        )
+    }
+
+    private fun functionBody(source: String, signature: String): String {
+        val signatureIndex = source.indexOf(signature)
+        assertTrue("Missing function signature: $signature", signatureIndex >= 0)
+
+        val openBrace = source.indexOf('{', signatureIndex)
+        assertTrue("Missing function body for: $signature", openBrace >= 0)
+
+        var depth = 0
+        for (index in openBrace until source.length) {
+            when (source[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) {
+                        return source.substring(openBrace, index + 1)
+                    }
+                }
+            }
+        }
+        throw AssertionError("Unclosed function body for: $signature")
+    }
+}

--- a/app/src/test/java/com/papi/nova/utils/UiHelperLocaleTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/UiHelperLocaleTest.kt
@@ -1,0 +1,38 @@
+package com.papi.nova.utils
+
+import com.papi.nova.preferences.PreferenceConfiguration
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UiHelperLocaleTest {
+    @Test
+    fun selectedLanguageOverridesSystemLocale() {
+        val systemLocale = Locale.forLanguageTag("sv-SE")
+
+        val resolved = UiHelper.resolveLocaleForTests("en", systemLocale)
+
+        assertEquals(Locale.forLanguageTag("en"), resolved)
+    }
+
+    @Test
+    fun defaultLanguageUsesSystemLocale() {
+        val systemLocale = Locale.forLanguageTag("sv-SE")
+
+        val resolved = UiHelper.resolveLocaleForTests(
+            PreferenceConfiguration.DEFAULT_LANGUAGE,
+            systemLocale,
+        )
+
+        assertEquals(systemLocale, resolved)
+    }
+
+    @Test
+    fun dashedLanguageTagsRemainStable() {
+        val systemLocale = Locale.forLanguageTag("sv-SE")
+
+        val resolved = UiHelper.resolveLocaleForTests("pt-BR", systemLocale)
+
+        assertEquals("pt-BR", resolved.toLanguageTag())
+    }
+}


### PR DESCRIPTION
## Summary
- preserve Nova's selected in-app language across stream/activity reconnects
- add a tested locale resolver for default/system vs explicit language choices
- guard `Game`, `AppView`, and `PcView` so locale is applied before content inflation

## Verification
- RED: locale tests failed before production changes because `UiHelper.resolveLocaleForTests` did not exist
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.utils.UiHelperLocaleTest --tests com.papi.nova.utils.NovaLocaleLifecycleSourceGuardTest --tests com.papi.nova.StartupCrashTest`
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest`
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:assembleNonRoot_gameDebug`
- `git show --check --oneline --stat HEAD`
- independent reviewer verdict: APPROVED

## Device smoke
- Installed `nonRoot_gameDebug` arm64 APK on Retroid Pocket 6 (`com.papi.nova.debug`, version `1.2.1 (31)`)
- Verified package path/version/update time after install
- Set Nova app language preference to English and requested system locale setting Swedish for the smoke
- Relaunched Nova Debug: Library UI stayed English
- Started a real MOUSE stream: foreground activity became `com.papi.nova.Game`, NovaHUD was visible, and FPS displayed a sane value (`55`) instead of the previous localized-parser collapse
- Pressed HOME and relaunched Nova: Library UI stayed English and showed the resumable stream card

## Note
During smoke, tapping `Resume stream` hit a separate Auto Safe/session replacement behavior and returned to Library. The UI stayed English throughout, so this appears separate from the locale persistence fix and should be tracked outside this PR.

Refs #118
