### PR TITLE
fix(nova): ignore stale terminal SSE events before resume starts

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -4,6 +4,7 @@ package com.papi.nova
 import com.papi.nova.utils.ServerHelper.getActiveDisplay
 import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
 
+import com.papi.nova.api.PolarisSessionEvents
 import com.papi.nova.binding.PlatformBinding
 import com.papi.nova.binding.audio.AndroidAudioRenderer
 import com.papi.nova.binding.input.ControllerHandler
@@ -194,6 +195,7 @@ private var currentOrientation:Int = 0
 private var polarisSessionStatusRefreshInFlight:AtomicBoolean = AtomicBoolean(false)
 private var novaResilienceManager:com.papi.nova.manager.ConnectionResilienceManager? = null
 private var novaEventSource:com.papi.nova.api.PolarisEventSource? = null
+private var polarisSseSawCurrentSessionEvent = false
 private var novaProgressOverlay:com.papi.nova.ui.SessionProgressOverlay? = null
 private var novaLockScreenOverlay:com.papi.nova.ui.LockScreenOverlay? = null
 private var novaReconnectOverlay:com.papi.nova.ui.ReconnectOverlay? = null
@@ -5392,19 +5394,27 @@ novaEventSource = com.papi.nova.api.PolarisEventSource(host ?: "",
 object : com.papi.nova.api.PolarisEventSource.EventListener {
 override fun onSessionEvent(event:String, state:String, message:String) {
 LimeLog.info("Nova SSE: " + event + " [" + state + "] " + message)
+if (PolarisSessionEvents.isCurrentSessionEvent(event, state))
+{
+polarisSseSawCurrentSessionEvent = true
+}
 novaProgressOverlay!!.updateState(state, message)
-if (event == "stream_ended" || (state == "idle" && (connected || isStreamActive)))
+if (PolarisSessionEvents.shouldFinishGameActivity(event, state, polarisSseSawCurrentSessionEvent))
 {
 handlePolarisHostSessionEnded()
 }
 }
 override fun onStateUpdate(sessionState:String, cageRunning:Boolean, screenLocked:Boolean) {
+if (PolarisSessionEvents.isCurrentSessionEvent("", sessionState))
+{
+polarisSseSawCurrentSessionEvent = true
+}
 novaProgressOverlay!!.updateState(sessionState, "")
 if ("streaming".equals(sessionState))
 {
 schedulePolarisLiveSessionStatusRefresh(true)
 }
-else if (sessionState == "idle" && (connected || isStreamActive))
+else if (PolarisSessionEvents.shouldFinishGameActivity("", sessionState, polarisSseSawCurrentSessionEvent))
 {
 handlePolarisHostSessionEnded()
 }

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionEvents.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionEvents.kt
@@ -7,13 +7,44 @@ object PolarisSessionEvents {
         "stream_resume_timeout",
     )
 
+    private val currentSessionEvents = setOf(
+        "session_starting",
+        "cage_starting",
+        "game_launching",
+        "stream_active",
+    )
+
+    private val currentSessionStates = setOf(
+        "initializing",
+        "cage_starting",
+        "game_launching",
+        "streaming",
+    )
+
     @JvmStatic
-    fun shouldFinishGameActivity(event: String?, state: String?): Boolean {
-        val normalizedEvent = event?.trim()?.lowercase().orEmpty()
-        val normalizedState = state?.trim()?.lowercase().orEmpty()
+    fun isCurrentSessionEvent(event: String?, state: String?): Boolean {
+        val normalizedEvent = event.normalizedSessionToken()
+        val normalizedState = state.normalizedSessionToken()
+        return currentSessionEvents.contains(normalizedEvent) || currentSessionStates.contains(normalizedState)
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun shouldFinishGameActivity(
+        event: String?,
+        state: String?,
+        hasObservedCurrentSessionEvent: Boolean = true
+    ): Boolean {
+        val normalizedEvent = event.normalizedSessionToken()
+        val normalizedState = state.normalizedSessionToken()
+        if (!hasObservedCurrentSessionEvent) {
+            return false
+        }
         if (terminalEvents.contains(normalizedEvent)) {
             return true
         }
-        return normalizedState == "idle" && normalizedEvent == "stream_ended"
+        return normalizedState == "idle" && normalizedEvent.isBlank()
     }
+
+    private fun String?.normalizedSessionToken(): String = this?.trim()?.lowercase().orEmpty()
 }

--- a/app/src/test/java/com/papi/nova/api/PolarisSessionEventsGameSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisSessionEventsGameSourceGuardTest.kt
@@ -1,0 +1,53 @@
+package com.papi.nova.api
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class PolarisSessionEventsGameSourceGuardTest {
+    @Test
+    fun gameIgnoresTerminalSseEventsUntilCurrentSessionEventArrives() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val startEventSource = functionBody(source, "private fun startNovaEventSourceIfSupported()")
+
+        assertTrue(
+            "Game should track whether this SSE connection has seen a current launch/session event before accepting terminal events.",
+            source.contains("polarisSseSawCurrentSessionEvent")
+        )
+        assertTrue(
+            "Game should mark current launch/session events through PolarisSessionEvents instead of ad-hoc string checks.",
+            startEventSource.contains("PolarisSessionEvents.isCurrentSessionEvent(event, state)")
+        )
+        assertTrue(
+            "Game should gate terminal events through PolarisSessionEvents with the observed-current-session flag.",
+            startEventSource.contains(
+                "PolarisSessionEvents.shouldFinishGameActivity(event, state, polarisSseSawCurrentSessionEvent)"
+            )
+        )
+        assertFalse(
+            "Raw stream_ended checks in the SSE callback can tear down a fresh Auto Safe launch with an old paused-session terminal event.",
+            startEventSource.contains("event == \"stream_ended\" || (state == \"idle\"")
+        )
+    }
+
+    private fun functionBody(source: String, signature: String): String {
+        val signatureIndex = source.indexOf(signature)
+        assertTrue("Missing function signature: $signature", signatureIndex >= 0)
+        val openBrace = source.indexOf('{', signatureIndex)
+        assertTrue("Missing function body for: $signature", openBrace >= 0)
+        var depth = 0
+        for (index in openBrace until source.length) {
+            when (source[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) {
+                        return source.substring(openBrace, index + 1)
+                    }
+                }
+            }
+        }
+        error("Unterminated function body for: $signature")
+    }
+}

--- a/app/src/test/java/com/papi/nova/api/PolarisSessionEventsTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisSessionEventsTest.kt
@@ -6,18 +6,69 @@ import org.junit.Test
 
 class PolarisSessionEventsTest {
     @Test
-    fun terminalStreamEndedFinishesGameActivity() {
-        assertTrue(PolarisSessionEvents.shouldFinishGameActivity("stream_ended", "idle"))
+    fun terminalStreamEndedFinishesGameActivityAfterCurrentSessionEvent() {
+        assertTrue(
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "stream_ended",
+                "idle",
+                hasObservedCurrentSessionEvent = true
+            )
+        )
     }
 
     @Test
-    fun streamResumeTimeoutFinishesGameActivity() {
-        assertTrue(PolarisSessionEvents.shouldFinishGameActivity("stream_resume_timeout", "idle"))
+    fun streamResumeTimeoutFinishesGameActivityAfterCurrentSessionEvent() {
+        assertTrue(
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "stream_resume_timeout",
+                "idle",
+                hasObservedCurrentSessionEvent = true
+            )
+        )
+    }
+
+    @Test
+    fun terminalEventBeforeCurrentSessionEventDoesNotFinishGameActivity() {
+        assertFalse(
+            "A terminal SSE event queued before the fresh launch starts belongs to the old paused session and must not tear down the new Game activity.",
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "stream_ended",
+                "idle",
+                hasObservedCurrentSessionEvent = false
+            )
+        )
+        assertFalse(
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "stream_resume_timeout",
+                "idle",
+                hasObservedCurrentSessionEvent = false
+            )
+        )
+    }
+
+    @Test
+    fun launchLifecycleEventsMarkCurrentSessionObserved() {
+        assertTrue(PolarisSessionEvents.isCurrentSessionEvent("session_starting", "initializing"))
+        assertTrue(PolarisSessionEvents.isCurrentSessionEvent("cage_starting", "cage_starting"))
+        assertTrue(PolarisSessionEvents.isCurrentSessionEvent("game_launching", "game_launching"))
+        assertTrue(PolarisSessionEvents.isCurrentSessionEvent("stream_active", "streaming"))
     }
 
     @Test
     fun activeStreamingEventsDoNotFinishGameActivity() {
-        assertFalse(PolarisSessionEvents.shouldFinishGameActivity("stream_active", "streaming"))
-        assertFalse(PolarisSessionEvents.shouldFinishGameActivity("cage_starting", "cage_starting"))
+        assertFalse(
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "stream_active",
+                "streaming",
+                hasObservedCurrentSessionEvent = true
+            )
+        )
+        assertFalse(
+            PolarisSessionEvents.shouldFinishGameActivity(
+                "cage_starting",
+                "cage_starting",
+                hasObservedCurrentSessionEvent = true
+            )
+        )
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -515,9 +515,10 @@ class NovaLaunchSourceGuardTest {
                 hostEnded.contains("finish()")
         )
         assertTrue(
-            "SSE idle/stream-ended events should use the same host-ended teardown path",
-            game.contains("event == " + 34.toChar() + "stream_ended" + 34.toChar()) &&
-                game.contains("state == " + 34.toChar() + "idle" + 34.toChar()) &&
+            "SSE terminal events should use the same host-ended teardown path after Nova observes a current-session event",
+            game.contains("polarisSseSawCurrentSessionEvent") &&
+                game.contains("PolarisSessionEvents.isCurrentSessionEvent(event, state)") &&
+                game.contains("PolarisSessionEvents.shouldFinishGameActivity(event, state, polarisSseSawCurrentSessionEvent)") &&
                 game.contains("handlePolarisHostSessionEnded()")
         )
         assertTrue(


### PR DESCRIPTION
## Summary
- ignore stale terminal Polaris SSE events until the Game activity observes an event/state for the current launch
- keep terminal `stream_ended` / `stream_resume_timeout` teardown behavior once the current session has started
- add local policy tests and a Game source guard for the Auto Safe resume event ordering

## Root cause
During Retroid smoke, tapping `Resume stream` could receive a stale terminal SSE event from the old paused session before the new Auto Safe launch events arrived. Nova treated that old `stream_ended [idle]` as belonging to the fresh Game activity and returned to Library even though Polaris immediately followed with `session_starting`, `cage_starting`, `game_launching`, and `stream_active` for the new session.

## Verification
- RED: focused tests failed before production changes because `hasObservedCurrentSessionEvent` / `isCurrentSessionEvent` did not exist
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.api.PolarisSessionEventsTest --tests com.papi.nova.api.PolarisSessionEventsGameSourceGuardTest --tests com.papi.nova.ui.NovaLaunchSourceGuardTest.gameReturnsToLibraryWhenPolarisReportsHostSessionEnded`
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:testNonRoot_gameDebugUnitTest`
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:assembleNonRoot_gameDebug`
- `ANDROID_HOME=/home/papi/Android/Sdk ANDROID_SDK_ROOT=/home/papi/Android/Sdk ./gradlew --no-configuration-cache :app:assembleNonRoot_gameRelease`
- `git diff --check`
- added-line static scan for secrets/shell/eval/deserialization/private paths

## Device smoke
- Installed `nonRoot_gameDebug` arm64 APK on Retroid Pocket 6 (`com.papi.nova.debug`, version `1.2.1 (31)`)
- Started MOUSE stream; foreground activity became `com.papi.nova.Game`, video rendered, and NovaHUD showed sane FPS
- Pressed HOME, relaunched Nova, and verified Library showed `RESUME YOUR STREAM`
- Tapped `Resume stream`
- Verified Nova stayed in `com.papi.nova.Game` after the previously failing event sequence
- Logcat showed stale terminal event followed by current launch events without `Polaris host session ended; returning to library`:
  - `Nova SSE: stream_ended [idle] All sessions ended`
  - `Nova SSE: session_starting [initializing] Preparing streaming session`
  - `Nova SSE: cage_starting [cage_starting] Starting compositor`
  - `Nova SSE: game_launching [game_launching] Launching MOUSE: P.I. For Hire`
  - `Nova SSE: stream_active [streaming] Streaming to RetroidPocket6 (4)`
- Final screenshot showed active MOUSE stream with NovaHUD at `30 FPS`

Refs #118 follow-up smoke finding
