### PR TITLE
fix: route Thor external-display audio to stream display

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -392,6 +392,20 @@ display = displayManager!!.getDisplay(streamingDisplayId)
 return if (display != null) display else getWindowManager().getDefaultDisplay()
 }
 
+private fun getStreamAudioContext(): Context {
+val streamingDisplay:Display? = this.streamingDisplay
+return if (streamingDisplay != null)
+{
+LimeLog.info("Nova: Android display audio context stream_id=$streamingDisplayId display_id=${streamingDisplay.displayId}")
+createDisplayContext(streamingDisplay)
+}
+else
+{
+LimeLog.info("Nova: Android display audio context stream_id=$streamingDisplayId fallback=activity")
+this
+}
+}
+
 fun streamingDisplayIdForCompanion(): Int = streamingDisplayId
 
 private fun getCompanionControlDisplay(): Display? {
@@ -1191,8 +1205,6 @@ applyMouseMode(2)
 }
 else
 {
-launchCompanionControlsIfAvailable()
-
  // Initialize touch contexts based on preferences
             // The mouse mode preference is also read in PreferenceConfiguration to set the boolean flags
             initMouseMode()
@@ -1247,7 +1259,7 @@ attemptedConnection = true
                 decoderRenderer!!.setRenderTarget(streamContainer!!.getSurface())
 
  // Starten Sie die NvConnection
-                conn!!.start(AndroidAudioRenderer(this@Game, prefConfig!!.playHostAudio),
+                conn!!.start(AndroidAudioRenderer(getStreamAudioContext(), prefConfig!!.playHostAudio),
 decoderRenderer!!, this@Game)
 } })
 
@@ -4763,6 +4775,11 @@ novaProgressOverlay?.dismiss()
 }, NOVA_PROGRESS_READY_DISMISS_DELAY_MS)
 
 handleStreamStartedState()
+
+if (!Objects.equals(appUUID, NvApp.REMOTE_INPUT_UUID))
+{
+launchCompanionControlsIfAvailable()
+}
 
  // Show Nova Stream HUD if enabled
                 if (com.papi.nova.ui.NovaStreamHud.Companion.isEnabled(this@Game))

--- a/app/src/main/java/com/papi/nova/binding/audio/AndroidAudioRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/audio/AndroidAudioRenderer.kt
@@ -21,6 +21,8 @@ class AndroidAudioRenderer(
     private var track: AudioTrack? = null
     @Volatile
     private var trackStarted = false
+    @Volatile
+    private var reportedAudioRoute = false
 
     private fun createAudioTrack(
         channelConfig: Int,
@@ -48,6 +50,10 @@ class AndroidAudioRenderer(
                 .setBufferSizeInBytes(bufferSize)
             if (lowLatency) {
                 trackBuilder.setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                LimeLog.info("Nova: Android display audio context display_id=${audioContextDisplayId()} api=${Build.VERSION.SDK_INT}")
+                trackBuilder.setContext(context)
             }
             trackBuilder.build()
         } else {
@@ -133,6 +139,7 @@ class AndroidAudioRenderer(
         if (!trackStarted) {
             audioTrack.play()
             trackStarted = true
+            logRoutedAudioDevice(audioTrack)
         }
 
         hapticEngine?.feedAudioShort(audioData, audioTrack.sampleRate, audioTrack.channelCount)
@@ -141,6 +148,30 @@ class AndroidAudioRenderer(
             audioTrack.write(audioData, 0, audioData.size)
         } else {
             LimeLog.info("Too much pending audio data: " + MoonBridge.getPendingAudioDuration() + " ms")
+        }
+    }
+
+    private fun audioContextDisplayId(): Int {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display.displayId
+        } else {
+            INVALID_DISPLAY_ID
+        }
+    }
+
+    private fun logRoutedAudioDevice(audioTrack: AudioTrack) {
+        if (reportedAudioRoute) return
+        reportedAudioRoute = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val routedDevice = audioTrack.routedDevice
+            if (routedDevice != null) {
+                LimeLog.info(
+                    "Nova: Android display audio route display_id=${audioContextDisplayId()} " +
+                        "device_id=${routedDevice.id} type=${routedDevice.type}"
+                )
+            } else {
+                LimeLog.info("Nova: Android display audio route display_id=${audioContextDisplayId()} device_id=none type=none")
+            }
         }
     }
 
@@ -176,6 +207,8 @@ class AndroidAudioRenderer(
     }
 
     companion object {
+        private const val INVALID_DISPLAY_ID = -1
+
         @Volatile
         @JvmField
         var hapticEngine: AudioHapticEngine? = null

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -116,4 +116,78 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue(source.contains("INVALID_DISPLAY_ID"))
         assertFalse(source.contains("Display.INVALID_DISPLAY"))
     }
+
+    @Test
+    fun gameCreatesAudioRendererWithStreamDisplayContext() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertTrue(
+            "Game should derive a display-scoped audio context from the selected stream display",
+            source.contains("private fun getStreamAudioContext(): Context")
+        )
+        assertTrue(
+            "Audio context should be created from the selected stream display, not whichever activity last focused controls",
+            source.contains("createDisplayContext(streamingDisplay)")
+        )
+        assertTrue(
+            "Audio renderer must be constructed with the stream display context",
+            source.contains("AndroidAudioRenderer(getStreamAudioContext(), prefConfig!!.playHostAudio)")
+        )
+        assertFalse(
+            "Passing the Game activity context lets Android bind audio to the bottom/control display",
+            source.contains("AndroidAudioRenderer(this@Game, prefConfig!!.playHostAudio)")
+        )
+    }
+
+    @Test
+    fun gameStartsCompanionControlsAfterStreamConnectionStart() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val inputSetupStart = source.indexOf("if (Objects.equals(appUUID, NvApp.REMOTE_INPUT_UUID))")
+        val inputSetupEnd = source.indexOf("if (prefConfig!!.onscreenController)", inputSetupStart)
+        val surfaceStartIndex = source.indexOf("streamContainer!!.setOnSurfaceAvailable")
+        val surfaceEndIndex = source.indexOf("gameMenuCallbacks", surfaceStartIndex)
+        val connectionStartedIndex = source.indexOf("override fun connectionStarted()")
+        val connectionStartedEnd = source.indexOf("fun handleStreamStartedState()", connectionStartedIndex)
+        assertTrue("Game should contain remote-input setup branch", inputSetupStart >= 0)
+        assertTrue("Game should contain onscreen-controller setup after remote-input setup", inputSetupEnd > inputSetupStart)
+        assertTrue("Game should contain surface-available startup callback", surfaceStartIndex >= 0)
+        assertTrue("Game should initialize game menu after surface callback", surfaceEndIndex > surfaceStartIndex)
+        assertTrue("Game should contain connectionStarted callback", connectionStartedIndex >= 0)
+        assertTrue("Game should define handleStreamStartedState after connectionStarted", connectionStartedEnd > connectionStartedIndex)
+
+        val inputSetup = source.substring(inputSetupStart, inputSetupEnd)
+        val surfaceStart = source.substring(surfaceStartIndex, surfaceEndIndex)
+        val connectionStarted = source.substring(connectionStartedIndex, connectionStartedEnd)
+
+        assertFalse(
+            "Companion controls should not take display focus before audio/stream startup",
+            inputSetup.contains("launchCompanionControlsIfAvailable()")
+        )
+        assertFalse(
+            "Surface callback starts NvConnection on a worker thread; companion controls should wait for connectionStarted",
+            surfaceStart.contains("launchCompanionControlsIfAvailable()")
+        )
+        val handleStarted = connectionStarted.indexOf("handleStreamStartedState()")
+        val controlsStart = connectionStarted.indexOf("launchCompanionControlsIfAvailable()")
+        assertTrue("connectionStarted should mark the stream active", handleStarted >= 0)
+        assertTrue("connectionStarted should start companion controls after stream/audio setup", controlsStart >= 0)
+        assertTrue(
+            "Companion controls should launch after connectionStarted marks the stream active so audio binds to the stream display first",
+            controlsStart > handleStarted
+        )
+    }
+
+    @Test
+    fun androidAudioRendererSetsBuilderContextOnAndroid14AndNewer() {
+        val source = File("src/main/java/com/papi/nova/binding/audio/AndroidAudioRenderer.kt").readText()
+
+        assertTrue(source.contains("Build.VERSION_CODES.UPSIDE_DOWN_CAKE"))
+        assertTrue(
+            "AudioTrack.Builder should receive the stream-display Context on API 34+ for display-roleful audio routing",
+            source.contains("trackBuilder.setContext(context)")
+        )
+        assertTrue(source.contains("Android display audio context"))
+        assertTrue(source.contains("Android display audio route"))
+        assertTrue(source.contains("display_id="))
+    }
 }


### PR DESCRIPTION
## Summary
- Route Nova audio through a stream-display `Context` instead of the currently-focused activity context.
- On Android 14+/API 34, call `AudioTrack.Builder.setContext(...)` so platform audio routing can associate playback with the selected game display.
- Delay the Thor companion-control surface until `connectionStarted()` so the bottom/control display does not steal focus before audio setup.
- Add privacy-safe field logs for audio display context and routed audio device id/type.

## Test plan
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew --no-daemon :app:testDebugUnitTest --tests 'com.papi.nova.utils.NovaExternalDisplayRoutingSourceGuardTest'`
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew --no-daemon :app:testDebugUnitTest`
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew --no-daemon :app:lintRootDebug`
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew --no-daemon :app:assembleDebug`

Refs #127

Note: this still needs Thor hardware validation before closing the issue; local/source guards prove the intended display-audio wiring, not the AYN firmware behavior. Tiny Android audio goblin, naturally.
