### PR TITLE
fix(nova): fit portrait cockpit on one screen

### DIFF
--- a/app/src/main/res/layout/activity_pc_view.xml
+++ b/app/src/main/res/layout/activity_pc_view.xml
@@ -53,20 +53,16 @@
                     android:textSize="11sp" />
             </LinearLayout>
 
-            <HorizontalScrollView
-                android:id="@+id/dashboardPillRailScroll"
+            <LinearLayout
+                android:id="@+id/dashboardPillRail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="14dp"
-                android:clipToPadding="false"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:overScrollMode="never"
-                android:scrollbars="none">
+                android:layout_marginTop="12dp"
+                android:orientation="vertical">
 
                 <LinearLayout
-                    android:id="@+id/dashboardPillRail"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/dashboardPillRailPrimaryRow"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="center_vertical"
                     android:orientation="horizontal">
@@ -74,15 +70,16 @@
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/actionStartPolaris"
                         style="@style/Widget.MaterialComponents.Button"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
+                        android:layout_marginEnd="8dp"
                         android:contentDescription="@string/pcview_quick_start_polaris"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:minWidth="44dp"
-                        android:paddingStart="14dp"
-                        android:paddingEnd="16dp"
+                        android:minWidth="0dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="10dp"
                         android:text="@string/pcview_quick_start_polaris"
                         android:textAllCaps="false"
                         app:backgroundTint="?attr/colorControlHighlight"
@@ -96,15 +93,15 @@
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/profilesButton"
                         style="@style/Widget.MaterialComponents.Button"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
                         android:contentDescription="@string/pcview_quick_profiles"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:minWidth="44dp"
-                        android:paddingStart="14dp"
-                        android:paddingEnd="16dp"
+                        android:minWidth="0dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="10dp"
                         android:text="@string/pcview_quick_profiles"
                         android:textAllCaps="false"
                         app:backgroundTint="?attr/colorControlHighlight"
@@ -114,19 +111,29 @@
                         app:iconGravity="textStart"
                         app:iconPadding="8dp"
                         app:iconTint="?attr/colorOnSurface" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/dashboardPillRailUtilityRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/actionTheme"
                         style="@style/Widget.MaterialComponents.Button"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
+                        android:layout_marginEnd="8dp"
                         android:contentDescription="@string/pcview_quick_theme"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:minWidth="44dp"
-                        android:paddingStart="14dp"
-                        android:paddingEnd="16dp"
+                        android:minWidth="0dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="10dp"
                         android:text="@string/pcview_quick_theme"
                         android:textAllCaps="false"
                         app:backgroundTint="?attr/colorControlHighlight"
@@ -140,15 +147,15 @@
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/actionGithub"
                         style="@style/Widget.MaterialComponents.Button"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
                         android:contentDescription="@string/pcview_quick_github"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:minWidth="44dp"
-                        android:paddingStart="14dp"
-                        android:paddingEnd="16dp"
+                        android:minWidth="0dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="10dp"
                         android:text="@string/pcview_quick_github"
                         android:textAllCaps="false"
                         app:backgroundTint="?attr/colorControlHighlight"
@@ -158,19 +165,29 @@
                         app:iconGravity="textStart"
                         app:iconPadding="8dp"
                         app:iconTint="?attr/colorOnSurface" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/dashboardPillRailSystemRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/actionSettings"
                         style="@style/Widget.MaterialComponents.Button"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
+                        android:layout_marginEnd="8dp"
                         android:contentDescription="@string/pcview_quick_settings"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
-                        android:minWidth="44dp"
-                        android:paddingStart="14dp"
-                        android:paddingEnd="16dp"
+                        android:minWidth="0dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="10dp"
                         android:text="@string/pcview_quick_settings"
                         android:textAllCaps="false"
                         app:backgroundTint="?attr/colorControlHighlight"
@@ -183,9 +200,9 @@
 
                     <com.google.android.material.card.MaterialCardView
                         android:id="@+id/actionNovaUpdate"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
                         android:layout_height="44dp"
-                        android:layout_marginEnd="10dp"
                         android:clickable="true"
                         android:contentDescription="@string/pcview_update_pill_content_current"
                         android:focusable="true"
@@ -245,13 +262,13 @@
                         </LinearLayout>
                     </com.google.android.material.card.MaterialCardView>
                 </LinearLayout>
-            </HorizontalScrollView>
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/topActionFocusLabel"
                 android:layout_width="match_parent"
-                android:layout_height="20dp"
-                android:layout_marginTop="4dp"
+                android:layout_height="18dp"
+                android:layout_marginTop="2dp"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="center"
                 android:textColor="?android:textColorSecondary"
@@ -263,7 +280,7 @@
                 android:id="@+id/dashboardHomeControls"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="10dp"
                 android:gravity="center_vertical"
                 android:orientation="vertical">
 
@@ -377,7 +394,7 @@
                     android:id="@+id/setupActionRow"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
+                    android:layout_marginTop="8dp"
                     android:gravity="center_vertical"
                     android:orientation="horizontal">
 

--- a/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
@@ -117,18 +117,31 @@ class NovaDashboardRevampContractTest {
     }
 
     @Test
-    fun laneTwoPortraitUsesHorizontalPillRailNotSidebar() {
+    fun laneTwoPortraitUsesVisibleActionGridNotHorizontalScroller() {
         val portrait = File("src/main/res/layout/activity_pc_view.xml").readText()
         val headerStart = portrait.indexOf("@+id/pcViewHeader")
         val selectorStart = portrait.indexOf("@+id/modeServers")
         assertTrue("portrait should keep header before mode cards", headerStart > 0 && selectorStart > headerStart)
         val headerXml = portrait.substring(headerStart, selectorStart)
+        val railXml = headerXml.substring(headerXml.indexOf("@+id/dashboardPillRail"), headerXml.indexOf("@+id/topActionFocusLabel"))
 
-        assertTrue("portrait should expose a horizontal scroll container for action pills", headerXml.contains("@+id/dashboardPillRailScroll"))
+        assertFalse("portrait top actions should not hide behind a horizontal scroller", headerXml.contains("@+id/dashboardPillRailScroll"))
         assertTrue("portrait should expose dashboardPillRail", headerXml.contains("@+id/dashboardPillRail"))
         assertFalse("portrait should not reserve a landscape cockpit rail", portrait.contains("@+id/dashboardCockpitRail"))
-        assertTrue("portrait pill rail should still contain Profiles through Settings", headerXml.indexOf("@+id/profilesButton") < headerXml.indexOf("@+id/actionSettings"))
-        assertTrue("portrait update label should be constrained so the rail can scroll cleanly", headerXml.contains("""android:maxWidth="128dp"""") && headerXml.contains("""android:ellipsize="end""""))
+        assertTrue("portrait action rail should stack rows so every top action is visible on the first screen", railXml.contains("@+id/dashboardPillRailPrimaryRow") && railXml.contains("@+id/dashboardPillRailUtilityRow") && railXml.contains("@+id/dashboardPillRailSystemRow"))
+        assertTrue("portrait action rail rows should use full-width equal targets", railXml.contains("""android:layout_width="match_parent"""") && railXml.contains("""android:layout_width="0dp"""") && railXml.contains("android:layout_weight"))
+        listOf(
+            "@+id/actionStartPolaris",
+            "@+id/profilesButton",
+            "@+id/actionTheme",
+            "@+id/actionGithub",
+            "@+id/actionSettings",
+            "@+id/actionNovaUpdate",
+        ).forEach { id ->
+            assertTrue("portrait one-screen action grid should keep $id visible before mode controls", railXml.contains(id))
+        }
+        assertTrue("portrait update label should remain bounded inside its grid cell", headerXml.contains("""android:maxWidth="128dp"""") && headerXml.contains("""android:ellipsize="end""""))
+        assertTrue("portrait controls should start close under the visible action grid to keep hosts on-screen", headerXml.contains("""android:id="@+id/dashboardHomeControls"""") && headerXml.contains("""android:layout_marginTop="10dp"""))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replaces the portrait quick-action horizontal scroller with a visible two-column action grid.
- Keeps all six top actions visible at once: Start Polaris, Profiles, Theme, GitHub, Settings, and Update.
- Tightens portrait vertical spacing so mode controls, setup controls, filters, and the host card stay on the same screen.
- Adds a source contract guard preventing portrait top actions from going back behind a horizontal scroller.

## Verification
- Proved RED: `laneTwoPortraitUsesVisibleActionGridNotHorizontalScroller` failed on the old horizontal scroller.
- `:app:testNonRoot_gameDebugUnitTest` targeted dashboard/update/focus/theme tests: PASS
- `:app:testRootDebugUnitTest` targeted dashboard/update/focus/theme tests: PASS
- `:app:compileRootDebugKotlin`: PASS
- `:app:lintNonRoot_gameDebug -PlintFailOnError=true`: PASS
- `:app:assembleNonRoot_gameDebug -PnovaAbis=arm64-v8a`: PASS
- `git diff --check`: PASS
- Retroid Pocket 6 portrait smoke:
  - exact debug APK SHA256: `3749a585ffffc25d858567830b35aa3fbf912b522c910afe7c9bcc123a1c4d31`
  - forced/verified portrait via `wm user-rotation lock 0`
  - display `1080x1920`, `ROTATION_0`, foreground `PcView`
  - no `FATAL EXCEPTION`, `ANR`, `InflateException`, or `Resources$NotFoundException`
  - screenshots visually confirmed all six top actions, mode/setup controls, filters, and host card fit on one portrait screen

No merge requested; opening this for review/approval.
