### PR TITLE
feat(nova): add stream doctor diagnostics

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -445,6 +445,73 @@ class PolarisApiClient @JvmOverloads constructor(
             )
         }
 
+        private fun parseDoctorStatus(
+            doctor: JSONObject?,
+            health: JSONObject?,
+            aiDoctor: JSONObject?
+        ): PolarisSessionStatus.DoctorStatus {
+            val explanation = aiDoctor?.optJSONObject("explanation")?.takeIf { aiDoctor.optBoolean("status", true) }
+            val primaryIssue = doctor?.optString("primary_issue", "")
+                ?.takeIf { it.isNotBlank() }
+                ?: health?.optString("primary_issue", "")
+                ?: ""
+            val likelyCause = explanation?.optString("likely_cause", "")?.takeIf { it.isNotBlank() }
+                ?: doctor?.optString("simple_state", "")?.takeIf { it.isNotBlank() }
+                ?: doctor?.optString("summary", "")?.takeIf { it.isNotBlank() }
+                ?: doctor?.optString("diagnosis", "")?.takeIf { it.isNotBlank() }
+                ?: health?.optString("summary", "")
+                ?: ""
+            val evidence = parseStringArray(explanation?.optJSONArray("evidence")).takeIf { it.isNotEmpty() }
+                ?: parseDoctorEvidence(doctor)
+            val recommendation = doctor?.optJSONObject("recommendation")
+            val safeAction = doctor?.optJSONObject("safe_recovery_action")
+            val tryFirst = parseStringArray(explanation?.optJSONArray("try_first")).takeIf { it.isNotEmpty() }
+                ?: listOfNotNull(
+                    recommendation?.optString("body", "")?.takeIf { it.isNotBlank() },
+                    recommendation?.optString("next_step_label", "")?.takeIf { it.isNotBlank() },
+                    safeAction?.optString("label", "")?.takeIf { it.isNotBlank() }
+                ).takeIf { it.isNotEmpty() }
+                ?: parseStringArray(health?.optJSONArray("recommendations"))
+            val confidence = explanation?.optString("confidence", "")?.takeIf { it.isNotBlank() }
+                ?: doctor?.optString("confidence", "")?.takeIf { it.isNotBlank() }
+                ?: if (doctor != null) "deterministic" else if (primaryIssue.isNotBlank() || likelyCause.isNotBlank()) "fallback" else ""
+            return PolarisSessionStatus.DoctorStatus(
+                available = doctor != null,
+                classification = classifyDoctorIssue(primaryIssue),
+                likelyCause = likelyCause,
+                evidence = evidence,
+                tryFirst = tryFirst,
+                confidence = confidence,
+                advancedDetail = explanation?.optString("advanced_detail", "")
+                    ?: doctor?.optJSONObject("advanced_evidence")?.optString("summary", "")
+                    ?: "",
+                primaryIssue = primaryIssue,
+                destructiveActionAllowed = false
+            )
+        }
+
+        private fun parseDoctorEvidence(doctor: JSONObject?): List<String> {
+            val array = doctor?.optJSONArray("evidence") ?: return emptyList()
+            return (0 until array.length()).mapNotNull { index ->
+                val value = array.opt(index)
+                when (value) {
+                    is JSONObject -> value.optString("detail", value.optString("value", "")).takeIf { it.isNotBlank() }
+                    is String -> value.takeIf { it.isNotBlank() }
+                    else -> null
+                }
+            }
+        }
+
+        private fun classifyDoctorIssue(issue: String): String {
+            val normalized = issue.lowercase()
+            return when {
+                normalized.isBlank() || normalized == "none" -> "UNKNOWN"
+                normalized.contains("network") || normalized.contains("packet") || normalized.contains("jitter") || normalized.contains("latency") -> "NET"
+                normalized.contains("client") || normalized.contains("decoder") || normalized.contains("presentation") || normalized.contains("refresh") -> "CLIENT"
+                else -> "HOST"
+            }
+        }
+
         @JvmStatic
         fun parseSessionStatusResponse(json: JSONObject): PolarisSessionStatus {
             val controls = json.optJSONObject("controls")
@@ -469,6 +536,10 @@ class PolarisApiClient @JvmOverloads constructor(
             val capture = json.optJSONObject("capture")
             val encoder = json.optJSONObject("encoder")
             val health = json.optJSONObject("health")
+            val doctor = json.optJSONObject("doctor") ?: health?.optJSONObject("doctor")
+            val aiDoctor = json.optJSONObject("ai_doctor_explanation")
+                ?: json.optJSONObject("doctor_ai_explanation")
+                ?: json.optJSONObject("ai_explanation")
             val autoQuality = json.optJSONObject("auto_quality")
                 ?: health?.optJSONObject("recovery_policy")
             val profileState = json.optJSONObject("profile_state")
@@ -644,7 +715,8 @@ class PolarisApiClient @JvmOverloads constructor(
                     renderFpsGap = health?.optDouble("render_fps_gap", 0.0) ?: 0.0,
                     recoveryProfile = health?.optString("recovery_profile", "") ?: "",
                     relaunchRecommended = health?.optBoolean("relaunch_recommended", false) ?: false
-                )
+                ),
+                doctor = parseDoctorStatus(doctor, health, aiDoctor)
             )
         }
     }

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -33,7 +33,8 @@ data class PolarisSessionStatus(
     val linuxGpuProfile: LinuxGpuProfile? = null,
     val autoQuality: AutoQualityPolicy = AutoQualityPolicy(),
     val profileState: ProfileState = ProfileState(),
-    val health: HealthStatus = HealthStatus()
+    val health: HealthStatus = HealthStatus(),
+    val doctor: DoctorStatus = DoctorStatus()
 ) {
     data class ControlsStatus(
         val hostTuningAllowed: Boolean = false,
@@ -247,6 +248,20 @@ data class PolarisSessionStatus(
         val isUpgradeAvailable get() = state.equals("upgrade_available", ignoreCase = true)
         val isLearning get() = state.equals("learning", ignoreCase = true)
         val isManualOverride get() = state.equals("manual_override", ignoreCase = true)
+    }
+
+    data class DoctorStatus(
+        val available: Boolean = false,
+        val classification: String = "UNKNOWN",
+        val likelyCause: String = "",
+        val evidence: List<String> = emptyList(),
+        val tryFirst: List<String> = emptyList(),
+        val confidence: String = "",
+        val advancedDetail: String = "",
+        val primaryIssue: String = "",
+        val destructiveActionAllowed: Boolean = false
+    ) {
+        val firstTry get() = tryFirst.firstOrNull().orEmpty()
     }
 
     data class HealthStatus(

--- a/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudSessionSummaryLog.kt
@@ -30,7 +30,11 @@ internal object NovaHudSessionSummaryLog {
         "safe_codec",
         "safe_display_mode",
         "safe_hdr",
-        "relaunch_recommended"
+        "relaunch_recommended",
+        "diagnosis_classification",
+        "diagnosis_likely_cause",
+        "diagnosis_try_first",
+        "diagnosis_confidence"
     )
 
     fun format(summary: Map<String, Any?>): String {
@@ -57,8 +61,26 @@ internal object NovaHudDiagnosticReport {
         lines += "Video: ${formatBitrate(summary["avg_bitrate_kbps"])} / ${safeString(summary["codec"], "unknown codec")}"
         lines += "Network: ${formatMs(summary["avg_latency_ms"])} RTT / ${formatPercent(summary["packet_loss_pct"])} loss"
         lines += "Health: ${safeString(summary["health_grade"], "unknown")} / ${safeString(summary["primary_issue"], "none")}"
+        diagnosisLine(summary)?.let { lines += it }
+        tryFirstLine(summary)?.let { lines += it }
         issuesLine(summary)?.let { lines += it }
         return lines.joinToString("\n")
+    }
+
+    private fun diagnosisLine(summary: Map<String, Any?>): String? {
+        val classification = safeString(summary["diagnosis_classification"], "").takeIf { it.isNotBlank() }
+            ?: return null
+        val cause = safeString(summary["diagnosis_likely_cause"], "stream evidence available")
+        val confidence = safeString(summary["diagnosis_confidence"], "").takeIf { it.isNotBlank() }
+            ?.let { " ($it)" }
+            ?: ""
+        return "Diagnosis: $classification / $cause$confidence"
+    }
+
+    private fun tryFirstLine(summary: Map<String, Any?>): String? {
+        val tryFirst = safeString(summary["diagnosis_try_first"], "").takeIf { it.isNotBlank() }
+            ?: return null
+        return "Try first: $tryFirst"
     }
 
     private fun suggestedLine(summary: Map<String, Any?>): String? {

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -518,6 +518,10 @@ class NovaHudSessionStats {
     private var safeTargetFps = 0.0
     private var safeHdr: Boolean? = null
     private var relaunchRecommended = false
+    private var diagnosisClassification = ""
+    private var diagnosisLikelyCause = ""
+    private var diagnosisTryFirst = ""
+    private var diagnosisConfidence = ""
 
     fun reset() {
         sessionFpsSum = 0.0
@@ -619,6 +623,10 @@ class NovaHudSessionStats {
         safeTargetFps = status.health.safeTargetFps
         safeHdr = status.health.safeHdr
         relaunchRecommended = status.health.relaunchRecommended
+        diagnosisClassification = status.doctor.classification
+        diagnosisLikelyCause = status.doctor.likelyCause
+        diagnosisTryFirst = status.doctor.firstTry
+        diagnosisConfidence = status.doctor.confidence
     }
 
     fun summary(nowMs: Long = System.currentTimeMillis()): Map<String, Any> {
@@ -719,6 +727,10 @@ class NovaHudSessionStats {
         if (safeDisplayMode.isNotBlank()) summary["safe_display_mode"] = safeDisplayMode
         safeHdr?.let { summary["safe_hdr"] = it }
         if (derivedRelaunchRecommended) summary["relaunch_recommended"] = true
+        if (diagnosisClassification.isNotBlank()) summary["diagnosis_classification"] = diagnosisClassification
+        if (diagnosisLikelyCause.isNotBlank()) summary["diagnosis_likely_cause"] = diagnosisLikelyCause
+        if (diagnosisTryFirst.isNotBlank()) summary["diagnosis_try_first"] = diagnosisTryFirst
+        if (diagnosisConfidence.isNotBlank()) summary["diagnosis_confidence"] = diagnosisConfidence
         return summary
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -399,6 +399,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                             }
                             game.toggleHUD()
                         }
+                        NovaQuickMenuActionId.DIAGNOSE_STREAM,
                         NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> {
                             game.copyNovaHudDiagnostics()
                         }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -102,6 +102,7 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,
             NovaQuickMenuActionId.PERF_STATS,
+            NovaQuickMenuActionId.DIAGNOSE_STREAM,
             NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> onOverlayAction(action.id)
             NovaQuickMenuActionId.MOUSE_MODE,
             NovaQuickMenuActionId.CONTROLLER,
@@ -271,6 +272,8 @@ fun NovaQuickMenuContent(
         Spacer(Modifier.height(8.dp))
         NovaQuickMenuSessionStrip(state)
         Spacer(Modifier.height(10.dp))
+        NovaQuickMenuDiagnosisCard(state.diagnosis)
+        Spacer(Modifier.height(10.dp))
         NovaQuickMenuStabilityCard(state.stability, callbacks)
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuInfoCard(
@@ -417,6 +420,28 @@ private fun NovaQuickMenuCloseButton(
         minHeight = 34.dp,
         fontSize = 12.sp,
         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 7.dp)
+    )
+}
+
+@Composable
+private fun NovaQuickMenuDiagnosisCard(diagnosis: NovaQuickMenuDiagnosisState) {
+    val detail = buildList {
+        diagnosis.tryFirst.takeIf { it.isNotBlank() }?.let { add("Try first: $it") }
+        diagnosis.evidence.firstOrNull()?.takeIf { it.isNotBlank() }?.let { add("Evidence: $it") }
+        diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
+    }.joinToString(" · ")
+    NovaQuickMenuInfoCard(
+        action = NovaQuickMenuAction(
+            id = NovaQuickMenuActionId.DIAGNOSE_STREAM,
+            label = "${diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") } ?: "DIAG"}: ${diagnosis.likelyCause}",
+            caption = detail.ifBlank { "HOST / NET / CLIENT self-service diagnostics" },
+            chip = NovaQuickMenuChip(
+                label = if (diagnosis.available) "Doctor" else "Fallback",
+                tone = if (diagnosis.available) NovaQuickMenuTone.INFO else NovaQuickMenuTone.MUTED
+            ),
+            enabled = diagnosis.available
+        ),
+        callbacks = NovaQuickMenuCallbacks()
     )
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -31,6 +31,7 @@ enum class NovaQuickMenuActionId {
     QUICK_CTRL_V,
     NOVA_HUD,
     PERF_STATS,
+    DIAGNOSE_STREAM,
     COPY_HUD_DIAGNOSTICS,
     MOUSE_MODE,
     CONTROLLER,
@@ -79,6 +80,15 @@ data class NovaQuickMenuHudOpacityState(
     val enabled: Boolean
 )
 
+data class NovaQuickMenuDiagnosisState(
+    val classification: String,
+    val likelyCause: String,
+    val evidence: List<String>,
+    val tryFirst: String,
+    val confidence: String,
+    val available: Boolean
+)
+
 data class NovaQuickMenuUiState(
     val title: String,
     val subtitle: String,
@@ -94,6 +104,7 @@ data class NovaQuickMenuUiState(
     val advancedExpanded: Boolean,
     val advancedRows: List<NovaQuickMenuAction>,
     val quickKeys: List<NovaQuickMenuAction>,
+    val diagnosis: NovaQuickMenuDiagnosisState,
     val hudOpacity: NovaQuickMenuHudOpacityState,
     val overlayRows: List<NovaQuickMenuAction>,
     val controlRows: List<NovaQuickMenuAction>,
@@ -308,8 +319,10 @@ data class NovaQuickMenuUiState(
                 presets = NovaHudPreferences.OPACITY_PRESETS,
                 enabled = hudShowing
             )
+            val diagnosis = diagnosisState(status)
 
             val overlays = listOf(
+                diagnoseAction(context, status, diagnosis),
                 NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.NOVA_HUD,
                     label = context.getString(R.string.nova_quick_menu_nova_hud),
@@ -401,6 +414,7 @@ data class NovaQuickMenuUiState(
                 advancedExpanded = advancedExpanded,
                 advancedRows = listOf(aiRow, clearRow, mangoRow),
                 quickKeys = quickKeyActions(context),
+                diagnosis = diagnosis,
                 hudOpacity = hudOpacity,
                 overlayRows = overlays,
                 controlRows = controls,
@@ -459,6 +473,37 @@ data class NovaQuickMenuUiState(
                 isOnExternalDisplay = false,
                 fallbackBitrateKbps = 50000,
                 fallbackTargetFps = 60.0
+            )
+        }
+
+        private fun diagnosisState(status: PolarisSessionStatus?): NovaQuickMenuDiagnosisState {
+            val doctor = status?.doctor
+            return NovaQuickMenuDiagnosisState(
+                classification = doctor?.classification?.takeIf { it.isNotBlank() } ?: "UNKNOWN",
+                likelyCause = doctor?.likelyCause?.takeIf { it.isNotBlank() } ?: "Connect to Polaris for HOST / NET / CLIENT diagnostics.",
+                evidence = doctor?.evidence ?: emptyList(),
+                tryFirst = doctor?.firstTry.orEmpty(),
+                confidence = doctor?.confidence.orEmpty(),
+                available = status != null && (doctor?.likelyCause?.isNotBlank() == true || doctor?.primaryIssue?.isNotBlank() == true)
+            )
+        }
+
+        private fun diagnoseAction(
+            context: Context,
+            status: PolarisSessionStatus?,
+            diagnosis: NovaQuickMenuDiagnosisState
+        ): NovaQuickMenuAction {
+            val classification = diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") } ?: "N/A"
+            val tone = when (classification) {
+                "HOST", "NET", "CLIENT" -> NovaQuickMenuTone.WARNING
+                else -> NovaQuickMenuTone.MUTED
+            }
+            return NovaQuickMenuAction(
+                id = NovaQuickMenuActionId.DIAGNOSE_STREAM,
+                label = context.getString(R.string.nova_quick_menu_diagnose_stream),
+                caption = diagnosis.likelyCause,
+                chip = chip(classification, tone),
+                enabled = status != null
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -857,6 +857,7 @@
     <string name="nova_quick_menu_hud_opacity_selected">Selected</string>
     <string name="nova_quick_menu_hud_opacity_not_selected">Not selected</string>
     <string name="nova_quick_menu_perf_stats">Stats Overlay</string>
+    <string name="nova_quick_menu_diagnose_stream">Diagnose This Stream</string>
     <string name="nova_quick_menu_copy_hud_diagnostics">Copy HUD Diagnostics</string>
     <string name="nova_quick_menu_copy_hud_diagnostics_caption">Privacy-safe stream summary for bug reports.</string>
     <string name="nova_quick_menu_hud_diagnostics_copied">Nova HUD diagnostics copied</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -213,6 +213,46 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
+    fun parseSessionStatusResponse_includesPolarisDoctorDiagnosis() {
+        val json = JSONObject(
+            "{\"state\":\"streaming\",\"streaming_active\":true," +
+                "\"doctor\":{\"simple_state\":\"Network issue detected\",\"primary_issue\":\"network_jitter\"," +
+                "\"evidence\":[{\"detail\":\"Packet loss is 3.4% over the last sample window.\"}]," +
+                "\"recommendation\":{\"body\":\"Lower bitrate one step or keep Adaptive Bitrate enabled.\",\"next_step_label\":\"Lower bitrate\"}}," +
+                "\"ai_doctor_explanation\":{\"status\":true,\"explanation\":{\"likely_cause\":\"Wi-Fi jitter is the likely bottleneck.\"," +
+                "\"evidence\":[\"3.4% packet loss\"],\"try_first\":[\"Lower bitrate\"]," +
+                "\"advanced_detail\":\"Network evidence beats encoder speculation.\",\"confidence\":\"high\",\"destructive_action_allowed\":true}}}"
+        )
+
+        val status = PolarisApiClient.parseSessionStatusResponse(json)
+
+        assertTrue(status.doctor.available)
+        assertEquals("NET", status.doctor.classification)
+        assertEquals("Wi-Fi jitter is the likely bottleneck.", status.doctor.likelyCause)
+        assertEquals("3.4% packet loss", status.doctor.evidence.first())
+        assertEquals("Lower bitrate", status.doctor.tryFirst.first())
+        assertEquals("high", status.doctor.confidence)
+        assertFalse(status.doctor.destructiveActionAllowed)
+    }
+
+    @Test
+    fun parseSessionStatusResponse_fallsBackForOlderHostsWithoutDoctorPayload() {
+        val json = JSONObject(
+            "{\"state\":\"streaming\",\"streaming_active\":true," +
+                "\"health\":{\"grade\":\"watch\",\"summary\":\"Host render is missing the stream FPS target.\"," +
+                "\"primary_issue\":\"host_render_limited\",\"recommendations\":[\"Lower game FPS before tuning bitrate.\"]}}"
+        )
+
+        val status = PolarisApiClient.parseSessionStatusResponse(json)
+
+        assertFalse(status.doctor.available)
+        assertEquals("HOST", status.doctor.classification)
+        assertEquals("Host render is missing the stream FPS target.", status.doctor.likelyCause)
+        assertEquals("Lower game FPS before tuning bitrate.", status.doctor.tryFirst.first())
+        assertEquals("fallback", status.doctor.confidence)
+    }
+
+    @Test
     fun parseSessionStatusResponse_includesHostRenderLimitedHealth() {
         val json = JSONObject(
             "{\"state\":\"streaming\",\"streaming_active\":true," +

--- a/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudSessionStatsTest.kt
@@ -161,4 +161,27 @@ class NovaHudSessionStatsTest {
         assertFalse(text.contains("example-stream-host"))
         assertFalse(text.contains("abc123"))
     }
+
+    @Test
+    fun diagnosticReportIncludesDoctorClassificationWithoutRawHostIdentifiers() {
+        val summary = mapOf(
+            "avg_fps" to 58.0,
+            "target_fps" to 60.0,
+            "avg_latency_ms" to 32.0,
+            "avg_bitrate_kbps" to 18000,
+            "packet_loss_pct" to 3.4,
+            "codec" to "HEVC",
+            "diagnosis_classification" to "NET",
+            "diagnosis_likely_cause" to "Wi-Fi jitter is the likely bottleneck.",
+            "diagnosis_try_first" to "Lower bitrate",
+            "diagnosis_confidence" to "high",
+            "host" to "private-host.lan"
+        )
+
+        val text = NovaHudDiagnosticReport.format(summary)
+
+        assertTrue(text.contains("Diagnosis: NET / Wi-Fi jitter is the likely bottleneck. (high)"))
+        assertTrue(text.contains("Try first: Lower bitrate"))
+        assertFalse(text.contains("private-host"))
+    }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -227,6 +227,42 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
+    fun commandCenterExposesDiagnoseThisStreamAsPrimaryOverlayAction() {
+        val state = quickState(
+            status = status(
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    classification = "NET",
+                    likelyCause = "Wi-Fi jitter is the likely bottleneck.",
+                    evidence = listOf("3.4% packet loss"),
+                    tryFirst = listOf("Lower bitrate"),
+                    confidence = "high"
+                )
+            )
+        )
+
+        val diagnose = state.overlayRows.first()
+        assertEquals(NovaQuickMenuActionId.DIAGNOSE_STREAM, diagnose.id)
+        assertEquals("Diagnose This Stream", diagnose.label)
+        assertEquals("Wi-Fi jitter is the likely bottleneck.", diagnose.caption)
+        assertEquals("NET", diagnose.chip!!.label)
+        assertEquals(NovaQuickMenuTone.WARNING, diagnose.chip.tone)
+        assertEquals("Lower bitrate", state.diagnosis.tryFirst)
+        assertEquals("3.4% packet loss", state.diagnosis.evidence.first())
+        assertEquals("high", state.diagnosis.confidence)
+    }
+
+    @Test
+    fun commandCenterDisablesDiagnoseThisStreamForMoonlightFallbackSession() {
+        val state = quickState(status = null, apiAvailable = false)
+        val diagnose = state.overlayRows.first { it.id == NovaQuickMenuActionId.DIAGNOSE_STREAM }
+
+        assertFalse(diagnose.enabled)
+        assertEquals("N/A", diagnose.chip!!.label)
+        assertEquals("Connect to Polaris for HOST / NET / CLIENT diagnostics.", diagnose.caption)
+    }
+
+    @Test
     fun overlayRowsExposePrivacySafeHudDiagnosticCopy() {
         val state = quickState(status = status(), currentGameName = "Portal")
         val diagnostics = state.overlayRows.first { it.id == NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS }
@@ -339,6 +375,7 @@ class NovaQuickMenuUiStateTest {
         ),
         autoQuality: PolarisSessionStatus.AutoQualityPolicy = PolarisSessionStatus.AutoQualityPolicy(),
         health: PolarisSessionStatus.HealthStatus = PolarisSessionStatus.HealthStatus(grade = "good"),
+        doctor: PolarisSessionStatus.DoctorStatus = PolarisSessionStatus.DoctorStatus(),
         encoder: PolarisSessionStatus.EncoderStatus = PolarisSessionStatus.EncoderStatus(),
         capture: PolarisSessionStatus.CaptureStatus = PolarisSessionStatus.CaptureStatus(),
         linuxGpuProfile: PolarisSessionStatus.LinuxGpuProfile? = null
@@ -356,6 +393,7 @@ class NovaQuickMenuUiStateTest {
         syncStatus = syncStatus,
         autoQuality = autoQuality,
         health = health,
+        doctor = doctor,
         encoder = encoder,
         capture = capture,
         linuxGpuProfile = linuxGpuProfile,


### PR DESCRIPTION
## Summary
- Parses Polaris Doctor / AI Doctor diagnosis payloads into a HOST / NET / CLIENT stream diagnosis model, with older-host health fallback.
- Surfaces Diagnose This Stream in Command Center / NovaHUD copy with likely cause, evidence, try-first guidance, and confidence while keeping Copy Diagnostics privacy-safe.
- Preserves Moonlight-compatible fallback: non-Polaris sessions show diagnostics unavailable instead of requiring Polaris-only data.

## Test Plan
- ./gradlew testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.api.PolarisApiClientParsingTest' --tests 'com.papi.nova.ui.NovaQuickMenuUiStateTest' --tests 'com.papi.nova.ui.NovaHudSessionStatsTest'
- ./gradlew assembleNonRoot_gameDebug

## Notes
- First assemble attempt failed because the clean worktree had not initialized the moonlight-common-c submodule; fixed with git submodule update --init --recursive app/src/main/jni/moonlight-core/moonlight-common-c and reran successfully.
