### PR TITLE
feat(nova): surface display planner launch presets

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
@@ -1,0 +1,145 @@
+package com.papi.nova.ui
+
+import com.papi.nova.api.PolarisSessionStatus
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.json.JSONObject
+import java.util.Locale
+import kotlin.math.roundToInt
+
+/**
+ * Handheld-first Nova wrapper for the Polaris display/resolution planner contract.
+ * Older Polaris hosts omit display_planner; in that case Nova keeps its existing launch flow.
+ */
+data class NovaDisplayResolutionPlanner(
+    val available: Boolean,
+    val sourceMode: String,
+    val recommendedId: String,
+    val recommendedMode: String,
+    val visibleChoices: List<NovaDisplayResolutionChoice>,
+    val hasAdvancedChoices: Boolean
+) {
+    companion object {
+        fun from(
+            contract: PolarisGame.DisplayPlannerContract?,
+            fallbackMode: String,
+            includeAdvanced: Boolean
+        ): NovaDisplayResolutionPlanner {
+            if (contract?.available != true) {
+                return NovaDisplayResolutionPlanner(
+                    available = false,
+                    sourceMode = fallbackMode,
+                    recommendedId = "",
+                    recommendedMode = "",
+                    visibleChoices = emptyList(),
+                    hasAdvancedChoices = false
+                )
+            }
+
+            val recommended = contract.recommendedId.ifBlank { "balanced" }
+            val choices = contract.choices
+                .filter { it.id.isNotBlank() && it.targetMode.isNotBlank() && it.safe && !it.hidden }
+                .map { choice ->
+                    NovaDisplayResolutionChoice(
+                        id = choice.id,
+                        title = plannerTitle(choice, recommended),
+                        targetMode = choice.targetMode,
+                        badge = meaningfulBadge(choice, recommended),
+                        reason = choice.reason.ifBlank { choice.intent },
+                        advanced = choice.advanced,
+                        custom = choice.custom,
+                        safe = choice.safe,
+                        recommended = choice.id == recommended
+                    )
+                }
+            return NovaDisplayResolutionPlanner(
+                available = true,
+                sourceMode = contract.sourceMode.ifBlank { fallbackMode },
+                recommendedId = recommended,
+                recommendedMode = contract.recommendedMode,
+                visibleChoices = choices.filter { includeAdvanced || !it.advanced },
+                hasAdvancedChoices = choices.any { it.advanced }
+            )
+        }
+
+        fun buildLaunchOptimizationOverride(choice: NovaDisplayResolutionChoice, source: String): JSONObject {
+            return JSONObject().apply {
+                put("source", source)
+                put("confidence", "high")
+                put("display_mode", choice.targetMode)
+                put("paired_profile_applied", true)
+                put("normalization_reason", "display_resolution_planner")
+                put("preference", "auto")
+                put("preference_applied", true)
+                put("display_planner_choice", choice.id)
+            }
+        }
+
+        private fun plannerTitle(choice: PolarisGame.DisplayPlannerChoice, recommendedId: String): String {
+            return if (choice.id == recommendedId) {
+                "Best for this device"
+            } else {
+                choice.title.ifBlank { choice.id.replaceFirstChar { it.titlecase(Locale.US) } }
+            }
+        }
+
+        private fun meaningfulBadge(choice: PolarisGame.DisplayPlannerChoice, recommendedId: String): String {
+            val badge = choice.badge.takeUnless { it.equals("Press A", ignoreCase = true) }.orEmpty()
+            return when {
+                choice.id == recommendedId -> "Recommended"
+                badge.isNotBlank() -> badge
+                choice.custom -> "Advanced"
+                choice.advanced -> "Advanced"
+                else -> choice.targetMode
+            }
+        }
+    }
+}
+
+data class NovaDisplayResolutionChoice(
+    val id: String,
+    val title: String,
+    val targetMode: String,
+    val badge: String,
+    val reason: String,
+    val advanced: Boolean,
+    val custom: Boolean,
+    val safe: Boolean,
+    val recommended: Boolean
+)
+
+data class NovaPostSessionReportUiState(
+    val visible: Boolean,
+    val qualityLine: String,
+    val issueLine: String,
+    val nextLaunchLine: String,
+    val recoveryLine: String,
+    val copyDiagnostics: String
+) {
+    companion object {
+        fun from(health: PolarisSessionStatus.HealthStatus): NovaPostSessionReportUiState {
+            val grade = health.grade.ifBlank { "unknown" }
+            val issue = health.primaryIssue.ifBlank { health.issues.firstOrNull().orEmpty() }
+            val nextLaunchParts = buildList {
+                health.safeDisplayMode.ifBlank { null }?.let { add(it.replace('_', ' ')) }
+                if (health.safeTargetFps > 0.0) add("${health.safeTargetFps.roundToInt()}fps")
+                if (health.safeBitrateKbps > 0) add("${health.safeBitrateKbps / 1000} Mbps")
+                health.safeCodec.ifBlank { null }?.let { add(it.uppercase(Locale.US)) }
+            }
+            val qualityLine = "Quality: ${grade.replaceFirstChar { it.titlecase(Locale.US) }}"
+            val issueLine = "Main issue: ${issue.ifBlank { "none" }.replace('_', ' ')}"
+            val nextLaunchLine = "Next launch: ${nextLaunchParts.joinToString(" · ").ifBlank { "keep current settings" }}"
+            val recoveryLine = "Recovery: ${health.recoveryProfile.ifBlank { "none" }.replace('_', ' ')}"
+            val summary = health.summary.ifBlank { "Post-session report unavailable on this Polaris host." }
+            return NovaPostSessionReportUiState(
+                visible = summary.isNotBlank() || grade != "unknown" || issue.isNotBlank(),
+                qualityLine = qualityLine,
+                issueLine = issueLine,
+                nextLaunchLine = nextLaunchLine,
+                recoveryLine = recoveryLine,
+                copyDiagnostics = listOf(summary, qualityLine, issueLine, nextLaunchLine, recoveryLine)
+                    .filter { it.isNotBlank() }
+                    .joinToString("\n")
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -328,13 +328,14 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                     onLaunchModeSelected = ::selectLaunchMode,
                     onLaunchOptionSelected = { option ->
                         fun launchSelected(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
+                            val selectedLaunchOptimization = option.launchOptimization ?: optimizationState.rawOptimization
                             onLaunch?.invoke(
                                 currentGame.copy(mangohud = mangoHudEnabled),
                                 option.usesVirtualDisplay,
                                 mirrorDesktop,
                                 forcePrivateAfterSteamClose,
                                 profilePreference,
-                                optimizationState.rawOptimization
+                                selectedLaunchOptimization
                             )
                             launchOptionsState = null
                             dismiss()
@@ -537,19 +538,44 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         uiState: NovaGameDetailUiState
     ): NovaLaunchOptionsState? {
         val options = mutableListOf<NovaLaunchOptionItem>()
-        if (uiState.headlessAllowed) {
-            options += NovaLaunchOptionItem(
-                label = optionLabel("headless", uiState.recommendedMode),
-                usesVirtualDisplay = false,
-                recommended = uiState.recommendedMode == "headless"
-            )
-        }
-        if (uiState.virtualDisplayAllowed) {
-            options += NovaLaunchOptionItem(
-                label = optionLabel("virtual_display", uiState.recommendedMode),
-                usesVirtualDisplay = true,
-                recommended = uiState.recommendedMode == "virtual_display"
-            )
+        val fallbackMode = clientSettings?.desired?.displayMode
+            ?.takeIf { it.isNotBlank() }
+            ?: clientSettings?.effective?.displayMode
+            ?: ""
+        val planner = NovaDisplayResolutionPlanner.from(
+            contract = game.displayPlanner,
+            fallbackMode = fallbackMode,
+            includeAdvanced = true
+        )
+        if (planner.available) {
+            planner.visibleChoices.forEach { choice ->
+                options += NovaLaunchOptionItem(
+                    label = choice.title,
+                    usesVirtualDisplay = uiState.playUsesVirtualDisplay,
+                    recommended = choice.recommended,
+                    caption = listOf(choice.targetMode, choice.reason).filter { it.isNotBlank() }.joinToString(" · "),
+                    badge = choice.badge,
+                    launchOptimization = NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(
+                        choice,
+                        source = "nova_display_planner"
+                    )
+                )
+            }
+        } else {
+            if (uiState.headlessAllowed) {
+                options += NovaLaunchOptionItem(
+                    label = optionLabel("headless", uiState.recommendedMode),
+                    usesVirtualDisplay = false,
+                    recommended = uiState.recommendedMode == "headless"
+                )
+            }
+            if (uiState.virtualDisplayAllowed) {
+                options += NovaLaunchOptionItem(
+                    label = optionLabel("virtual_display", uiState.recommendedMode),
+                    usesVirtualDisplay = true,
+                    recommended = uiState.recommendedMode == "virtual_display"
+                )
+            }
         }
 
         if (options.isEmpty()) return null
@@ -1090,7 +1116,10 @@ data class NovaLaunchOptionsState(
 data class NovaLaunchOptionItem(
     val label: String,
     val usesVirtualDisplay: Boolean,
-    val recommended: Boolean
+    val recommended: Boolean,
+    val caption: String = "",
+    val badge: String = "",
+    val launchOptimization: JSONObject? = null
 )
 
 data class NovaProfilePreferenceOptionsState(
@@ -2018,19 +2047,47 @@ private fun NovaLaunchOptionsSheet(
         onDismiss = onDismiss
     ) {
         state.options.forEach { option ->
-            NovaActionButton(
-                text = option.label,
-                onClick = { onLaunch(option) },
+            NovaFocusableCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 8.dp),
-                primary = option.recommended,
-                contentDescription = option.label,
-                minHeight = 44.dp,
-                cornerRadius = 10.dp,
-                fontSize = 13.sp,
+                onClick = { onLaunch(option) },
+                contentDescription = listOf(option.label, option.badge, option.caption).filter { it.isNotBlank() }.joinToString(". "),
                 contentPadding = PaddingValues(horizontal = 12.dp, vertical = 9.dp)
-            )
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = option.label,
+                            color = LocalNovaComposeColors.current.textPrimary,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (option.caption.isNotBlank()) {
+                            Text(
+                                text = option.caption,
+                                modifier = Modifier.padding(top = 3.dp),
+                                color = LocalNovaComposeColors.current.textMuted,
+                                fontSize = 10.sp,
+                                lineHeight = 13.sp,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    if (option.recommended || option.badge.isNotBlank()) {
+                        NovaBadge(
+                            text = option.badge.ifBlank { stringResource(R.string.nova_library_filter_selected) },
+                            color = if (option.recommended) LocalNovaComposeColors.current.onAccent else LocalNovaComposeColors.current.textSecondary,
+                            backgroundColor = if (option.recommended) LocalNovaComposeColors.current.accent else LocalNovaLibrarySurfaces.current.control,
+                            borderColor = if (option.recommended) LocalNovaComposeColors.current.accent else LocalNovaLibrarySurfaces.current.tileBorder,
+                            fontSize = 10.sp
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -275,6 +275,10 @@ fun NovaQuickMenuContent(
         NovaQuickMenuDiagnosisCard(state.diagnosis)
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuStabilityCard(state.stability, callbacks)
+        if (state.postSessionReport.visible) {
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuPostSessionReportCard(state.postSessionReport)
+        }
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuInfoCard(
             action = state.sync,
@@ -483,6 +487,44 @@ private fun NovaQuickMenuSessionStrip(state: NovaQuickMenuUiState) {
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaQuickMenuPostSessionReportCard(report: NovaPostSessionReportUiState) {
+    val colors = LocalNovaComposeColors.current
+    NovaQuickMenuClickableSurface(
+        enabled = false,
+        onClick = {},
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(14.dp),
+        contentDescription = listOf(
+            "Post-session recovery report",
+            report.qualityLine,
+            report.issueLine,
+            report.nextLaunchLine,
+            report.recoveryLine
+        ).joinToString(". ")
+    ) {
+        Column {
+            Text(
+                text = "Post-session recovery report",
+                color = colors.textPrimary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            listOf(report.qualityLine, report.issueLine, report.nextLaunchLine, report.recoveryLine).forEach { line ->
+                Text(
+                    text = line,
+                    modifier = Modifier.padding(top = 4.dp),
+                    color = colors.textSecondary,
+                    fontSize = 10.sp,
+                    lineHeight = 13.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -105,6 +105,7 @@ data class NovaQuickMenuUiState(
     val advancedRows: List<NovaQuickMenuAction>,
     val quickKeys: List<NovaQuickMenuAction>,
     val diagnosis: NovaQuickMenuDiagnosisState,
+    val postSessionReport: NovaPostSessionReportUiState,
     val hudOpacity: NovaQuickMenuHudOpacityState,
     val overlayRows: List<NovaQuickMenuAction>,
     val controlRows: List<NovaQuickMenuAction>,
@@ -158,6 +159,7 @@ data class NovaQuickMenuUiState(
                 effectiveAdaptiveEnabled
             val currentGame = currentGameName?.takeIf { it.isNotBlank() }
             val currentUuid = currentGameUuid?.takeIf { it.isNotBlank() }
+            val postSessionReport = NovaPostSessionReportUiState.from(status?.health ?: PolarisSessionStatus.HealthStatus())
             val mangoToggleAllowed = canAdjustHostTuning && currentUuid != null
             val mangoRisk = status?.game.equals("Steam Big Picture", ignoreCase = true)
 
@@ -415,6 +417,7 @@ data class NovaQuickMenuUiState(
                 advancedRows = listOf(aiRow, clearRow, mangoRow),
                 quickKeys = quickKeyActions(context),
                 diagnosis = diagnosis,
+                postSessionReport = postSessionReport,
                 hudOpacity = hudOpacity,
                 overlayRows = overlays,
                 controlRows = controls,

--- a/app/src/test/java/com/papi/nova/ui/NovaDisplayResolutionPlannerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDisplayResolutionPlannerTest.kt
@@ -1,0 +1,110 @@
+package com.papi.nova.ui
+
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaDisplayResolutionPlannerTest {
+    @Test
+    fun plannerBuildsHandheldFirstPresetRowsAndHidesAdvancedUntilCustom() {
+        val planner = NovaDisplayResolutionPlanner.from(
+            contract = PolarisGame.DisplayPlannerContract(
+                available = true,
+                sourceMode = "2560x1600x90",
+                recommendedId = "balanced",
+                choices = listOf(
+                    PolarisGame.DisplayPlannerChoice(id = "balanced", title = "Best for this device", targetMode = "1920x1200x90", badge = "Best for this device"),
+                    PolarisGame.DisplayPlannerChoice(id = "sharp", title = "Sharp / Supersampled", targetMode = "3840x2400x90", badge = "1.5x supersample", advanced = true),
+                    PolarisGame.DisplayPlannerChoice(id = "performance", title = "Performance", targetMode = "1280x800x90", badge = "0.5x downscale"),
+                    PolarisGame.DisplayPlannerChoice(id = "custom", title = "Custom", targetMode = "2560x1600x90", badge = "Advanced", custom = true, advanced = true)
+                )
+            ),
+            fallbackMode = "2560x1600x90",
+            includeAdvanced = false
+        )
+
+        assertEquals("balanced", planner.recommendedId)
+        assertEquals(listOf("Best for this device", "Performance"), planner.visibleChoices.map { it.title })
+        assertTrue(planner.visibleChoices.none { it.badge.equals("Press A", ignoreCase = true) })
+        assertTrue(planner.hasAdvancedChoices)
+    }
+
+    @Test
+    fun fallbackPlannerKeepsOlderPolarisHostsCompatible() {
+        val planner = NovaDisplayResolutionPlanner.from(
+            contract = null,
+            fallbackMode = "1920x1080x60",
+            includeAdvanced = false
+        )
+
+        assertFalse(planner.available)
+        assertEquals(emptyList<NovaDisplayResolutionChoice>(), planner.visibleChoices)
+    }
+
+    @Test
+    fun selectedPresetBuildsLaunchOptimizationOverrideForGameStartup() {
+        val choice = NovaDisplayResolutionChoice(
+            id = "performance",
+            title = "Performance",
+            targetMode = "1280x800x90",
+            badge = "0.5x downscale",
+            reason = "Favor frame pacing.",
+            advanced = false,
+            custom = false,
+            safe = true,
+            recommended = false
+        )
+
+        val json = NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(choice, source = "nova_display_planner")
+
+        assertEquals("1280x800x90", json.optString("display_mode"))
+        assertTrue(json.optBoolean("paired_profile_applied"))
+        assertEquals("nova_display_planner", json.optString("source"))
+        assertEquals("display_resolution_planner", json.optString("normalization_reason"))
+    }
+
+    @Test
+    fun postSessionReportSummarizesQualityIssueSuggestedLaunchAndRecoveryProfile() {
+        val report = NovaPostSessionReportUiState.from(
+            health = com.papi.nova.api.PolarisSessionStatus.HealthStatus(
+                grade = "watch",
+                summary = "Network jitter is the most likely source of hitching.",
+                primaryIssue = "network_jitter",
+                recommendations = listOf("Lower bitrate or keep Adaptive Bitrate enabled."),
+                safeDisplayMode = "headless",
+                safeBitrateKbps = 16000,
+                safeTargetFps = 60.0,
+                recoveryProfile = "network_jitter",
+                relaunchRecommended = true
+            )
+        )
+
+        assertEquals("Quality: Watch", report.qualityLine)
+        assertEquals("Main issue: network jitter", report.issueLine)
+        assertEquals("Next launch: headless · 60fps · 16 Mbps", report.nextLaunchLine)
+        assertEquals("Recovery: network jitter", report.recoveryLine)
+        assertTrue(report.copyDiagnostics.contains("Network jitter"))
+        assertTrue(report.visible)
+    }
+
+    @Test
+    fun parserToleratesLegacyHealthWithoutReportFields() {
+        val report = NovaPostSessionReportUiState.from(
+            health = com.papi.nova.api.PolarisSessionStatus.HealthStatus(summary = "Session looks steady.")
+        )
+
+        assertEquals("Quality: Unknown", report.qualityLine)
+        assertEquals("Main issue: none", report.issueLine)
+        assertEquals("Next launch: keep current settings", report.nextLaunchLine)
+        assertEquals("Recovery: none", report.recoveryLine)
+        assertTrue(report.visible)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -343,6 +343,39 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun displayPlannerAndPostSessionReportStayControllerFirstAndLowNoise() {
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt")
+        val quickContent = readSource("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt")
+        val planner = readSource("src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt")
+        val optionSheet = detail.section(
+            "private fun NovaLaunchOptionsSheet(",
+            "@Composable\nprivate fun NovaProfilePreferenceSheet"
+        )
+
+        assertTrue(
+            "Launch Options should switch to Polaris display planner rows when display_planner is advertised",
+            detail.contains("game.displayPlanner") &&
+                detail.contains("NovaDisplayResolutionPlanner.from(") &&
+                detail.contains("NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(")
+        )
+        assertTrue(
+            "Planner choices should keep DPAD focus on meaningful cards rather than redundant Press A badges",
+            optionSheet.contains("NovaFocusableCard(") &&
+                optionSheet.contains("option.caption") &&
+                !optionSheet.contains("Press A") &&
+                planner.contains("takeUnless { it.equals(\"Press A\", ignoreCase = true) }")
+        )
+        assertTrue(
+            "Post-session recovery report should surface quality, issue, next launch, and recovery copy in Command Center",
+            quickContent.contains("NovaQuickMenuPostSessionReportCard") &&
+                quickContent.contains("report.qualityLine") &&
+                quickContent.contains("report.issueLine") &&
+                quickContent.contains("report.nextLaunchLine") &&
+                quickContent.contains("report.recoveryLine")
+        )
+    }
+
+    @Test
     fun streamStartupOverlayWaitsForNativeConnectionStartedBeforeDismissal() {
         val game = readSource("src/main/java/com/papi/nova/Game.kt")
         val overlay = readSource("src/main/java/com/papi/nova/ui/SessionProgressOverlay.kt")

--- a/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
+++ b/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
@@ -24,8 +24,45 @@ data class PolarisGame(
     @SerialName("mangohud") val mangohud: Boolean = false,
     @SerialName("hdr_supported") val hdrSupported: Boolean = false,
     @SerialName("launch_mode") val launchMode: LaunchModeContract? = null,
-    @SerialName("steam_launch") val steamLaunch: SteamLaunchContract? = null
+    @SerialName("steam_launch") val steamLaunch: SteamLaunchContract? = null,
+    @SerialName("display_planner") val displayPlanner: DisplayPlannerContract? = null
 ) {
+    @Serializable
+    data class DisplayPlannerContract(
+        @SerialName("available") val available: Boolean = false,
+        @SerialName("source_mode") val sourceMode: String = "",
+        @SerialName("source_aspect_ratio") val sourceAspectRatio: String = "",
+        @SerialName("source_fps") val sourceFps: Double = 0.0,
+        @SerialName("recommended_id") val recommendedId: String = "",
+        @SerialName("recommended_title") val recommendedTitle: String = "",
+        @SerialName("recommended_mode") val recommendedMode: String = "",
+        @SerialName("choices") val choices: List<DisplayPlannerChoice> = emptyList(),
+        @SerialName("advanced_scale_factors") val advancedScaleFactors: List<DisplayPlannerScaleChoice> = emptyList()
+    )
+
+    @Serializable
+    data class DisplayPlannerChoice(
+        @SerialName("id") val id: String = "",
+        @SerialName("title") val title: String = "",
+        @SerialName("intent") val intent: String = "",
+        @SerialName("target_mode") val targetMode: String = "",
+        @SerialName("badge") val badge: String = "",
+        @SerialName("reason") val reason: String = "",
+        @SerialName("advanced") val advanced: Boolean = false,
+        @SerialName("custom") val custom: Boolean = false,
+        @SerialName("safe") val safe: Boolean = true,
+        @SerialName("hidden") val hidden: Boolean = false,
+        @SerialName("scale_factor") val scaleFactor: Double = 1.0,
+        @SerialName("aspect_ratio") val aspectRatio: String = ""
+    )
+
+    @Serializable
+    data class DisplayPlannerScaleChoice(
+        @SerialName("scale_factor") val scaleFactor: Double = 1.0,
+        @SerialName("label") val label: String = "",
+        @SerialName("target_mode") val targetMode: String = "",
+        @SerialName("safe") val safe: Boolean = true
+    )
     @Serializable
     data class LaunchModeContract(
         @SerialName("preferred_mode") val preferredMode: String = "",

--- a/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
+++ b/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
@@ -89,8 +89,44 @@ class PolarisGameContractTest {
         assertFalse(game.mangohud)
         assertEquals(null, game.launchMode)
         assertEquals(null, game.steamLaunch)
+        assertEquals(null, game.displayPlanner)
         assertEquals("direct", game.steamLaunchMode)
     }
+
+    @Test
+    fun decodesDisplayResolutionPlannerContractWhenAdvertised() {
+        val game = json.decodeFromString<PolarisGame>(
+            """
+            {
+              "id":"game-planner",
+              "app_id":42,
+              "name":"Planner Game",
+              "display_planner":{
+                "available":true,
+                "source_mode":"2560x1600x90",
+                "source_aspect_ratio":"8:5",
+                "recommended_id":"balanced",
+                "recommended_title":"Best for this device",
+                "recommended_mode":"1920x1200x90",
+                "choices":[
+                  {"id":"balanced","title":"Best for this device","target_mode":"1920x1200x90","badge":"Best for this device","reason":"Preserve aspect ratio."},
+                  {"id":"sharp","title":"Sharp / Supersampled","target_mode":"3840x2400x90","badge":"1.5x supersample","advanced":true,"safe":true}
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val planner = game.displayPlanner!!
+        assertTrue(planner.available)
+        assertEquals("2560x1600x90", planner.sourceMode)
+        assertEquals("balanced", planner.recommendedId)
+        assertEquals("Best for this device", planner.recommendedTitle)
+        assertEquals("1920x1200x90", planner.recommendedMode)
+        assertEquals(listOf("balanced", "sharp"), planner.choices.map { it.id })
+        assertTrue(planner.choices.last().advanced)
+    }
+
 
     @Test
     fun serializesLaunchModeAndSteamLaunchUsingServerSnakeCaseKeys() {


### PR DESCRIPTION
## Summary
- parse Polaris display_planner contracts in shared Nova/Polaris game metadata
- show handheld-first display/resolution planner launch rows with meaningful badges and DPAD-focusable cards
- add Command Center post-session recovery report summary copy from Polaris health data

## Test Plan
- ./gradlew :app:testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.ui.NovaDisplayResolutionPlannerTest' --tests 'com.papi.nova.ui.NovaLaunchSourceGuardTest.displayPlannerAndPostSessionReportStayControllerFirstAndLowNoise' :shared:polaris:model:jvmTest :app:lintNonRoot_gameDebug :app:assembleNonRoot_gameDebug

Notes: initialized Moonlight native submodules in the clean worktree before assemble/lint.