### PR TITLE
chore(release): prepare Nova v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+## 1.3.0 - 2026-07-11
+
+Nova 1.3.0 is the matched Polaris 1.3 client release. It adds a self-service stream doctor, display planning, a signature-validating in-app updater, and a denser controller-friendly dashboard across portrait, landscape, Android TV, and external-display use.
+
+### Highlights
+
+- Adds **Diagnose This Stream** with HOST / NET / CLIENT findings and actionable recovery guidance backed by Polaris session diagnostics.
+- Adds display-resolution planning and launch presets so requested modes, host capabilities, and stream-display choices are visible before launch.
+- Adds an in-app Update Center that checks GitHub release metadata, validates package identity, signing certificate, and version before handing installation to Android's package installer.
+- Refines Private Headless Stream, Host Virtual Display, Mirror Desktop, Steam Launch, and Direct launch wording while preserving Polaris display-mode intent.
+- Reworks the server dashboard for denser one-screen portrait use, stronger landscape hierarchy, and predictable DPAD focus across cockpit actions.
+- Hardens Command Center initial and follow-up focus so controllers and Android TV remotes land on useful actions consistently.
+- Improves post-session recovery and terminal-event handling so stale events do not hijack a resumed or newly launched session.
+- Preserves the selected app language across reconnects and refreshed host sessions.
+- Surfaces AMD host and capture-path truth alongside the existing Polaris diagnostics.
+- Routes Thor companion controls and stream audio to the selected external display while retaining safe handheld fallbacks.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.0 and versionCode 32.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksum files through the GitHub release workflow.
+- Targets Polaris v1.3.0 while retaining standard Moonlight-compatible host support.
+
+### Validation notes
+
+- Current master CI is green across APK build, CodeQL, public hygiene, and dependency submission before this release-prep branch.
+- Final publication validation uses the tagged ARM64 release APK for Library, preflight, live stream, Command Center, Update Center, and cleanup smoke evidence.
+
 ## 1.2.1 - 2026-07-04
 
 Nova 1.2.1 is a focused post-1.2 polish patch. It keeps the Polaris 1.2 streaming contract intact while tightening the public theme language, Library option persistence, README showcase assets, and Retroid smoke diagnostics for handheld dogfooding.

--- a/README.md
+++ b/README.md
@@ -105,17 +105,19 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.2.1
+## Latest release: v1.3.0
 
-Nova v1.2.1 is a small post-1.2 polish release for Polaris v1.2.x users. It keeps the streaming contract stable while tightening Portable Chrome language, Miami theme personality, Library option persistence, public showcase media, and Retroid smoke diagnostics.
+Nova v1.3.0 is the matched Polaris 1.3 handheld and Android TV release: stronger self-service diagnostics, display planning, safe in-app updates, and a denser controller-friendly cockpit from portrait handhelds to external displays.
 
-- **Portable Chrome copy cleanup**: the public picker/settings language now centers on Portable Chrome, smoked graphite, dim silver, and PlayStation-symbol accents.
-- **Miami Nebula guardrails**: flamingo pink stays the hero accent, with cyan and aqua acting as supporting neon-water contrast.
-- **Persistent Library Options**: sorting, layout, poster-title visibility, and source filters survive restarts and controller shortcut changes.
-- **Showcase refresh**: README media and positioning were refreshed with lighter WebP/GIF assets and clearer install/readiness copy.
-- **Retroid diagnostics**: UI dump tooling now reports whether failures came from device state, package launch, or the accessibility dump path.
-- **Release packaging**: public GitHub Releases ship ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode is bumped to 31 so Obtainium/GitHub installs update cleanly.
-- **Release validation**: final publication should use the tagged ARM64 release APK for fresh Retroid Library, preflight, live stream, Command Center, and cleanup smoke evidence.
+- **Diagnose This Stream**: HOST / NET / CLIENT findings turn Polaris session evidence into actionable recovery guidance inside Nova.
+- **Display planner and launch presets**: requested modes, host capability, and stream-display choices are visible before launch instead of becoming post-launch folklore.
+- **In-app Update Center**: Nova can check GitHub release metadata, validate APK package identity, signing certificate, and version before handing installation to Android's package installer.
+- **Launch-mode clarity**: Private Headless Stream, Host Virtual Display, Mirror Desktop, Steam Launch, and Direct retain their Polaris intent with clearer copy.
+- **Portrait and landscape cockpit polish**: the dashboard fits more useful state on one screen while hardening Command Center DPAD focus across handheld and Android TV layouts.
+- **External-display and recovery hardening**: Thor companion controls and audio follow the selected stream display, and stale terminal events no longer hijack resumed sessions.
+- **Host truth and persistence**: AMD capture-path details stay visible, and the selected app language survives reconnects and refreshed host sessions.
+- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 32 keeps Obtainium and manual installs on a clean upgrade path.
+- **Release validation**: publication uses the tagged ARM64 release APK for fresh Library, preflight, live stream, Command Center, Update Center, and cleanup smoke evidence.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.2.1"
-        versionCode = 31
+        versionName "1.3.0"
+        versionCode = 32
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
@@ -22,20 +22,20 @@ class NovaUpdateInstallerSecurityTest {
     @Test
     fun downloadedApkValidationBlocksPackageSignatureAndDowngradeMismatches() {
         val release = NovaUpdateRelease(
-            tagName = "v1.3.0",
-            versionName = "1.3.0",
-            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.0",
+            tagName = "v1.3.1",
+            versionName = "1.3.1",
+            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.1",
             apkAssetName = "Nova-Android-arm64-v8a.apk",
-            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.0/Nova-Android-arm64-v8a.apk"
+            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.1/Nova-Android-arm64-v8a.apk"
         )
 
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 31L,
+                currentVersionCode = 32L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 32L,
+                downloadedVersionCode = 33L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Valid
@@ -44,10 +44,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 31L,
+                currentVersionCode = 32L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova.debug",
-                downloadedVersionCode = 32L,
+                downloadedVersionCode = 33L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -56,10 +56,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 31L,
+                currentVersionCode = 32L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 32L,
+                downloadedVersionCode = 33L,
                 downloadedSignerDigests = setOf("BB"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -68,10 +68,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 31L,
+                currentVersionCode = 32L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 31L,
+                downloadedVersionCode = 32L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid

--- a/fastlane/metadata/android/en-US/changelogs/32.txt
+++ b/fastlane/metadata/android/en-US/changelogs/32.txt
@@ -1,0 +1,7 @@
+Nova 1.3.0
+
+- Adds Diagnose This Stream with HOST / NET / CLIENT recovery guidance.
+- Adds display planning, launch presets, and clearer Polaris launch-mode choices.
+- Adds a signature-validating in-app Update Center.
+- Refines portrait, Android TV, DPAD focus, Thor external-display, language, and AMD host behavior.
+- Ships signed ARM64, ARMv7, and x86_64 APKs with SHA-256 checksums.


### PR DESCRIPTION
## Summary
- bump Nova to versionName 1.3.0 and versionCode 32
- promote the diagnostics, display planner, updater, dashboard, DPAD, Thor, locale, and AMD host-truth work into the public changelog
- add Fastlane changelog 32 and refresh the README release headline
- advance the updater security fixture to the next hypothetical upgrade after the version bump

## Test plan
- [x] lintNonRoot_gameDebug
- [x] testNonRoot_gameDebugUnitTest
- [x] assembleNonRoot_gameRelease (ARM64, ARMv7, x86_64)
- [x] scripts/check-public-docs.sh
- [x] git diff --check