### PR TITLE
fix(release): write portable APK checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,12 @@ jobs:
           shopt -s nullglob
 
           for apk in "${APK_ASSET_DIR}"/*.apk; do
-            sha256sum "$apk" > "$apk.sha256"
+            apk_dir="$(dirname "$apk")"
+            apk_name="$(basename "$apk")"
+            (
+              cd "$apk_dir"
+              sha256sum "$apk_name" > "$apk_name.sha256"
+            )
           done
 
       - name: Upload APK artifact

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -151,6 +151,31 @@ class NovaComposeBuildConfigurationTest {
     }
 
     @Test
+    fun releaseWorkflowWritesPortableChecksumBasenames() {
+        val workflow = String(
+            Files.readAllBytes(Paths.get("../.github/workflows/build.yml")),
+            StandardCharsets.UTF_8
+        )
+
+        assertTrue(
+            "release checksum generation should derive the public APK basename",
+            workflow.contains("apk_name=\"\$(basename \"\$apk\")\"")
+        )
+        assertTrue(
+            "release checksum generation should run inside the asset directory",
+            workflow.contains("cd \"\$apk_dir\"")
+        )
+        assertTrue(
+            "release checksum files should contain portable APK basenames instead of runner-absolute paths",
+            workflow.contains("sha256sum \"\$apk_name\" > \"\$apk_name.sha256\"")
+        )
+        assertFalse(
+            "release checksum files should not embed the GitHub runner path",
+            workflow.contains("sha256sum \"\$apk\" > \"\$apk.sha256\"")
+        )
+    }
+
+    @Test
     fun baselineProfileGenerationTargetsNovaReleaseJourneys() {
         val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
         val appBuild = String(Files.readAllBytes(Paths.get("build.gradle")), StandardCharsets.UTF_8)


### PR DESCRIPTION
## Summary
- generate release checksum sidecars from APK basenames instead of GitHub runner-absolute paths
- run checksum generation inside the release asset directory so downloaded `sha256sum -c` works anywhere
- add a source regression guard for the portable checksum contract

The published v1.3.0 checksum assets were already repaired manually; this fixes future tag workflows at the source.

## Test plan
- [x] RED: focused regression test failed against the old workflow
- [x] GREEN: focused regression test passed after the workflow fix
- [x] `lintNonRoot_gameDebug testNonRoot_gameDebugUnitTest`
- [x] shell simulation moved generated assets to a new directory and `sha256sum -c` passed
- [x] GitHub Actions YAML parsed with PyYAML
- [x] `git diff --check`
- [x] added-line security scan