### PR TITLE
fix(hud): polish performance layout and zero opacity

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaHudPerformanceLayoutComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaHudPerformanceLayoutComposeTest.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.papi.nova.ui.compose.NovaComposeTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class NovaHudPerformanceLayoutComposeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun performancePrimaryAndDetailRowsDoNotOverlap() {
+        composeRule.setContent {
+            NovaComposeTheme {
+                NovaStreamHudContent(
+                    state = NovaHudUiState.preview(NovaHudMode.PERFORMANCE),
+                    opacityScale = 0f
+                )
+            }
+        }
+
+        val primaryBounds = composeRule
+            .onNodeWithTag(NOVA_HUD_PERFORMANCE_PRIMARY_TAG)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val detailBounds = composeRule
+            .onNodeWithTag(NOVA_HUD_PERFORMANCE_DETAILS_TAG)
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue("FPS primary row should have measurable bounds", primaryBounds.width > 0f)
+        assertTrue("Performance detail row should have measurable bounds", detailBounds.width > 0f)
+        assertTrue(
+            "FPS/target/sparkline row must end before latency/bitrate/resolution/codec details begin",
+            primaryBounds.bottom <= detailBounds.top
+        )
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
@@ -59,6 +60,9 @@ fun NovaStreamHudContent(
 }
 
 private val LocalNovaHudOpacityScale = compositionLocalOf { 1f }
+
+internal const val NOVA_HUD_PERFORMANCE_PRIMARY_TAG = "nova_hud_performance_primary"
+internal const val NOVA_HUD_PERFORMANCE_DETAILS_TAG = "nova_hud_performance_details"
 
 @Composable
 private fun rememberHudOpacityScale(opacityScale: Float): Float {
@@ -168,24 +172,39 @@ private fun NovaStreamHudPerformance(state: NovaHudUiState, modifier: Modifier) 
         cornerRadius = 16.dp,
         padding = 8.dp
     ) {
+        HudPerformancePrimaryRow(state)
+        HudPerformanceDetailRow(state)
+        HudCompactDiagnosticStrip(state)
+        HudEventBreadcrumb(state.eventBreadcrumbLabel)
+    }
+}
+
+@Composable
+private fun HudPerformancePrimaryRow(state: NovaHudUiState) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(NOVA_HUD_PERFORMANCE_PRIMARY_TAG),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        HudStatusDot(state.statusTone, height = 20.dp)
+        Text(
+            text = state.autopilotCompactLabel,
+            color = state.statusTone.hudColor(),
+            fontSize = 9.sp,
+            lineHeight = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier
+                .padding(start = 5.dp)
+                .widthIn(min = 28.dp, max = 42.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        HudDivider(horizontalPadding = 5.dp)
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.Bottom
         ) {
-            HudStatusDot(state.statusTone, height = 20.dp)
-            Text(
-                text = state.autopilotCompactLabel,
-                color = state.statusTone.hudColor(),
-                fontSize = 9.sp,
-                lineHeight = 11.sp,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier
-                    .padding(start = 5.dp)
-                    .widthIn(min = 28.dp, max = 42.dp),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            HudDivider(horizontalPadding = 5.dp)
             HudValueText(state.fpsLabel, state.fpsTone, size = 15)
             if (state.targetFpsLabel.isNotBlank()) {
                 Text(
@@ -199,21 +218,52 @@ private fun NovaStreamHudPerformance(state: NovaHudUiState, modifier: Modifier) 
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            HudCompactText(state.latencyLabel, state.latencyTone, minWidth = 34.dp, startPadding = 5.dp)
-            HudCompactText(state.bitrateLabel, NovaHudTone.INFO, minWidth = 34.dp, startPadding = 5.dp)
-            HudCompactText(state.resolutionLabel, NovaHudTone.MUTED, minWidth = 34.dp, startPadding = 5.dp)
-            HudCompactText(state.codecLabel, NovaHudTone.MUTED, minWidth = 28.dp, startPadding = 5.dp)
-            NovaHudSparkline(
-                samples = state.sparklineSamples,
-                tone = state.fpsTone,
-                modifier = Modifier
-                    .padding(start = 5.dp)
-                    .width(40.dp)
-                    .height(15.dp)
-            )
         }
-        HudCompactDiagnosticStrip(state)
-        HudEventBreadcrumb(state.eventBreadcrumbLabel)
+        NovaHudSparkline(
+            samples = state.sparklineSamples,
+            tone = state.fpsTone,
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .width(48.dp)
+                .height(15.dp)
+        )
+    }
+}
+
+@Composable
+private fun HudPerformanceDetailRow(state: NovaHudUiState) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 5.dp)
+            .testTag(NOVA_HUD_PERFORMANCE_DETAILS_TAG),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        HudCompactText(
+            state.latencyLabel,
+            state.latencyTone,
+            modifier = Modifier.weight(1f),
+            startPadding = 0.dp
+        )
+        HudCompactText(
+            state.bitrateLabel,
+            NovaHudTone.INFO,
+            modifier = Modifier.weight(1f),
+            startPadding = 0.dp
+        )
+        HudCompactText(
+            state.resolutionLabel,
+            NovaHudTone.MUTED,
+            modifier = Modifier.weight(1f),
+            startPadding = 0.dp
+        )
+        HudCompactText(
+            state.codecLabel,
+            NovaHudTone.MUTED,
+            modifier = Modifier.weight(1f),
+            startPadding = 0.dp
+        )
     }
 }
 
@@ -280,7 +330,7 @@ private fun HudPanel(
     val panelShape = RoundedCornerShape(cornerRadius)
     Column(
         modifier = modifier
-            .shadow(16.dp, panelShape, clip = false)
+            .shadow(16.dp * hudOpacityScale, panelShape, clip = false)
             .clip(panelShape)
             .background(surfaces.panel.copy(alpha = NovaInGameOverlayAlpha.GlassPanel * hudOpacityScale))
             .border(
@@ -457,6 +507,7 @@ private fun HudValueText(text: String, tone: NovaHudTone, size: Int) {
 private fun HudCompactText(
     text: String,
     tone: NovaHudTone,
+    modifier: Modifier = Modifier,
     minWidth: Dp = 0.dp,
     startPadding: Dp = 9.dp
 ) {
@@ -468,7 +519,7 @@ private fun HudCompactText(
         fontWeight = FontWeight.SemiBold,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
-        modifier = Modifier
+        modifier = modifier
             .padding(start = startPadding)
             .widthIn(min = minWidth)
     )

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2100,6 +2100,62 @@ class NovaComposeSourceGuardTest {
         )
     }
 
+    @Test
+    fun streamHudPerformanceSeparatesFpsFromDetailMetrics() {
+        val source = readNovaStreamHudContent()
+        val performanceHud = source.section(
+            "private fun NovaStreamHudPerformance(",
+            "@Composable\nprivate fun NovaStreamHudMinimal("
+        )
+
+        assertTrue(
+            "FPS display should place the FPS/target/sparkline and added detail metrics in separate bounded rows",
+            performanceHud.contains("HudPerformancePrimaryRow(state)") &&
+                performanceHud.contains("HudPerformanceDetailRow(state)")
+        )
+
+        val primaryRow = source.section(
+            "private fun HudPerformancePrimaryRow(",
+            "@Composable\nprivate fun HudPerformanceDetailRow("
+        )
+        val detailRow = source.section(
+            "private fun HudPerformanceDetailRow(",
+            "@Composable\nprivate fun NovaStreamHudMinimal("
+        )
+
+        assertTrue(primaryRow.contains("state.fpsLabel"))
+        assertTrue(primaryRow.contains("state.targetFpsLabel"))
+        assertTrue(primaryRow.contains("NovaHudSparkline("))
+        assertFalse(primaryRow.contains("state.latencyLabel"))
+        assertFalse(primaryRow.contains("state.bitrateLabel"))
+        assertFalse(primaryRow.contains("state.resolutionLabel"))
+        assertFalse(primaryRow.contains("state.codecLabel"))
+
+        assertTrue(detailRow.contains("state.latencyLabel"))
+        assertTrue(detailRow.contains("state.bitrateLabel"))
+        assertTrue(detailRow.contains("state.resolutionLabel"))
+        assertTrue(detailRow.contains("state.codecLabel"))
+        assertFalse(detailRow.contains("state.fpsLabel"))
+    }
+
+    @Test
+    fun streamHudZeroOpacityRemovesPanelShadowChrome() {
+        val source = readNovaStreamHudContent()
+        val panel = source.section(
+            "private fun HudPanel(",
+            "@Composable\nprivate fun HudDiagnosticStrip("
+        )
+
+        assertTrue(
+            "0% NovaHUD opacity should remove the panel shadow instead of leaving faint ghost boxes",
+            panel.contains(".shadow(16.dp * hudOpacityScale, panelShape, clip = false)")
+        )
+        assertFalse(
+            "NovaHUD panel shadow must not remain fully opaque when glass opacity is 0%",
+            panel.contains(".shadow(16.dp, panelShape, clip = false)")
+        )
+    }
+
     private fun readNovaLibraryActivity(): String =
         readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
 


### PR DESCRIPTION
## Summary
- split the performance HUD into a dedicated FPS/target/sparkline row and a separate latency/bitrate/resolution/codec row
- scale panel shadow elevation with the selected HUD opacity so the 0% preset leaves no faint glass box
- keep telemetry text and the sparkline signal readable while removing only panel chrome
- add source guards and a physical-device Compose geometry test for row separation

## Why
The added performance details were competing horizontally with the FPS display, and the panel shadow remained visible even when the opacity preset was set to 0%.

## Verification
- targeted source guards: RED before implementation, GREEN after
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest.performanceHudSeparatesFpsFromDetailMetrics' --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest.zeroOpacityScalesPanelShadowToZero' --tests 'com.papi.nova.ui.NovaComposeSourceGuardTest.streamHudUsesCompactBoundedLabels'`
- `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug testNonRoot_gameDebugUnitTest`
- `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug`
- `./gradlew -PnovaAbis=arm64-v8a connectedNonRoot_gameDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.papi.nova.ui.NovaHudPerformanceLayoutComposeTest`
  - 1/1 passed on physical Retroid Pocket 6 (Android 13)
- `bash scripts/check-public-docs.sh`
- `git diff --check`

## Safety
- based on clean `origin/master` in an isolated worktree
- does not modify the existing dirty Nova checkout
