### PR TITLE
fix: keep NovaHUD headline FPS readable

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaHudPerformanceLayoutComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaHudPerformanceLayoutComposeTest.kt
@@ -1,8 +1,14 @@
 package com.papi.nova.ui
 
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.text.TextLayoutResult
 import com.papi.nova.ui.compose.NovaComposeTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -38,4 +44,37 @@ class NovaHudPerformanceLayoutComposeTest {
             primaryBounds.bottom <= detailBounds.top
         )
     }
+
+    @Test
+    fun debugHeadlineFpsDoesNotEllipsizeWithLongStreamMode() {
+        composeRule.setContent {
+            NovaComposeTheme {
+                NovaStreamHudContent(
+                    state = NovaHudUiState.preview(NovaHudMode.DEBUG).copy(
+                        fpsLabel = "120",
+                        targetFpsLabel = "TGT 120",
+                        streamModeLabel = "Private Stream · GPU-native DMA-BUF 8b EXP",
+                        autopilotHudLabel = "Auto Safe"
+                    ),
+                    opacityScale = 0.9f
+                )
+            }
+        }
+
+        val layoutResults = mutableListOf<TextLayoutResult>()
+        composeRule
+            .onNodeWithText("120", useUnmergedTree = true)
+            .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action ->
+                assertTrue("FPS text layout result should be available", action(layoutResults))
+            }
+
+        val fpsLayout = layoutResults.single()
+        assertEquals(
+            "Every headline FPS character must remain visible",
+            fpsLayout.layoutInput.text.length,
+            fpsLayout.getLineEnd(0, visibleEnd = true)
+        )
+        assertFalse("Headline FPS must not be ellipsized", fpsLayout.isLineEllipsized(0))
+    }
+
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -106,7 +106,10 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
                     }
                 }
             }
-            Column(horizontalAlignment = Alignment.End) {
+            Column(
+                modifier = Modifier.widthIn(max = 96.dp),
+                horizontalAlignment = Alignment.End
+            ) {
                 Text(
                     text = state.autopilotHudLabel,
                     color = state.statusTone.hudColor(),


### PR DESCRIPTION
## Summary

- keep the complete three-digit headline FPS readable in the 236dp DEBUG NovaHUD
- constrain the lower-priority stream metadata column to 96dp so it yields width before the FPS lane
- add an RP6 Compose regression test using `TextLayoutResult` to require every FPS character visible with no ellipsis

## Verification

- [x] TDD RED reproduced the defect: expected 3 visible FPS characters, got 1
- [x] `NovaHudPerformanceLayoutComposeTest`: 2/2 passed on physical Retroid Pocket 6
- [x] `NovaComposeSourceGuardTest`: 59/59 passed
- [x] `assembleNonRoot_gameDebug` passed for ARM64
- [x] `lintNonRoot_gameDebug` completed successfully against the project baseline
- [x] physical RP6 live-stream proof: DEBUG showed `114 TGT 120`; Minimal showed `118`; Performance showed `120/120`
- [x] Polaris returned to idle with zero test-session residuals
- [x] independent Codex and delegated reviews found no correctness or security issues

## Scope

This PR does not deploy or release Nova. The APK still identifies as version `1.3.0` / code `32`; release gating remains separate.

