### PR TITLE
fix(library): match Watch streams to active owner profile

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -144,20 +144,32 @@ data class NovaLibraryActiveSessionUiState(
 
     companion object {
         private val STREAM_MODE_PATTERN = Regex("""^\s*(\d+)x(\d+)x(\d+(?:\.\d+)?)\s*$""")
+        private val STREAM_RESOLUTION_PATTERN = Regex("""^\s*(\d+)x(\d+)\s*$""")
 
         fun from(status: PolarisSessionStatus?): NovaLibraryActiveSessionUiState? {
             if (status == null || status.isShuttingDown || status.gameId <= 0) {
                 return null
             }
-            if (!status.isResumable) {
+            if (!status.isResumable || (!status.ownedByClient && !status.streamingActive)) {
                 return null
             }
 
-            val streamProfile = parseStreamProfile(
+            val fallbackStreamProfile = parseStreamProfile(
                 status.syncStatus.applied.displayMode
                     .ifBlank { status.syncStatus.effective.displayMode }
                     .ifBlank { status.profileState.currentProfile.displayMode }
             )
+            val streamProfile = if (!status.ownedByClient && status.streamingActive) {
+                val liveResolution = parseStreamResolution(status.capture.resolution)
+                StreamProfile(
+                    width = liveResolution.width.takeIf { it > 0 } ?: fallbackStreamProfile.width,
+                    height = liveResolution.height.takeIf { it > 0 } ?: fallbackStreamProfile.height,
+                    fps = status.encoder.sessionTargetFps.toFloat().takeIf { it > 0f }
+                        ?: fallbackStreamProfile.fps
+                )
+            } else {
+                fallbackStreamProfile
+            }
             return NovaLibraryActiveSessionUiState(
                 gameId = status.gameId,
                 gameUuid = status.gameUuid,
@@ -181,6 +193,14 @@ data class NovaLibraryActiveSessionUiState(
                 width = match.groupValues[1].toIntOrNull() ?: 0,
                 height = match.groupValues[2].toIntOrNull() ?: 0,
                 fps = match.groupValues[3].toFloatOrNull() ?: 0f
+            )
+        }
+
+        private fun parseStreamResolution(resolution: String): StreamProfile {
+            val match = STREAM_RESOLUTION_PATTERN.matchEntire(resolution) ?: return StreamProfile()
+            return StreamProfile(
+                width = match.groupValues[1].toIntOrNull() ?: 0,
+                height = match.groupValues[2].toIntOrNull() ?: 0
             )
         }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -787,10 +787,28 @@ class NovaLibraryUiStateTest {
     }
 
     @Test
+    fun activeSessionHidesPausedSessionOwnedByOtherClient() {
+        val session = NovaLibraryActiveSessionUiState.from(
+            PolarisSessionStatus(
+                state = "paused",
+                streamingActive = false,
+                game = "MOUSE: P.I. For Hire",
+                gameId = 2416450,
+                gameUuid = "mouse-uuid",
+                ownerDeviceName = "RetroidPocket6 (3)",
+                ownedByClient = false
+            )
+        )
+
+        assertNull(session)
+    }
+
+    @Test
     fun activeSessionUsesWatchPolicyForOtherClientOwner() {
         val session = NovaLibraryActiveSessionUiState.from(
             PolarisSessionStatus(
                 state = "streaming",
+                streamingActive = true,
                 game = "Desktop",
                 gameId = 42,
                 gameUuid = "desktop-uuid",
@@ -820,6 +838,38 @@ class NovaLibraryUiStateTest {
         assertEquals(1920, session.streamWidth)
         assertEquals(1080, session.streamHeight)
         assertEquals(30.0f, session.streamFps, 0.001f)
+    }
+
+    @Test
+    fun activeSessionUsesLiveOwnerProfileInsteadOfViewerSyncProfileForWatch() {
+        val session = NovaLibraryActiveSessionUiState.from(
+            PolarisSessionStatus(
+                state = "streaming",
+                streamingActive = true,
+                game = "MOUSE: P.I. For Hire",
+                gameId = 2416450,
+                gameUuid = "mouse-uuid",
+                ownerDeviceName = "RetroidPocket6 (4)",
+                ownedByClient = false,
+                syncStatus = PolarisSessionStatus.SyncStatus(
+                    applied = PolarisSessionStatus.SyncValues(
+                        displayMode = "2560x1600x60"
+                    )
+                ),
+                capture = PolarisSessionStatus.CaptureStatus(
+                    resolution = "1920x1080"
+                ),
+                encoder = PolarisSessionStatus.EncoderStatus(
+                    sessionTargetFps = 120.0
+                )
+            )
+        )
+
+        requireNotNull(session)
+        assertTrue(session.watchOnly)
+        assertEquals(1920, session.streamWidth)
+        assertEquals(1080, session.streamHeight)
+        assertEquals(120.0f, session.streamFps, 0.001f)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- hide Watch Stream for foreign-owned paused sessions that have no active owner stream
- derive Watch launch resolution and FPS from the owner’s live capture/encoder status instead of the viewer’s synchronized display preference
- add regression coverage for paused-session eligibility and mismatched owner/viewer stream profiles

## Root cause

Nova treated any resumable foreign-owned session as watchable and built the Watch resume mode from client-scoped sync settings. A paused session has no owner stream to join, while a viewer-local mode can differ from the active owner profile and be rejected by Polaris’ strict Watch admission check.

## Verification

- `./gradlew --no-daemon testDebugUnitTest`
- `./gradlew --no-daemon -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug`
- `git diff --check`
- independent pre-commit review passed after strengthening the profile-mismatch fixture

## Device smoke

Verified with two independently paired debug clients: a headless Android emulator as owner and a Retroid Pocket 6 as viewer.

- Retroid Library showed `WATCH ACTIVE STREAM` with the owner’s live `1920x1080 60fps` profile
- Nova sent a Watch resume request with `mode=1920x1080x60` and `watch=1`
- Polaris pinned the viewer to the active owner profile and reported two active sessions
- Retroid rendered live MOUSE: P.I. For Hire video with video/audio startup and no 412, black frame, or error overlay
- both test client sessions were disconnected after the smoke