### PR TITLE
chore(release): prepare Nova v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 1.3.1 - 2026-07-11
+
+Nova 1.3.1 is a focused follow-up to the matched Polaris 1.3 client release. It tightens Watch-stream ownership, keeps NovaHUD readable at Retroid-class widths, and makes the published checksum files portable for normal download-and-verify workflows.
+
+### Highlights
+
+- Shows **Watch active stream** only when a foreign-owned session has a live owner stream, and derives Watch launch resolution and FPS from the owner's active capture/encoder profile instead of the viewer's local display preference.
+- Refines NovaHUD Performance and Debug layouts so the headline FPS remains prominent, detail metrics stay visually separate, and the 0% opacity preset removes panel chrome without hiding the text.
+- Preserves complete three-digit headline FPS values in the compact Debug HUD by constraining lower-priority stream metadata before the FPS lane is allowed to ellipsize.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.1 and versionCode 33.
+- Writes portable SHA-256 sidecars for the signed ARM64, ARMv7, and x86_64 APK assets so `sha256sum -c` works from a clean download directory.
+
+### Validation notes
+
+- The Watch-stream fix was exercised with an independently paired owner emulator and Retroid Pocket 6 viewer using the owner's live `1920x1080 60fps` profile.
+- NovaHUD Minimal, Performance, and Debug modes were verified during a physical RP6 live stream, including a complete `114 TGT 120` Debug headline without FPS clipping.
+- Final publication validation must use the tagged ARM64 release APK for package identity, Library, preflight, live stream, physical controller, Command Center, NovaHUD, and cleanup proof.
+
 ## 1.3.0 - 2026-07-11
 
 Nova 1.3.0 is the matched Polaris 1.3 client release. It adds a self-service stream doctor, display planning, a signature-validating in-app updater, and a denser controller-friendly dashboard across portrait, landscape, Android TV, and external-display use.

--- a/README.md
+++ b/README.md
@@ -105,19 +105,16 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.3.0
+## Latest release: v1.3.1
 
-Nova v1.3.0 is the matched Polaris 1.3 handheld and Android TV release: stronger self-service diagnostics, display planning, safe in-app updates, and a denser controller-friendly cockpit from portrait handhelds to external displays.
+Nova v1.3.1 is a focused follow-up to the Polaris 1.3 client release: safer Watch-stream admission, cleaner NovaHUD presentation on Retroid-class displays, and portable checksum files for public APK verification.
 
-- **Diagnose This Stream**: HOST / NET / CLIENT findings turn Polaris session evidence into actionable recovery guidance inside Nova.
-- **Display planner and launch presets**: requested modes, host capability, and stream-display choices are visible before launch instead of becoming post-launch folklore.
-- **In-app Update Center**: Nova can check GitHub release metadata, validate APK package identity, signing certificate, and version before handing installation to Android's package installer.
-- **Launch-mode clarity**: Private Headless Stream, Host Virtual Display, Mirror Desktop, Steam Launch, and Direct retain their Polaris intent with clearer copy.
-- **Portrait and landscape cockpit polish**: the dashboard fits more useful state on one screen while hardening Command Center DPAD focus across handheld and Android TV layouts.
-- **External-display and recovery hardening**: Thor companion controls and audio follow the selected stream display, and stale terminal events no longer hijack resumed sessions.
-- **Host truth and persistence**: AMD capture-path details stay visible, and the selected app language survives reconnects and refreshed host sessions.
-- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 32 keeps Obtainium and manual installs on a clean upgrade path.
-- **Release validation**: publication uses the tagged ARM64 release APK for fresh Library, preflight, live stream, Command Center, Update Center, and cleanup smoke evidence.
+- **Watch the real owner stream**: Nova offers Watch only for a live foreign-owned stream and requests the owner's active resolution and FPS profile instead of a mismatched viewer-local mode.
+- **Clearer NovaHUD modes**: Performance and Debug preserve the headline FPS, separate lower-priority detail metrics, and make the 0% opacity preset truly text-only.
+- **Three-digit FPS readability**: compact Debug HUD layouts keep values such as `114 TGT 120` visible by constraining stream metadata before the FPS lane ellipsizes.
+- **Portable checksums**: every public APK sidecar is generated with a relative filename so the documented `sha256sum -c` workflow works from a clean download directory.
+- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 33 keeps Obtainium and manual installs on a clean upgrade path.
+- **Release validation**: publication uses the tagged ARM64 release APK for package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ while you play, and what is safe to do when you leave.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v121) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v131) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -114,7 +114,7 @@ Nova v1.3.1 is a focused follow-up to the Polaris 1.3 client release: safer Watc
 - **Three-digit FPS readability**: compact Debug HUD layouts keep values such as `114 TGT 120` visible by constraining stream metadata before the FPS lane ellipsizes.
 - **Portable checksums**: every public APK sidecar is generated with a relative filename so the documented `sha256sum -c` workflow works from a clean download directory.
 - **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 33 keeps Obtainium and manual installs on a clean upgrade path.
-- **Release validation**: publication uses the tagged ARM64 release APK for package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
+- **Release validation**: final publication validation must use the tagged ARM64 release APK for package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.0"
-        versionCode = 32
+        versionName "1.3.1"
+        versionCode = 33
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
@@ -22,20 +22,20 @@ class NovaUpdateInstallerSecurityTest {
     @Test
     fun downloadedApkValidationBlocksPackageSignatureAndDowngradeMismatches() {
         val release = NovaUpdateRelease(
-            tagName = "v1.3.1",
-            versionName = "1.3.1",
-            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.1",
+            tagName = "v1.3.2",
+            versionName = "1.3.2",
+            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.2",
             apkAssetName = "Nova-Android-arm64-v8a.apk",
-            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.1/Nova-Android-arm64-v8a.apk"
+            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.2/Nova-Android-arm64-v8a.apk"
         )
 
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 32L,
+                currentVersionCode = 33L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 33L,
+                downloadedVersionCode = 34L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Valid
@@ -44,10 +44,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 32L,
+                currentVersionCode = 33L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova.debug",
-                downloadedVersionCode = 33L,
+                downloadedVersionCode = 34L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -56,10 +56,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 32L,
+                currentVersionCode = 33L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 33L,
+                downloadedVersionCode = 34L,
                 downloadedSignerDigests = setOf("BB"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -68,10 +68,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 32L,
+                currentVersionCode = 33L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 32L,
+                downloadedVersionCode = 33L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid

--- a/fastlane/metadata/android/en-US/changelogs/33.txt
+++ b/fastlane/metadata/android/en-US/changelogs/33.txt
@@ -1,0 +1,6 @@
+Nova 1.3.1
+
+- Fixes Watch Stream eligibility and uses the active owner's live resolution and FPS profile.
+- Improves NovaHUD Performance and Debug readability, including true text-only 0% opacity.
+- Keeps complete three-digit FPS values visible in the compact Debug HUD.
+- Ships portable SHA-256 checksum files for every published APK.


### PR DESCRIPTION
## Summary

- bump Nova to `versionName 1.3.1` and `versionCode 33`
- add v1.3.1 release notes to the main changelog, README latest-release block, and Fastlane changelog `33.txt`
- advance the updater security fixture to the next hypothetical upgrade (`1.3.2` / code `34`)

## Included since v1.3.0

- portable APK checksum sidecars that work with `sha256sum -c` from a clean directory
- NovaHUD Performance/Debug readability and true text-only 0% opacity
- complete three-digit Debug headline FPS rendering at compact Retroid widths
- Watch-stream eligibility and launch profile aligned to the live owner stream

## Verification

- [x] fail-on-error `lintNonRoot_gameDebug`
- [x] `testNonRoot_gameDebugUnitTest`: 751 tests, 0 failures/errors
- [x] Retroid smoke/native-submodule Python helpers: 51 tests, 0 failures
- [x] all-ABI `assembleNonRoot_gameRelease`
- [x] ARM64, ARMv7, and x86_64 release APKs all report `com.papi.nova`, version `1.3.1` / code `33`
- [x] focused post-commit `NovaUpdateInstallerSecurityTest`: 2/2 passed
- [x] staged static/security scan clean
- [x] independent Codex review found no actionable issues
- [x] delegated review findings resolved: latest-release anchor updated and tagged-APK validation wording made explicitly pending

## Remaining fail-closed release gates

This PR does **not** tag, publish, deploy, or release Nova. After merge, the final signed ARM64 candidate still needs package-identity and physical RP6 Library/preflight/stream/controller/Command Center/NovaHUD/cleanup proof. Physical Thor companion-display/controller validation remains required unless routing-only surrogate proof is explicitly accepted.