### PR TITLE
feat(display): host companion controls in Presentation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,13 +161,6 @@
             <meta-data android:name="WindowManagerPreference:FreeformWindowSize" android:value="system-default" />
             <meta-data android:name="WindowManagerPreference:FreeformWindowOrientation" android:value="landscape" />
         </activity>
-        <activity android:name=".utils.ExternalDisplayControlActivity"
-            android:exported="false"
-            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
-            android:excludeFromRecents="true"
-            android:launchMode="singleInstance"
-            android:taskAffinity=""
-            android:theme="@style/ExternalDisplayControllerTheme"/>
         <activity android:name=".utils.GameDisplayLaunchTrampolineActivity"
             android:exported="false"
             android:noHistory="true"

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -52,7 +52,7 @@ import com.papi.nova.ui.StreamContainer
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
-import com.papi.nova.utils.ExternalDisplayControlActivity
+import com.papi.nova.utils.ExternalDisplayControlPresentation
 import com.papi.nova.utils.GameDisplayLaunchTrampolineActivity
 import com.papi.nova.utils.MouseModeOption
 import com.papi.nova.utils.PanZoomHandler
@@ -222,6 +222,7 @@ private var cursorVisible:Boolean = false
 private var currentMouseModeIndex:Int = 0
 private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
 private var companionControlDisplayId:Int = INVALID_DISPLAY_ID
+private var externalDisplayControlPresentation:ExternalDisplayControlPresentation? = null
 private var externalDisplayListener:DisplayManager.DisplayListener? = null
 @Volatile private var lastClientPresentationRefreshRate:Float = 0f
 @Volatile private var lastClientPresentationDisplayModeId:Int = 0
@@ -424,10 +425,40 @@ private fun launchCompanionControlsIfAvailable() {
 val companionDisplay:Display? = getCompanionControlDisplay()
 if (::prefConfig.isInitialized && prefConfig.enableFullExDisplay && companionDisplay != null)
 {
-companionControlDisplayId = companionDisplay.getDisplayId()
-StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl(this, streamingDisplayId)
+val companionDisplayId:Int = companionDisplay.getDisplayId()
+val currentPresentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
+if (currentPresentation == null || !currentPresentation.isShowing || companionControlDisplayId != companionDisplayId)
+{
+currentPresentation?.dismiss()
+val presentation = ExternalDisplayControlPresentation(this, companionDisplay)
+presentation.setOnDismissListener {
+if (externalDisplayControlPresentation === presentation)
+{
+externalDisplayControlPresentation = null
+companionControlDisplayId = INVALID_DISPLAY_ID
+}
+}
+externalDisplayControlPresentation = presentation
+companionControlDisplayId = companionDisplayId
+try
+{
+presentation.show()
+ExternalDisplayControlPresentation.ensureCompanionControlsNotification(this)
+}
+catch (e:WindowManager.InvalidDisplayException)
+{
+presentation.disposeAfterFailedShow()
+externalDisplayControlPresentation = null
+companionControlDisplayId = INVALID_DISPLAY_ID
+LimeLog.warning("Nova: Android companion presentation unavailable display_id=$companionDisplayId")
+}
+}
 listenForExternalDisplayRemoval()
 }
+}
+
+fun showCompanionControls() {
+runOnUiThread { launchCompanionControlsIfAvailable() }
 }
 
 @SuppressLint("InlinedApi")
@@ -1467,7 +1498,12 @@ if (externalDisplayListener != null) return
 
 val displayManager:DisplayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 val listener:DisplayManager.DisplayListener = object : DisplayManager.DisplayListener {
-override fun onDisplayAdded(displayId:Int) = Unit
+override fun onDisplayAdded(displayId:Int) {
+if (isStreamActive && !isFinishing()) {
+LimeLog.info("Nova: Android companion display added id=$displayId stream_id=$streamingDisplayId")
+showCompanionControls()
+}
+}
 override fun onDisplayChanged(displayId:Int) = Unit
 override fun onDisplayRemoved(displayId:Int) {
 handleDisplayRemoved(displayId)
@@ -1486,29 +1522,24 @@ externalDisplayListener = null
 
 private fun closeCompanionControls() {
 NotificationManagerCompat.from(baseContext)
-.cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
-ExternalDisplayControlActivity.closeExternalDisplayControl()
+.cancel(ExternalDisplayControlPresentation.SECONDARY_SCREEN_NOTIFICATION_ID)
+val presentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
+externalDisplayControlPresentation = null
 companionControlDisplayId = INVALID_DISPLAY_ID
+presentation?.dismiss()
 }
 
 private fun handleDisplayRemoved(removedDisplayId:Int) {
-NotificationManagerCompat.from(baseContext)
-.cancel(ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
-
 when {
 removedDisplayId == streamingDisplayId -> {
-ExternalDisplayControlActivity.closeExternalDisplayControl()
+closeCompanionControls()
 finish()
 }
-removedDisplayId == companionControlDisplayId -> {
-ExternalDisplayControlActivity.closeExternalDisplayControl()
-companionControlDisplayId = INVALID_DISPLAY_ID
-}
+removedDisplayId == companionControlDisplayId -> closeCompanionControls()
 else -> {
 if (getCompanionControlDisplay() == null)
 {
-ExternalDisplayControlActivity.closeExternalDisplayControl()
-companionControlDisplayId = INVALID_DISPLAY_ID
+closeCompanionControls()
 }
 }
 }
@@ -1600,9 +1631,9 @@ return
 keyBoardController!!.toggleVisibility()
 }
  fun toggleFullKeyboard() {
-if (isOnExternalDisplay)
+if (externalDisplayControlPresentation?.isShowing == true)
 {
-ExternalDisplayControlActivity.toggleFullKeyboard()
+externalDisplayControlPresentation?.toggleFullKeyboard()
 return
 }
 if (keyBoardLayoutController == null)
@@ -2535,6 +2566,19 @@ streamContainer!!.onDestroy()
 }
 }
 
+override fun onRequestPermissionsResult(requestCode:Int, permissions:Array<String>, grantResults:IntArray) {
+super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+if (requestCode == ExternalDisplayControlPresentation.NOTIFICATION_PERMISSION_REQUEST_CODE)
+{
+val granted:Boolean = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+ExternalDisplayControlPresentation.onCompanionNotificationPermissionResult(
+this,
+granted,
+!isFinishing() && isStreamActive && shouldLaunchCompanionControls()
+)
+}
+}
+
 override fun onNewIntent(intent:Intent?) {
 super.onNewIntent(intent)
 
@@ -3294,9 +3338,9 @@ return null
 }
 }
 override fun toggleKeyboard() {
-if (isOnExternalDisplay)
+if (externalDisplayControlPresentation?.isShowing == true)
 {
-ExternalDisplayControlActivity.toggleKeyboard()
+externalDisplayControlPresentation?.toggleKeyboard()
 }
 else
 {
@@ -5141,7 +5185,7 @@ Toast.makeText(this, getString(R.string.pan_zoom_mode_disabled), Toast.LENGTH_SH
 }
 updateZoomButtonAppearance()
 
-ExternalDisplayControlActivity.instance?.toggleZoomMode(false)
+externalDisplayControlPresentation?.toggleZoomMode(false)
 }
  fun rotateScreen() {
 if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE)
@@ -5210,7 +5254,8 @@ applyMouseMode(savedMouseModeIndex)
 }
 }
 // Converted JavaDoc marker retained as a line comment.
-     fun selectMouseMode(context:Context?) {
+     @JvmOverloads
+     fun selectMouseMode(context:Context?, dialogWindowType:Int? = null, dialogWindowToken:IBinder? = null) {
 var allModes:Array<String?>? = getResources().getStringArray(R.array.mouse_mode_names)
 
 var allowedLabels:Set<String> = HashSet(Arrays.asList(
@@ -5240,7 +5285,7 @@ labels[i] = options[i].label
 }
 var optionArray:Array<MouseModeOption> = options.toTypedArray()
 
-AlertDialog.Builder(context)
+val mouseModeDialog = AlertDialog.Builder(context)
 .setTitle(getString(R.string.game_menu_select_mouse_mode))
 .setItems(labels, { dialog, which->
 dialog!!.dismiss()
@@ -5261,7 +5306,11 @@ ProfilesManager.getInstance().getOverlayingSharedPreferences(this)
 }
 } })
 .create()
-.show()
+dialogWindowType?.let { windowType ->
+mouseModeDialog.window?.setType(windowType)
+}
+mouseModeDialog.window?.attributes?.token = dialogWindowToken
+mouseModeDialog.show()
 }
 
  //本地鼠标光标切换
@@ -6070,16 +6119,16 @@ Handler(Looper.getMainLooper()).postDelayed({ GameDisplayLaunchTrampolineActivit
 overridePendingTransition(0, 0) }, 900)
 }
  fun quit() {
-val context:Context = if (isOnExternalDisplay && ExternalDisplayControlActivity.instance != null)
-{
-ExternalDisplayControlActivity.instance ?: this
-}
-else
-{
-this
-}
+val companionPresentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
+?.takeIf { it.isShowing }
+val context:Context = companionPresentation?.companionDialogContext ?: this
 
 val sheet = BottomSheetDialog(context)
+if (companionPresentation != null)
+{
+sheet.window?.setType(companionPresentation.companionDialogWindowType)
+sheet.window?.attributes?.token = companionPresentation.companionDialogWindowToken()
+}
 val container = NovaSheetChrome.createSheetContainer(context)
 
 val title = TextView(context).apply {
@@ -6126,9 +6175,9 @@ sheet.show()
 NovaSheetChrome.applyBottomSheetChrome(sheet, container)
 }
 override fun showGameMenu(device:GameInputDevice?) {
-if (isOnExternalDisplay)
+if (externalDisplayControlPresentation?.isShowing == true)
 {
-ExternalDisplayControlActivity.toggleGameMenu()
+externalDisplayControlPresentation?.toggleGameMenu()
 }
 else
 {

--- a/app/src/main/java/com/papi/nova/GameMenu.kt
+++ b/app/src/main/java/com/papi/nova/GameMenu.kt
@@ -2,9 +2,11 @@ package com.papi.nova
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
 import android.os.Handler
+import android.os.IBinder
 import android.os.Looper
 import android.view.ContextThemeWrapper
 import android.view.Gravity
@@ -22,9 +24,11 @@ import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.utils.KeyMapper
 import java.util.concurrent.atomic.AtomicInteger
 
-class GameMenu(
+class GameMenu @JvmOverloads constructor(
     private val game: Game,
     private val dialogScreenContext: Context,
+    private val dialogWindowType: Int? = null,
+    private val dialogWindowTokenProvider: (() -> IBinder?)? = null,
 ) : Game.GameMenuCallbacks {
     constructor(game: Game) : this(game, game)
 
@@ -37,6 +41,16 @@ class GameMenu(
     }
 
     private var currentSheet: BottomSheetDialog? = null
+
+    private fun applyDialogWindowType(dialog: Dialog) {
+        val window = dialog.window ?: return
+        dialogWindowType?.let { windowType ->
+            window.setType(windowType)
+        }
+        dialogWindowTokenProvider?.invoke()?.let { token ->
+            window.attributes.token = token
+        }
+    }
 
     private fun getString(id: Int): String = game.resources.getString(id)
 
@@ -147,6 +161,7 @@ class GameMenu(
                 currentSheet = null
             }
         }
+        applyDialogWindowType(sheet)
         sheet.show()
         NovaSheetChrome.applyBottomSheetChrome(
             sheet,
@@ -280,7 +295,7 @@ class GameMenu(
         val options = ArrayList<MenuOption>()
         if (game.allowChangeMouseMode) {
             options.add(MenuOption(getString(R.string.game_menu_select_mouse_mode), true, Runnable {
-                game.selectMouseMode(dialogScreenContext)
+                game.selectMouseMode(dialogScreenContext, dialogWindowType, dialogWindowTokenProvider?.invoke())
             }))
         }
 
@@ -358,6 +373,7 @@ class GameMenu(
                     .setTitle(R.string.game_dialog_title_server_cmd_empty)
                     .setMessage(R.string.game_dialog_message_server_cmd_empty)
                     .create()
+                applyDialogWindowType(serverCommandDialog)
                 NovaSheetChrome.applyAlertDialogChrome(serverCommandDialog)
                 serverCommandDialog.show()
             } else {

--- a/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
+++ b/app/src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt
@@ -1,22 +1,13 @@
 package com.papi.nova
 
 import android.app.ActivityManager
-import android.app.ActivityOptions
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
-import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.view.Display
-import androidx.annotation.RequiresApi
-import com.papi.nova.preferences.PreferenceConfiguration
-import com.papi.nova.utils.ExternalDisplayControlActivity
-import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
 
 class StartExternalDisplayControlReceiver : BroadcastReceiver() {
-    @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != ACTION_START_EXTERNAL_DISPLAY_CONTROL) {
             return
@@ -34,51 +25,46 @@ class StartExternalDisplayControlReceiver : BroadcastReceiver() {
         private var isTimeoutActive = false
 
         @JvmStatic
+        @Deprecated("Companion controls are now Game-owned; use requestFocusToGameActivity(true)")
+        @Suppress("UNUSED_PARAMETER")
         fun requestFocusToExternalDisplayControl(context: Context) {
-            requestFocusToExternalDisplayControl(
-                context,
-                Game.instance?.streamingDisplayIdForCompanion() ?: Display.DEFAULT_DISPLAY,
-            )
+            requestFocusToGameActivity(true)
         }
 
         @JvmStatic
+        @Deprecated("Companion controls are now Game-owned; use requestFocusToGameActivity(true)")
+        @Suppress("UNUSED_PARAMETER")
         fun requestFocusToExternalDisplayControl(context: Context, streamDisplayId: Int) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                val prefConfig = PreferenceConfiguration.readPreferences(context)
-                val controlsDisplay = getAndroidCompanionDisplay(context, prefConfig, streamDisplayId)
-                    ?: return
-
-                val intentTouchpad = Intent(context, ExternalDisplayControlActivity::class.java)
-                intentTouchpad.addFlags(
-                    Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                        Intent.FLAG_ACTIVITY_CLEAR_TOP,
-                )
-                val optionsDefault: Bundle = ActivityOptions.makeBasic()
-                    .setLaunchDisplayId(controlsDisplay.displayId)
-                    .toBundle()
-                context.startActivity(intentTouchpad, optionsDefault)
-            }
+            requestFocusToGameActivity(true)
         }
 
         @JvmStatic
-        fun requestFocusToGameActivity(focusExternalDisplayControl: Boolean) {
+        fun requestFocusToGameActivity(showCompanionControls: Boolean) {
             if (isTimeoutActive) {
                 return
             }
 
             isTimeoutActive = true
-
             val game = Game.instance
             if (game != null) {
-                if (focusExternalDisplayControl) {
-                    requestFocusToExternalDisplayControl(game, game.streamingDisplayIdForCompanion())
-                }
                 val activityManager = game.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
                 activityManager?.moveTaskToFront(game.taskId, 0)
             }
 
-            handler.postDelayed({ isTimeoutActive = false }, TIMEOUT_MS)
+            handler.postDelayed(
+                {
+                    if (
+                        showCompanionControls &&
+                        game != null &&
+                        Game.instance === game &&
+                        !game.isFinishing
+                    ) {
+                        game.showCompanionControls()
+                    }
+                    isTimeoutActive = false
+                },
+                TIMEOUT_MS,
+            )
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
@@ -6,28 +6,29 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.app.Presentation
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.os.IBinder
 import android.os.Looper
+import android.view.Display
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.Toast
-import androidx.annotation.NonNull
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -45,11 +46,13 @@ import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.ExternalControllerView
 
 /**
- * A standalone Activity providing a full-screen touchpad controller for the secondary display.
- * It creates its own UI programmatically and hosts the GameMenu for in-game options.
+ * Game-owned controller surface rendered on the derived companion display without creating
+ * another Activity/task that can become Android's top-resumed audio owner.
  */
-class ExternalDisplayControlActivity :
-    AppCompatActivity(),
+class ExternalDisplayControlPresentation(
+    private val game: Game,
+    display: Display,
+) : Presentation(game, display, R.style.ExternalDisplayControllerTheme),
     View.OnKeyListener,
     KeyBoardLayoutController.ViewCallbacks {
 
@@ -62,33 +65,37 @@ class ExternalDisplayControlActivity :
     private var isKeyboardVisible = false
 
     private val handler = Handler(Looper.getMainLooper())
-    private var failCount = 0
     private var dimScreenRunnable = Runnable {}
     private var originalBrightness = -1f // -1 = use system default
 
     private var gameMenu: GameMenu? = null
+    private val presentationWindow: Window
+        get() = requireNotNull(window)
+
+    val companionDialogContext: Context by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            game.createDisplayContext(display).createWindowContext(
+                WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG,
+                null,
+            )
+        } else {
+            context
+        }
+    }
+
+    val companionDialogWindowType: Int
+        get() = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
+
+    fun companionDialogWindowToken(): IBinder? = presentationWindow.decorView.windowToken
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        instance = this
-        prefConfig = PreferenceConfiguration.readPreferences(this)
-
+        prefConfig = PreferenceConfiguration.readPreferences(context)
         initViews()
     }
 
     private fun initViews() {
-        if (Game.instance == null) {
-            if (failCount > 10) {
-                Toast.makeText(this, getString(R.string.no_game_instance), Toast.LENGTH_LONG).show()
-                finish()
-            }
-            handler.postDelayed({ initViews() }, 500)
-            failCount++
-            return
-        }
-
-        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+        val windowInsetsController = WindowCompat.getInsetsController(presentationWindow, presentationWindow.decorView)
 
         windowInsetsController.systemBarsBehavior =
             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
@@ -97,8 +104,8 @@ class ExternalDisplayControlActivity :
         windowInsetsController.hide(WindowInsetsCompat.Type.navigationBars())
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { view, insets ->
+            WindowCompat.setDecorFitsSystemWindows(presentationWindow, false)
+            ViewCompat.setOnApplyWindowInsetsListener(presentationWindow.decorView) { view, insets ->
                 val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
                 updateKeyboardVisibility(
                     imeVisible ||
@@ -110,7 +117,6 @@ class ExternalDisplayControlActivity :
 
         initializeComponents()
         createProgrammaticUI()
-        checkNotificationPermission()
         initTouchEventHandling()
         setupInactivityTimeoutForBrightness()
         StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
@@ -120,28 +126,31 @@ class ExternalDisplayControlActivity :
     private fun initTouchEventHandling() {
         rootLayout.setOnTouchListener { view, event ->
             handleUserActivity()
-            Game.instance?.handleMotionEvent(view, event)
+            game.handleMotionEvent(view, event)
             true
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (!isGameInstanceAvailable() && gameMenu != null) {
-            finish()
+    override fun onStart() {
+        super.onStart()
+        if (game.isFinishing) {
+            dismiss()
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        if (!isGameInstanceAvailable()) {
-            finish()
-        }
+    private fun disposeTransientState() {
+        handler.removeCallbacksAndMessages(null)
+        gameMenu?.hideMenu()
+        restoreBrightnessIfNeeded()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        instance = null
+    fun disposeAfterFailedShow() {
+        disposeTransientState()
+    }
+
+    override fun onStop() {
+        disposeTransientState()
+        super.onStop()
     }
 
     override fun onKeyboardControllerVisibilityChange(visible: Boolean) {
@@ -150,12 +159,12 @@ class ExternalDisplayControlActivity :
 
     @SuppressLint("ClickableViewAccessibility")
     private fun setupInactivityTimeoutForBrightness() {
-        originalBrightness = window.attributes.screenBrightness
+        originalBrightness = presentationWindow.attributes.screenBrightness
 
         dimScreenRunnable = Runnable {
-            val layout = window.attributes
+            val layout = presentationWindow.attributes
             layout.screenBrightness = 0.0f
-            window.attributes = layout
+            presentationWindow.attributes = layout
         }
 
         resetInactivityTimer()
@@ -174,10 +183,10 @@ class ExternalDisplayControlActivity :
     }
 
     private fun restoreBrightnessIfNeeded() {
-        val layout = window.attributes
+        val layout = presentationWindow.attributes
         if (layout.screenBrightness == 0.0f) {
             layout.screenBrightness = originalBrightness
-            window.attributes = layout
+            presentationWindow.attributes = layout
         }
     }
 
@@ -195,20 +204,19 @@ class ExternalDisplayControlActivity :
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        val game = Game.instance
-        if (game != null) {
-            game.handleFocusChange(hasFocus)
-        } else {
-            finish()
+        LimeLog.info(
+            "Nova: Android display focus role=presentation display_id=${display.displayId} window=$hasFocus",
+        )
+        if (game.isFinishing) {
+            dismiss()
         }
     }
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
-        val game = Game.instance
-        if (game != null && game.isKeyboardLayoutVisible) {
+        if (game.isKeyboardLayoutVisible) {
             toggleFullKeyboard()
-        } else if (gameMenu != null && gameMenu?.isMenuOpen() == false && game != null) {
+        } else if (gameMenu != null && gameMenu?.isMenuOpen() == false) {
             game.onBackPressed()
         } else {
             @Suppress("DEPRECATION")
@@ -216,81 +224,52 @@ class ExternalDisplayControlActivity :
         }
     }
 
-    private fun isGameInstanceAvailable(): Boolean {
-        return Game.instance != null
-    }
-
     private fun initializeComponents() {
-        gameMenu = GameMenu(Game.instance ?: return, this)
-    }
-
-    override fun onConfigurationChanged(@NonNull newConfig: Configuration) {
-        Game.instance?.onConfigurationChanged(newConfig)
-        super.onConfigurationChanged(newConfig)
+        gameMenu = GameMenu(game, companionDialogContext, companionDialogWindowType, ::companionDialogWindowToken)
     }
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
-        val game = Game.instance
-        if (game != null) {
-            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-            return game.onGenericMotionEvent(event)
-        }
-        return false
+        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        return game.onGenericMotionEvent(event)
     }
 
+    @Suppress("DEPRECATION")
     override fun onKey(view: View, keyCode: Int, keyEvent: KeyEvent): Boolean {
-        val game = Game.instance
-        if (game != null) {
-            if (keyEvent.deviceId >= 0) {
-                StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-            }
-            return when (keyEvent.action) {
-                KeyEvent.ACTION_DOWN -> game.handleKeyDown(keyEvent)
-                KeyEvent.ACTION_UP -> game.handleKeyUp(keyEvent)
-                KeyEvent.ACTION_MULTIPLE -> game.handleKeyMultiple(keyEvent)
-                else -> false
-            }
+        if (keyEvent.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
         }
-
-        return false
+        return when (keyEvent.action) {
+            KeyEvent.ACTION_DOWN -> game.handleKeyDown(keyEvent)
+            KeyEvent.ACTION_UP -> game.handleKeyUp(keyEvent)
+            KeyEvent.ACTION_MULTIPLE -> game.handleKeyMultiple(keyEvent)
+            else -> false
+        }
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        val game = Game.instance
-        if (game != null) {
-            if (event.deviceId >= 0) {
-                StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-            }
-            return game.onKeyDown(keyCode, event)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
         }
-        return false
+        return game.onKeyDown(keyCode, event)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        val game = Game.instance
-        if (game != null) {
-            if (event.deviceId >= 0) {
-                StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-            }
-            return game.onKeyUp(keyCode, event)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
         }
-        return false
+        return game.onKeyUp(keyCode, event)
     }
 
     override fun onKeyMultiple(keyCode: Int, repeatCount: Int, event: KeyEvent): Boolean {
-        val game = Game.instance
-        if (game != null) {
-            if (event.deviceId >= 0) {
-                StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-            }
-            return game.onKeyMultiple(keyCode, repeatCount, event)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
         }
-        return false
+        return game.onKeyMultiple(keyCode, repeatCount, event)
     }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun createProgrammaticUI() {
-        rootLayout = ExternalControllerView(this)
+        rootLayout = ExternalControllerView(context)
         rootLayout.layoutParams = ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -300,7 +279,7 @@ class ExternalDisplayControlActivity :
             rootLayout.isFocusedByDefault = true
         }
 
-        rootLayout.setInputCallbacks(Game.instance)
+        rootLayout.setInputCallbacks(game)
         rootLayout.setCommitTextEnabled(prefConfig.enableCommitText)
 
         setContentView(rootLayout)
@@ -308,7 +287,7 @@ class ExternalDisplayControlActivity :
         val topLeftButtons = createButtonContainer(Gravity.TOP or Gravity.START)
         topLeftButtons.isFocusable = false
         zoomButton = createImageButton(R.drawable.ic_zoom_toggle) { toggleZoomMode(true) }
-        if (Game.instance?.isZoomModeEnabled == true) {
+        if (game.isZoomModeEnabled) {
             zoomButton.alpha = 1.0f
         } else {
             zoomButton.alpha = 0.5f
@@ -319,7 +298,7 @@ class ExternalDisplayControlActivity :
         val topRightButtons = createButtonContainer(Gravity.TOP or Gravity.END)
         topRightButtons.isFocusable = false
         topRightButtons.addView(createImageButton(R.drawable.ic_menu_external) { showGameMenu() })
-        topRightButtons.addView(createImageButton(R.drawable.ic_close_external) { finish() })
+        topRightButtons.addView(createImageButton(R.drawable.ic_close_external) { dismiss() })
         rootLayout.addView(topRightButtons)
 
         val bottomLeftButton = createButtonContainer(Gravity.BOTTOM or Gravity.START)
@@ -333,14 +312,15 @@ class ExternalDisplayControlActivity :
         rootLayout.addView(bottomRightButton)
     }
 
+    @Suppress("DEPRECATION")
     private fun _toggleKeyboard() {
-        LimeLog.info("Toggling keyboard overlay on ExternalDisplayControlActivity")
-        val inputManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        LimeLog.info("Toggling keyboard overlay on ExternalDisplayControlPresentation")
+        val inputManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         inputManager.toggleSoftInput(0, 0)
     }
 
     private fun initFullKeyboard(prefConfig: PreferenceConfiguration) {
-        keyBoardLayoutController = KeyBoardLayoutController(rootLayout, this, prefConfig).also {
+        keyBoardLayoutController = KeyBoardLayoutController(rootLayout, context, prefConfig).also {
             it.setViewCallbacks(this)
             it.refreshLayout()
             it.show()
@@ -357,13 +337,10 @@ class ExternalDisplayControlActivity :
     }
 
     fun toggleZoomMode(callGame: Boolean) {
-        val game = Game.instance
-        if (game != null) {
-            if (callGame) {
-                game.toggleZoomMode()
-            } else {
-                zoomButton.alpha = if (game.isZoomModeEnabled) 1.0f else 0.5f
-            }
+        if (callGame) {
+            game.toggleZoomMode()
+        } else {
+            zoomButton.alpha = if (game.isZoomModeEnabled) 1.0f else 0.5f
         }
     }
 
@@ -372,7 +349,7 @@ class ExternalDisplayControlActivity :
     }
 
     private fun createButtonContainer(gravity: Int): LinearLayout {
-        return LinearLayout(this).apply {
+        return LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
             setGravity(gravity)
             layoutParams = FrameLayout.LayoutParams(
@@ -384,7 +361,7 @@ class ExternalDisplayControlActivity :
     }
 
     private fun createImageButton(imageResourceId: Int, listener: View.OnClickListener): ImageButton {
-        return ImageButton(this).apply {
+        return ImageButton(context).apply {
             setImageResource(imageResourceId)
             setBackgroundColor(Color.TRANSPARENT)
             setOnClickListener(listener)
@@ -392,105 +369,92 @@ class ExternalDisplayControlActivity :
         }
     }
 
-    private fun checkNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
-                PackageManager.PERMISSION_GRANTED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                    PERMISSION_REQUEST_CODE,
-                )
-                return
-            }
-        }
-        showStickyNotification()
-    }
-
-    private fun showStickyNotification() {
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                NOTIFICATION_CHANNEL_ID,
-                getString(R.string.notification_channel_name),
-                NotificationManager.IMPORTANCE_LOW,
-            )
-            channel.setShowBadge(false)
-            notificationManager.createNotificationChannel(channel)
-        }
-
-        val broadcastIntent = Intent(this, StartExternalDisplayControlReceiver::class.java)
-            .setAction(StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL)
-            .setPackage(packageName)
-        val pendingIntent = PendingIntent.getBroadcast(
-            this,
-            0,
-            broadcastIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-
-        val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle(getString(R.string.notification_title))
-            .setContentText(getString(R.string.notification_text))
-            .setSmallIcon(R.drawable.app_icon)
-            .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setOngoing(true)
-
-        val notification: Notification = notificationBuilder.build()
-
-        notificationManager.notify(SECONDARY_SCREEN_NOTIFICATION_ID, notification)
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSION_REQUEST_CODE) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                showStickyNotification()
-            } else {
-                Toast.makeText(this, getString(R.string.permission_denied), Toast.LENGTH_SHORT).show()
-            }
-        }
-    }
-
     private fun dpToPx(dp: Int): Int {
-        return (dp * resources.displayMetrics.density).toInt()
+        return (dp * context.resources.displayMetrics.density).toInt()
+    }
+
+    fun toggleKeyboard() {
+        _toggleKeyboard()
+    }
+
+    fun toggleFullKeyboard() {
+        _toggleFullKeyboard()
+    }
+
+    fun toggleGameMenu() {
+        showGameMenu()
     }
 
     companion object {
-        @SuppressLint("StaticFieldLeak")
-        @JvmField
-        var instance: ExternalDisplayControlActivity? = null
-
         private const val INACTIVITY_TIMEOUT_MS = 10_000
         private const val NOTIFICATION_CHANNEL_ID = "secondary_screen_active_channel_id"
 
         const val SECONDARY_SCREEN_NOTIFICATION_ID = 1
-        private const val PERMISSION_REQUEST_CODE = 1001
+        const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1001
 
         @JvmStatic
-        fun closeExternalDisplayControl() {
-            instance?.finish()
+        fun ensureCompanionControlsNotification(game: Game) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                ContextCompat.checkSelfPermission(game, Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                ActivityCompat.requestPermissions(
+                    game,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    NOTIFICATION_PERMISSION_REQUEST_CODE,
+                )
+                return
+            }
+            postCompanionControlsNotification(game)
         }
 
         @JvmStatic
-        fun toggleKeyboard() {
-            instance?._toggleKeyboard()
+        fun onCompanionNotificationPermissionResult(
+            game: Game,
+            granted: Boolean,
+            shouldPost: Boolean,
+        ) {
+            if (granted && shouldPost) {
+                postCompanionControlsNotification(game)
+            } else if (!granted) {
+                Toast.makeText(game, game.getString(R.string.permission_denied), Toast.LENGTH_SHORT).show()
+            }
         }
 
-        @JvmStatic
-        fun toggleFullKeyboard() {
-            instance?._toggleFullKeyboard()
-        }
+        private fun postCompanionControlsNotification(context: Context) {
+            val notificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    context.getString(R.string.notification_channel_name),
+                    NotificationManager.IMPORTANCE_LOW,
+                )
+                channel.setShowBadge(false)
+                notificationManager.createNotificationChannel(channel)
+            }
 
-        @JvmStatic
-        fun toggleGameMenu() {
-            instance?.showGameMenu()
+            val broadcastIntent = Intent(context, StartExternalDisplayControlReceiver::class.java)
+                .setAction(StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL)
+                .setPackage(context.packageName)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                broadcastIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+            val notificationBuilder = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(context.getString(R.string.notification_title))
+                .setContentText(context.getString(R.string.notification_text))
+                .setSmallIcon(R.drawable.app_icon)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setOngoing(true)
+
+            val notification: Notification = notificationBuilder.build()
+            notificationManager.notify(SECONDARY_SCREEN_NOTIFICATION_ID, notification)
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/utils/GameDisplayLaunchTrampolineActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/GameDisplayLaunchTrampolineActivity.kt
@@ -17,9 +17,9 @@ import com.papi.nova.R
 /**
  * One-shot activity used only to force the stream Game activity onto the selected Android display.
  *
- * Do not use ExternalDisplayControlActivity for this: that activity is a singleton companion/control
- * surface. Reusing it as a bootstrap can strand Thor-style bottom-screen launches as a black
- * control placeholder before Game owns the top display.
+ * Do not use the companion Presentation for this: it is a Game-owned control surface, not a stream
+ * bootstrap. The trampoline must place Game first so Thor-style bottom-screen launches still stream
+ * on the explicitly selected display before companion controls appear.
  */
 class GameDisplayLaunchTrampolineActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/KotlinExternalDisplayUiMigrationTest.kt
@@ -1,7 +1,9 @@
 package com.papi.nova.utils
 
 import android.app.Activity
+import android.app.Presentation
 import android.content.Context
+import android.view.Display
 import android.view.View
 import com.papi.nova.StartExternalDisplayControlReceiver
 import com.papi.nova.nvstream.http.ComputerDetails
@@ -16,7 +18,7 @@ class KotlinExternalDisplayUiMigrationTest {
     @Test
     fun externalDisplayUiHelpersAreKotlinSources() {
         val names = arrayOf(
-            "utils/ExternalDisplayControlActivity",
+            "utils/ExternalDisplayControlPresentation",
             "utils/GameDisplayLaunchTrampolineActivity",
             "utils/UiHelper"
         )
@@ -32,7 +34,7 @@ class KotlinExternalDisplayUiMigrationTest {
     @Test
     fun externalDisplayUiHelpersKeepJavaCompatibleApis() {
         assertEquals("launchIntent", GameDisplayLaunchTrampolineActivity.EXTRA_LAUNCH_INTENT)
-        assertEquals(1, ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID)
+        assertEquals(1, ExternalDisplayControlPresentation.SECONDARY_SCREEN_NOTIFICATION_ID)
         assertEquals(
             "com.papi.nova.action.START_EXTERNAL_DISPLAY_CONTROL",
             StartExternalDisplayControlReceiver.ACTION_START_EXTERNAL_DISPLAY_CONTROL
@@ -44,7 +46,7 @@ class KotlinExternalDisplayUiMigrationTest {
                     .modifiers
             )
         )
-        assertTrue(Modifier.isStatic(ExternalDisplayControlActivity::class.java.getField("instance").modifiers))
+        assertTrue(Presentation::class.java.isAssignableFrom(ExternalDisplayControlPresentation::class.java))
         assertTrue(
             Modifier.isStatic(
                 StartExternalDisplayControlReceiver::class.java
@@ -52,13 +54,31 @@ class KotlinExternalDisplayUiMigrationTest {
                     .modifiers
             )
         )
-        ExternalDisplayControlActivity::class.java.getConstructor()
-        ExternalDisplayControlActivity::class.java.getMethod("closeExternalDisplayControl")
-        ExternalDisplayControlActivity::class.java.getMethod("toggleKeyboard")
-        ExternalDisplayControlActivity::class.java.getMethod("toggleFullKeyboard")
-        ExternalDisplayControlActivity::class.java.getMethod("toggleGameMenu")
-        ExternalDisplayControlActivity::class.java.getMethod("toggleZoomMode", Boolean::class.javaPrimitiveType!!)
-        ExternalDisplayControlActivity::class.java.getMethod("showGameMenu")
+        ExternalDisplayControlPresentation::class.java.getConstructor(
+            com.papi.nova.Game::class.java,
+            Display::class.java
+        )
+        ExternalDisplayControlPresentation::class.java.getMethod("toggleKeyboard")
+        ExternalDisplayControlPresentation::class.java.getMethod("toggleFullKeyboard")
+        ExternalDisplayControlPresentation::class.java.getMethod("toggleGameMenu")
+        ExternalDisplayControlPresentation::class.java.getMethod("toggleZoomMode", Boolean::class.javaPrimitiveType!!)
+        ExternalDisplayControlPresentation::class.java.getMethod("showGameMenu")
+        com.papi.nova.GameMenu::class.java.getConstructor(com.papi.nova.Game::class.java)
+        com.papi.nova.GameMenu::class.java.getConstructor(
+            com.papi.nova.Game::class.java,
+            Context::class.java
+        )
+        com.papi.nova.GameMenu::class.java.getConstructor(
+            com.papi.nova.Game::class.java,
+            Context::class.java,
+            Int::class.javaObjectType
+        )
+        com.papi.nova.Game::class.java.getMethod("selectMouseMode", Context::class.java)
+        com.papi.nova.Game::class.java.getMethod(
+            "selectMouseMode",
+            Context::class.java,
+            Int::class.javaObjectType
+        )
         GameDisplayLaunchTrampolineActivity::class.java.getMethod(
             "launchGameOnRequestedDisplay",
             Context::class.java,
@@ -77,6 +97,10 @@ class KotlinExternalDisplayUiMigrationTest {
         UiHelper::class.java.getMethod("applyStatusBarPadding", View::class.java)
         UiHelper::class.java.getMethod("notifyNewRootView", Activity::class.java)
         UiHelper::class.java.getMethod("showDecoderCrashDialog", Activity::class.java)
+        StartExternalDisplayControlReceiver::class.java.getMethod(
+            "requestFocusToExternalDisplayControl",
+            Context::class.java
+        )
         StartExternalDisplayControlReceiver::class.java.getMethod(
             "requestFocusToExternalDisplayControl",
             Context::class.java,

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -25,17 +25,14 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
-    fun externalControlReceiverDoesNotHardcodeDefaultDisplay() {
+    fun notificationReceiverReopensGameOwnedPresentationWithoutStartingActivity() {
         val source = File("src/main/java/com/papi/nova/StartExternalDisplayControlReceiver.kt").readText()
 
-        assertFalse(
-            "External controls must launch on the derived companion display, not always Display.DEFAULT_DISPLAY",
-            source.contains("setLaunchDisplayId(Display.DEFAULT_DISPLAY)")
-        )
-        assertTrue(
-            "External controls should resolve through ServerHelper.getAndroidCompanionDisplay",
-            source.contains("getAndroidCompanionDisplay")
-        )
+        assertFalse(source.contains("ActivityOptions"))
+        assertFalse(Regex("""\bstartActivit(?:y|ies)\s*\(""").containsMatchIn(source))
+        assertFalse(source.contains("ExternalDisplayControlActivity"))
+        assertTrue(source.contains("Game.instance"))
+        assertTrue(source.contains("game.showCompanionControls()"))
     }
 
     @Test
@@ -57,21 +54,21 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue(serverHelper.contains("GameDisplayLaunchTrampolineActivity"))
         assertTrue(manifest.contains(".utils.GameDisplayLaunchTrampolineActivity"))
         assertFalse(
-            "The singleton control activity must not double as the stream launch trampoline",
-            serverHelper.contains("ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT")
+            "The companion Presentation must not double as the stream launch trampoline",
+            serverHelper.contains("ExternalDisplayControlPresentation.EXTRA_LAUNCH_INTENT")
         )
     }
 
     @Test
-    fun externalControlActivityDoesNotBootstrapGameLaunches() {
-        val source = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt").readText()
+    fun externalControlPresentationDoesNotBootstrapGameLaunches() {
+        val source = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
 
         assertFalse(
-            "The companion control activity should only host controls; stream bootstrapping belongs to the dedicated trampoline",
+            "The companion Presentation should only host controls; stream bootstrapping belongs to the dedicated trampoline",
             source.contains("EXTRA_LAUNCH_INTENT")
         )
         assertFalse(
-            "The companion control activity must not launch Game itself from whichever display created it",
+            "The companion Presentation must not launch Game itself from its target display",
             source.contains("startActivity(gameIntent")
         )
     }
@@ -189,5 +186,171 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue(source.contains("Android display audio context"))
         assertTrue(source.contains("Android display audio route"))
         assertTrue(source.contains("display_id="))
+    }
+
+    @Test
+    fun companionDialogsAttachToTheLivePresentationWindowToken() {
+        val presentation =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val gameMenu = File("src/main/java/com/papi/nova/GameMenu.kt").readText()
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+
+        assertTrue(presentation.contains("TYPE_APPLICATION_ATTACHED_DIALOG"))
+        assertTrue(presentation.contains("createWindowContext("))
+        assertTrue(presentation.contains("presentationWindow.decorView.windowToken"))
+        assertFalse(
+            "A second TYPE_PRESENTATION window reuses the wrong WindowContext token and crashes",
+            presentation.contains("presentationWindow.attributes.type")
+        )
+        assertTrue(
+            presentation.contains(
+                "GameMenu(game, companionDialogContext, companionDialogWindowType, ::companionDialogWindowToken)"
+            )
+        )
+        assertTrue(gameMenu.contains("private val dialogWindowTokenProvider: (() -> IBinder?)? = null"))
+        assertTrue(gameMenu.contains("window.setType(windowType)"))
+        assertTrue(gameMenu.contains("window.attributes.token = token"))
+
+        val showMenuDialog =
+            gameMenu.substringAfter("private fun showMenuDialog(").substringBefore("private fun showSpecialKeysMenu(")
+        val menuWindowBinding = showMenuDialog.indexOf("applyDialogWindowType(sheet)")
+        val menuShow = showMenuDialog.indexOf("sheet.show()")
+        assertTrue("Menu BottomSheetDialog must be bound before show()", menuWindowBinding in 0 until menuShow)
+
+        val serverCommandDialog =
+            gameMenu.substringAfter("val serverCommandDialog =").substringBefore("} else {")
+        val serverWindowBinding = serverCommandDialog.indexOf("applyDialogWindowType(serverCommandDialog)")
+        val serverShow = serverCommandDialog.indexOf("serverCommandDialog.show()")
+        assertTrue("Server-command AlertDialog must be bound before show()", serverWindowBinding in 0 until serverShow)
+
+        assertTrue(
+            gameMenu.contains(
+                "selectMouseMode(dialogScreenContext, dialogWindowType, dialogWindowTokenProvider?.invoke())"
+            )
+        )
+        val mouseMode =
+            game.substringAfter("fun selectMouseMode(").substringBefore("private fun toggleMouseLocalCursor(")
+        val mouseType = mouseMode.indexOf("mouseModeDialog.window?.setType(windowType)")
+        val mouseToken = mouseMode.indexOf("mouseModeDialog.window?.attributes?.token = dialogWindowToken")
+        val mouseShow = mouseMode.indexOf("mouseModeDialog.show()")
+        assertTrue("Mouse-mode dialog type must be assigned before show()", mouseType in 0 until mouseShow)
+        assertTrue("Mouse-mode dialog token must be assigned before show()", mouseToken in 0 until mouseShow)
+
+        val quit = game.substringAfter("fun quit()").substringBefore("override fun showGameMenu(")
+        val quitType = quit.indexOf("sheet.window?.setType(companionPresentation.companionDialogWindowType)")
+        val quitToken = quit.indexOf("sheet.window?.attributes?.token = companionPresentation.companionDialogWindowToken()")
+        val quitShow = quit.indexOf("sheet.show()")
+        assertTrue("Quit sheet type must be assigned before show()", quitType in 0 until quitShow)
+        assertTrue("Quit sheet token must be assigned before show()", quitToken in 0 until quitShow)
+    }
+
+    @Test
+    fun companionControlsAreGameOwnedPresentationInsteadOfManifestActivity() {
+        val presentationFile =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt")
+        val activityFile =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt")
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val manifest = File("src/main/AndroidManifest.xml").readText()
+
+        assertTrue("Companion controls should have a Presentation source", presentationFile.exists())
+        val presentation = presentationFile.readText()
+        assertTrue(presentation.contains("class ExternalDisplayControlPresentation"))
+        assertTrue(presentation.contains("Presentation(game, display"))
+        assertTrue(game.contains("private var externalDisplayControlPresentation"))
+        assertTrue(game.contains("ExternalDisplayControlPresentation(this, companionDisplay"))
+        assertFalse("The obsolete companion Activity source should be removed", activityFile.exists())
+        assertFalse(
+            "A Game-owned Presentation must not be registered as an Activity",
+            manifest.contains("ExternalDisplayControlPresentation")
+        )
+    }
+
+    @Test
+    fun failedPresentationShowDisposesPartialStateBeforeClearingGameReferences() {
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val presentation =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val showBlock =
+            game.substringAfter("val presentation = ExternalDisplayControlPresentation")
+                .substringBefore("listenForExternalDisplayRemoval()")
+        val dispose = showBlock.indexOf("presentation.disposeAfterFailedShow()")
+        val clearReference = showBlock.indexOf("externalDisplayControlPresentation = null", dispose)
+
+        assertTrue("Failed show must explicitly dispose partial Presentation state", dispose >= 0)
+        assertTrue("Disposal must happen before Game clears its owner reference", clearReference > dispose)
+        val transientDisposal =
+            presentation.substringAfter("private fun disposeTransientState()")
+                .substringBefore("fun disposeAfterFailedShow()")
+        val failedShowDisposal =
+            presentation.substringAfter("fun disposeAfterFailedShow()")
+                .substringBefore("override fun onStop()")
+        assertTrue(transientDisposal.contains("handler.removeCallbacksAndMessages(null)"))
+        assertTrue(
+            "Failed-show disposal must invoke the real transient-state cleanup",
+            failedShowDisposal.contains("disposeTransientState()")
+        )
+    }
+
+    @Test
+    fun companionNotificationPermissionContinuationIsOwnedByGame() {
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val presentation =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val launchBlock =
+            game.substringAfter("presentation.show()").substringBefore("catch (e:WindowManager.InvalidDisplayException)")
+        val permissionBlock =
+            game.substringAfter("override fun onRequestPermissionsResult(")
+                .substringBefore("override fun onNewIntent(")
+        val compactPermissionBlock = permissionBlock.replace(Regex("""\s+"""), " ")
+        val initViews = presentation.substringAfter("private fun initViews()").substringBefore("private fun initTouchEventHandling()")
+
+        assertTrue(
+            launchBlock.contains(
+                "ExternalDisplayControlPresentation.ensureCompanionControlsNotification(this)"
+            )
+        )
+        assertFalse("Presentation onCreate must not request notification permission", initViews.contains("checkNotificationPermission()"))
+        assertFalse(
+            "Permission result must not depend on a still-showing Presentation instance",
+            permissionBlock.contains("externalDisplayControlPresentation")
+        )
+        assertTrue(
+            permissionBlock.contains(
+                "ExternalDisplayControlPresentation.onCompanionNotificationPermissionResult("
+            )
+        )
+        assertTrue(
+            compactPermissionBlock.contains(
+                "if (requestCode == ExternalDisplayControlPresentation.NOTIFICATION_PERMISSION_REQUEST_CODE)"
+            )
+        )
+        assertTrue(
+            compactPermissionBlock.contains(
+                "val granted:Boolean = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED"
+            )
+        )
+        assertTrue(
+            "The actual permission result and live companion lifecycle predicate must be passed to the continuation",
+            compactPermissionBlock.contains(
+                "onCompanionNotificationPermissionResult( this, granted, !isFinishing() && isStreamActive && shouldLaunchCompanionControls() )"
+            )
+        )
+    }
+
+    @Test
+    fun newlyAddedDisplayReopensCompanionControlsUsingTheNewLogicalDisplayId() {
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val listener =
+            game.substringAfter("val listener:DisplayManager.DisplayListener")
+                .substringBefore("externalDisplayListener = listener")
+        val displayAdded =
+            listener.substringAfter("override fun onDisplayAdded")
+                .substringBefore("override fun onDisplayChanged")
+
+        assertTrue(
+            "A hot-added replacement display must re-derive and reopen companion controls",
+            displayAdded.contains("showCompanionControls()")
+        )
     }
 }


### PR DESCRIPTION
## Summary
- replace the external-display companion Activity with a Game-owned `Presentation`
- place companion controls on the explicitly requested display while preserving stream launch routing
- retain both public static JVM focus entry points for Java callers
- clean up the Presentation with the owning Game lifecycle

## Compatibility and safety
- keeps `requestFocusToExternalDisplayControl(Context)` and `requestFocusToExternalDisplayControl(Context, int)` as `@JvmStatic` APIs
- removes the companion Activity declaration and avoids focusable overlay/window behavior
- preserves explicit display selection through receiver and trampoline paths
- physical Thor verification remains a final validation gate; local JVM evidence is not presented as physical-device proof

## Test plan
- [x] `:app:testRootDebugUnitTest` — 762/762
- [x] `:app:testNonRoot_gameDebugUnitTest` — 756/756
- [x] reflected both public static JVM overloads with correct reference/primitive parameter types
- [x] deletion mutation for the Context-only overload fails the compatibility test
- [x] independent production/runtime review PASS
- [x] independent compatibility test-contract review PASS

Refs #127