### PR TITLE
fix: prevent stale companion controls after teardown

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -52,6 +52,7 @@ import com.papi.nova.ui.StreamContainer
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
+import com.papi.nova.utils.CompanionControlLifecyclePolicy
 import com.papi.nova.utils.ExternalDisplayControlPresentation
 import com.papi.nova.utils.GameDisplayLaunchTrampolineActivity
 import com.papi.nova.utils.MouseModeOption
@@ -458,7 +459,14 @@ listenForExternalDisplayRemoval()
 }
 
 fun showCompanionControls() {
-runOnUiThread { launchCompanionControlsIfAvailable() }
+runOnUiThread {
+if (!CompanionControlLifecyclePolicy.canShow(isStreamActive, isFinishing(), isDestroyed)) {
+LimeLog.info("Nova: Skipping companion controls for inactive Game lifecycle active=$isStreamActive finishing=${isFinishing()} destroyed=$isDestroyed")
+closeCompanionControls()
+return@runOnUiThread
+}
+launchCompanionControlsIfAvailable()
+}
 }
 
 @SuppressLint("InlinedApi")
@@ -4442,6 +4450,7 @@ if (connecting || connected)
 connected = false
 connecting = connected
 isStreamActive = false
+closeCompanionControls()
 stopPolarisLiveSessionStatusRefresh()
 runtimeTasks.cancel("NovaBitrateAdjust")
  // Send AI session report before dismissing HUD

--- a/app/src/main/java/com/papi/nova/utils/CompanionControlLifecyclePolicy.kt
+++ b/app/src/main/java/com/papi/nova/utils/CompanionControlLifecyclePolicy.kt
@@ -1,0 +1,10 @@
+package com.papi.nova.utils
+
+internal object CompanionControlLifecyclePolicy {
+    @JvmStatic
+    fun canShow(
+        streamActive: Boolean,
+        gameFinishing: Boolean,
+        gameDestroyed: Boolean
+    ): Boolean = streamActive && !gameFinishing && !gameDestroyed
+}

--- a/app/src/test/java/com/papi/nova/utils/CompanionControlLifecyclePolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/CompanionControlLifecyclePolicyTest.kt
@@ -1,0 +1,27 @@
+package com.papi.nova.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionControlLifecyclePolicyTest {
+    @Test
+    fun activeLiveGameCanShowCompanionControls() {
+        assertTrue(CompanionControlLifecyclePolicy.canShow(true, false, false))
+    }
+
+    @Test
+    fun inactiveStreamCannotShowCompanionControls() {
+        assertFalse(CompanionControlLifecyclePolicy.canShow(false, false, false))
+    }
+
+    @Test
+    fun finishingGameCannotShowCompanionControls() {
+        assertFalse(CompanionControlLifecyclePolicy.canShow(true, true, false))
+    }
+
+    @Test
+    fun destroyedGameCannotShowCompanionControls() {
+        assertFalse(CompanionControlLifecyclePolicy.canShow(true, false, true))
+    }
+}

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -339,6 +339,47 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
+    fun stoppedStreamDismissesCompanionControlsBeforeBackgroundCleanup() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val stopConnection =
+            source.substringAfter("private fun stopConnection()")
+                .substringBefore("override fun stageFailed(")
+        val streamInactive = stopConnection.indexOf("isStreamActive = false")
+        val controlsClosed = stopConnection.indexOf("closeCompanionControls()", streamInactive)
+        val backgroundCleanup = stopConnection.indexOf("launchRuntimeIo(\"NovaSessionReport\")")
+
+        assertTrue("stopConnection must mark the stream inactive", streamInactive >= 0)
+        assertTrue("stopConnection must dismiss companion controls after marking the stream inactive", controlsClosed > streamInactive)
+        assertTrue("companion controls must close before asynchronous teardown work", controlsClosed in 0 until backgroundCleanup)
+    }
+
+    @Test
+    fun companionReopenChecksLiveGameLifecycleAtExecutionTime() {
+        val source = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val showControls =
+            source.substringAfter("fun showCompanionControls() {")
+                .substringBefore("@SuppressLint(\"InlinedApi\")")
+        val uiDispatch = showControls.indexOf("runOnUiThread {")
+        val lifecycleDecision = showControls.indexOf("CompanionControlLifecyclePolicy.canShow(")
+        val deniedClose = showControls.indexOf("closeCompanionControls()")
+        val deniedReturn = showControls.indexOf("return@runOnUiThread")
+        val presentationLaunch = showControls.indexOf("launchCompanionControlsIfAvailable()")
+
+        assertTrue("showCompanionControls must dispatch before reading lifecycle state", uiDispatch >= 0)
+        assertTrue("lifecycle state must be checked inside the UI-thread callback", lifecycleDecision > uiDispatch)
+        assertTrue("denied reopen must close stale controls", deniedClose > lifecycleDecision)
+        assertTrue("denied reopen must return before presentation launch", deniedReturn > deniedClose)
+        assertTrue("presentation launch must follow the lifecycle gate", presentationLaunch > deniedReturn)
+        val compactShowControls = showControls.replace(Regex("\\s+"), " ")
+        assertTrue(
+            "The execution-time lifecycle decision must receive the live Game state, not constants",
+            compactShowControls.contains(
+                "CompanionControlLifecyclePolicy.canShow(isStreamActive, isFinishing(), isDestroyed)"
+            )
+        )
+    }
+
+    @Test
     fun newlyAddedDisplayReopensCompanionControlsUsingTheNewLogicalDisplayId() {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val listener =


### PR DESCRIPTION
## Summary

Prevents stale Nova companion controls from surviving or reopening after stream teardown.

- marks the stream inactive before asynchronous teardown begins;
- synchronously dismisses the companion notification and `Presentation` when streaming stops;
- dispatches delayed display/notification reopen requests to the UI thread;
- re-evaluates the live stream/activity lifecycle tuple at execution time;
- blocks companion controls when the stream is inactive or `Game` is finishing/destroyed;
- preserves partial-`Presentation` cleanup and API 21 compatibility.

## Lifecycle contract

`CompanionControlLifecyclePolicy.canShow(...)` allows companion controls only when all three live conditions hold:

```text
isStreamActive == true
isFinishing() == false
isDestroyed == false
```

The decision is made on the UI thread when the queued reopen callback executes, rather than using stale state captured when the request was queued.

## Verification

Reviewed commit:

```text
093605e237773d63259e4c3f79247991bb09e045
```

Exact reviewed binary-diff SHA-256:

```text
3b2739cc670d169c3bab4d1628aaa42824fd481533b8bf18bb2ea48dfe50a228
```

Base/current `origin/master` at freeze:

```text
481e2eb5c42904690bc3164aa4b6a8a94801f432
```

Fresh pc-papi gates:

- Root JVM suite: **786/786 passed**
- Non-root JVM suite: **780/780 passed**
- Helper/onboarding suite: **51/51 passed**
- Root fail-on-error lint: **passed**
- Non-root fail-on-error lint: **passed**
- ARM64 unsigned release APK assembly: **passed**
- ARMv7 unsigned release APK assembly: **passed**
- x86_64 unsigned release APK assembly: **passed**
- Live-tuple-to-permissive-constants compiling mutation: **RED**
- Restored focused lifecycle source guard: **GREEN**
- Added-production-line security/privacy scan: **0 findings**
- Fresh exact-hash fail-closed review: **passed with no blockers**
- Post-commit diff reproduced the exact reviewed SHA-256

Unsigned APK metadata:

| ABI | Package | Version | Version code |
|---|---|---:|---:|
| arm64-v8a | `com.papi.nova` | 1.3.1 | 33 |
| armeabi-v7a | `com.papi.nova` | 1.3.1 | 33 |
| x86_64 | `com.papi.nova` | 1.3.1 | 33 |

## Scope boundary

This PR does **not** install an APK, claim Retroid/Thor hardware validation, publish a release, or deploy/restart Polaris. Physical Thor remains a separate v1.3.2 release gate.
