### PR TITLE
feat: enrich launch diagnostics and classify near-target health

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLaunchProfilePrimaryNoticeComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLaunchProfilePrimaryNoticeComposeTest.kt
@@ -1,0 +1,97 @@
+package com.papi.nova.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.unit.dp
+import com.papi.nova.ui.compose.NovaActionButton
+import com.papi.nova.ui.compose.NovaComposeTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NovaLaunchProfilePrimaryNoticeComposeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun compactNoticeIsDpadReachableExpandableAndHorizontallyContained() {
+        val detail = "Last stream: 115.6/120 FPS. 1% low: 110.8 FPS. Bad pacing: 0%."
+        val recommendation =
+            "Next launch keeps the verified profile while preserving every compact cockpit control."
+        val summary = NovaLaunchProfileSummary(
+            primaryLaunchLabel = "Launch 120 FPS",
+            requestedLine = "Requested: High FPS stream / 120 FPS",
+            selectedLine = "Selected: High FPS stream / 120 FPS",
+            reasonLine = "Reason: diagnostic evidence needs attention",
+            limitingLine = "Limited by: Host render telemetry with a deliberately long compact label",
+            noticeDetail = detail,
+            noticeRecommendation = recommendation,
+            noticeTone = NovaLaunchProfileNoticeTone.WARNING,
+            noticeLabel = "Heads up",
+            freshnessLine = "",
+            historyLines = emptyList(),
+            showRetryHighFps = false,
+            retryHighFpsLabel = "Try High FPS once"
+        )
+
+        val playFocusRequester = FocusRequester()
+        composeRule.setContent {
+            NovaComposeTheme {
+                Column(
+                    modifier = Modifier
+                        .width(320.dp)
+                        .testTag("compact-launch-root")
+                ) {
+                    LaunchProfilePrimaryNotice(summary)
+                    NovaActionButton(
+                        text = "Play",
+                        onClick = {},
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(playFocusRequester)
+                    )
+                }
+            }
+        }
+
+        composeRule.runOnIdle {
+            playFocusRequester.requestFocus()
+        }
+        composeRule.onNodeWithText("Play").performKeyInput {
+            pressKey(Key.DirectionUp)
+        }
+        composeRule.onNodeWithText("More details").assertIsDisplayed().performKeyInput {
+            pressKey(Key.DirectionCenter)
+        }
+
+        composeRule.onNodeWithText("Hide details").assertIsDisplayed()
+        composeRule.onNodeWithText(detail).assertIsDisplayed()
+        composeRule.onNodeWithText(recommendation).assertIsDisplayed()
+
+        val rootBounds = composeRule.onNodeWithTag("compact-launch-root").fetchSemanticsNode().boundsInRoot
+        val detailBounds = composeRule.onNodeWithText(detail).fetchSemanticsNode().boundsInRoot
+        val recommendationBounds = composeRule.onNodeWithText(recommendation).fetchSemanticsNode().boundsInRoot
+        assertTrue(
+            "detail must stay within compact root",
+            detailBounds.left >= rootBounds.left && detailBounds.right <= rootBounds.right
+        )
+        assertTrue(
+            "recommendation must stay within compact root",
+            recommendationBounds.left >= rootBounds.left && recommendationBounds.right <= rootBounds.right
+        )
+    }
+}

--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLaunchProfilePrimaryNoticeComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLaunchProfilePrimaryNoticeComposeTest.kt
@@ -1,21 +1,22 @@
 package com.papi.nova.ui
 
+import android.view.KeyEvent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performKeyInput
-import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
 import com.papi.nova.ui.compose.NovaActionButton
 import com.papi.nova.ui.compose.NovaComposeTheme
 import org.junit.Assert.assertTrue
@@ -49,6 +50,7 @@ class NovaLaunchProfilePrimaryNoticeComposeTest {
         )
 
         val playFocusRequester = FocusRequester()
+        val detailsFocusRequester = FocusRequester()
         composeRule.setContent {
             NovaComposeTheme {
                 Column(
@@ -56,27 +58,41 @@ class NovaLaunchProfilePrimaryNoticeComposeTest {
                         .width(320.dp)
                         .testTag("compact-launch-root")
                 ) {
-                    LaunchProfilePrimaryNotice(summary)
+                    LaunchProfilePrimaryNotice(
+                        summary = summary,
+                        detailsFocusRequester = detailsFocusRequester,
+                        playFocusRequester = playFocusRequester
+                    )
                     NovaActionButton(
                         text = "Play",
                         onClick = {},
                         modifier = Modifier
                             .fillMaxWidth()
                             .focusRequester(playFocusRequester)
+                            .focusProperties { up = detailsFocusRequester }
                     )
                 }
             }
         }
 
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_DOWN)
+        instrumentation.waitForIdleSync()
+        composeRule.onNodeWithText("Play").assertIsDisplayed()
         composeRule.runOnIdle {
-            playFocusRequester.requestFocus()
+            assertTrue("Play focus request must be accepted", playFocusRequester.requestFocus())
         }
-        composeRule.onNodeWithText("Play").performKeyInput {
-            pressKey(Key.DirectionUp)
-        }
-        composeRule.onNodeWithText("More details").assertIsDisplayed().performKeyInput {
-            pressKey(Key.DirectionCenter)
-        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Play").assertIsFocused()
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_UP)
+        instrumentation.waitForIdleSync()
+        composeRule.onNodeWithText("More details")
+            .assertIsDisplayed()
+            .assertIsFocused()
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_CENTER)
+        instrumentation.waitForIdleSync()
 
         composeRule.onNodeWithText("Hide details").assertIsDisplayed()
         composeRule.onNodeWithText(detail).assertIsDisplayed()

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
@@ -1689,6 +1690,7 @@ private fun LaunchControls(
 ) {
     val colors = LocalNovaComposeColors.current
     val playFocusRequester = remember { FocusRequester() }
+    val detailsFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(uiState.playEnabled) {
         if (uiState.playEnabled) {
@@ -1755,7 +1757,13 @@ private fun LaunchControls(
             )
         }
 
-        profileSummary?.let { LaunchProfilePrimaryNotice(it) }
+        profileSummary?.let {
+            LaunchProfilePrimaryNotice(
+                summary = it,
+                detailsFocusRequester = detailsFocusRequester,
+                playFocusRequester = playFocusRequester
+            )
+        }
 
         NovaActionButton(
             text = playLabel,
@@ -1763,6 +1771,7 @@ private fun LaunchControls(
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(playFocusRequester)
+                .focusProperties { up = detailsFocusRequester }
                 .padding(top = 10.dp),
             enabled = uiState.playEnabled,
             primary = true,
@@ -1866,7 +1875,11 @@ private fun LaunchControls(
 }
 
 @Composable
-internal fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
+internal fun LaunchProfilePrimaryNotice(
+    summary: NovaLaunchProfileSummary,
+    detailsFocusRequester: FocusRequester,
+    playFocusRequester: FocusRequester
+) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
     val notice = summary.limitingLine.takeIf { it.isNotBlank() }
@@ -1918,7 +1931,10 @@ internal fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
                 NovaActionButton(
                     text = if (noticeExpanded) "Hide details" else "More details",
                     onClick = { noticeExpanded = !noticeExpanded },
-                    modifier = Modifier.width(104.dp),
+                    modifier = Modifier
+                        .width(104.dp)
+                        .focusRequester(detailsFocusRequester)
+                        .focusProperties { down = playFocusRequester },
                     contentDescription = if (noticeExpanded) {
                         "Hide launch profile details"
                     } else {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -1868,12 +1868,20 @@ private fun LaunchControls(
 private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
-    val notice = listOf(summary.limitingLine, summary.reasonLine)
-        .firstOrNull { it.isNotBlank() }
+    val notice = summary.limitingLine.takeIf { it.isNotBlank() }
+        ?: summary.reasonLine.takeIf { it.isNotBlank() }
         ?: summary.freshnessLine.takeIf { it.isNotBlank() }
-        ?: return
+        ?: ""
+    val hasNoticeContent = listOf(
+        notice,
+        summary.noticeDetail,
+        summary.noticeRecommendation
+    ).any { it.isNotBlank() }
+    val hasExpandableDetails = summary.noticeDetail.isNotBlank() || summary.noticeRecommendation.isNotBlank()
+    var noticeExpanded by remember(summary.noticeDetail, summary.noticeRecommendation) { mutableStateOf(false) }
+    if (!hasNoticeContent) return
 
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 8.dp)
@@ -1881,25 +1889,64 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
             .background(colors.warning.copy(alpha = 0.14f))
             .border(1.dp, colors.warning.copy(alpha = 0.52f), RoundedCornerShape(12.dp))
             .padding(horizontal = 12.dp, vertical = 9.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        NovaBadge(
-            text = "Heads up",
-            color = colors.warning,
-            backgroundColor = surfaces.control.copy(alpha = 0.72f),
-            borderColor = colors.warning.copy(alpha = 0.35f),
-            fontWeight = FontWeight.SemiBold
-        )
-        Text(
-            text = notice,
-            color = colors.textSecondary,
-            fontSize = 11.sp,
-            lineHeight = 14.sp,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            NovaBadge(
+                text = "Heads up",
+                color = colors.warning,
+                backgroundColor = surfaces.control.copy(alpha = 0.72f),
+                borderColor = colors.warning.copy(alpha = 0.35f),
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = notice.ifBlank { "Launch profile adjusted" },
+                color = colors.textSecondary,
+                fontSize = 11.sp,
+                lineHeight = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            if (hasExpandableDetails) {
+                NovaActionButton(
+                    text = if (noticeExpanded) "Hide details" else "More details",
+                    onClick = { noticeExpanded = !noticeExpanded },
+                    modifier = Modifier.width(104.dp),
+                    contentDescription = if (noticeExpanded) {
+                        "Hide launch profile details"
+                    } else {
+                        "Show launch profile details"
+                    },
+                    stateDescription = if (noticeExpanded) "Expanded" else "Collapsed",
+                    minHeight = 32.dp,
+                    cornerRadius = 9.dp,
+                    fontSize = 10.sp,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp)
+                )
+            }
+        }
+        if (noticeExpanded && summary.noticeDetail.isNotBlank()) {
+            Text(
+                text = summary.noticeDetail,
+                color = colors.textPrimary,
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                modifier = Modifier.padding(top = 7.dp)
+            )
+        }
+        if (noticeExpanded && summary.noticeRecommendation.isNotBlank()) {
+            Text(
+                text = summary.noticeRecommendation,
+                color = colors.warning,
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(top = 5.dp)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.pointer.pointerInput
@@ -1872,6 +1873,9 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
         ?: summary.reasonLine.takeIf { it.isNotBlank() }
         ?: summary.freshnessLine.takeIf { it.isNotBlank() }
         ?: ""
+    val isHealthy = summary.noticeTone == NovaLaunchProfileNoticeTone.HEALTHY
+    val toneColor = if (isHealthy) Color(0xFF4ADE80) else colors.warning
+    val badgeLabel = if (isHealthy) summary.noticeLabel else "Heads up"
     val hasNoticeContent = listOf(
         notice,
         summary.noticeDetail,
@@ -1886,8 +1890,8 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
             .fillMaxWidth()
             .padding(top = 8.dp)
             .clip(RoundedCornerShape(12.dp))
-            .background(colors.warning.copy(alpha = 0.14f))
-            .border(1.dp, colors.warning.copy(alpha = 0.52f), RoundedCornerShape(12.dp))
+            .background(toneColor.copy(alpha = 0.14f))
+            .border(1.dp, toneColor.copy(alpha = 0.52f), RoundedCornerShape(12.dp))
             .padding(horizontal = 12.dp, vertical = 9.dp),
     ) {
         Row(
@@ -1895,10 +1899,10 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             NovaBadge(
-                text = "Heads up",
-                color = colors.warning,
+                text = badgeLabel,
+                color = toneColor,
                 backgroundColor = surfaces.control.copy(alpha = 0.72f),
-                borderColor = colors.warning.copy(alpha = 0.35f),
+                borderColor = toneColor.copy(alpha = 0.35f),
                 fontWeight = FontWeight.SemiBold
             )
             Text(
@@ -1940,7 +1944,7 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
         if (noticeExpanded && summary.noticeRecommendation.isNotBlank()) {
             Text(
                 text = summary.noticeRecommendation,
-                color = colors.warning,
+                color = toneColor,
                 fontSize = 11.sp,
                 lineHeight = 15.sp,
                 fontWeight = FontWeight.Medium,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -43,7 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.pointer.pointerInput
@@ -1866,7 +1866,7 @@ private fun LaunchControls(
 }
 
 @Composable
-private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
+internal fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
     val notice = summary.limitingLine.takeIf { it.isNotBlank() }
@@ -1874,7 +1874,7 @@ private fun LaunchProfilePrimaryNotice(summary: NovaLaunchProfileSummary) {
         ?: summary.freshnessLine.takeIf { it.isNotBlank() }
         ?: ""
     val isHealthy = summary.noticeTone == NovaLaunchProfileNoticeTone.HEALTHY
-    val toneColor = if (isHealthy) Color(0xFF4ADE80) else colors.warning
+    val toneColor = if (isHealthy) colorResource(R.color.nova_success) else colors.warning
     val badgeLabel = if (isHealthy) summary.noticeLabel else "Heads up"
     val hasNoticeContent = listOf(
         notice,

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -10,6 +10,8 @@ enum class NovaLaunchProfileNoticeTone {
     HEALTHY
 }
 
+private const val HEALTHY_PROFILE_TARGET_TOLERANCE_FPS = 0.5
+
 data class NovaLaunchProfileSummary(
     val primaryLaunchLabel: String,
     val requestedLine: String,
@@ -115,6 +117,7 @@ internal fun buildNovaLaunchProfileSummary(
         requestedFps = requestedFps,
         effectiveFps = effectiveFps,
         selectedLabel = selectedLabel,
+        rawSelectedLabel = rawSelectedLabel,
         trialProfile = trialProfile,
         hasAuthoritativeProfileFps = requestedProfileFps != null && selectedProfileFps != null
     )
@@ -314,14 +317,17 @@ private fun healthyPerformanceStatus(
     requestedFps: Double,
     effectiveFps: Double,
     selectedLabel: String,
+    rawSelectedLabel: String,
     trialProfile: Boolean,
     hasAuthoritativeProfileFps: Boolean
 ): String? {
     if (lastResult == null || !completeIssueEvidence || reportedIssues.isEmpty()) return null
     val issueClasses = reportedIssues.map(::healthyIssueClass)
     if (issueClasses.any { it == null } || issueClasses.distinct().size != 1) return null
-    if (trialProfile || state == "trial" || state == "recovering") return null
-    if (selectedLabel.startsWith("Recovery", ignoreCase = true) ||
+    if (trialProfile || state !in setOf("stable", "blocked")) return null
+    if (rawSelectedLabel.contains("recovery", ignoreCase = true) ||
+        rawSelectedLabel.contains("trial", ignoreCase = true) ||
+        selectedLabel.startsWith("Recovery", ignoreCase = true) ||
         selectedLabel.contains("trial", ignoreCase = true)
     ) {
         return null
@@ -340,6 +346,11 @@ private fun healthyPerformanceStatus(
     val lowOnePercentFps = strictFiniteNumber(lastResult, "low_1_percent_fps") ?: return null
     val minFps = strictFiniteNumber(lastResult, "min_fps") ?: return null
     val badPacingPct = strictFiniteNumber(lastResult, "frame_pacing_bad_pct") ?: return null
+    if (abs(targetFps - requestedFps) > HEALTHY_PROFILE_TARGET_TOLERANCE_FPS ||
+        abs(targetFps - effectiveFps) > HEALTHY_PROFILE_TARGET_TOLERANCE_FPS
+    ) {
+        return null
+    }
     if (deliveredFps <= 0.0 || targetFps < 24.0) return null
     if (deliveredFps / targetFps < 0.95) return null
     if (lowOnePercentFps <= 0.0 || lowOnePercentFps / targetFps < 0.85) return null

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -5,6 +5,11 @@ import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.round
 
+enum class NovaLaunchProfileNoticeTone {
+    WARNING,
+    HEALTHY
+}
+
 data class NovaLaunchProfileSummary(
     val primaryLaunchLabel: String,
     val requestedLine: String,
@@ -13,6 +18,8 @@ data class NovaLaunchProfileSummary(
     val limitingLine: String,
     val noticeDetail: String,
     val noticeRecommendation: String,
+    val noticeTone: NovaLaunchProfileNoticeTone,
+    val noticeLabel: String,
     val freshnessLine: String,
     val historyLines: List<String>,
     val showRetryHighFps: Boolean,
@@ -96,9 +103,25 @@ internal fun buildNovaLaunchProfileSummary(
         ?.optString("reason", "")
         ?.takeIf { it.isNotBlank() }
         ?: optimization.optString("reasoning", "").takeIf { it.isNotBlank() }.orEmpty()
-    val reasonLine = reasonText.takeIf { it.isNotBlank() }?.let { "Reason: $it" }.orEmpty()
+    val reportedIssues = diagnosticIssues(optimization, lastResult)
+    val reportedIssue = preferredIssueForDisplay(reportedIssues)
+    val healthyPerformanceStatus = healthyPerformanceStatus(
+        lastResult = lastResult,
+        reportedIssues = reportedIssues,
+        completeIssueEvidence = hasCompleteDiagnosticIssueEvidence(optimization, lastResult),
+        state = state,
+        requestedFps = requestedFps,
+        effectiveFps = effectiveFps,
+        selectedLabel = selectedLabel
+    )
+    val healthyPerformance = healthyPerformanceStatus != null
+    val reasonLine = if (healthyPerformance) {
+        "Performance: $healthyPerformanceStatus"
+    } else {
+        reasonText.takeIf { it.isNotBlank() }?.let { "Reason: $it" }.orEmpty()
+    }
 
-    val issue = limitingIssue(optimization, lastResult)
+    val issue = if (healthyPerformance) "" else reportedIssue
     val limitingLine = issue.takeIf { it.isNotBlank() }?.let { "Limited by: ${issueLabel(it)}" }.orEmpty()
 
     val updatedAt = lastResult?.optLong("updated_at", 0L) ?: 0L
@@ -111,7 +134,7 @@ internal fun buildNovaLaunchProfileSummary(
         else -> ""
     }
 
-    val historyLines = buildHistoryLines(lastResult, issue, selectedLabel)
+    val historyLines = buildHistoryLines(lastResult, issue, selectedLabel, healthyPerformanceStatus)
     val highFpsHeldBelowRequest = preference == "high_fps" &&
         requestedFps > 0.0 &&
         effectiveFps > 0.0 &&
@@ -131,13 +154,26 @@ internal fun buildNovaLaunchProfileSummary(
     } else {
         "Try High FPS once"
     }
-    val noticeDetail = buildNoticeDetail(lastResult, issue)
-    val noticeRecommendation = buildNoticeRecommendation(
-        state = state,
-        requestedFps = requestedFps,
-        effectiveFps = effectiveFps,
-        showRetryHighFps = showRetryHighFps
-    )
+    val noticeDetail = if (healthyPerformance) {
+        buildHealthyPerformanceNoticeDetail(lastResult, requireNotNull(healthyPerformanceStatus))
+    } else {
+        buildNoticeDetail(lastResult, issue)
+    }
+    val noticeRecommendation = if (healthyPerformance) {
+        "No recovery adjustment is needed."
+    } else {
+        buildNoticeRecommendation(
+            state = state,
+            requestedFps = requestedFps,
+            effectiveFps = effectiveFps,
+            showRetryHighFps = showRetryHighFps
+        )
+    }
+    val noticeTone = if (healthyPerformance) {
+        NovaLaunchProfileNoticeTone.HEALTHY
+    } else {
+        NovaLaunchProfileNoticeTone.WARNING
+    }
 
     return NovaLaunchProfileSummary(
         primaryLaunchLabel = primaryLabel,
@@ -147,11 +183,37 @@ internal fun buildNovaLaunchProfileSummary(
         limitingLine = limitingLine,
         noticeDetail = noticeDetail,
         noticeRecommendation = noticeRecommendation,
+        noticeTone = noticeTone,
+        noticeLabel = healthyPerformanceStatus ?: "Heads up",
         freshnessLine = freshnessLine,
         historyLines = historyLines,
         showRetryHighFps = showRetryHighFps,
         retryHighFpsLabel = retryLabel
     )
+}
+
+private fun buildHealthyPerformanceNoticeDetail(lastResult: JSONObject?, performanceStatus: String): String {
+    if (lastResult == null) return ""
+    val deliveredFps = lastResult.optDouble("delivered_fps", 0.0)
+    val targetFps = lastResult.optDouble("target_fps", 0.0)
+    if (deliveredFps <= 0.0 || targetFps <= 0.0) return ""
+
+    val evidence = mutableListOf(
+        "Last stream: ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS."
+    )
+    val lowOnePercentFps = lastResult.optDouble("low_1_percent_fps", 0.0)
+    if (lowOnePercentFps > 0.0) {
+        evidence += "1% low: ${formatFps(lowOnePercentFps)} FPS."
+    }
+    if (lastResult.has("frame_pacing_bad_pct")) {
+        evidence += "Bad pacing: ${formatFps(lastResult.optDouble("frame_pacing_bad_pct", 0.0))}%."
+    }
+    evidence += if (performanceStatus == "Target met") {
+        "Stream target met."
+    } else {
+        "Normal gameplay variation."
+    }
+    return evidence.joinToString(" ")
 }
 
 private fun buildNoticeDetail(lastResult: JSONObject?, issue: String): String {
@@ -207,7 +269,8 @@ private fun buildNoticeRecommendation(
 private fun buildHistoryLines(
     lastResult: JSONObject?,
     issue: String,
-    selectedLabel: String
+    selectedLabel: String,
+    healthyPerformanceStatus: String?
 ): List<String> {
     if (lastResult == null) return emptyList()
 
@@ -215,7 +278,9 @@ private fun buildHistoryLines(
     val grade = lastResult.optString("grade", "").takeIf { it.isNotBlank() }
     val deliveredFps = lastResult.optDouble("delivered_fps", 0.0)
     val targetFps = lastResult.optDouble("target_fps", 0.0)
-    if (grade != null && deliveredFps > 0.0 && targetFps > 0.0) {
+    if (healthyPerformanceStatus != null && grade != null && deliveredFps > 0.0 && targetFps > 0.0) {
+        lines += "Last: grade $grade · $healthyPerformanceStatus at ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS"
+    } else if (grade != null && deliveredFps > 0.0 && targetFps > 0.0) {
         lines += "Last: grade $grade at ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS"
     } else if (grade != null) {
         lines += "Last: grade $grade"
@@ -229,12 +294,79 @@ private fun buildHistoryLines(
     return lines
 }
 
-private fun limitingIssue(optimization: JSONObject, lastResult: JSONObject?): String {
-    val limitingFactor = meaningfulIssue(optimization.optString("limiting_factor", ""))
-    if (limitingFactor.isNotBlank()) {
-        return limitingFactor
+private val healthyContradictionIssues = setOf(
+    "host_render",
+    "host_render_limited",
+    "pacing",
+    "frame_pacing"
+)
+
+private fun healthyPerformanceStatus(
+    lastResult: JSONObject?,
+    reportedIssues: List<String>,
+    completeIssueEvidence: Boolean,
+    state: String,
+    requestedFps: Double,
+    effectiveFps: Double,
+    selectedLabel: String
+): String? {
+    if (lastResult == null || !completeIssueEvidence || reportedIssues.isEmpty()) return null
+    if (reportedIssues.any { normalized(it) !in healthyContradictionIssues }) return null
+    if (state == "recovering" || selectedLabel.startsWith("Recovery", ignoreCase = true)) return null
+    if (requestedFps > effectiveFps + 0.5 && effectiveFps > 0.0) return null
+    if (lastResult.optBoolean("relaunch_recommended", false)) return null
+    if (normalized(lastResult.optString("grade", "")) != "a") return null
+
+    val deliveredFps = strictFiniteNumber(lastResult, "delivered_fps") ?: return null
+    val targetFps = strictFiniteNumber(lastResult, "target_fps") ?: return null
+    val lowOnePercentFps = strictFiniteNumber(lastResult, "low_1_percent_fps") ?: return null
+    val minFps = strictFiniteNumber(lastResult, "min_fps") ?: return null
+    val badPacingPct = strictFiniteNumber(lastResult, "frame_pacing_bad_pct") ?: return null
+    if (deliveredFps <= 0.0 || targetFps < 24.0) return null
+    if (deliveredFps / targetFps < 0.95) return null
+    if (lowOnePercentFps <= 0.0 || lowOnePercentFps / targetFps < 0.85) return null
+    if (minFps <= 0.0 || minFps / targetFps < 0.60) return null
+    if (badPacingPct < 0.0 || badPacingPct >= 5.0) return null
+
+    val normalRiskValues = setOf("normal", "low", "none", "steady", "stable", "good", "ok", "healthy")
+    for (key in listOf("network_risk", "decoder_risk", "hdr_risk")) {
+        if (!lastResult.has(key) || lastResult.isNull(key)) return null
+        val risk = lastResult.opt(key) as? String ?: return null
+        if (normalized(risk) !in normalRiskValues) return null
     }
-    return meaningfulIssue(lastResult?.optString("primary_issue", "") ?: "")
+
+    return if (deliveredFps >= targetFps) "Target met" else "Near target"
+}
+
+private fun strictFiniteNumber(source: JSONObject, key: String): Double? {
+    val value = source.opt(key) as? Number ?: return null
+    return value.toDouble().takeIf { it.isFinite() }
+}
+
+private fun hasCompleteDiagnosticIssueEvidence(
+    optimization: JSONObject,
+    lastResult: JSONObject?
+): Boolean {
+    if (!optimization.has("limiting_factor") ||
+        lastResult == null ||
+        !lastResult.has("primary_issue")
+    ) {
+        return false
+    }
+    return meaningfulIssue(optimization.optString("limiting_factor", "")).isNotBlank() &&
+        meaningfulIssue(lastResult.optString("primary_issue", "")).isNotBlank()
+}
+
+private fun diagnosticIssues(optimization: JSONObject, lastResult: JSONObject?): List<String> {
+    return listOf(
+        meaningfulIssue(optimization.optString("limiting_factor", "")),
+        meaningfulIssue(lastResult?.optString("primary_issue", "") ?: "")
+    ).filter { it.isNotBlank() }.distinct()
+}
+
+private fun preferredIssueForDisplay(reportedIssues: List<String>): String {
+    return reportedIssues.firstOrNull { normalized(it) !in healthyContradictionIssues }
+        ?: reportedIssues.firstOrNull().orEmpty()
 }
 
 private fun meaningfulIssue(value: String): String {

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -55,15 +55,17 @@ internal fun buildNovaLaunchProfileSummary(
     val trialProfile = optimization.optBoolean("trial_profile", false) ||
         profileState?.optBoolean("trial_profile", false) == true
 
+    val requestedProfileFps = strictPositiveFiniteNumber(requestedProfile, "target_fps")
+    val selectedProfileFps = strictPositiveFiniteNumber(currentProfile, "target_fps")
     val requestedFps = firstPositive(
-        requestedProfile?.optDouble("target_fps", 0.0) ?: 0.0,
-        optimization.optDouble("preference_requested_target_fps", 0.0),
-        optimization.optDouble("requested_target_fps", 0.0),
+        requestedProfileFps ?: 0.0,
+        strictFiniteNumber(optimization, "preference_requested_target_fps") ?: 0.0,
+        strictFiniteNumber(optimization, "requested_target_fps") ?: 0.0,
         parseDisplayModeFps(requestedProfile?.optString("display_mode", ""))
     )
     val effectiveFps = firstPositive(
-        currentProfile?.optDouble("target_fps", 0.0) ?: 0.0,
-        optimization.optDouble("effective_target_fps", 0.0),
+        selectedProfileFps ?: 0.0,
+        strictFiniteNumber(optimization, "effective_target_fps") ?: 0.0,
         parseDisplayModeFps(currentProfile?.optString("display_mode", "")),
         parseDisplayModeFps(optimization.optString("display_mode", ""))
     )
@@ -112,7 +114,9 @@ internal fun buildNovaLaunchProfileSummary(
         state = state,
         requestedFps = requestedFps,
         effectiveFps = effectiveFps,
-        selectedLabel = selectedLabel
+        selectedLabel = selectedLabel,
+        trialProfile = trialProfile,
+        hasAuthoritativeProfileFps = requestedProfileFps != null && selectedProfileFps != null
     )
     val healthyPerformance = healthyPerformanceStatus != null
     val reasonLine = if (healthyPerformance) {
@@ -194,19 +198,20 @@ internal fun buildNovaLaunchProfileSummary(
 
 private fun buildHealthyPerformanceNoticeDetail(lastResult: JSONObject?, performanceStatus: String): String {
     if (lastResult == null) return ""
-    val deliveredFps = lastResult.optDouble("delivered_fps", 0.0)
-    val targetFps = lastResult.optDouble("target_fps", 0.0)
+    val deliveredFps = strictFiniteNumber(lastResult, "delivered_fps") ?: return ""
+    val targetFps = strictFiniteNumber(lastResult, "target_fps") ?: return ""
     if (deliveredFps <= 0.0 || targetFps <= 0.0) return ""
 
     val evidence = mutableListOf(
         "Last stream: ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS."
     )
-    val lowOnePercentFps = lastResult.optDouble("low_1_percent_fps", 0.0)
-    if (lowOnePercentFps > 0.0) {
+    val lowOnePercentFps = strictFiniteNumber(lastResult, "low_1_percent_fps")
+    if (lowOnePercentFps != null && lowOnePercentFps > 0.0) {
         evidence += "1% low: ${formatFps(lowOnePercentFps)} FPS."
     }
-    if (lastResult.has("frame_pacing_bad_pct")) {
-        evidence += "Bad pacing: ${formatFps(lastResult.optDouble("frame_pacing_bad_pct", 0.0))}%."
+    val badPacingPct = strictFiniteNumber(lastResult, "frame_pacing_bad_pct")
+    if (badPacingPct != null) {
+        evidence += "Bad pacing: ${formatFps(badPacingPct)}%."
     }
     evidence += if (performanceStatus == "Target met") {
         "Stream target met."
@@ -217,8 +222,8 @@ private fun buildHealthyPerformanceNoticeDetail(lastResult: JSONObject?, perform
 }
 
 private fun buildNoticeDetail(lastResult: JSONObject?, issue: String): String {
-    val deliveredFps = lastResult?.optDouble("delivered_fps", 0.0) ?: 0.0
-    val targetFps = lastResult?.optDouble("target_fps", 0.0) ?: 0.0
+    val deliveredFps = strictFiniteNumber(lastResult, "delivered_fps") ?: 0.0
+    val targetFps = strictFiniteNumber(lastResult, "target_fps") ?: 0.0
     val evidence = if (deliveredFps > 0.0 && targetFps > 0.0) {
         "Last stream: ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS."
     } else {
@@ -276,8 +281,8 @@ private fun buildHistoryLines(
 
     val lines = mutableListOf<String>()
     val grade = lastResult.optString("grade", "").takeIf { it.isNotBlank() }
-    val deliveredFps = lastResult.optDouble("delivered_fps", 0.0)
-    val targetFps = lastResult.optDouble("target_fps", 0.0)
+    val deliveredFps = strictFiniteNumber(lastResult, "delivered_fps") ?: 0.0
+    val targetFps = strictFiniteNumber(lastResult, "target_fps") ?: 0.0
     if (healthyPerformanceStatus != null && grade != null && deliveredFps > 0.0 && targetFps > 0.0) {
         lines += "Last: grade $grade · $healthyPerformanceStatus at ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS"
     } else if (grade != null && deliveredFps > 0.0 && targetFps > 0.0) {
@@ -308,12 +313,25 @@ private fun healthyPerformanceStatus(
     state: String,
     requestedFps: Double,
     effectiveFps: Double,
-    selectedLabel: String
+    selectedLabel: String,
+    trialProfile: Boolean,
+    hasAuthoritativeProfileFps: Boolean
 ): String? {
     if (lastResult == null || !completeIssueEvidence || reportedIssues.isEmpty()) return null
-    if (reportedIssues.any { normalized(it) !in healthyContradictionIssues }) return null
-    if (state == "recovering" || selectedLabel.startsWith("Recovery", ignoreCase = true)) return null
-    if (requestedFps > effectiveFps + 0.5 && effectiveFps > 0.0) return null
+    val issueClasses = reportedIssues.map(::healthyIssueClass)
+    if (issueClasses.any { it == null } || issueClasses.distinct().size != 1) return null
+    if (trialProfile || state == "trial" || state == "recovering") return null
+    if (selectedLabel.startsWith("Recovery", ignoreCase = true) ||
+        selectedLabel.contains("trial", ignoreCase = true)
+    ) {
+        return null
+    }
+    if (!hasAuthoritativeProfileFps || !requestedFps.isFinite() || requestedFps <= 0.0 ||
+        !effectiveFps.isFinite() || effectiveFps <= 0.0
+    ) {
+        return null
+    }
+    if (requestedFps > effectiveFps + 0.5) return null
     if (lastResult.optBoolean("relaunch_recommended", false)) return null
     if (normalized(lastResult.optString("grade", "")) != "a") return null
 
@@ -338,9 +356,21 @@ private fun healthyPerformanceStatus(
     return if (deliveredFps >= targetFps) "Target met" else "Near target"
 }
 
-private fun strictFiniteNumber(source: JSONObject, key: String): Double? {
-    val value = source.opt(key) as? Number ?: return null
+private fun strictFiniteNumber(source: JSONObject?, key: String): Double? {
+    val value = source?.opt(key) as? Number ?: return null
     return value.toDouble().takeIf { it.isFinite() }
+}
+
+private fun strictPositiveFiniteNumber(source: JSONObject?, key: String): Double? {
+    return strictFiniteNumber(source, key)?.takeIf { it > 0.0 }
+}
+
+private fun healthyIssueClass(issue: String): String? {
+    return when (normalized(issue)) {
+        "host_render", "host_render_limited" -> "host_render"
+        "pacing", "frame_pacing" -> "frame_pacing"
+        else -> null
+    }
 }
 
 private fun hasCompleteDiagnosticIssueEvidence(
@@ -445,11 +475,11 @@ private fun parseDisplayModeFps(displayMode: String?): Double {
     if (displayMode.isNullOrBlank()) return 0.0
     val parts = displayMode.split("x")
     if (parts.size < 3) return 0.0
-    return parts[2].toDoubleOrNull() ?: 0.0
+    return parts[2].toDoubleOrNull()?.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
 }
 
 private fun firstPositive(vararg values: Double): Double {
-    return values.firstOrNull { it > 0.0 } ?: 0.0
+    return values.firstOrNull { it.isFinite() && it > 0.0 } ?: 0.0
 }
 
 private fun normalized(value: String): String {

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -11,6 +11,8 @@ data class NovaLaunchProfileSummary(
     val selectedLine: String,
     val reasonLine: String,
     val limitingLine: String,
+    val noticeDetail: String,
+    val noticeRecommendation: String,
     val freshnessLine: String,
     val historyLines: List<String>,
     val showRetryHighFps: Boolean,
@@ -129,6 +131,13 @@ internal fun buildNovaLaunchProfileSummary(
     } else {
         "Try High FPS once"
     }
+    val noticeDetail = buildNoticeDetail(lastResult, issue)
+    val noticeRecommendation = buildNoticeRecommendation(
+        state = state,
+        requestedFps = requestedFps,
+        effectiveFps = effectiveFps,
+        showRetryHighFps = showRetryHighFps
+    )
 
     return NovaLaunchProfileSummary(
         primaryLaunchLabel = primaryLabel,
@@ -136,11 +145,63 @@ internal fun buildNovaLaunchProfileSummary(
         selectedLine = selectedLine,
         reasonLine = reasonLine,
         limitingLine = limitingLine,
+        noticeDetail = noticeDetail,
+        noticeRecommendation = noticeRecommendation,
         freshnessLine = freshnessLine,
         historyLines = historyLines,
         showRetryHighFps = showRetryHighFps,
         retryHighFpsLabel = retryLabel
     )
+}
+
+private fun buildNoticeDetail(lastResult: JSONObject?, issue: String): String {
+    val deliveredFps = lastResult?.optDouble("delivered_fps", 0.0) ?: 0.0
+    val targetFps = lastResult?.optDouble("target_fps", 0.0) ?: 0.0
+    val evidence = if (deliveredFps > 0.0 && targetFps > 0.0) {
+        "Last stream: ${formatFps(deliveredFps)}/${formatFps(targetFps)} FPS."
+    } else {
+        ""
+    }
+    val impact = when (normalized(issue)) {
+        "host_render", "host_render_limited" ->
+            "The host missed the stream target, which can cause repeated frames or uneven motion."
+        "decoder", "decoder_path" ->
+            "The client decoder missed frames, which can cause stutter or uneven motion."
+        "network" ->
+            "The network path was unstable, which can cause hitching or dropped frames."
+        "encoder" ->
+            "The host encoder missed frames, which can cause uneven frame delivery."
+        "pacing", "frame_pacing" ->
+            "Frames arrived unevenly, which can look like judder even when average FPS is high."
+        "" -> ""
+        else -> "Polaris reported ${issueLabel(issue)} for the last session."
+    }
+    return listOf(evidence, impact).filter { it.isNotBlank() }.joinToString(" ")
+}
+
+private fun buildNoticeRecommendation(
+    state: String,
+    requestedFps: Double,
+    effectiveFps: Double,
+    showRetryHighFps: Boolean
+): String {
+    val recoveryActive = state == "recovering"
+    val retry = if (showRetryHighFps && requestedFps > 0.0) {
+        " Try ${formatFps(requestedFps)} FPS once remains available below."
+    } else {
+        ""
+    }
+    if (requestedFps > effectiveFps + 0.5 && effectiveFps > 0.0) {
+        return if (recoveryActive) {
+            "Next launch: ${formatFps(effectiveFps)} FPS Recovery instead of your requested ${formatFps(requestedFps)} FPS because the learned recovery profile is active.$retry"
+        } else {
+            "Next launch: Nova selected ${formatFps(effectiveFps)} FPS instead of your requested ${formatFps(requestedFps)} FPS.$retry"
+        }
+    }
+    if (recoveryActive && effectiveFps > 0.0) {
+        return "Next launch: ${formatFps(effectiveFps)} FPS Recovery remains active. One clean launch can release it, or reset this game profile below."
+    }
+    return ""
 }
 
 private fun buildHistoryLines(

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1141,6 +1141,27 @@ class NovaComposeSourceGuardTest {
             launchControls.contains("LaunchProfilePrimaryNotice(") &&
                 launchControls.indexOf("LaunchProfilePrimaryNotice(") < launchControls.indexOf("text = playLabel")
         )
+        assertTrue(
+            "Heads up should explain evidence and the recommended next launch instead of showing one vague limited-by line",
+            launchControls.contains("text = summary.noticeDetail") &&
+                launchControls.contains("text = summary.noticeRecommendation")
+        )
+        assertTrue(
+            "Heads up should remain visible when only the new evidence or recommendation fields are available",
+            launchControls.contains("val hasNoticeContent = listOf(") &&
+                launchControls.contains("summary.noticeDetail") &&
+                launchControls.contains("summary.noticeRecommendation") &&
+                launchControls.contains("if (!hasNoticeContent) return") &&
+                launchControls.contains("text = notice.ifBlank { \"Launch profile adjusted\" }")
+        )
+        assertTrue(
+            "Heads up should stay compact until the player opens the DPAD-friendly detail control",
+            launchControls.contains("var noticeExpanded by remember(") &&
+                launchControls.contains("text = if (noticeExpanded) \"Hide details\" else \"More details\"") &&
+                launchControls.contains("stateDescription = if (noticeExpanded) \"Expanded\" else \"Collapsed\"") &&
+                launchControls.contains("if (noticeExpanded && summary.noticeDetail.isNotBlank())") &&
+                launchControls.contains("if (noticeExpanded && summary.noticeRecommendation.isNotBlank())")
+        )
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1126,6 +1126,14 @@ class NovaComposeSourceGuardTest {
                 launchControls.contains(".focusRequester(playFocusRequester)")
         )
         assertTrue(
+            "game detail should wire an explicit controller focus route between Play and More details",
+            launchControls.contains("val detailsFocusRequester = remember { FocusRequester() }") &&
+                launchControls.contains("detailsFocusRequester = detailsFocusRequester") &&
+                launchControls.contains("playFocusRequester = playFocusRequester") &&
+                launchControls.contains(".focusProperties { up = detailsFocusRequester }") &&
+                launchControls.contains(".focusProperties { down = playFocusRequester }")
+        )
+        assertTrue(
             "game detail should make Play the full-width primary action before secondary tuning actions",
             launchControls.section("text = playLabel", "enabled = uiState.playEnabled")
                 .contains(".fillMaxWidth()\n                .focusRequester(playFocusRequester)") &&

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1158,7 +1158,7 @@ class NovaComposeSourceGuardTest {
             "near-target performance should use an explicit healthy status tone instead of warning styling",
             launchControls.contains("summary.noticeTone == NovaLaunchProfileNoticeTone.HEALTHY") &&
                 launchControls.contains("val badgeLabel = if (isHealthy) summary.noticeLabel else \"Heads up\"") &&
-                launchControls.contains("Color(0xFF4ADE80)")
+                launchControls.contains("colorResource(R.color.nova_success)")
         )
         assertTrue(
             "Heads up should stay compact until the player opens the DPAD-friendly detail control",

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1155,6 +1155,12 @@ class NovaComposeSourceGuardTest {
                 launchControls.contains("text = notice.ifBlank { \"Launch profile adjusted\" }")
         )
         assertTrue(
+            "near-target performance should use an explicit healthy status tone instead of warning styling",
+            launchControls.contains("summary.noticeTone == NovaLaunchProfileNoticeTone.HEALTHY") &&
+                launchControls.contains("val badgeLabel = if (isHealthy) summary.noticeLabel else \"Heads up\"") &&
+                launchControls.contains("Color(0xFF4ADE80)")
+        )
+        assertTrue(
             "Heads up should stay compact until the player opens the DPAD-friendly detail control",
             launchControls.contains("var noticeExpanded by remember(") &&
                 launchControls.contains("text = if (noticeExpanded) \"Hide details\" else \"More details\"") &&

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
@@ -715,6 +715,69 @@ class NovaLaunchProfileSummaryTest {
         assertFalse(summary.historyLines.any { it.contains("Infinity") })
     }
 
+    @Test
+    fun healthyTelemetryTargetMustMatchRequestedAndSelectedProfile() {
+        val input = healthyNearTargetOptimization()
+        input.getJSONObject("profile_state").getJSONObject("last_result")
+            .put("target_fps", 60)
+            .put("delivered_fps", 60)
+            .put("low_1_percent_fps", 58)
+            .put("min_fps", 55)
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun healthyTelemetryTargetWithinHalfFpsMatchesProfile() {
+        val input = healthyNearTargetOptimization()
+        input.getJSONObject("profile_state").getJSONObject("last_result")
+            .put("target_fps", 119.5)
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.HEALTHY, summary.noticeTone)
+        assertEquals("Near target", summary.noticeLabel)
+    }
+
+    @Test
+    fun rawRecoveryOrTrialLabelCannotBeHiddenByHighFpsDisplayLabel() {
+        listOf("Recovery profile", "High FPS Trial").forEach { label ->
+            val input = healthyNearTargetOptimization()
+            input.put("preference", "high_fps")
+            input.getJSONObject("profile_state").put("label", label)
+
+            val summary = buildNovaLaunchProfileSummary(input)
+
+            requireNotNull(summary)
+            assertEquals(label, NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+            assertFalse(label, summary.noticeRecommendation.contains("No recovery adjustment"))
+        }
+    }
+
+    @Test
+    fun missingUnknownOrDownshiftedLifecycleStateCannotRenderHealthy() {
+        val cases = listOf<String?>(null, "unknown", "downshifted")
+        cases.forEach { state ->
+            val input = healthyNearTargetOptimization()
+            val profileState = input.getJSONObject("profile_state")
+            if (state == null) {
+                profileState.remove("state")
+            } else {
+                profileState.put("state", state)
+            }
+
+            val summary = buildNovaLaunchProfileSummary(input)
+
+            requireNotNull(summary)
+            assertEquals(state ?: "missing", NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        }
+    }
+
     private fun healthyNearTargetOptimization(): JSONObject {
         return JSONObject(
             "{" +

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
@@ -597,4 +597,142 @@ class NovaLaunchProfileSummaryTest {
         assertEquals("Reason: Nova recommends High FPS for this game.", summary.reasonLine)
     }
 
+
+    @Test
+    fun healthyStatusRequiresFiniteRequestedAndSelectedProfileFps() {
+        val cases = mapOf<String, (JSONObject) -> Unit>(
+            "missing requested FPS with finite fallbacks" to { root ->
+                root.put("preference_requested_target_fps", 120)
+                root.getJSONObject("preference_requested_profile")
+                    .remove("target_fps")
+                root.getJSONObject("preference_requested_profile")
+                    .put("display_mode", "1920x1080x120")
+            },
+            "missing selected FPS with finite fallbacks" to { root ->
+                root.getJSONObject("profile_state").getJSONObject("current_profile")
+                    .remove("target_fps")
+                root.getJSONObject("profile_state").getJSONObject("current_profile")
+                    .put("display_mode", "1920x1080x120")
+            },
+            "non-finite requested FPS with finite fallbacks" to { root ->
+                root.put("preference_requested_target_fps", 120)
+                root.getJSONObject("preference_requested_profile")
+                    .put("target_fps", "Infinity")
+                    .put("display_mode", "1920x1080x120")
+            },
+            "non-finite selected FPS with finite fallbacks" to { root ->
+                root.getJSONObject("profile_state").getJSONObject("current_profile")
+                    .put("target_fps", "Infinity")
+                    .put("display_mode", "1920x1080x120")
+            }
+        )
+
+        cases.forEach { (label, mutate) ->
+            val input = healthyNearTargetOptimization()
+            mutate(input)
+            val summary = buildNovaLaunchProfileSummary(input)
+
+            requireNotNull(summary)
+            assertEquals(label, NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+            assertFalse(label, summary.noticeRecommendation.contains("No recovery adjustment"))
+        }
+    }
+
+    @Test
+    fun trialProfileNeverRendersHealthyEvenWithOtherwiseHealthyEvidence() {
+        val input = healthyNearTargetOptimization()
+        input.put("trial_profile", true)
+        input.getJSONObject("profile_state").put("state", "trial")
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertTrue(summary.freshnessLine.contains("learned recovery remains active"))
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun conflictingAllowlistedDiagnosesNeverRenderHealthy() {
+        val input = healthyNearTargetOptimization()
+        input.getJSONObject("profile_state").getJSONObject("last_result")
+            .put("primary_issue", "frame_pacing")
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun isolatedBadOrMalformedPacingEvidenceNeverRendersHealthy() {
+        val cases = mapOf<String, Any>(
+            "bad pacing threshold" to 5.0,
+            "non-finite pacing" to "Infinity",
+            "malformed pacing" to "unknown"
+        )
+
+        cases.forEach { (label, pacing) ->
+            val input = healthyNearTargetOptimization()
+            input.getJSONObject("profile_state").getJSONObject("last_result")
+                .put("frame_pacing_bad_pct", pacing)
+            val summary = buildNovaLaunchProfileSummary(input)
+
+            requireNotNull(summary)
+            assertEquals(label, NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        }
+    }
+
+    @Test
+    fun isolatedRecoveryStateNeverRendersHealthy() {
+        val input = healthyNearTargetOptimization()
+        input.getJSONObject("profile_state")
+            .put("state", "recovering")
+            .put("label", "Recovery")
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun warningDetailsAndHistoryNeverRenderNonFiniteFps() {
+        val input = healthyNearTargetOptimization()
+        input.put("limiting_factor", "network")
+        input.getJSONObject("profile_state").getJSONObject("last_result")
+            .put("grade", "B")
+            .put("primary_issue", "network")
+            .put("delivered_fps", "Infinity")
+
+        val summary = buildNovaLaunchProfileSummary(input)
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeDetail.contains("Infinity"))
+        assertFalse(summary.historyLines.any { it.contains("Infinity") })
+    }
+
+    private fun healthyNearTargetOptimization(): JSONObject {
+        return JSONObject(
+            "{" +
+                "\"effective_target_fps\":120," +
+                "\"limiting_factor\":\"host_render_limited\"," +
+                "\"preference_requested_profile\":{\"target_fps\":120}," +
+                "\"profile_state\":{" +
+                "\"state\":\"blocked\",\"label\":\"High FPS held\"," +
+                "\"current_profile\":{\"target_fps\":120}," +
+                "\"last_result\":{" +
+                "\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                "\"low_1_percent_fps\":110.8,\"min_fps\":110.8," +
+                "\"frame_pacing_bad_pct\":0.0," +
+                "\"network_risk\":\"normal\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"," +
+                "\"primary_issue\":\"host_render_limited\"}" +
+                "}" +
+                "}"
+        )
+    }
+
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
@@ -91,6 +91,7 @@ class NovaLaunchProfileSummaryTest {
         )
 
         requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
         assertEquals("Limited by: Host render", summary.limitingLine)
         assertEquals(
             "Last stream: 54/60 FPS. The host missed the stream target, which can cause repeated frames or uneven motion.",
@@ -265,6 +266,279 @@ class NovaLaunchProfileSummaryTest {
         assertEquals("Launch High FPS stream 120 FPS", summary.primaryLaunchLabel)
         assertEquals("Selected: High FPS stream / 120 FPS", summary.selectedLine)
         assertFalse(summary.showRetryHighFps)
+    }
+
+    @Test
+    fun healthyNearTargetResultOverridesStaleHostLimitWithPositiveEvidence() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"display_mode\":\"1920x1080x120\"," +
+                    "\"effective_target_fps\":120," +
+                    "\"preference\":\"high_fps\"," +
+                    "\"preference_applied\":true," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"preference_requested_profile\":{\"display_mode\":\"1920x1080x120\",\"target_fps\":120}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"label\":\"High FPS held\"," +
+                    "\"reason\":\"Holding quality until the host render path reaches the stream FPS target.\"," +
+                    "\"current_profile\":{\"display_mode\":\"1920x1080x120\",\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.78,\"min_fps\":110.78,\"frame_pacing_bad_pct\":0.0," +
+                    "\"network_risk\":\"normal\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"," +
+                    "\"primary_issue\":\"host_render_limited\",\"updated_at\":1780000000}" +
+                    "}" +
+                    "}"
+            ),
+            nowSeconds = 1780000060L
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.HEALTHY, summary.noticeTone)
+        assertEquals("", summary.limitingLine)
+        assertEquals("Performance: Near target", summary.reasonLine)
+        assertEquals(
+            "Last stream: 115.6/120 FPS. 1% low: 110.8 FPS. Bad pacing: 0%. Normal gameplay variation.",
+            summary.noticeDetail
+        )
+        assertEquals("No recovery adjustment is needed.", summary.noticeRecommendation)
+        assertTrue(summary.historyLines.contains("Last: grade A · Near target at 115.6/120 FPS"))
+        assertFalse(summary.historyLines.any { it.contains("Issue:") })
+    }
+
+    @Test
+    fun missingDetailedPacingEvidenceDoesNotOverrideHostWarning() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"display_mode\":\"1920x1080x120\"," +
+                    "\"limiting_factor\":\"host_render\"," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\"," +
+                    "\"last_result\":{" +
+                    "\"grade\":\"A\"," +
+                    "\"delivered_fps\":115.6," +
+                    "\"target_fps\":120.0," +
+                    "\"primary_issue\":\"host_render_limited\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Limited by: Host render", summary.limitingLine)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun nearTargetAverageWithBadPacingKeepsWarning() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"frame_pacing_bad_pct\":10.0," +
+                    "\"primary_issue\":\"host_render_limited\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Limited by: Host render", summary.limitingLine)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun malformedPacingEvidenceDoesNotOverrideHostWarning() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":\"unknown\"," +
+                    "\"primary_issue\":\"host_render_limited\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun conflictingNetworkIssueOverridesStaleHostFactor() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"primary_issue\":\"network\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Limited by: Network", summary.limitingLine)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun absentIssueDoesNotManufactureHealthyStatus() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun limitingFactorWithoutPrimaryIssueDoesNotRenderHealthy() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120,\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"network_risk\":\"normal\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"}}}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Limited by: Host render", summary.limitingLine)
+    }
+
+    @Test
+    fun primaryIssueWithoutLimitingFactorDoesNotRenderHealthy() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"profile_state\":{\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"network_risk\":\"normal\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"," +
+                    "\"primary_issue\":\"host_render_limited\"}}}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Limited by: Host render", summary.limitingLine)
+    }
+
+    @Test
+    fun missingRiskEvidenceDoesNotRenderHealthy() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120,\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"primary_issue\":\"host_render_limited\"}}}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+    }
+
+    @Test
+    fun unknownRiskEvidenceDoesNotRenderHealthy() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120,\"limiting_factor\":\"host_render_limited\"," +
+                    "\"profile_state\":{\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"network_risk\":\"unknown\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"," +
+                    "\"primary_issue\":\"host_render_limited\"}}}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+    }
+
+    @Test
+    fun activeRecoveryNeverRendersAsHealthyNearTarget() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":60," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"preference_requested_profile\":{\"target_fps\":120}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"recovering\",\"current_profile\":{\"target_fps\":60}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":115.6,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":110.8,\"min_fps\":110.8,\"frame_pacing_bad_pct\":0.0," +
+                    "\"primary_issue\":\"host_render_limited\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.WARNING, summary.noticeTone)
+        assertEquals("Launch Recovery profile 60 FPS", summary.primaryLaunchLabel)
+        assertFalse(summary.noticeRecommendation.contains("No recovery adjustment"))
+    }
+
+    @Test
+    fun targetMetResultOverridesStaleHostWarning() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":120," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"preference_requested_profile\":{\"target_fps\":120}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"blocked\",\"current_profile\":{\"target_fps\":120}," +
+                    "\"last_result\":{\"grade\":\"A\",\"delivered_fps\":120.1,\"target_fps\":120," +
+                    "\"low_1_percent_fps\":115.0,\"min_fps\":110.0,\"frame_pacing_bad_pct\":0.0," +
+                    "\"network_risk\":\"normal\",\"decoder_risk\":\"normal\",\"hdr_risk\":\"normal\"," +
+                    "\"primary_issue\":\"host_render_limited\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(NovaLaunchProfileNoticeTone.HEALTHY, summary.noticeTone)
+        assertEquals("Performance: Target met", summary.reasonLine)
+        assertEquals("No recovery adjustment is needed.", summary.noticeRecommendation)
+        assertTrue(summary.historyLines.contains("Last: grade A · Target met at 120.1/120 FPS"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchProfileSummaryTest.kt
@@ -50,12 +50,150 @@ class NovaLaunchProfileSummaryTest {
         assertEquals("Requested: High FPS stream / 120 FPS", summary.requestedLine)
         assertEquals("Selected: Recovery profile / 40 FPS", summary.selectedLine)
         assertEquals("Limited by: Decoder path", summary.limitingLine)
+        assertEquals(
+            "Last stream: 58.5/60 FPS. The client decoder missed frames, which can cause stutter or uneven motion.",
+            summary.noticeDetail
+        )
+        assertEquals(
+            "Next launch: 40 FPS Recovery instead of your requested 120 FPS because the learned recovery profile is active. Try 120 FPS once remains available below.",
+            summary.noticeRecommendation
+        )
         assertEquals("Recovery active from last session · 1 min ago", summary.freshnessLine)
         assertEquals("Try 120 FPS once", summary.retryHighFpsLabel)
         assertTrue(summary.showRetryHighFps)
         assertTrue(summary.historyLines.contains("Last: grade B at 58.5/60 FPS"))
         assertTrue(summary.historyLines.contains("Issue: Decoder path"))
         assertTrue(summary.historyLines.contains("Next: one clean launch can release recovery, or reset this game profile."))
+    }
+
+    @Test
+    fun hostRenderLimitNoticeExplainsEvidenceImpactAndRecoveryTarget() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"display_mode\":\"1920x1080x30\"," +
+                    "\"effective_target_fps\":30," +
+                    "\"preference\":\"high_fps\"," +
+                    "\"preference_applied\":false," +
+                    "\"limiting_factor\":\"host_render_limited\"," +
+                    "\"preference_requested_profile\":{\"display_mode\":\"1920x1080x60\",\"target_fps\":60}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"recovering\"," +
+                    "\"label\":\"Recovery\"," +
+                    "\"current_profile\":{\"display_mode\":\"1920x1080x30\",\"target_fps\":30}," +
+                    "\"last_result\":{\"grade\":\"C\",\"delivered_fps\":54,\"target_fps\":60," +
+                    "\"primary_issue\":\"host_render_limited\",\"updated_at\":1780000000}," +
+                    "\"actions\":{\"can_retry_high_fps\":true}" +
+                    "}" +
+                    "}"
+            ),
+            nowSeconds = 1780000060L
+        )
+
+        requireNotNull(summary)
+        assertEquals("Limited by: Host render", summary.limitingLine)
+        assertEquals(
+            "Last stream: 54/60 FPS. The host missed the stream target, which can cause repeated frames or uneven motion.",
+            summary.noticeDetail
+        )
+        assertEquals(
+            "Next launch: 30 FPS Recovery instead of your requested 60 FPS because the learned recovery profile is active. Try 60 FPS once remains available below.",
+            summary.noticeRecommendation
+        )
+    }
+
+    @Test
+    fun unknownIssueReportsSourceTruthWithoutInventingAnFpsMiss() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":60," +
+                    "\"limiting_factor\":\"thermal_throttle\"," +
+                    "\"preference_requested_profile\":{\"target_fps\":60}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"stable\",\"label\":\"Quality\"," +
+                    "\"current_profile\":{\"target_fps\":60}," +
+                    "\"last_result\":{\"delivered_fps\":60,\"target_fps\":60," +
+                    "\"primary_issue\":\"thermal_throttle\"}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(
+            "Last stream: 60/60 FPS. Polaris reported Thermal throttle for the last session.",
+            summary.noticeDetail
+        )
+        assertFalse(summary.noticeDetail.contains("did not meet"))
+        assertEquals("", summary.noticeRecommendation)
+    }
+
+    @Test
+    fun lowerNonRecoveryProfileUsesNeutralSelectionCopy() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":60," +
+                    "\"preference\":\"high_fps\",\"preference_applied\":false," +
+                    "\"limiting_factor\":\"network\"," +
+                    "\"preference_requested_profile\":{\"target_fps\":120}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"stable\",\"label\":\"Quality\"," +
+                    "\"current_profile\":{\"target_fps\":60}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(
+            "Next launch: Nova selected 60 FPS instead of your requested 120 FPS. Try 120 FPS once remains available below.",
+            summary.noticeRecommendation
+        )
+        assertFalse(summary.noticeRecommendation.contains("Recovery"))
+        assertFalse(summary.noticeRecommendation.contains("steadier"))
+    }
+
+    @Test
+    fun equalTargetRecoveryExplainsReleaseWithoutPromisingPacing() {
+        val summary = buildNovaLaunchProfileSummary(
+            JSONObject(
+                "{" +
+                    "\"effective_target_fps\":60," +
+                    "\"preference_requested_profile\":{\"target_fps\":60}," +
+                    "\"profile_state\":{" +
+                    "\"state\":\"recovering\",\"label\":\"Recovery\"," +
+                    "\"current_profile\":{\"target_fps\":60}" +
+                    "}" +
+                    "}"
+            )
+        )
+
+        requireNotNull(summary)
+        assertEquals(
+            "Next launch: 60 FPS Recovery remains active. One clean launch can release it, or reset this game profile below.",
+            summary.noticeRecommendation
+        )
+        assertFalse(summary.noticeRecommendation.contains("steadier"))
+    }
+
+    @Test
+    fun knownLimitTypesExplainPlayerVisibleImpactWithoutFpsEvidence() {
+        val expected = mapOf(
+            "network" to "The network path was unstable, which can cause hitching or dropped frames.",
+            "encoder" to "The host encoder missed frames, which can cause uneven frame delivery.",
+            "frame_pacing" to "Frames arrived unevenly, which can look like judder even when average FPS is high."
+        )
+
+        expected.forEach { (issue, detail) ->
+            val summary = buildNovaLaunchProfileSummary(
+                JSONObject("{\"limiting_factor\":\"$issue\",\"profile_state\":{\"state\":\"stable\"}}")
+            )
+
+            requireNotNull(summary)
+            assertEquals(issue, detail, summary.noticeDetail)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- enrich game-detail Heads Up diagnostics with launch-profile provenance and structured health evidence
- classify **HEALTHY** only when grade, strict finite profile/telemetry evidence, target association, pacing, lifecycle, issue agreement, and all risk fields agree
- keep trial, recovery, learning, manual, upgrade, downshifted, missing, and unknown states fail-closed as warnings
- render finite-only diagnostic history and use semantic `nova_success` only for healthy state
- keep compact first paint while exposing expandable details
- wire deterministic controller focus: Play **Up → More details**, More details **Down → Play**

## Exact review identity
- PR head: `2e8111a10ffc3f91d05e849ac47ee5eafc64edfe`
- complete five-file diff SHA-256: `b9815a68a793bf5d7534a37b1db75c720e359f3e8836e8b06bd69dc2250efc14`
- exact read-only Codex review: pass, zero security or logic concerns
- added-line security scan: clean

## Local verification
- JVM unit tests: **807/807 passed**
- CI-equivalent x86_64 JVM lane: passed
- Android lint: passed
- debug APK assembly: arm64-v8a, armeabi-v7a, and x86_64 passed
- `git diff --check`: passed

## Physical Retroid Pocket 6 verification
- device serial: `98ea526f`
- behavioral Compose instrumentation: **1/1 passed**
  - exits Android touch mode with a real DPAD event
  - observes Play focus
  - sends real DPAD Up and observes More details focus
  - sends real DPAD Center and verifies expansion
  - verifies expanded content remains within a 320dp compact root
- final ARM64 APK package/version: `com.papi.nova.debug` / `1.3.1` (`33`)
- final ARM64 APK SHA-256: `052653c90b64e54cfaf69a692c80d22304faf9c6a89814c2e1d03bde33632f7a`
- v1/v2 signatures verified
- installed APK pullback matched byte-for-byte
- runtime settled at `NovaWelcomeActivity`; zero fatal/ANR/native-abort markers
- visual frame clean; device restored to Home
- no game or stream launched

## GitHub CI for exact head
- Lint and unit test: passed
- Analyze Java/Kotlin: passed
- CodeQL: passed
- public-hygiene: passed
- Assemble release APK: passed
- Emulator smoke test: intentionally skipped by the PR workflow

The initial lint/unit run hit the unrelated timing-sensitive `NovaUpdateRecoveryTest.cancellationAfterAtomicCommitDeletesFinalArtifact`. The exact test passed 10/10 fresh local repetitions, the complete x86_64 JVM lane passed, and the unchanged-SHA failed-job rerun passed.

## Scope
- Nova client only
- no Polaris deployment, service restart, release, merge, game launch, or stream launch
