### PR TITLE
feat(ui): add adaptive menu and drawer opacity

### DIFF
--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt
@@ -14,9 +14,13 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.preference.PreferenceManager
 import java.io.File
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 
 private val Context.novaSettingsDataStore by preferencesDataStore(name = "nova_settings")
+private val novaSettingsWriteMutex = Mutex()
 
 class NovaSharedPreferencesSettingsStore(
     private val prefs: SharedPreferences,
@@ -39,6 +43,18 @@ class NovaSharedPreferencesSettingsStore(
 
     override suspend fun set(definition: NovaSettingDefinition, value: NovaSettingValue) {
         prefs.edit().putSettingValue(definition.key, value).apply()
+    }
+
+    override suspend fun updateAtomically(
+        updates: List<Pair<NovaSettingDefinition, NovaSettingValue>>,
+        removeKeys: Set<String>
+    ) {
+        val editor = prefs.edit()
+        removeKeys.forEach(editor::remove)
+        updates.forEach { (definition, value) ->
+            editor.putSettingValue(definition.key, value)
+        }
+        check(editor.commit()) { "Failed to persist Nova settings batch" }
     }
 
     override suspend fun reset(definition: NovaSettingDefinition) {
@@ -83,6 +99,10 @@ class NovaSharedPreferencesSettingsStore(
 interface NovaSettingsStore {
     suspend fun snapshot(definitions: NovaSettingsDefinitionSet): Map<String, NovaSettingValue>
     suspend fun set(definition: NovaSettingDefinition, value: NovaSettingValue)
+    suspend fun updateAtomically(
+        updates: List<Pair<NovaSettingDefinition, NovaSettingValue>>,
+        removeKeys: Set<String> = emptySet()
+    )
     suspend fun reset(definition: NovaSettingDefinition)
     suspend fun overrideKeys(definitions: NovaSettingsDefinitionSet): Set<String>
     suspend fun resettableKeys(definitions: NovaSettingsDefinitionSet): Set<String>
@@ -104,17 +124,41 @@ class NovaSettingsRepository private constructor(
     }
 
     override suspend fun set(definition: NovaSettingDefinition, value: NovaSettingValue) {
-        dataStore.edit { preferences ->
-            preferences.writeSettingValue(definition, value)
+        persistWithoutCancellation {
+            dataStore.edit { preferences ->
+                preferences.writeSettingValue(definition, value)
+            }
+            mirrorPrefs.edit().putSettingValue(definition.key, value).apply()
         }
-        mirrorPrefs.edit().putSettingValue(definition.key, value).apply()
+    }
+
+    override suspend fun updateAtomically(
+        updates: List<Pair<NovaSettingDefinition, NovaSettingValue>>,
+        removeKeys: Set<String>
+    ) {
+        persistWithoutCancellation {
+            dataStore.edit { preferences ->
+                removeKeys.forEach(preferences::removeRawSettingKey)
+                updates.forEach { (definition, value) ->
+                    preferences.writeSettingValue(definition, value)
+                }
+            }
+            val editor = mirrorPrefs.edit()
+            removeKeys.forEach(editor::remove)
+            updates.forEach { (definition, value) ->
+                editor.putSettingValue(definition.key, value)
+            }
+            check(editor.commit()) { "Failed to persist Nova settings mirror batch" }
+        }
     }
 
     override suspend fun reset(definition: NovaSettingDefinition) {
-        dataStore.edit { preferences ->
-            preferences.removeSettingValue(definition)
+        persistWithoutCancellation {
+            dataStore.edit { preferences ->
+                preferences.removeSettingValue(definition)
+            }
+            mirrorPrefs.edit().remove(definition.key).apply()
         }
-        mirrorPrefs.edit().remove(definition.key).apply()
     }
 
     override suspend fun overrideKeys(definitions: NovaSettingsDefinitionSet): Set<String> = emptySet()
@@ -122,15 +166,28 @@ class NovaSettingsRepository private constructor(
     override suspend fun resettableKeys(definitions: NovaSettingsDefinitionSet): Set<String> = emptySet()
 
     private suspend fun ensureMigrated(definitions: NovaSettingsDefinitionSet) {
-        val preferences = dataStore.data.first()
-        if (preferences[MIGRATED_KEY] == true) return
+        persistWithoutCancellation {
+            val preferences = dataStore.data.first()
+            if (preferences[MIGRATED_KEY] == true) return@persistWithoutCancellation
 
-        dataStore.edit { mutablePreferences ->
-            for (definition in definitions.settings) {
-                val value = mirrorPrefs.readSettingValue(definition) ?: continue
-                mutablePreferences.writeSettingValue(definition, value)
+            dataStore.edit { mutablePreferences ->
+                for (definition in definitions.settings) {
+                    val value = mirrorPrefs.readSettingValue(definition) ?: continue
+                    mutablePreferences.writeSettingValue(definition, value)
+                }
+                mutablePreferences[MIGRATED_KEY] = true
             }
-            mutablePreferences[MIGRATED_KEY] = true
+        }
+    }
+
+    private suspend fun persistWithoutCancellation(block: suspend () -> Unit) {
+        withContext(NonCancellable) {
+            novaSettingsWriteMutex.lock()
+            try {
+                block()
+            } finally {
+                novaSettingsWriteMutex.unlock()
+            }
         }
     }
 
@@ -209,6 +266,13 @@ private fun MutablePreferences.removeSettingValue(definition: NovaSettingDefinit
         NovaSettingType.Text -> remove(stringPreferencesKey(definition.key))
         NovaSettingType.Action -> Unit
     }
+}
+
+private fun MutablePreferences.removeRawSettingKey(key: String) {
+    remove(booleanPreferencesKey(key))
+    remove(intPreferencesKey(key))
+    remove(stringPreferencesKey(key))
+    remove(stringSetPreferencesKey(key))
 }
 
 private fun SharedPreferences.Editor.putSettingValue(

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt
@@ -14,9 +14,11 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.preference.PreferenceManager
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 private val Context.novaSettingsDataStore by preferencesDataStore(name = "nova_settings")
@@ -110,25 +112,31 @@ interface NovaSettingsStore {
 
 class NovaSettingsRepository private constructor(
     private val dataStore: DataStore<Preferences>,
-    private val mirrorPrefs: SharedPreferences
+    private val mirrorPrefs: SharedPreferences,
+    private val canonicalDefinitions: NovaSettingsDefinitionSet
 ) : NovaSettingsStore {
+    /**
+     * Default SharedPreferences is authoritative because legacy/runtime consumers read it
+     * synchronously. DataStore is a reconciled typed mirror, never a competing source of truth.
+     */
     override suspend fun snapshot(definitions: NovaSettingsDefinitionSet): Map<String, NovaSettingValue> {
-        ensureMigrated(definitions)
-        val preferences = dataStore.data.first()
-        return definitions.settings.mapNotNull { definition ->
-            val value = preferences.readSettingValue(definition)
-                ?: mirrorPrefs.readSettingValue(definition)
-                ?: definition.defaultValue
-            if (value == null) null else definition.key to value
-        }.toMap()
+        return persistSerialized {
+            reconcileDataStoreMirror()
+            definitions.settings.mapNotNull { definition ->
+                val value = mirrorPrefs.readSettingValue(definition) ?: definition.defaultValue
+                if (value == null) null else definition.key to value
+            }.toMap()
+        }
     }
 
     override suspend fun set(definition: NovaSettingDefinition, value: NovaSettingValue) {
-        persistWithoutCancellation {
-            dataStore.edit { preferences ->
-                preferences.writeSettingValue(definition, value)
+        persistSerialized {
+            check(mirrorPrefs.edit().putSettingValue(definition.key, value).commit()) {
+                "Failed to persist Nova setting ${definition.key}"
             }
-            mirrorPrefs.edit().putSettingValue(definition.key, value).apply()
+            mirrorDataStoreBestEffort {
+                it.writeSettingValue(definition, value)
+            }
         }
     }
 
@@ -136,28 +144,31 @@ class NovaSettingsRepository private constructor(
         updates: List<Pair<NovaSettingDefinition, NovaSettingValue>>,
         removeKeys: Set<String>
     ) {
-        persistWithoutCancellation {
-            dataStore.edit { preferences ->
-                removeKeys.forEach(preferences::removeRawSettingKey)
-                updates.forEach { (definition, value) ->
-                    preferences.writeSettingValue(definition, value)
-                }
-            }
+        persistSerialized {
             val editor = mirrorPrefs.edit()
             removeKeys.forEach(editor::remove)
             updates.forEach { (definition, value) ->
                 editor.putSettingValue(definition.key, value)
             }
-            check(editor.commit()) { "Failed to persist Nova settings mirror batch" }
+            check(editor.commit()) { "Failed to persist Nova settings batch" }
+
+            mirrorDataStoreBestEffort { preferences ->
+                removeKeys.forEach(preferences::removeRawSettingKey)
+                updates.forEach { (definition, value) ->
+                    preferences.writeSettingValue(definition, value)
+                }
+            }
         }
     }
 
     override suspend fun reset(definition: NovaSettingDefinition) {
-        persistWithoutCancellation {
-            dataStore.edit { preferences ->
-                preferences.removeSettingValue(definition)
+        persistSerialized {
+            check(mirrorPrefs.edit().remove(definition.key).commit()) {
+                "Failed to reset Nova setting ${definition.key}"
             }
-            mirrorPrefs.edit().remove(definition.key).apply()
+            mirrorDataStoreBestEffort {
+                it.removeSettingValue(definition)
+            }
         }
     }
 
@@ -165,37 +176,57 @@ class NovaSettingsRepository private constructor(
 
     override suspend fun resettableKeys(definitions: NovaSettingsDefinitionSet): Set<String> = emptySet()
 
-    private suspend fun ensureMigrated(definitions: NovaSettingsDefinitionSet) {
-        persistWithoutCancellation {
-            val preferences = dataStore.data.first()
-            if (preferences[MIGRATED_KEY] == true) return@persistWithoutCancellation
+    private suspend fun reconcileDataStoreMirror() {
+        val current = runCatching { dataStore.data.first() }.getOrElse {
+            android.util.Log.w(TAG, "Unable to read Nova DataStore mirror", it)
+            return
+        }
+        val needsRepair = current[MIGRATED_KEY] != true || canonicalDefinitions.settings.any { definition ->
+            current.readSettingValue(definition) != mirrorPrefs.readSettingValue(definition)
+        }
+        if (!needsRepair) return
 
-            dataStore.edit { mutablePreferences ->
-                for (definition in definitions.settings) {
-                    val value = mirrorPrefs.readSettingValue(definition) ?: continue
-                    mutablePreferences.writeSettingValue(definition, value)
+        mirrorDataStoreBestEffort { preferences ->
+            canonicalDefinitions.settings.forEach { definition ->
+                val authoritativeValue = mirrorPrefs.readSettingValue(definition)
+                if (authoritativeValue == null) {
+                    preferences.removeSettingValue(definition)
+                } else {
+                    preferences.writeSettingValue(definition, authoritativeValue)
                 }
-                mutablePreferences[MIGRATED_KEY] = true
             }
+            preferences[MIGRATED_KEY] = true
         }
     }
 
-    private suspend fun persistWithoutCancellation(block: suspend () -> Unit) {
-        withContext(NonCancellable) {
-            novaSettingsWriteMutex.lock()
-            try {
+    private suspend fun mirrorDataStoreBestEffort(
+        update: (MutablePreferences) -> Unit
+    ) {
+        runCatching {
+            dataStore.edit { preferences -> update(preferences) }
+        }.onFailure {
+            // SharedPreferences already committed and remains authoritative. The next
+            // snapshot reconciles this typed mirror, including after process death.
+            android.util.Log.w(TAG, "Unable to update Nova DataStore mirror", it)
+        }
+    }
+
+    private suspend fun <T> persistSerialized(block: suspend () -> T): T {
+        return novaSettingsWriteMutex.withLock {
+            withContext(NonCancellable + Dispatchers.IO) {
                 block()
-            } finally {
-                novaSettingsWriteMutex.unlock()
             }
         }
     }
 
     companion object {
+        private const val TAG = "NovaSettingsRepository"
+
         fun create(context: Context): NovaSettingsRepository {
             return NovaSettingsRepository(
                 dataStore = context.novaSettingsDataStore,
-                mirrorPrefs = PreferenceManager.getDefaultSharedPreferences(context)
+                mirrorPrefs = PreferenceManager.getDefaultSharedPreferences(context),
+                canonicalDefinitions = NovaSettingDefinitions.load(context)
             )
         }
 
@@ -212,7 +243,11 @@ class NovaSettingsRepository private constructor(
                 ),
                 produceFile = { storeFile }
             )
-            return NovaSettingsRepository(dataStore = dataStore, mirrorPrefs = mirrorPrefs)
+            return NovaSettingsRepository(
+                dataStore = dataStore,
+                mirrorPrefs = mirrorPrefs,
+                canonicalDefinitions = NovaSettingDefinitions.load(context)
+            )
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -93,17 +94,24 @@ fun NovaSettingsScreen(
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     var activeDialog by remember { mutableStateOf<NovaSettingsDialog?>(null) }
+    var menuOpacityPreviewOwner by remember { mutableStateOf<Long?>(null) }
+    val latestPreviewOwner by rememberUpdatedState(menuOpacityPreviewOwner)
 
     DisposableEffect(Unit) {
-        onDispose { NovaMenuOpacityPreview.clear() }
+        onDispose {
+            latestPreviewOwner?.let(NovaMenuOpacityPreview::clear)
+        }
     }
     val restoreMenuOpacityPreview = {
-        if ((activeDialog as? NovaSettingsDialog.Slider)?.definition?.key == NovaMenuPreferences.KEY_OPACITY) {
-            NovaMenuOpacityPreview.clear()
-        }
+        menuOpacityPreviewOwner?.let(NovaMenuOpacityPreview::clear)
+        menuOpacityPreviewOwner = null
         activeDialog = null
     }
-    val onMenuOpacityPreview: (Int) -> Unit = NovaMenuOpacityPreview::update
+    val onMenuOpacityPreview: (Int) -> Unit = { percent ->
+        menuOpacityPreviewOwner?.let { owner ->
+            NovaMenuOpacityPreview.update(owner, percent)
+        }
+    }
 
     NovaSettingsContent(
         state = state,
@@ -123,10 +131,16 @@ fun NovaSettingsScreen(
                     NovaSettingValue.BooleanValue(!state.booleanValue(definition))
                 )
                 NovaSettingType.Select -> activeDialog = NovaSettingsDialog.Select(definition)
-                NovaSettingType.Slider -> activeDialog = NovaSettingsDialog.Slider(
-                    definition = definition,
-                    originalValue = state.intValue(definition)
-                )
+                NovaSettingType.Slider -> {
+                    if (definition.key == NovaMenuPreferences.KEY_OPACITY) {
+                        menuOpacityPreviewOwner?.let(NovaMenuOpacityPreview::clear)
+                        menuOpacityPreviewOwner = NovaMenuOpacityPreview.newOwner()
+                    }
+                    activeDialog = NovaSettingsDialog.Slider(
+                        definition = definition,
+                        originalValue = state.intValue(definition)
+                    )
+                }
                 NovaSettingType.Text -> activeDialog = NovaSettingsDialog.Text(definition)
                 NovaSettingType.Action -> {
                     if (definition.key == RESET_STREAM_UI_DEFAULTS_KEY) {
@@ -147,12 +161,16 @@ fun NovaSettingsScreen(
             onDismiss = restoreMenuOpacityPreview,
             onMenuOpacityPreview = onMenuOpacityPreview,
             onSave = { definition, value ->
+                val previewOwnerAtSave = menuOpacityPreviewOwner.takeIf {
+                    definition.key == NovaMenuPreferences.KEY_OPACITY
+                }
                 viewModel.setValue(
                     definition = definition,
                     value = value,
                     onCompleted = {
-                        if (definition.key == NovaMenuPreferences.KEY_OPACITY) {
-                            NovaMenuOpacityPreview.clear()
+                        previewOwnerAtSave?.let(NovaMenuOpacityPreview::clear)
+                        if (previewOwnerAtSave != null && menuOpacityPreviewOwner == previewOwnerAtSave) {
+                            menuOpacityPreviewOwner = null
                         }
                     }
                 )

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
@@ -3,6 +3,7 @@ package com.papi.nova.preferences
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.graphics.drawable.ColorDrawable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -36,6 +37,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,8 +50,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -58,10 +62,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.preference.PreferenceManager
+import androidx.compose.ui.window.DialogWindowProvider
 import com.papi.nova.ui.NovaHudMode
 import com.papi.nova.ui.NovaHudPreferences
 import com.papi.nova.ui.NovaHudUiState
+import com.papi.nova.ui.NovaMenuOpacityPreview
 import com.papi.nova.ui.NovaMenuPreferences
 import com.papi.nova.ui.NovaStreamHudContent
 import com.papi.nova.ui.NovaThemeManager
@@ -87,19 +92,18 @@ fun NovaSettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
-    val prefs = remember(context) { PreferenceManager.getDefaultSharedPreferences(context) }
     var activeDialog by remember { mutableStateOf<NovaSettingsDialog?>(null) }
 
+    DisposableEffect(Unit) {
+        onDispose { NovaMenuOpacityPreview.clear() }
+    }
     val restoreMenuOpacityPreview = {
-        val slider = activeDialog as? NovaSettingsDialog.Slider
-        if (slider?.definition?.key == NovaMenuPreferences.KEY_OPACITY) {
-            NovaMenuPreferences.writeOpacityPercent(prefs, slider.originalValue)
+        if ((activeDialog as? NovaSettingsDialog.Slider)?.definition?.key == NovaMenuPreferences.KEY_OPACITY) {
+            NovaMenuOpacityPreview.clear()
         }
         activeDialog = null
     }
-    val onMenuOpacityPreview: (Int) -> Unit = { percent ->
-        NovaMenuPreferences.writeOpacityPercent(prefs, percent)
-    }
+    val onMenuOpacityPreview: (Int) -> Unit = NovaMenuOpacityPreview::update
 
     NovaSettingsContent(
         state = state,
@@ -143,7 +147,15 @@ fun NovaSettingsScreen(
             onDismiss = restoreMenuOpacityPreview,
             onMenuOpacityPreview = onMenuOpacityPreview,
             onSave = { definition, value ->
-                viewModel.setValue(definition, value)
+                viewModel.setValue(
+                    definition = definition,
+                    value = value,
+                    onCompleted = {
+                        if (definition.key == NovaMenuPreferences.KEY_OPACITY) {
+                            NovaMenuOpacityPreview.clear()
+                        }
+                    }
+                )
                 activeDialog = null
                 applyThemeSelectionIfNeeded(context, definition, value)
             }
@@ -976,6 +988,7 @@ private fun NovaSelectDialogShell(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
+        NovaDialogContrastBackdrop()
         Column(
             modifier = Modifier
                 .fillMaxWidth(0.72f)
@@ -994,6 +1007,25 @@ private fun NovaSelectDialogShell(
             ) {
                 confirmButton()
                 dismissButton()
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaDialogContrastBackdrop() {
+    val view = LocalView.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val opacityScale = LocalNovaMenuOpacityScale.current
+    DisposableEffect(view, surfaces.backgroundScrim, opacityScale) {
+        val window = (view.parent as? DialogWindowProvider)?.window
+        val previousBackground = window?.decorView?.background
+        if (opacityScale < 1f) {
+            window?.setBackgroundDrawable(ColorDrawable(surfaces.backgroundScrim.toArgb()))
+        }
+        onDispose {
+            if (opacityScale < 1f) {
+                window?.setBackgroundDrawable(previousBackground)
             }
         }
     }

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
@@ -58,16 +58,20 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.preference.PreferenceManager
 import com.papi.nova.ui.NovaHudMode
 import com.papi.nova.ui.NovaHudPreferences
 import com.papi.nova.ui.NovaHudUiState
+import com.papi.nova.ui.NovaMenuPreferences
 import com.papi.nova.ui.NovaStreamHudContent
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.R
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.LocalNovaMenuOpacityScale
 import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
+import com.papi.nova.ui.compose.NovaMenuBackdropBlur
 import com.papi.nova.ui.compose.novaFocusMotion
 import kotlin.math.roundToInt
 
@@ -83,7 +87,19 @@ fun NovaSettingsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
+    val prefs = remember(context) { PreferenceManager.getDefaultSharedPreferences(context) }
     var activeDialog by remember { mutableStateOf<NovaSettingsDialog?>(null) }
+
+    val restoreMenuOpacityPreview = {
+        val slider = activeDialog as? NovaSettingsDialog.Slider
+        if (slider?.definition?.key == NovaMenuPreferences.KEY_OPACITY) {
+            NovaMenuPreferences.writeOpacityPercent(prefs, slider.originalValue)
+        }
+        activeDialog = null
+    }
+    val onMenuOpacityPreview: (Int) -> Unit = { percent ->
+        NovaMenuPreferences.writeOpacityPercent(prefs, percent)
+    }
 
     NovaSettingsContent(
         state = state,
@@ -103,12 +119,14 @@ fun NovaSettingsScreen(
                     NovaSettingValue.BooleanValue(!state.booleanValue(definition))
                 )
                 NovaSettingType.Select -> activeDialog = NovaSettingsDialog.Select(definition)
-                NovaSettingType.Slider -> activeDialog = NovaSettingsDialog.Slider(definition)
+                NovaSettingType.Slider -> activeDialog = NovaSettingsDialog.Slider(
+                    definition = definition,
+                    originalValue = state.intValue(definition)
+                )
                 NovaSettingType.Text -> activeDialog = NovaSettingsDialog.Text(definition)
                 NovaSettingType.Action -> {
                     if (definition.key == RESET_STREAM_UI_DEFAULTS_KEY) {
                         viewModel.resetStreamUiDefaults()
-                        onAction(definition)
                     } else {
                         onAction(definition)
                     }
@@ -118,11 +136,13 @@ fun NovaSettingsScreen(
     )
 
     activeDialog?.let { dialog ->
+        NovaMenuBackdropBlur()
         NovaSettingDialog(
             dialog = dialog,
             state = state,
-            onDismiss = { activeDialog = null },
-            onSave = {definition, value ->
+            onDismiss = restoreMenuOpacityPreview,
+            onMenuOpacityPreview = onMenuOpacityPreview,
+            onSave = { definition, value ->
                 viewModel.setValue(definition, value)
                 activeDialog = null
                 applyThemeSelectionIfNeeded(context, definition, value)
@@ -677,7 +697,7 @@ private fun NovaHudSettingsPreview(state: NovaSettingsUiState) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(NovaSettingsCardShape)
-            .background(surfaces.panel.copy(alpha = 0.86f))
+            .background(surfaces.panel.copy(alpha = 0.86f * LocalNovaMenuOpacityScale.current))
             .border(1.dp, surfaces.panelBorder, NovaSettingsCardShape)
             .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
@@ -829,7 +849,7 @@ private fun NovaSettingOverrideBadge(alpha: Float) {
         fontWeight = FontWeight.SemiBold,
         modifier = Modifier
             .clip(shape)
-            .background(surfaces.selectedControl.copy(alpha = alpha))
+            .background(surfaces.selectedControl.copy(alpha = alpha * LocalNovaMenuOpacityScale.current))
             .border(1.dp, surfaces.focusRing.copy(alpha = alpha), shape)
             .padding(horizontal = 7.dp, vertical = 3.dp),
         maxLines = 1,
@@ -853,8 +873,8 @@ private fun NovaSettingApplyBadge(
         fontWeight = FontWeight.Medium,
         modifier = Modifier
             .clip(shape)
-            .background(surfaces.control.copy(alpha = alpha))
-            .border(1.dp, surfaces.tileBorder.copy(alpha = alpha), shape)
+            .background(surfaces.control.copy(alpha = alpha * LocalNovaMenuOpacityScale.current))
+            .border(1.dp, surfaces.tileBorder.copy(alpha = alpha * LocalNovaMenuOpacityScale.current), shape)
             .padding(horizontal = 7.dp, vertical = 3.dp),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis
@@ -874,8 +894,8 @@ private fun NovaSettingValueChip(
             .widthIn(min = 92.dp, max = 220.dp)
             .heightIn(min = NovaSettingsMetrics.valueChipMinHeightDp().dp)
             .clip(shape)
-            .background(surfaces.control.copy(alpha = alpha))
-            .border(1.dp, surfaces.tileBorder.copy(alpha = alpha), shape)
+            .background(surfaces.control.copy(alpha = alpha * LocalNovaMenuOpacityScale.current))
+            .border(1.dp, surfaces.tileBorder.copy(alpha = alpha * LocalNovaMenuOpacityScale.current), shape)
             .padding(horizontal = 12.dp, vertical = 7.dp),
         contentAlignment = Alignment.CenterEnd
     ) {
@@ -896,11 +916,18 @@ private fun NovaSettingDialog(
     dialog: NovaSettingsDialog,
     state: NovaSettingsUiState,
     onDismiss: () -> Unit,
+    onMenuOpacityPreview: (Int) -> Unit,
     onSave: (NovaSettingDefinition, NovaSettingValue) -> Unit
 ) {
     when (dialog) {
         is NovaSettingsDialog.Select -> NovaSelectDialog(dialog.definition, state, onDismiss, onSave)
-        is NovaSettingsDialog.Slider -> NovaSliderDialog(dialog.definition, state, onDismiss, onSave)
+        is NovaSettingsDialog.Slider -> NovaSliderDialog(
+            definition = dialog.definition,
+            state = state,
+            onDismiss = onDismiss,
+            onMenuOpacityPreview = onMenuOpacityPreview,
+            onSave = onSave
+        )
         is NovaSettingsDialog.Text -> NovaTextDialog(dialog.definition, state, onDismiss, onSave)
     }
 }
@@ -954,7 +981,7 @@ private fun NovaSelectDialogShell(
                 .fillMaxWidth(0.72f)
                 .widthIn(max = 720.dp)
                 .clip(NovaSettingsCardShape)
-                .background(surfaces.panel.copy(alpha = 0.96f))
+                .background(surfaces.panel.copy(alpha = 0.96f * LocalNovaMenuOpacityScale.current))
                 .border(1.dp, surfaces.panelBorder, NovaSettingsCardShape)
                 .padding(18.dp)
         ) {
@@ -986,7 +1013,7 @@ private fun NovaSettingsSelectOptionRow(
     val background = when {
         selected -> colors.accent.copy(alpha = 0.20f)
         focused -> surfaces.selectedControl
-        else -> surfaces.control.copy(alpha = 0.74f)
+        else -> surfaces.control.copy(alpha = 0.74f * LocalNovaMenuOpacityScale.current)
     }
     Row(
         modifier = Modifier
@@ -1127,6 +1154,7 @@ private fun NovaSliderDialog(
     definition: NovaSettingDefinition,
     state: NovaSettingsUiState,
     onDismiss: () -> Unit,
+    onMenuOpacityPreview: (Int) -> Unit,
     onSave: (NovaSettingDefinition, NovaSettingValue) -> Unit
 ) {
     var value by remember(definition.key) {
@@ -1151,7 +1179,12 @@ private fun NovaSliderDialog(
                 Spacer(Modifier.height(16.dp))
                 Slider(
                     value = value.coerceIn(min, max),
-                    onValueChange = { value = it },
+                    onValueChange = { nextValue ->
+                        value = nextValue
+                        if (definition.key == NovaMenuPreferences.KEY_OPACITY) {
+                            onMenuOpacityPreview(nextValue.roundToInt())
+                        }
+                    },
                     valueRange = min..max
                 )
             }
@@ -1236,7 +1269,10 @@ private fun validationMessage(key: String): String {
 
 private sealed interface NovaSettingsDialog {
     data class Select(val definition: NovaSettingDefinition) : NovaSettingsDialog
-    data class Slider(val definition: NovaSettingDefinition) : NovaSettingsDialog
+    data class Slider(
+        val definition: NovaSettingDefinition,
+        val originalValue: Int
+    ) : NovaSettingsDialog
     data class Text(val definition: NovaSettingDefinition) : NovaSettingsDialog
 }
 

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
@@ -35,8 +35,8 @@ internal suspend fun persistNovaStreamUiDefaults(
     store: NovaSettingsStore,
     definitions: NovaSettingsDefinitionSet
 ) {
-    val updates = NOVA_STREAM_UI_DEFAULT_UPDATES.mapNotNull { (key, value) ->
-        definitions.find(key)?.let { definition -> definition to value }
+    val updates = NOVA_STREAM_UI_DEFAULT_UPDATES.map { (key, value) ->
+        definitions.require(key) to value
     }
     store.updateAtomically(updates, NOVA_STREAM_UI_RESET_REMOVALS)
 }
@@ -44,6 +44,7 @@ internal suspend fun persistNovaStreamUiDefaults(
 class NovaSettingsViewModel(
     private val definitions: NovaSettingsDefinitionSet,
     private val store: NovaSettingsStore,
+    private val resetDefinitions: NovaSettingsDefinitionSet = definitions,
     initialCategoryKey: String = definitions.categories.firstOrNull()?.key.orEmpty()
 ) : ViewModel() {
     private var selectedCategoryKey = initialCategoryKey
@@ -76,13 +77,21 @@ class NovaSettingsViewModel(
         emit()
     }
 
-    fun setValue(definition: NovaSettingDefinition, value: NovaSettingValue) {
+    fun setValue(
+        definition: NovaSettingDefinition,
+        value: NovaSettingValue,
+        onCompleted: () -> Unit = {}
+    ) {
         viewModelScope.launch {
-            store.set(definition, value)
-            values = values + (definition.key to value)
-            applyPresetIfNeeded(definition, value)
-            loadStoreState()
-            emit()
+            try {
+                store.set(definition, value)
+                values = values + (definition.key to value)
+                applyPresetIfNeeded(definition, value)
+                loadStoreState()
+                emit()
+            } finally {
+                onCompleted()
+            }
         }
     }
 
@@ -96,7 +105,7 @@ class NovaSettingsViewModel(
 
     fun resetStreamUiDefaults() {
         viewModelScope.launch {
-            persistNovaStreamUiDefaults(store, definitions)
+            persistNovaStreamUiDefaults(store, resetDefinitions)
             loadStoreState()
             emit()
         }
@@ -149,11 +158,17 @@ class NovaSettingsViewModel(
     class Factory(
         private val definitions: NovaSettingsDefinitionSet,
         private val store: NovaSettingsStore,
+        private val resetDefinitions: NovaSettingsDefinitionSet = definitions,
         private val initialCategoryKey: String = definitions.categories.firstOrNull()?.key.orEmpty()
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return NovaSettingsViewModel(definitions, store, initialCategoryKey) as T
+            return NovaSettingsViewModel(
+                definitions = definitions,
+                store = store,
+                resetDefinitions = resetDefinitions,
+                initialCategoryKey = initialCategoryKey
+            ) as T
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
@@ -3,10 +3,43 @@ package com.papi.nova.preferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.papi.nova.ui.NovaHudPreferences
+import com.papi.nova.ui.NovaMenuPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+internal val NOVA_STREAM_UI_DEFAULT_UPDATES = listOf(
+    "nova_polaris_hud" to NovaSettingValue.BooleanValue(false),
+    "nova_polaris_hud_mode" to NovaSettingValue.StringValue("minimal"),
+    "nova_polaris_hud_position" to NovaSettingValue.StringValue("top_left"),
+    NovaHudPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaHudPreferences.DEFAULT_OPACITY_PERCENT),
+    NovaMenuPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaMenuPreferences.DEFAULT_OPACITY_PERCENT),
+    "checkbox_enable_perf_overlay" to NovaSettingValue.BooleanValue(false),
+    "checkbox_enable_perf_logging" to NovaSettingValue.BooleanValue(false),
+    "checkbox_show_onscreen_controls" to NovaSettingValue.BooleanValue(false),
+    "seekbar_osc_opacity" to NovaSettingValue.IntValue(90),
+    "checkbox_enable_keyboard" to NovaSettingValue.BooleanValue(false),
+    "checkbox_enable_floating_button" to NovaSettingValue.BooleanValue(false),
+    "checkbox_show_overlay_zoom_toggle_button" to NovaSettingValue.BooleanValue(false),
+    "checkbox_disable_warnings" to NovaSettingValue.BooleanValue(false)
+)
+
+internal val NOVA_STREAM_UI_RESET_REMOVALS = setOf(
+    "nova_polaris_hud_x",
+    "nova_polaris_hud_y"
+)
+
+internal suspend fun persistNovaStreamUiDefaults(
+    store: NovaSettingsStore,
+    definitions: NovaSettingsDefinitionSet
+) {
+    val updates = NOVA_STREAM_UI_DEFAULT_UPDATES.mapNotNull { (key, value) ->
+        definitions.find(key)?.let { definition -> definition to value }
+    }
+    store.updateAtomically(updates, NOVA_STREAM_UI_RESET_REMOVALS)
+}
 
 class NovaSettingsViewModel(
     private val definitions: NovaSettingsDefinitionSet,
@@ -63,24 +96,7 @@ class NovaSettingsViewModel(
 
     fun resetStreamUiDefaults() {
         viewModelScope.launch {
-            val updates = listOf(
-                "nova_polaris_hud" to NovaSettingValue.BooleanValue(false),
-                "nova_polaris_hud_mode" to NovaSettingValue.StringValue("minimal"),
-                "nova_polaris_hud_position" to NovaSettingValue.StringValue("top_left"),
-                "nova_polaris_hud_opacity" to NovaSettingValue.IntValue(90),
-                "checkbox_enable_perf_overlay" to NovaSettingValue.BooleanValue(false),
-                "checkbox_enable_perf_logging" to NovaSettingValue.BooleanValue(false),
-                "checkbox_show_onscreen_controls" to NovaSettingValue.BooleanValue(false),
-                "seekbar_osc_opacity" to NovaSettingValue.IntValue(90),
-                "checkbox_enable_keyboard" to NovaSettingValue.BooleanValue(false),
-                "checkbox_enable_floating_button" to NovaSettingValue.BooleanValue(false),
-                "checkbox_show_overlay_zoom_toggle_button" to NovaSettingValue.BooleanValue(false),
-                "checkbox_disable_warnings" to NovaSettingValue.BooleanValue(false)
-            )
-            for ((key, value) in updates) {
-                val definition = definitions.find(key) ?: continue
-                store.set(definition, value)
-            }
+            persistNovaStreamUiDefaults(store, definitions)
             loadStoreState()
             emit()
         }

--- a/app/src/main/java/com/papi/nova/preferences/SeekBarPreference.kt
+++ b/app/src/main/java/com/papi/nova/preferences/SeekBarPreference.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import com.papi.nova.R
+import com.papi.nova.ui.NovaSheetChrome
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -145,6 +146,7 @@ class SeekBarPreference(context: Context, attrs: AttributeSet) : Preference(cont
             }
             .setNegativeButton(context.getString(R.string.cancel)) { dialog, _ -> dialog.dismiss() }
             .create()
+        NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdDialog)
         dialog = createdDialog
         return createdDialog
     }

--- a/app/src/main/java/com/papi/nova/preferences/SeekBarPreference.kt
+++ b/app/src/main/java/com/papi/nova/preferences/SeekBarPreference.kt
@@ -146,6 +146,13 @@ class SeekBarPreference(context: Context, attrs: AttributeSet) : Preference(cont
             }
             .setNegativeButton(context.getString(R.string.cancel)) { dialog, _ -> dialog.dismiss() }
             .create()
+        createdDialog.setOnDismissListener {
+            if (dialog === createdDialog) {
+                dialog = null
+                seekBar = null
+                valueText = null
+            }
+        }
         NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdDialog)
         dialog = createdDialog
         return createdDialog

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -52,7 +52,6 @@ import com.papi.nova.PcView
 import com.papi.nova.R
 import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardControllerConfigurationLoader
 import com.papi.nova.binding.video.MediaCodecHelper
-import com.papi.nova.ui.NovaHudPreferences
 import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.compose.NovaComposeTheme
@@ -187,7 +186,6 @@ class StreamSettings : AppCompatActivity() {
     private fun handleComposeAction(definition: NovaSettingDefinition) {
         when (definition.key) {
             "nova_app_version" -> Unit
-            "nova_reset_stream_ui" -> resetStreamUiRuntimePreferences()
             "pref_debug_info" -> startActivity(Intent(this, DebugInfoActivity::class.java))
             "option_software_release" -> checkForNovaUpdate()
             "option_follow_update" -> HelpLauncher.launchUrl(this, getString(R.string.obtainium_app_url))
@@ -323,21 +321,6 @@ class StreamSettings : AppCompatActivity() {
                 HelpLauncher.launchUrl(this, "https://github.com/papi-ux/nova/releases")
             },
         )
-    }
-
-    private fun resetStreamUiRuntimePreferences() {
-        PreferenceManager.getDefaultSharedPreferences(this)
-            .edit()
-            .remove("nova_polaris_hud_x")
-            .remove("nova_polaris_hud_y")
-            .putBoolean("nova_polaris_hud", false)
-            .putString("nova_polaris_hud_mode", "minimal")
-            .putString("nova_polaris_hud_position", "top_left")
-            .putInt(NovaHudPreferences.KEY_OPACITY, NovaHudPreferences.DEFAULT_OPACITY_PERCENT)
-            .putBoolean("checkbox_enable_perf_overlay", false)
-            .putBoolean("checkbox_show_onscreen_controls", false)
-            .apply()
-        Toast.makeText(this, "Stream UI defaults restored", Toast.LENGTH_SHORT).show()
     }
 
     override fun onAttachedToWindow() {

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -120,7 +120,8 @@ class StreamSettings : AppCompatActivity() {
 
     private fun showComposeSettings() {
         legacyMode = false
-        val definitions = NovaSettingsAvailability.filter(this, NovaSettingDefinitions.load(this)).let { filtered ->
+        val canonicalDefinitions = NovaSettingDefinitions.load(this)
+        val definitions = NovaSettingsAvailability.filter(this, canonicalDefinitions).let { filtered ->
             filtered.copy(
                 settings = filtered.settings.filterNot { it.key == NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY }
             )
@@ -128,7 +129,11 @@ class StreamSettings : AppCompatActivity() {
         val store = NovaSettingsRepository.create(this)
         val viewModel = ViewModelProvider(
             this,
-            NovaSettingsViewModel.Factory(definitions, store)
+            NovaSettingsViewModel.Factory(
+                definitions = definitions,
+                store = store,
+                resetDefinitions = canonicalDefinitions
+            )
         )[NovaSettingsViewModel::class.java]
         val content = ComposeView(this).apply {
             setContent {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -74,6 +74,7 @@ import com.papi.nova.manager.StreamSyncManager
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.LocalNovaMenuOpacityScale
 import com.papi.nova.ui.compose.NovaActionButton
 import com.papi.nova.ui.compose.NovaBadge
 import com.papi.nova.ui.compose.NovaComposeTheme
@@ -624,13 +625,15 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         onResetProfile: () -> Unit
     ) {
         val reason = optimizationState.reviewReason.ifBlank { "fps_override" }
-        AlertDialog.Builder(requireContext())
+        val dialog = AlertDialog.Builder(requireContext())
             .setTitle(R.string.nova_library_preflight_review_title)
             .setMessage(getString(R.string.nova_library_preflight_review_message, reason))
             .setPositiveButton(R.string.nova_library_preflight_launch) { _, _ -> onLaunchConfirmed() }
             .setNeutralButton(R.string.nova_library_retry_high_fps) { _, _ -> onRetryHighFps() }
             .setNegativeButton(R.string.nova_library_reset_game_profile) { _, _ -> onResetProfile() }
-            .show()
+            .create()
+        NovaSheetChrome.applyMenuOpacityToLegacyAlert(dialog)
+        dialog.show()
     }
 
     private fun showDesktopSteamLaunchDecision(
@@ -1567,7 +1570,7 @@ private fun GameDetailsPanel(
                         text = lastPlayedText,
                         modifier = Modifier.padding(top = 7.dp),
                         color = colors.textSecondary,
-                        backgroundColor = surfaces.control.copy(alpha = 0.78f),
+                        backgroundColor = surfaces.control.copy(alpha = 0.78f * LocalNovaMenuOpacityScale.current),
                         borderColor = surfaces.tileBorder,
                         fontSize = 11.sp,
                         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 5.dp)
@@ -1914,7 +1917,7 @@ internal fun LaunchProfilePrimaryNotice(
             NovaBadge(
                 text = badgeLabel,
                 color = toneColor,
-                backgroundColor = surfaces.control.copy(alpha = 0.72f),
+                backgroundColor = surfaces.control.copy(alpha = 0.72f * LocalNovaMenuOpacityScale.current),
                 borderColor = toneColor.copy(alpha = 0.35f),
                 fontWeight = FontWeight.SemiBold
             )
@@ -2382,7 +2385,7 @@ private fun MangoHudPassiveStatus(
         NovaBadge(
             text = label,
             color = if (warning) colors.warning else colors.textSecondary,
-            backgroundColor = surfaces.control.copy(alpha = 0.56f),
+            backgroundColor = surfaces.control.copy(alpha = 0.56f * LocalNovaMenuOpacityScale.current),
             borderColor = if (warning) colors.warning.copy(alpha = 0.44f) else surfaces.tileBorder,
             fontSize = 10.sp,
             contentPadding = PaddingValues(horizontal = 9.dp, vertical = 4.dp)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -129,11 +129,13 @@ import com.papi.nova.utils.UiHelper
 import com.papi.nova.ui.SpaceParticleView
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.LocalNovaMenuOpacityScale
 import com.papi.nova.ui.compose.NovaActionButton
 import com.papi.nova.ui.compose.NovaComposeTheme
 import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaFocusMotionSpec
+import com.papi.nova.ui.compose.NovaMenuBackdropBlur
 import com.papi.nova.ui.compose.novaFocusMotion
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -931,6 +933,9 @@ class NovaLibraryActivity : AppCompatActivity() {
         onGenreFilter: (String) -> Unit,
         onClearFilters: () -> Unit,
     ) {
+        if (activeOptionsSheet || activeSystemMenu) {
+            NovaMenuBackdropBlur()
+        }
         val configuration = LocalConfiguration.current
         val isLandscape = configuration.screenWidthDp > configuration.screenHeightDp
         val showLandscapeControlRail = NovaLibraryUiStateMapper.showLandscapeControlRail()
@@ -1318,8 +1323,8 @@ class NovaLibraryActivity : AppCompatActivity() {
                 .background(
                     Brush.horizontalGradient(
                         colors = listOf(
-                            surfaces.tile.copy(alpha = 0.98f),
-                            surfaces.tile.copy(alpha = 0.82f),
+                            surfaces.tile.copy(alpha = 0.98f * LocalNovaMenuOpacityScale.current),
+                            surfaces.tile.copy(alpha = 0.82f * LocalNovaMenuOpacityScale.current),
                             colors.accent.copy(alpha = if (focused) 0.22f else 0.12f)
                         )
                     )
@@ -1459,7 +1464,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                 .fillMaxHeight()
                 .clip(shape)
                 .background(surfaces.mediaPlaceholder)
-                .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f), shape)
+                .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f * LocalNovaMenuOpacityScale.current), shape)
         ) {
             key(targetGame.id, targetGame.coverUrl) {
                 AndroidView(
@@ -1508,11 +1513,11 @@ class NovaLibraryActivity : AppCompatActivity() {
                     Brush.linearGradient(
                         colors = listOf(
                             colors.accent.copy(alpha = 0.34f),
-                            surfaces.tile.copy(alpha = 0.92f)
+                            surfaces.tile.copy(alpha = 0.92f * LocalNovaMenuOpacityScale.current)
                         )
                     )
                 )
-                .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f), shape)
+                .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f * LocalNovaMenuOpacityScale.current), shape)
                 .padding(horizontal = if (compact) 6.dp else 10.dp, vertical = if (compact) 5.dp else 10.dp),
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.Start
@@ -1568,7 +1573,7 @@ class NovaLibraryActivity : AppCompatActivity() {
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(shape)
-                .background(surfaces.panel.copy(alpha = 0.72f))
+                .background(surfaces.panel.copy(alpha = 0.72f * LocalNovaMenuOpacityScale.current))
                 .border(1.dp, surfaces.tileBorder, shape)
                 .padding(horizontal = 10.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -2362,7 +2367,7 @@ class NovaLibraryActivity : AppCompatActivity() {
                     cornerRadius = 14.dp
                 )
                 .clip(RoundedCornerShape(14.dp))
-                .background(if (focused) surfaces.tile.copy(alpha = 1f) else surfaces.tile)
+                .background(if (focused) surfaces.tile.copy(alpha = LocalNovaMenuOpacityScale.current) else surfaces.tile)
                 .border(
                     width = if (focused) 3.dp else 1.dp,
                     color = if (focused) surfaces.focusRing else surfaces.tileBorder,
@@ -2873,7 +2878,14 @@ class NovaLibraryActivity : AppCompatActivity() {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(surfaces.backgroundScrim.copy(alpha = 0.58f))
+                        .background(
+                            surfaces.backgroundScrim.copy(
+                                alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                                    0.58f,
+                                    LocalNovaMenuOpacityScale.current
+                                )
+                            )
+                        )
                         .pointerInput(onDismiss) {
                             detectTapGestures { onDismiss() }
                         }
@@ -3107,7 +3119,14 @@ class NovaLibraryActivity : AppCompatActivity() {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(surfaces.backgroundScrim.copy(alpha = 0.58f))
+                        .background(
+                            surfaces.backgroundScrim.copy(
+                                alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                                    0.58f,
+                                    LocalNovaMenuOpacityScale.current
+                                )
+                            )
+                        )
                         .pointerInput(onDismiss) {
                             detectTapGestures { onDismiss() }
                         }
@@ -3321,7 +3340,12 @@ class NovaLibraryActivity : AppCompatActivity() {
             ),
             containerColor = surfaces.panel,
             contentColor = colors.textPrimary,
-            scrimColor = surfaces.backgroundScrim.copy(alpha = NovaSheetChrome.SCRIM_ALPHA)
+            scrimColor = surfaces.backgroundScrim.copy(
+                alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                    NovaSheetChrome.SCRIM_ALPHA,
+                    LocalNovaMenuOpacityScale.current
+                )
+            )
         ) {
             Column(
                 modifier = Modifier
@@ -3499,10 +3523,10 @@ class NovaLibraryActivity : AppCompatActivity() {
         Surface(
             modifier = modifier,
             shape = RoundedCornerShape(18.dp),
-            color = if (subtle) surfaces.panel.copy(alpha = 0.34f) else surfaces.panel,
+            color = if (subtle) surfaces.panel.copy(alpha = 0.34f * LocalNovaMenuOpacityScale.current) else surfaces.panel,
             border = BorderStroke(
                 1.dp,
-                if (subtle) surfaces.panelBorder.copy(alpha = 0.30f) else surfaces.panelBorder
+                if (subtle) surfaces.panelBorder.copy(alpha = 0.30f * LocalNovaMenuOpacityScale.current) else surfaces.panelBorder
             ),
             content = content
         )

--- a/app/src/main/java/com/papi/nova/ui/NovaMenuBlur.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaMenuBlur.kt
@@ -1,0 +1,212 @@
+package com.papi.nova.ui
+
+import android.app.Activity
+import android.app.Dialog
+import android.content.Context
+import android.content.ContextWrapper
+import android.graphics.RenderEffect
+import android.graphics.Shader
+import android.os.Build
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import java.util.IdentityHashMap
+import java.util.WeakHashMap
+
+/**
+ * Adaptive blur for content underneath Nova menus and dialogs.
+ *
+ * This intentionally uses View RenderEffect instead of optional cross-window blur,
+ * which OEMs can disable even on Android 12+. Menu/dialog content stays in its own
+ * sharp window or overlay while only the owning Activity background is softened.
+ *
+ * Blur is lease-based: overlapping Nova overlays can share a target without one
+ * overlay clearing another overlay's effect when it closes.
+ */
+object NovaMenuBlur {
+    class BlurLease internal constructor(
+        private var target: View?,
+        private var owner: Any?
+    ) {
+        fun release() {
+            val releaseTarget: View
+            val releaseOwner: Any
+            synchronized(this) {
+                releaseTarget = target ?: return
+                releaseOwner = owner ?: return
+                NovaMenuBlur.requireMainThread()
+                target = null
+                owner = null
+            }
+            NovaMenuBlur.release(releaseTarget, releaseOwner)
+        }
+    }
+
+    private data class ViewBlurState(
+        val ownerRadiiDp: IdentityHashMap<Any, Float> = IdentityHashMap(),
+        var novaEffectApplied: Boolean = false
+    )
+
+    private data class DialogBinding(
+        val listener: View.OnAttachStateChangeListener,
+        var lease: BlurLease? = null
+    )
+
+    private val viewBlurStates = WeakHashMap<View, ViewBlurState>()
+    private val dialogBindings = WeakHashMap<View, DialogBinding>()
+
+    internal fun acquire(view: View, opacityPercent: Int): BlurLease {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return BlurLease(null, null)
+        }
+        requireMainThread()
+        val owner = Any()
+        val radiusDp = NovaMenuPreferences.blurRadiusDp(opacityPercent)
+        synchronized(viewBlurStates) {
+            val state = viewBlurStates.getOrPut(view) { ViewBlurState() }
+            state.ownerRadiiDp[owner] = radiusDp
+            applyStrongestOwnedEffect(view, state)
+        }
+        return BlurLease(view, owner)
+    }
+
+    fun acquireActivityBackground(context: Context, opacityPercent: Int): BlurLease? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+        requireMainThread()
+        val activity = context.findActivity() ?: return null
+        return acquire(activity.window.decorView, opacityPercent)
+    }
+
+    fun attachBehindDialog(dialog: Dialog, opacityPercent: Int) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        requireMainThread()
+        val activity = dialog.context.findActivity() ?: return
+        val dialogDecor = dialog.window?.decorView ?: return
+        val target = activity.window.decorView
+
+        dialogBindings.remove(dialogDecor)?.let { existing ->
+            dialogDecor.removeOnAttachStateChangeListener(existing.listener)
+            existing.lease?.release()
+        }
+
+        lateinit var binding: DialogBinding
+        val listener = object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(view: View) {
+                requireMainThread()
+                if (dialogBindings[view] !== binding) {
+                    view.removeOnAttachStateChangeListener(this)
+                    return
+                }
+                binding.lease?.release()
+                binding.lease = acquire(target, opacityPercent)
+            }
+
+            override fun onViewDetachedFromWindow(view: View) {
+                requireMainThread()
+                if (dialogBindings[view] === binding) {
+                    binding.lease?.release()
+                    binding.lease = null
+                    dialogBindings.remove(view)
+                }
+                view.removeOnAttachStateChangeListener(this)
+            }
+        }
+        binding = DialogBinding(listener = listener)
+        dialogDecor.addOnAttachStateChangeListener(listener)
+        dialogBindings[dialogDecor] = binding
+        if (dialogDecor.isAttachedToWindow) {
+            binding.lease = acquire(target, opacityPercent)
+        }
+    }
+
+    fun acquireChildren(parent: ViewGroup, opacityPercent: Int): List<BlurLease> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return emptyList()
+        requireMainThread()
+        return buildList {
+            for (index in 0 until parent.childCount) {
+                add(acquire(parent.getChildAt(index), opacityPercent))
+            }
+        }
+    }
+
+    fun releaseAll(leases: List<BlurLease>) {
+        leases.forEach(BlurLease::release)
+    }
+
+    internal fun releaseOnUnexpectedDetach(view: View, cleanup: () -> Unit) {
+        requireMainThread()
+        view.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(view: View) = Unit
+
+            override fun onViewDetachedFromWindow(view: View) {
+                view.removeOnAttachStateChangeListener(this)
+                cleanup()
+            }
+        })
+    }
+
+    internal fun currentRadiusDp(view: View): Float? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+        return synchronized(viewBlurStates) {
+            viewBlurStates[view]?.ownerRadiiDp?.values?.maxOrNull()
+        }
+    }
+
+    private fun release(view: View, owner: Any) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        synchronized(viewBlurStates) {
+            val state = viewBlurStates[view] ?: return
+            state.ownerRadiiDp.remove(owner)
+            if (state.ownerRadiiDp.isEmpty()) {
+                if (state.novaEffectApplied) {
+                    view.setRenderEffect(null)
+                }
+                viewBlurStates.remove(view)
+            } else {
+                applyStrongestOwnedEffect(view, state)
+            }
+        }
+    }
+
+    private fun applyStrongestOwnedEffect(view: View, state: ViewBlurState) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        val radiusDp = state.ownerRadiiDp.values.maxOrNull() ?: 0f
+        if (radiusDp <= 0f) {
+            if (state.novaEffectApplied) {
+                view.setRenderEffect(null)
+                state.novaEffectApplied = false
+            }
+            return
+        }
+        val radiusPx = radiusDp * view.resources.displayMetrics.density
+        runCatching {
+            view.setRenderEffect(
+                RenderEffect.createBlurEffect(
+                    radiusPx,
+                    radiusPx,
+                    Shader.TileMode.CLAMP
+                )
+            )
+            state.novaEffectApplied = true
+        }.onFailure {
+            if (state.novaEffectApplied) {
+                view.setRenderEffect(null)
+            }
+            state.novaEffectApplied = false
+        }
+    }
+
+    private fun requireMainThread() {
+        check(Looper.myLooper() == Looper.getMainLooper()) {
+            "NovaMenuBlur View and dialog mutations must run on the main thread"
+        }
+    }
+
+    private tailrec fun Context.findActivity(): Activity? {
+        return when (this) {
+            is Activity -> this
+            is ContextWrapper -> baseContext.findActivity()
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
@@ -7,6 +7,22 @@ import com.papi.nova.preferences.NovaSettingDefinitions
 import com.papi.nova.preferences.NovaSettingValue
 import com.papi.nova.preferences.NovaSettingsRepository
 import com.papi.nova.preferences.NovaSettingsStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object NovaMenuOpacityPreview {
+    private val mutableOpacityPercent = MutableStateFlow<Int?>(null)
+    val opacityPercent: StateFlow<Int?> = mutableOpacityPercent.asStateFlow()
+
+    fun update(percent: Int) {
+        mutableOpacityPercent.value = NovaMenuPreferences.coerceOpacityPercent(percent)
+    }
+
+    fun clear() {
+        mutableOpacityPercent.value = null
+    }
+}
 
 object NovaMenuPreferences {
     const val KEY_OPACITY = "nova_menu_opacity"
@@ -15,6 +31,7 @@ object NovaMenuPreferences {
     const val MAX_OPACITY_PERCENT = 100
     const val MAX_BLUR_RADIUS_DP = 24f
     const val MIN_READABILITY_SCRIM_ALPHA = 0.54f
+    const val MIN_READABILITY_SURFACE_ALPHA = 0.54f
 
     val OPACITY_PRESETS = listOf(0, 25, 64, 90, 100)
 
@@ -63,6 +80,16 @@ object NovaMenuPreferences {
             baseAlpha.coerceIn(0f, 1f) * scale +
                 MIN_READABILITY_SCRIM_ALPHA * (1f - scale)
             ).coerceIn(0f, 1f)
+    }
+
+    fun readabilitySurfaceAlpha(
+        baseAlpha: Float,
+        opacityPercent: Int,
+        usesDarkText: Boolean
+    ): Float {
+        val scaled = scaleAlpha(baseAlpha, opacityPercent)
+        if (!usesDarkText || opacityPercent >= MAX_OPACITY_PERCENT) return scaled
+        return maxOf(scaled, MIN_READABILITY_SURFACE_ALPHA)
     }
 
     fun alphaByte(baseAlpha: Float, percent: Int): Int {

--- a/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
@@ -7,19 +7,29 @@ import com.papi.nova.preferences.NovaSettingDefinitions
 import com.papi.nova.preferences.NovaSettingValue
 import com.papi.nova.preferences.NovaSettingsRepository
 import com.papi.nova.preferences.NovaSettingsStore
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 object NovaMenuOpacityPreview {
+    private val nextOwner = AtomicLong()
     private val mutableOpacityPercent = MutableStateFlow<Int?>(null)
+    private var activeOwner: Long? = null
     val opacityPercent: StateFlow<Int?> = mutableOpacityPercent.asStateFlow()
 
-    fun update(percent: Int) {
+    fun newOwner(): Long = nextOwner.incrementAndGet()
+
+    @Synchronized
+    fun update(owner: Long, percent: Int) {
+        activeOwner = owner
         mutableOpacityPercent.value = NovaMenuPreferences.coerceOpacityPercent(percent)
     }
 
-    fun clear() {
+    @Synchronized
+    fun clear(owner: Long) {
+        if (activeOwner != owner) return
+        activeOwner = null
         mutableOpacityPercent.value = null
     }
 }
@@ -31,7 +41,8 @@ object NovaMenuPreferences {
     const val MAX_OPACITY_PERCENT = 100
     const val MAX_BLUR_RADIUS_DP = 24f
     const val MIN_READABILITY_SCRIM_ALPHA = 0.54f
-    const val MIN_READABILITY_SURFACE_ALPHA = 0.54f
+    const val MIN_DARK_TEXT_SCRIM_ALPHA = 0.57f
+    const val MIN_DARK_TEXT_SURFACE_ALPHA = 0.71f
 
     val OPACITY_PRESETS = listOf(0, 25, 64, 90, 100)
 
@@ -75,10 +86,19 @@ object NovaMenuPreferences {
     }
 
     fun readabilityScrimAlpha(baseAlpha: Float, opacityScale: Float): Float {
+        return readabilityScrimAlpha(baseAlpha, opacityScale, usesDarkText = false)
+    }
+
+    fun readabilityScrimAlpha(
+        baseAlpha: Float,
+        opacityScale: Float,
+        usesDarkText: Boolean
+    ): Float {
         val scale = opacityScale.coerceIn(0f, 1f)
+        val floor = if (usesDarkText) MIN_DARK_TEXT_SCRIM_ALPHA else MIN_READABILITY_SCRIM_ALPHA
         return (
             baseAlpha.coerceIn(0f, 1f) * scale +
-                MIN_READABILITY_SCRIM_ALPHA * (1f - scale)
+                floor * (1f - scale)
             ).coerceIn(0f, 1f)
     }
 
@@ -89,7 +109,7 @@ object NovaMenuPreferences {
     ): Float {
         val scaled = scaleAlpha(baseAlpha, opacityPercent)
         if (!usesDarkText || opacityPercent >= MAX_OPACITY_PERCENT) return scaled
-        return maxOf(scaled, MIN_READABILITY_SURFACE_ALPHA)
+        return maxOf(scaled, MIN_DARK_TEXT_SURFACE_ALPHA)
     }
 
     fun alphaByte(baseAlpha: Float, percent: Int): Int {

--- a/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaMenuPreferences.kt
@@ -1,0 +1,81 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.papi.nova.preferences.NovaSettingDefinition
+import com.papi.nova.preferences.NovaSettingDefinitions
+import com.papi.nova.preferences.NovaSettingValue
+import com.papi.nova.preferences.NovaSettingsRepository
+import com.papi.nova.preferences.NovaSettingsStore
+
+object NovaMenuPreferences {
+    const val KEY_OPACITY = "nova_menu_opacity"
+    const val DEFAULT_OPACITY_PERCENT = 100
+    const val MIN_OPACITY_PERCENT = 0
+    const val MAX_OPACITY_PERCENT = 100
+    const val MAX_BLUR_RADIUS_DP = 24f
+    const val MIN_READABILITY_SCRIM_ALPHA = 0.54f
+
+    val OPACITY_PRESETS = listOf(0, 25, 64, 90, 100)
+
+    fun coerceOpacityPercent(percent: Int): Int {
+        return percent.coerceIn(MIN_OPACITY_PERCENT, MAX_OPACITY_PERCENT)
+    }
+
+    fun readOpacityPercent(prefs: SharedPreferences): Int {
+        return coerceOpacityPercent(prefs.getInt(KEY_OPACITY, DEFAULT_OPACITY_PERCENT))
+    }
+
+    fun writeOpacityPercent(prefs: SharedPreferences, percent: Int) {
+        prefs.edit()
+            .putInt(KEY_OPACITY, coerceOpacityPercent(percent))
+            .apply()
+    }
+
+    suspend fun writeOpacityPercent(context: Context, percent: Int) {
+        val definitions = NovaSettingDefinitions.load(context)
+        writeOpacityPercent(
+            store = NovaSettingsRepository.create(context),
+            definition = definitions.require(KEY_OPACITY),
+            percent = percent
+        )
+    }
+
+    suspend fun writeOpacityPercent(
+        store: NovaSettingsStore,
+        definition: NovaSettingDefinition,
+        percent: Int
+    ) {
+        store.set(definition, NovaSettingValue.IntValue(coerceOpacityPercent(percent)))
+    }
+
+    fun opacityScale(percent: Int): Float {
+        return coerceOpacityPercent(percent) / 100f
+    }
+
+    fun readabilityScrimAlpha(baseAlpha: Float, opacityPercent: Int): Float {
+        return readabilityScrimAlpha(baseAlpha, opacityScale(opacityPercent))
+    }
+
+    fun readabilityScrimAlpha(baseAlpha: Float, opacityScale: Float): Float {
+        val scale = opacityScale.coerceIn(0f, 1f)
+        return (
+            baseAlpha.coerceIn(0f, 1f) * scale +
+                MIN_READABILITY_SCRIM_ALPHA * (1f - scale)
+            ).coerceIn(0f, 1f)
+    }
+
+    fun alphaByte(baseAlpha: Float, percent: Int): Int {
+        return (baseAlpha.coerceIn(0f, 1f) * opacityScale(percent) * 255f)
+            .toInt()
+            .coerceIn(0, 255)
+    }
+
+    fun blurRadiusDp(percent: Int): Float {
+        return MAX_BLUR_RADIUS_DP * (1f - opacityScale(percent))
+    }
+
+    fun scaleAlpha(baseAlpha: Float, percent: Int): Float {
+        return (baseAlpha.coerceIn(0f, 1f) * opacityScale(percent)).coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -148,6 +148,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 profilePreference = currentProfilePreference(gameName),
                 hudShowing = game.isNovaHudShowing(),
                 hudOpacityPercent = NovaHudPreferences.readOpacityPercent(prefs),
+                menuOpacityPercent = NovaMenuPreferences.readOpacityPercent(prefs),
                 perfOverlayEnabled = game.prefConfig.enablePerfOverlay,
                 onscreenControllerEnabled = game.prefConfig.onscreenController,
                 keyboardVisible = game.isKeyboardLayoutVisible,
@@ -418,6 +419,16 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     }
                 }
             },
+            onMenuOpacityChange = { percent ->
+                haptic {
+                    game.launchRuntimeIo("NovaQuickMenuMenuOpacity") {
+                        NovaMenuPreferences.writeOpacityPercent(game, percent)
+                        game.runOnMainIfRuntimeActive {
+                            refreshState()
+                        }
+                    }
+                }
+            },
             onControlAction = { actionId ->
                 haptic {
                     when (actionId) {
@@ -462,7 +473,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         )
 
         composeView.setContent {
-            NovaComposeTheme {
+            NovaComposeTheme(menuOpacityPercent = uiState.menuOpacity.percent) {
                 NovaQuickMenuDrawer(
                     state = uiState,
                     callbacks = callbacks

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -60,7 +60,9 @@ import androidx.compose.ui.unit.sp
 import com.papi.nova.R
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.LocalNovaMenuOpacityScale
 import com.papi.nova.ui.compose.NovaActionButton
+import com.papi.nova.ui.compose.NovaMenuBackdropBlur
 import com.papi.nova.ui.compose.NovaInGameOverlayAlpha
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
@@ -80,6 +82,7 @@ data class NovaQuickMenuCallbacks(
     val onQuickKey: (NovaQuickMenuActionId) -> Unit = {},
     val onOverlayAction: (NovaQuickMenuActionId) -> Unit = {},
     val onHudOpacityChange: (Int) -> Unit = {},
+    val onMenuOpacityChange: (Int) -> Unit = {},
     val onControlAction: (NovaQuickMenuActionId) -> Unit = {},
     val onSessionAction: (NovaQuickMenuActionId) -> Unit = {}
 ) {
@@ -122,6 +125,7 @@ fun NovaQuickMenuDrawer(
     callbacks: NovaQuickMenuCallbacks,
     modifier: Modifier = Modifier
 ) {
+    NovaMenuBackdropBlur()
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -173,7 +177,10 @@ fun NovaQuickMenuDrawer(
                 .fillMaxSize()
                 .background(
                     surfaces.backgroundScrim.copy(
-                        alpha = NovaInGameOverlayAlpha.CommandCenterScrim * drawerProgress.value
+                        alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                            NovaInGameOverlayAlpha.CommandCenterScrim,
+                            LocalNovaMenuOpacityScale.current
+                        ) * drawerProgress.value
                     )
                 )
                 .clickable(
@@ -250,10 +257,10 @@ fun NovaQuickMenuContent(
             .fillMaxWidth()
             .fillMaxHeight()
             .clip(drawerShape)
-            .background(surfaces.panel.copy(alpha = NovaInGameOverlayAlpha.GlassPanel))
+            .background(surfaces.panel.copy(alpha = NovaInGameOverlayAlpha.GlassPanel * LocalNovaMenuOpacityScale.current))
             .border(
                 width = 1.dp,
-                color = surfaces.panelBorder.copy(alpha = NovaInGameOverlayAlpha.Border),
+                color = surfaces.panelBorder.copy(alpha = NovaInGameOverlayAlpha.Border * LocalNovaMenuOpacityScale.current),
                 shape = drawerShape
             )
             .verticalScroll(rememberScrollState())
@@ -289,6 +296,10 @@ fun NovaQuickMenuContent(
             state.overlayRows.forEach { row ->
                 NovaQuickMenuRow(action = row, callbacks = callbacks)
             }
+            NovaQuickMenuMenuOpacityControl(
+                state = state,
+                callbacks = callbacks
+            )
             NovaQuickMenuHudOpacityControl(
                 state = state,
                 callbacks = callbacks
@@ -458,10 +469,10 @@ private fun NovaQuickMenuSessionStrip(state: NovaQuickMenuUiState) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
-            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl))
+            .background(surfaces.control.copy(alpha = NovaInGameOverlayAlpha.NestedControl * LocalNovaMenuOpacityScale.current))
             .border(
                 1.dp,
-                surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border),
+                surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border * LocalNovaMenuOpacityScale.current),
                 RoundedCornerShape(14.dp)
             )
             .padding(horizontal = 10.dp, vertical = 8.dp),
@@ -716,10 +727,10 @@ private fun NovaQuickMenuPanel(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
-            .background(surfaces.tile.copy(alpha = NovaInGameOverlayAlpha.NestedTile))
+            .background(surfaces.tile.copy(alpha = NovaInGameOverlayAlpha.NestedTile * LocalNovaMenuOpacityScale.current))
             .border(
                 1.dp,
-                surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border),
+                surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border * LocalNovaMenuOpacityScale.current),
                 RoundedCornerShape(14.dp)
             )
             .padding(contentPadding)
@@ -797,6 +808,76 @@ private fun NovaQuickMenuRow(action: NovaQuickMenuAction, callbacks: NovaQuickMe
             action.chip?.let {
                 Spacer(Modifier.width(8.dp))
                 NovaQuickMenuChipView(it)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaQuickMenuMenuOpacityControl(
+    state: NovaQuickMenuUiState,
+    callbacks: NovaQuickMenuCallbacks
+) {
+    val colors = LocalNovaComposeColors.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.nova_quick_menu_menu_opacity),
+                color = colors.textPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            NovaQuickMenuChipView(
+                NovaQuickMenuChip(
+                    label = state.menuOpacity.percent.toString() + "%",
+                    tone = NovaQuickMenuTone.INFO
+                )
+            )
+        }
+        Text(
+            text = stringResource(R.string.nova_quick_menu_menu_opacity_caption),
+            color = colors.textMuted,
+            fontSize = 10.sp,
+            lineHeight = 13.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 5.dp)
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            state.menuOpacity.presets.forEach { percent ->
+                val selected = percent == state.menuOpacity.percent
+                NovaActionButton(
+                    text = percent.toString() + "%",
+                    onClick = { callbacks.onMenuOpacityChange(percent) },
+                    modifier = Modifier.weight(1f),
+                    primary = selected,
+                    contentDescription = stringResource(
+                        R.string.nova_quick_menu_menu_opacity_preset_cd,
+                        percent
+                    ),
+                    selected = selected,
+                    stateDescription = stringResource(
+                        if (selected) {
+                            R.string.nova_quick_menu_hud_opacity_selected
+                        } else {
+                            R.string.nova_quick_menu_hud_opacity_not_selected
+                        }
+                    ),
+                    cornerRadius = 9.dp,
+                    minHeight = 44.dp,
+                    fontSize = 10.sp,
+                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
+                )
             }
         }
     }
@@ -892,12 +973,12 @@ private fun NovaQuickMenuClickableSurface(
     var focused by remember { mutableStateOf(false) }
     val surfaces = LocalNovaLibrarySurfaces.current
     val shape = RoundedCornerShape(if (flat) 10.dp else 14.dp)
-    val base = if (flat) Color.Transparent else surfaces.tile.copy(alpha = NovaInGameOverlayAlpha.NestedTile)
+    val base = if (flat) Color.Transparent else surfaces.tile.copy(alpha = NovaInGameOverlayAlpha.NestedTile * LocalNovaMenuOpacityScale.current)
     val focusedBackground = if (focused) surfaces.selectedControl else base
     val borderColor = when {
         focused -> surfaces.focusRing
         flat -> Color.Transparent
-        else -> surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border)
+        else -> surfaces.tileBorder.copy(alpha = NovaInGameOverlayAlpha.Border * LocalNovaMenuOpacityScale.current)
     }
     val borderWidth = if (focused) 2.dp else if (flat) 0.dp else 1.dp
 

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -80,6 +80,11 @@ data class NovaQuickMenuHudOpacityState(
     val enabled: Boolean
 )
 
+data class NovaQuickMenuMenuOpacityState(
+    val percent: Int,
+    val presets: List<Int>
+)
+
 data class NovaQuickMenuDiagnosisState(
     val classification: String,
     val likelyCause: String,
@@ -107,6 +112,7 @@ data class NovaQuickMenuUiState(
     val diagnosis: NovaQuickMenuDiagnosisState,
     val postSessionReport: NovaPostSessionReportUiState,
     val hudOpacity: NovaQuickMenuHudOpacityState,
+    val menuOpacity: NovaQuickMenuMenuOpacityState,
     val overlayRows: List<NovaQuickMenuAction>,
     val controlRows: List<NovaQuickMenuAction>,
     val sessionRows: List<NovaQuickMenuAction>
@@ -131,6 +137,7 @@ data class NovaQuickMenuUiState(
             profilePreference: String,
             hudShowing: Boolean,
             hudOpacityPercent: Int = NovaHudPreferences.DEFAULT_OPACITY_PERCENT,
+            menuOpacityPercent: Int = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT,
             perfOverlayEnabled: Boolean,
             onscreenControllerEnabled: Boolean,
             keyboardVisible: Boolean,
@@ -321,6 +328,10 @@ data class NovaQuickMenuUiState(
                 presets = NovaHudPreferences.OPACITY_PRESETS,
                 enabled = hudShowing
             )
+            val menuOpacity = NovaQuickMenuMenuOpacityState(
+                percent = NovaMenuPreferences.coerceOpacityPercent(menuOpacityPercent),
+                presets = NovaMenuPreferences.OPACITY_PRESETS
+            )
             val diagnosis = diagnosisState(status)
 
             val overlays = listOf(
@@ -419,6 +430,7 @@ data class NovaQuickMenuUiState(
                 diagnosis = diagnosis,
                 postSessionReport = postSessionReport,
                 hudOpacity = hudOpacity,
+                menuOpacity = menuOpacity,
                 overlayRows = overlays,
                 controlRows = controls,
                 sessionRows = sessionRows
@@ -468,6 +480,7 @@ data class NovaQuickMenuUiState(
                 profilePreference = "auto",
                 hudShowing = false,
                 hudOpacityPercent = NovaHudPreferences.DEFAULT_OPACITY_PERCENT,
+                menuOpacityPercent = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT,
                 perfOverlayEnabled = false,
                 onscreenControllerEnabled = false,
                 keyboardVisible = false,

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -19,6 +19,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.setPadding
 import androidx.core.widget.NestedScrollView
+import androidx.preference.PreferenceManager
+import androidx.appcompat.app.AlertDialog as AppCompatAlertDialog
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.R
@@ -71,8 +73,9 @@ object NovaSheetChrome {
         maxHeightPortrait: Float = 0.90f
     ) {
         val context = dialog.context
+        NovaMenuBlur.attachBehindDialog(dialog, readMenuOpacityPercent(context))
         dialog.window?.let { window ->
-            window.setDimAmount(SCRIM_ALPHA)
+            window.setDimAmount(getSheetScrimAlpha(context))
             window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         }
@@ -136,11 +139,22 @@ object NovaSheetChrome {
     }
 
 
+    fun applyMenuOpacityToLegacyAlert(dialog: AlertDialog, destructivePositive: Boolean = false) {
+        if (readMenuOpacityPercent(dialog.context) == NovaMenuPreferences.DEFAULT_OPACITY_PERCENT) return
+        applyAlertDialogChrome(dialog, destructivePositive)
+    }
+
+    fun applyMenuOpacityToLegacyAlert(dialog: AppCompatAlertDialog, destructivePositive: Boolean = false) {
+        if (readMenuOpacityPercent(dialog.context) == NovaMenuPreferences.DEFAULT_OPACITY_PERCENT) return
+        applyAlertDialogChrome(dialog, destructivePositive)
+    }
+
     fun applyAlertDialogChrome(dialog: AlertDialog, destructivePositive: Boolean = false) {
-        dialog.setOnShowListener {
+        val applyChrome = {
             val context = dialog.context
+            NovaMenuBlur.attachBehindDialog(dialog, readMenuOpacityPercent(context))
             dialog.window?.let { window ->
-                window.setDimAmount(SCRIM_ALPHA)
+                window.setDimAmount(getSheetScrimAlpha(context))
                 window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
                 window.setBackgroundDrawable(createAlertDialogBackground(context))
             }
@@ -154,6 +168,29 @@ object NovaSheetChrome {
                 button.setTextColor(NovaThemeManager.getTextSecondaryColor(context))
             }
         }
+        if (dialog.isShowing) applyChrome() else dialog.setOnShowListener { applyChrome() }
+    }
+
+    fun applyAlertDialogChrome(dialog: AppCompatAlertDialog, destructivePositive: Boolean = false) {
+        val applyChrome = {
+            val context = dialog.context
+            NovaMenuBlur.attachBehindDialog(dialog, readMenuOpacityPercent(context))
+            dialog.window?.let { window ->
+                window.setDimAmount(getSheetScrimAlpha(context))
+                window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                window.setBackgroundDrawable(createAlertDialogBackground(context))
+            }
+            val alertTitleId = context.resources.getIdentifier("alertTitle", "id", "android")
+            dialog.findViewById<TextView>(alertTitleId)?.setTextColor(NovaThemeManager.getTextPrimaryColor(context))
+            dialog.findViewById<TextView>(android.R.id.message)?.setTextColor(NovaThemeManager.getTextPrimaryColor(context))
+            dialog.getButton(AppCompatAlertDialog.BUTTON_POSITIVE)?.let { button ->
+                button.setTextColor(if (destructivePositive) ContextCompat.getColor(context, R.color.nova_error) else NovaThemeManager.getAccentColor(context))
+            }
+            dialog.getButton(AppCompatAlertDialog.BUTTON_NEGATIVE)?.let { button ->
+                button.setTextColor(NovaThemeManager.getTextSecondaryColor(context))
+            }
+        }
+        if (dialog.isShowing) applyChrome() else dialog.setOnShowListener { applyChrome() }
     }
 
     fun createAlertDialogBackground(context: Context): GradientDrawable {
@@ -192,12 +229,7 @@ object NovaSheetChrome {
 
     fun createSheetSurfaceColor(context: Context): Int {
         val baseSurface = NovaThemeManager.getDialogBackgroundColor(context)
-        val alpha = (getSheetGlassAlpha(context) * 255).toInt().coerceIn(0, 255)
-        return ColorUtils.setAlphaComponent(baseSurface, alpha)
-    }
-
-    fun getSheetGlassAlpha(context: Context): Float {
-        return when {
+        val themedAlpha = when {
             NovaThemeManager.isHighContrast(context) -> HIGH_CONTRAST_SHEET_GLASS_ALPHA
             NovaThemeManager.isPortableChrome(context) -> PORTABLE_CHROME_SHEET_GLASS_ALPHA
             NovaThemeManager.isMiami(context) -> MIAMI_SHEET_GLASS_ALPHA
@@ -205,17 +237,52 @@ object NovaSheetChrome {
             NovaThemeManager.isMaterialYou(context) -> MATERIAL_YOU_SHEET_GLASS_ALPHA
             else -> SHEET_GLASS_ALPHA
         }
+        val alpha = NovaMenuPreferences.alphaByte(themedAlpha, readMenuOpacityPercent(context))
+        return ColorUtils.setAlphaComponent(baseSurface, alpha)
+    }
+
+    fun getSheetScrimAlpha(context: Context): Float {
+        return NovaMenuPreferences.readabilityScrimAlpha(
+            SCRIM_ALPHA,
+            readMenuOpacityPercent(context)
+        )
+    }
+
+    fun getSheetGlassAlpha(context: Context): Float {
+        val themedAlpha = when {
+            NovaThemeManager.isHighContrast(context) -> HIGH_CONTRAST_SHEET_GLASS_ALPHA
+            NovaThemeManager.isPortableChrome(context) -> PORTABLE_CHROME_SHEET_GLASS_ALPHA
+            NovaThemeManager.isMiami(context) -> MIAMI_SHEET_GLASS_ALPHA
+            NovaThemeManager.isOled(context) -> OLED_SHEET_GLASS_ALPHA
+            NovaThemeManager.isMaterialYou(context) -> MATERIAL_YOU_SHEET_GLASS_ALPHA
+            else -> SHEET_GLASS_ALPHA
+        }
+        return NovaMenuPreferences.scaleAlpha(themedAlpha, readMenuOpacityPercent(context))
     }
 
     fun getSheetStrokeColor(context: Context): Int {
         val surface = NovaThemeManager.getDialogBackgroundColor(context)
         val accent = NovaThemeManager.getAccentColor(context)
-        return when {
+        val themedStroke = when {
             NovaThemeManager.isHighContrast(context) -> NovaThemeManager.getDividerColor(context)
             NovaThemeManager.isPortableChrome(context) -> ColorUtils.blendARGB(surface, accent, 0.46f)
             NovaThemeManager.isOled(context) -> ColorUtils.blendARGB(surface, Color.WHITE, 0.12f)
             else -> ColorUtils.blendARGB(surface, accent, 0.32f)
         }
+        val opacityPercent = readMenuOpacityPercent(context)
+        if (opacityPercent == NovaMenuPreferences.MAX_OPACITY_PERCENT) {
+            return themedStroke
+        }
+        val scaledAlpha = NovaMenuPreferences.alphaByte(
+            Color.alpha(themedStroke) / 255f,
+            opacityPercent
+        )
+        return ColorUtils.setAlphaComponent(themedStroke, scaledAlpha)
+    }
+
+    private fun readMenuOpacityPercent(context: Context): Int {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        return NovaMenuPreferences.readOpacityPercent(prefs)
     }
 
     fun createActionBackground(context: Context): StateListDrawable {
@@ -292,11 +359,18 @@ object NovaSheetChrome {
         val radius = dp(context, 16).toFloat()
         val surface = createSheetSurfaceColor(context)
         val accent = NovaThemeManager.getAccentColor(context)
+        val preservesFocusCue = fillAccentBlend > 0f
+        val menuOpacityScale = NovaMenuPreferences.opacityScale(readMenuOpacityPercent(context))
+        val effectiveStrokeBlend = if (preservesFocusCue) {
+            strokeAccentBlend
+        } else {
+            strokeAccentBlend * menuOpacityScale
+        }
         return GradientDrawable().apply {
             shape = GradientDrawable.RECTANGLE
             setColor(if (fillAccentBlend > 0f) ColorUtils.blendARGB(surface, accent, fillAccentBlend) else Color.TRANSPARENT)
             cornerRadius = radius
-            setStroke(dp(context, 1), ColorUtils.blendARGB(surface, accent, strokeAccentBlend))
+            setStroke(dp(context, 1), ColorUtils.blendARGB(surface, accent, effectiveStrokeBlend))
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaSheetChrome.kt
@@ -237,8 +237,16 @@ object NovaSheetChrome {
             NovaThemeManager.isMaterialYou(context) -> MATERIAL_YOU_SHEET_GLASS_ALPHA
             else -> SHEET_GLASS_ALPHA
         }
-        val alpha = NovaMenuPreferences.alphaByte(themedAlpha, readMenuOpacityPercent(context))
-        return ColorUtils.setAlphaComponent(baseSurface, alpha)
+        val opacityPercent = readMenuOpacityPercent(context)
+        val usesDarkText = ColorUtils.calculateLuminance(
+            NovaThemeManager.getTextPrimaryColor(context)
+        ) < 0.5
+        val alpha = NovaMenuPreferences.readabilitySurfaceAlpha(
+            baseAlpha = themedAlpha,
+            opacityPercent = opacityPercent,
+            usesDarkText = usesDarkText
+        )
+        return ColorUtils.setAlphaComponent(baseSurface, (alpha * 255f).toInt().coerceIn(0, 255))
     }
 
     fun getSheetScrimAlpha(context: Context): Float {

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -88,7 +88,7 @@ class NovaStreamHud(
             val composeView = ComposeView(activity).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
                 setContent {
-                    NovaComposeTheme {
+                    NovaComposeTheme(menuOpacityPercent = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT) {
                         NovaStreamHudContent(
                             state = hudState.value,
                             opacityScale = hudOpacityScale.value

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamOverlayContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamOverlayContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.papi.nova.ui.compose.LocalNovaComposeColors
+import com.papi.nova.ui.compose.LocalNovaMenuOpacityScale
 
 data class NovaReconnectOverlayState(
     val attempt: Int,
@@ -303,7 +304,14 @@ private fun StreamOverlayScaffold(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.Black.copy(alpha = scrimAlpha))
+            .background(
+                Color.Black.copy(
+                    alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                        scrimAlpha,
+                        LocalNovaMenuOpacityScale.current
+                    )
+                )
+            )
             .padding(horizontal = 48.dp, vertical = 32.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/papi/nova/ui/ReconnectOverlay.kt
+++ b/app/src/main/java/com/papi/nova/ui/ReconnectOverlay.kt
@@ -7,6 +7,7 @@ import android.widget.FrameLayout
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.preference.PreferenceManager
 import com.papi.nova.LimeLog
 import com.papi.nova.ui.compose.NovaComposeTheme
 
@@ -15,6 +16,7 @@ import com.papi.nova.ui.compose.NovaComposeTheme
  */
 class ReconnectOverlay(private val activity: Activity) {
     private var overlayView: ComposeView? = null
+    private var backgroundBlurLeases: List<NovaMenuBlur.BlurLease> = emptyList()
     private val overlayState = mutableStateOf(NovaReconnectOverlayState(attempt = 1, maxAttempts = 1))
 
     fun show(attempt: Int, maxAttempts: Int) {
@@ -26,6 +28,12 @@ class ReconnectOverlay(private val activity: Activity) {
 
             val composeView = ComposeView(activity).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                NovaMenuBlur.releaseOnUnexpectedDetach(this) {
+                    if (overlayView === this) {
+                        overlayView = null
+                        releaseBackgroundBlur()
+                    }
+                }
                 setContent {
                     NovaComposeTheme {
                         NovaReconnectOverlayContent(state = overlayState.value)
@@ -37,6 +45,11 @@ class ReconnectOverlay(private val activity: Activity) {
                 ViewGroup.LayoutParams.MATCH_PARENT
             )
             val rootView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
+            backgroundBlurLeases = NovaMenuBlur.acquireChildren(
+                rootView,
+                NovaMenuPreferences.readOpacityPercent(prefs)
+            )
             rootView.addView(composeView, params)
             overlayView = composeView
             LimeLog.info("Nova: Reconnect overlay shown (attempt $attempt)")
@@ -47,11 +60,17 @@ class ReconnectOverlay(private val activity: Activity) {
         activity.runOnUiThread {
             val view = overlayView
             overlayView = null
+            releaseBackgroundBlur()
             view?.let {
                 safeRemoveFromParent(it)
                 LimeLog.info("Nova: Reconnect overlay dismissed")
             }
         }
+    }
+
+    private fun releaseBackgroundBlur() {
+        NovaMenuBlur.releaseAll(backgroundBlurLeases)
+        backgroundBlurLeases = emptyList()
     }
 
     private fun safeRemoveFromParent(view: View) {

--- a/app/src/main/java/com/papi/nova/ui/SessionProgressOverlay.kt
+++ b/app/src/main/java/com/papi/nova/ui/SessionProgressOverlay.kt
@@ -7,6 +7,7 @@ import android.widget.FrameLayout
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.preference.PreferenceManager
 import com.papi.nova.LimeLog
 import com.papi.nova.ui.compose.NovaComposeTheme
 
@@ -15,6 +16,7 @@ import com.papi.nova.ui.compose.NovaComposeTheme
  */
 class SessionProgressOverlay(private val activity: Activity) {
     private var overlayView: ComposeView? = null
+    private var backgroundBlurLeases: List<NovaMenuBlur.BlurLease> = emptyList()
     private val overlayState = mutableStateOf(NovaSessionProgressUiState.from("initializing"))
 
     fun show() {
@@ -25,6 +27,12 @@ class SessionProgressOverlay(private val activity: Activity) {
             overlayState.value = NovaSessionProgressUiState.from("initializing")
             val composeView = ComposeView(activity).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                NovaMenuBlur.releaseOnUnexpectedDetach(this) {
+                    if (overlayView === this) {
+                        overlayView = null
+                        releaseBackgroundBlur()
+                    }
+                }
                 setContent {
                     NovaComposeTheme {
                         NovaSessionProgressOverlayContent(state = overlayState.value)
@@ -36,6 +44,11 @@ class SessionProgressOverlay(private val activity: Activity) {
                 ViewGroup.LayoutParams.MATCH_PARENT
             )
             val rootView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
+            backgroundBlurLeases = NovaMenuBlur.acquireChildren(
+                rootView,
+                NovaMenuPreferences.readOpacityPercent(prefs)
+            )
             rootView.addView(composeView, params)
             overlayView = composeView
             LimeLog.info("Nova: Session progress overlay shown")
@@ -55,11 +68,17 @@ class SessionProgressOverlay(private val activity: Activity) {
         activity.runOnUiThread {
             val view = overlayView
             overlayView = null
+            releaseBackgroundBlur()
             view?.let {
                 safeRemoveFromParent(it)
                 LimeLog.info("Nova: Session progress overlay dismissed")
             }
         }
+    }
+
+    private fun releaseBackgroundBlur() {
+        NovaMenuBlur.releaseAll(backgroundBlurLeases)
+        backgroundBlurLeases = emptyList()
     }
 
     private fun safeRemoveFromParent(view: View) {

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -17,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.papi.nova.R
+import com.papi.nova.ui.NovaMenuOpacityPreview
 import com.papi.nova.ui.NovaMenuPreferences
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.NovaSheetChrome
@@ -245,7 +247,10 @@ fun NovaComposeTheme(
             onDispose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
         }
     }
-    val resolvedMenuOpacityPercent = menuOpacityPercent ?: observedMenuOpacityPercent
+    val previewMenuOpacityPercent by NovaMenuOpacityPreview.opacityPercent.collectAsState()
+    val resolvedMenuOpacityPercent = menuOpacityPercent
+        ?: previewMenuOpacityPercent
+        ?: observedMenuOpacityPercent
     val menuOpacityScale = NovaMenuPreferences.opacityScale(resolvedMenuOpacityPercent)
     val colors = NovaComposeColors(
         window = Color(NovaThemeManager.getWindowBackgroundColor(context)),

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -209,8 +209,9 @@ fun NovaComposeColors.librarySurfaces(
         surfaces.copy(
             backgroundScrim = readableScrimColor.copy(
                 alpha = NovaMenuPreferences.readabilityScrimAlpha(
-                    surfaces.backgroundScrim.alpha,
-                    opacityScale
+                    baseAlpha = surfaces.backgroundScrim.alpha,
+                    opacityScale = opacityScale,
+                    usesDarkText = textPrimary.luminance() < 0.5f
                 )
             ),
             panel = surfaces.panel.copy(alpha = surfaces.panel.alpha * opacityScale),

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt
@@ -3,12 +3,21 @@ package com.papi.nova.ui.compose
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
 import com.papi.nova.R
+import com.papi.nova.ui.NovaMenuPreferences
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.NovaSheetChrome
 
@@ -75,7 +84,13 @@ val LocalNovaLibrarySurfaces = staticCompositionLocalOf {
     defaultNovaComposeColors().librarySurfaces(NovaThemeManager.THEME_POLARIS)
 }
 
-fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
+val LocalNovaMenuOpacityScale = staticCompositionLocalOf { 1f }
+
+fun NovaComposeColors.librarySurfaces(
+    theme: String,
+    menuOpacityScale: Float = 1f
+): NovaLibrarySurfaces {
+    val opacityScale = menuOpacityScale.coerceIn(0f, 1f)
     val isOled = theme == NovaThemeManager.THEME_OLED
     val isMiami = theme == NovaThemeManager.THEME_MIAMI
     val isPortableChrome = theme == NovaThemeManager.THEME_PORTABLE_CHROME
@@ -182,13 +197,56 @@ fun NovaComposeColors.librarySurfaces(theme: String): NovaLibrarySurfaces {
             isMaterialYou -> 0.42f
             else -> 1f
         }
-    )
+    ).let { surfaces ->
+        val readabilityBackdrop = if (textPrimary.luminance() >= 0.5f) Color.Black else Color.White
+        val readableScrimColor = lerp(
+            surfaces.backgroundScrim,
+            readabilityBackdrop,
+            1f - opacityScale
+        )
+        surfaces.copy(
+            backgroundScrim = readableScrimColor.copy(
+                alpha = NovaMenuPreferences.readabilityScrimAlpha(
+                    surfaces.backgroundScrim.alpha,
+                    opacityScale
+                )
+            ),
+            panel = surfaces.panel.copy(alpha = surfaces.panel.alpha * opacityScale),
+            panelBorder = surfaces.panelBorder.copy(alpha = surfaces.panelBorder.alpha * opacityScale),
+            tile = surfaces.tile.copy(alpha = surfaces.tile.alpha * opacityScale),
+            tileBorder = surfaces.tileBorder.copy(alpha = surfaces.tileBorder.alpha * opacityScale),
+            control = surfaces.control.copy(alpha = surfaces.control.alpha * opacityScale),
+            selectedControl = surfaces.selectedControl.copy(alpha = surfaces.selectedControl.alpha * opacityScale)
+        )
+    }
 }
 
 @Composable
-fun NovaComposeTheme(content: @Composable () -> Unit) {
+fun NovaComposeTheme(
+    menuOpacityPercent: Int? = null,
+    content: @Composable () -> Unit
+) {
     val context = LocalContext.current
     val theme = NovaThemeManager.getTheme(context)
+    val prefs = remember(context) { PreferenceManager.getDefaultSharedPreferences(context) }
+    var observedMenuOpacityPercent by remember(prefs) {
+        mutableIntStateOf(NovaMenuPreferences.readOpacityPercent(prefs))
+    }
+    DisposableEffect(prefs, menuOpacityPercent) {
+        if (menuOpacityPercent != null) {
+            onDispose { }
+        } else {
+            val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                if (key == NovaMenuPreferences.KEY_OPACITY) {
+                    observedMenuOpacityPercent = NovaMenuPreferences.readOpacityPercent(prefs)
+                }
+            }
+            prefs.registerOnSharedPreferenceChangeListener(listener)
+            onDispose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+        }
+    }
+    val resolvedMenuOpacityPercent = menuOpacityPercent ?: observedMenuOpacityPercent
+    val menuOpacityScale = NovaMenuPreferences.opacityScale(resolvedMenuOpacityPercent)
     val colors = NovaComposeColors(
         window = Color(NovaThemeManager.getWindowBackgroundColor(context)),
         card = Color(NovaThemeManager.getCardBackgroundColor(context)),
@@ -208,11 +266,12 @@ fun NovaComposeTheme(content: @Composable () -> Unit) {
             )
         )
     )
-    val librarySurfaces = colors.librarySurfaces(theme)
+    val librarySurfaces = colors.librarySurfaces(theme, menuOpacityScale)
 
     androidx.compose.runtime.CompositionLocalProvider(
         LocalNovaComposeColors provides colors,
-        LocalNovaLibrarySurfaces provides librarySurfaces
+        LocalNovaLibrarySurfaces provides librarySurfaces,
+        LocalNovaMenuOpacityScale provides menuOpacityScale
     ) {
         MaterialTheme(
             colorScheme = darkColorScheme(

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
@@ -164,7 +164,7 @@ fun NovaControllerHintBar(
             .fillMaxWidth()
             .heightIn(min = 30.dp)
             .clip(shape)
-            .background(surfaces.panel.copy(alpha = 0.86f))
+            .background(surfaces.panel.copy(alpha = 0.86f * LocalNovaMenuOpacityScale.current))
             .border(1.dp, surfaces.panelBorder, shape)
             .semantics { contentDescription = hintContentDescription }
             .horizontalScroll(rememberScrollState())

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaMenuBackdropBlur.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaMenuBackdropBlur.kt
@@ -1,0 +1,20 @@
+package com.papi.nova.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import com.papi.nova.ui.NovaMenuBlur
+import kotlin.math.roundToInt
+
+/** Keeps menu content sharp while adaptively blurring the owning Activity beneath it. */
+@Composable
+fun NovaMenuBackdropBlur() {
+    val context = LocalContext.current
+    val opacityPercent = (LocalNovaMenuOpacityScale.current * 100f).roundToInt()
+    DisposableEffect(context, opacityPercent) {
+        val lease = NovaMenuBlur.acquireActivityBackground(context, opacityPercent)
+        onDispose {
+            lease?.release()
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/Dialog.kt
+++ b/app/src/main/java/com/papi/nova/utils/Dialog.kt
@@ -2,9 +2,8 @@ package com.papi.nova.utils
 
 import android.app.Activity
 import android.app.AlertDialog
-import android.content.DialogInterface
-import android.widget.Button
 import com.papi.nova.R
+import com.papi.nova.ui.NovaSheetChrome
 
 class Dialog private constructor(
     private val activity: Activity,
@@ -49,18 +48,15 @@ class Dialog private constructor(
             runOnDismiss.run()
             HelpLauncher.launchTroubleshooting(activity)
         }
-        createdAlert.setOnShowListener(object : DialogInterface.OnShowListener {
-            override fun onShow(dialog: DialogInterface) {
-                val button: Button = createdAlert.getButton(AlertDialog.BUTTON_POSITIVE)
-                button.isFocusable = true
-                button.isFocusableInTouchMode = true
-                button.requestFocus()
-            }
-        })
-
         synchronized(rundownDialogs) {
             rundownDialogs.add(this)
             createdAlert.show()
+            NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdAlert)
+            createdAlert.getButton(AlertDialog.BUTTON_POSITIVE)?.apply {
+                isFocusable = true
+                isFocusableInTouchMode = true
+                requestFocus()
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -850,6 +850,9 @@
     <string name="nova_quick_menu_session">Session</string>
     <string name="nova_quick_menu_nova_hud">Nova HUD</string>
     <string name="nova_quick_menu_nova_hud_caption">Tap HUD to cycle modes; long-press to open Command Center.</string>
+    <string name="nova_quick_menu_menu_opacity">Menu Opacity</string>
+    <string name="nova_quick_menu_menu_opacity_caption">Adjust Nova menus, drawers, options, and session glass without dimming text or focus cues.</string>
+    <string name="nova_quick_menu_menu_opacity_preset_cd">Set menu opacity to %1$d percent</string>
     <string name="nova_quick_menu_hud_opacity">HUD Opacity</string>
     <string name="nova_quick_menu_hud_opacity_caption">Adjust NovaHUD glass without dimming telemetry text.</string>
     <string name="nova_quick_menu_hud_opacity_disabled_caption">Enable Nova HUD first to change glass opacity.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -427,6 +427,17 @@
             app:iconSpaceReserved="false"
             seekbar:min="0"
             seekbar:step="1" />
+        <com.papi.nova.preferences.SeekBarPreference
+            android:key="nova_menu_opacity"
+            android:title="Menu &amp; Drawer Opacity"
+            android:summary="Adjust Nova menu, drawer, options, and session glass without dimming text or focus cues"
+            android:dialogMessage="Adjust Nova menu, drawer, options, and session glass without dimming text or focus cues"
+            android:defaultValue="100"
+            android:max="100"
+            android:text="@string/suffix_osc_opacity"
+            app:iconSpaceReserved="false"
+            seekbar:min="0"
+            seekbar:step="1" />
         <Preference
             android:key="nova_reset_stream_ui"
             android:title="Reset Stream UI Defaults"

--- a/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceScreensMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceScreensMigrationTest.kt
@@ -176,6 +176,8 @@ class KotlinPreferenceScreensMigrationTest {
         val preferences = File("src/main/res/xml/preferences.xml").readText()
         val settingsScreen = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
         val viewModel = File("src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt").readText()
+        val repository = File("src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt").readText()
+        val streamSettings = File("src/main/java/com/papi/nova/preferences/StreamSettings.kt").readText()
 
         assertTrue(preferences.contains("nova_reset_stream_ui"))
         assertTrue(settingsScreen.contains("resetStreamUiDefaults"))
@@ -183,8 +185,23 @@ class KotlinPreferenceScreensMigrationTest {
         assertTrue(viewModel.contains("fun resetStreamUiDefaults()"))
         assertTrue(viewModel.contains("nova_polaris_hud"))
         assertTrue(viewModel.contains("nova_polaris_hud_mode"))
-        assertTrue(viewModel.contains("nova_polaris_hud_opacity"))
+        assertTrue(viewModel.contains("NovaHudPreferences.KEY_OPACITY"))
+        assertTrue(viewModel.contains("NovaMenuPreferences.KEY_OPACITY"))
         assertTrue(viewModel.contains("checkbox_enable_perf_overlay"))
         assertTrue(viewModel.contains("checkbox_show_onscreen_controls"))
+
+        val resetBranch = settingsScreen
+            .substringAfter("if (definition.key == RESET_STREAM_UI_DEFAULTS_KEY)")
+            .substringBefore("} else")
+        assertTrue("Compose reset should have one ViewModel owner", resetBranch.contains("viewModel.resetStreamUiDefaults()"))
+        assertFalse("Compose reset must not also dispatch the Activity action", resetBranch.contains("onAction(definition)"))
+
+        val persistHelper = viewModel
+            .substringAfter("internal suspend fun persistNovaStreamUiDefaults(")
+            .substringBefore("\n}\n\nclass NovaSettingsViewModel")
+        assertTrue("reset defaults should use one store batch", persistHelper.contains("store.updateAtomically("))
+        assertFalse("reset defaults must not loop over individual store writes", persistHelper.contains("store.set("))
+        assertTrue("repository must implement a dedicated atomic batch", repository.contains("override suspend fun updateAtomically("))
+        assertFalse("StreamSettings must not own a second reset coroutine", streamSettings.contains("resetStreamUiRuntimePreferences()"))
     }
 }

--- a/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceWidgetsMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/KotlinPreferenceWidgetsMigrationTest.kt
@@ -96,6 +96,17 @@ class KotlinPreferenceWidgetsMigrationTest {
     }
 
     @Test
+    fun legacySeekBarDialogIsRecreatedSoOpacityTransitionsNeverReuseStaleChrome() {
+        val source = File("src/main/java/com/papi/nova/preferences/SeekBarPreference.kt").readText()
+
+        assertTrue(source.contains("createdDialog.setOnDismissListener"))
+        assertTrue(source.contains("dialog = null"))
+        assertTrue(source.contains("seekBar = null"))
+        assertTrue(source.contains("valueText = null"))
+        assertTrue(source.contains("NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdDialog)"))
+    }
+
+    @Test
     fun webLauncherPreferenceStillRequiresUrlAttribute() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -134,6 +134,23 @@ class NovaSettingsDefinitionsTest {
     }
 
     @Test
+    fun menuOpacityPreferenceIsIndependentAdjustableInstantSlider() {
+        val definitions = NovaSettingDefinitions.load(context)
+        val menuOpacity = definitions.require("nova_menu_opacity")
+
+        assertEquals("Menu & Drawer Opacity", menuOpacity.title)
+        assertEquals("category_overlays", menuOpacity.categoryKey)
+        assertEquals(NovaSettingType.Slider, menuOpacity.type)
+        assertEquals(NovaSettingValue.IntValue(100), menuOpacity.defaultValue)
+        assertEquals(0, menuOpacity.min)
+        assertEquals(100, menuOpacity.max)
+        assertEquals(1, menuOpacity.step)
+        assertEquals("%", menuOpacity.suffix)
+        assertEquals(NovaSettingApplyTiming.Instant, menuOpacity.applyTiming)
+        assertEquals(null, menuOpacity.dependencyKey)
+    }
+
+    @Test
     fun upgradedBalancedInstallMigratesLegacy720Resolution() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         prefs.edit()

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsStoreTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsStoreTest.kt
@@ -73,6 +73,29 @@ class NovaSettingsStoreTest {
     }
 
     @Test
+    fun runtimeSharedPreferencesAreAuthoritativeAndRepairStaleDataStoreState() = runBlocking {
+        val mirrorPrefs = context.getSharedPreferences("nova-settings-authority-test", Context.MODE_PRIVATE)
+        mirrorPrefs.edit().clear().commit()
+        val storeFile = File(context.filesDir, "nova-settings-authority-${System.nanoTime()}.preferences_pb")
+        val repository = NovaSettingsRepository.createForTest(
+            context = context,
+            mirrorPrefs = mirrorPrefs,
+            storeFile = storeFile
+        )
+        val definitions = NovaSettingDefinitions.load(context)
+        val menuOpacity = definitions.require("nova_menu_opacity")
+
+        repository.set(menuOpacity, NovaSettingValue.IntValue(100))
+        mirrorPrefs.edit().putInt(menuOpacity.key, 25).commit()
+
+        assertEquals(NovaSettingValue.IntValue(25), repository.snapshot(definitions)[menuOpacity.key])
+
+        mirrorPrefs.edit().remove(menuOpacity.key).commit()
+
+        assertEquals(menuOpacity.defaultValue, repository.snapshot(definitions)[menuOpacity.key])
+    }
+
+    @Test
     fun dataStoreRepositoryMigratesAndMirrorsLegacySharedPreferences() = runBlocking {
         val mirrorPrefs = context.getSharedPreferences("nova-settings-mirror-test", Context.MODE_PRIVATE)
         mirrorPrefs.edit()

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -173,7 +173,7 @@ class NovaComposeSourceGuardTest {
 
         assertTrue(
             "landscape toolbar should be a slim nav overlay, not another padded card slab above the grid",
-            landscapeToolbar.contains("surfaces.panel.copy(alpha = 0.72f)") &&
+            landscapeToolbar.contains("surfaces.panel.copy(alpha = 0.72f * LocalNovaMenuOpacityScale.current)") &&
                 landscapeToolbar.contains(".padding(horizontal = 10.dp, vertical = 6.dp)") &&
                 landscapeToolbar.contains("fontSize = 16.sp")
         )
@@ -212,7 +212,7 @@ class NovaComposeSourceGuardTest {
                 optionsSheet.contains("usePlatformDefaultWidth = false") &&
                 optionsSheet.contains("align(Alignment.CenterStart)") &&
                 optionsSheet.contains("widthIn(max = 420.dp)") &&
-                optionsSheet.contains("surfaces.backgroundScrim.copy(alpha = 0.58f)")
+                optionsSheet.contains("NovaMenuPreferences.readabilityScrimAlpha(")
         )
         assertFalse(
             "library options should not use the giant Material bottom sheet now that it is the primary browse drawer",

--- a/app/src/test/java/com/papi/nova/ui/NovaMenuBlurOwnershipTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaMenuBlurOwnershipTest.kt
@@ -60,6 +60,29 @@ class NovaMenuBlurOwnershipTest {
     }
 
     @Test
+    fun separateDialogWindowKeepsCommandCenterContentOutsideTheBlurredActivityTree() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val activityDecor = activity.window.decorView
+        val dialog = Dialog(activity)
+        val menuContent = View(activity)
+        dialog.setContentView(menuContent)
+
+        NovaMenuBlur.attachBehindDialog(dialog, 25)
+        dialog.show()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(activityDecor)), 0.001f)
+        assertNull(NovaMenuBlur.currentRadiusDp(dialog.window!!.decorView))
+        assertNull(NovaMenuBlur.currentRadiusDp(menuContent))
+        assertTrue(menuContent.rootView === dialog.window!!.decorView)
+        assertTrue(menuContent.rootView !== activityDecor)
+
+        dialog.dismiss()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertNull(NovaMenuBlur.currentRadiusDp(activityDecor))
+    }
+
+    @Test
     fun reattachingShownDialogReplacesItsLeaseWithoutLeakingTheOldRadius() {
         val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
         val target = activity.window.decorView

--- a/app/src/test/java/com/papi/nova/ui/NovaMenuBlurOwnershipTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaMenuBlurOwnershipTest.kt
@@ -1,0 +1,155 @@
+package com.papi.nova.ui
+
+import android.app.Dialog
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicReference
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaMenuBlurOwnershipTest {
+    @Test
+    fun releasingOneOwnerKeepsTheStrongestRemainingBlur() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val view = View(activity)
+
+        val strong = NovaMenuBlur.acquire(view, 25)
+        val medium = NovaMenuBlur.acquire(view, 64)
+
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(view)), 0.001f)
+
+        strong.release()
+
+        assertEquals(8.64f, requireNotNull(NovaMenuBlur.currentRadiusDp(view)), 0.001f)
+
+        medium.release()
+
+        assertNull(NovaMenuBlur.currentRadiusDp(view))
+    }
+
+    @Test
+    fun dialogAcquiresOnlyWhenAttachedAndReleasesOnDismiss() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val target = activity.window.decorView
+        val dialog = Dialog(activity)
+
+        NovaMenuBlur.attachBehindDialog(dialog, 25)
+
+        assertNull(NovaMenuBlur.currentRadiusDp(target))
+
+        dialog.show()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(target)), 0.001f)
+
+        dialog.dismiss()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertNull(NovaMenuBlur.currentRadiusDp(target))
+    }
+
+    @Test
+    fun reattachingShownDialogReplacesItsLeaseWithoutLeakingTheOldRadius() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val target = activity.window.decorView
+        val dialog = Dialog(activity)
+
+        NovaMenuBlur.attachBehindDialog(dialog, 25)
+        dialog.show()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(target)), 0.001f)
+
+        NovaMenuBlur.attachBehindDialog(dialog, 64)
+        assertEquals(8.64f, requireNotNull(NovaMenuBlur.currentRadiusDp(target)), 0.001f)
+
+        dialog.dismiss()
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertNull(NovaMenuBlur.currentRadiusDp(target))
+    }
+
+    @Test
+    fun dialogBindingRejectsBackgroundMutation() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val dialog = Dialog(activity)
+        val failure = AtomicReference<Throwable?>()
+
+        Thread {
+            runCatching { NovaMenuBlur.attachBehindDialog(dialog, 25) }
+                .onFailure(failure::set)
+        }.apply {
+            start()
+            join()
+        }
+
+        assertTrue(failure.get() is IllegalStateException)
+    }
+
+    @Test
+    fun backgroundReleaseIsRejectedWithoutDiscardingOwnership() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val view = View(activity)
+        val lease = NovaMenuBlur.acquire(view, 25)
+        val failure = AtomicReference<Throwable?>()
+
+        Thread {
+            runCatching { lease.release() }
+                .onFailure(failure::set)
+        }.apply {
+            start()
+            join()
+        }
+
+        assertTrue(failure.get() is IllegalStateException)
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(view)), 0.001f)
+
+        lease.release()
+        assertNull(NovaMenuBlur.currentRadiusDp(view))
+    }
+
+    @Test
+    fun unexpectedOverlayDetachReleasesBackgroundLease() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val root: ViewGroup = activity.window.decorView.findViewById(android.R.id.content)
+        val background = View(activity)
+        val overlay = View(activity)
+        root.addView(background)
+        val lease = NovaMenuBlur.acquire(background, 25)
+        NovaMenuBlur.releaseOnUnexpectedDetach(overlay) { lease.release() }
+
+        root.addView(overlay)
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(background)), 0.001f)
+
+        root.removeView(overlay)
+
+        assertNull(NovaMenuBlur.currentRadiusDp(background))
+    }
+
+    @Test
+    fun releaseIsIdempotentAndZeroBlurOwnerDoesNotClearAnotherOwner() {
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        val view = View(activity)
+
+        val compatibilityOwner = NovaMenuBlur.acquire(view, 100)
+        val blurredOwner = NovaMenuBlur.acquire(view, 25)
+
+        compatibilityOwner.release()
+        compatibilityOwner.release()
+
+        assertEquals(18f, requireNotNull(NovaMenuBlur.currentRadiusDp(view)), 0.001f)
+
+        blurredOwner.release()
+
+        assertNull(NovaMenuBlur.currentRadiusDp(view))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
@@ -9,11 +9,14 @@ import com.papi.nova.preferences.NOVA_STREAM_UI_RESET_REMOVALS
 import com.papi.nova.preferences.NovaSettingDefinitions
 import com.papi.nova.preferences.NovaSettingValue
 import com.papi.nova.preferences.NovaSettingsRepository
+import com.papi.nova.preferences.NovaSharedPreferencesSettingsStore
 import com.papi.nova.preferences.persistNovaStreamUiDefaults
 import java.io.File
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -55,6 +58,38 @@ class NovaMenuPreferencesTest {
     }
 
     @Test
+    fun livePreviewIsProcessLocalAndNeverMutatesTheDurablePreference() {
+        val prefs = context.getSharedPreferences("nova-menu-preview", Context.MODE_PRIVATE)
+        prefs.edit().clear().putInt(NovaMenuPreferences.KEY_OPACITY, 100).commit()
+        NovaMenuOpacityPreview.clear()
+
+        NovaMenuOpacityPreview.update(25)
+
+        assertEquals(25, NovaMenuOpacityPreview.opacityPercent.value)
+        assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
+
+        NovaMenuOpacityPreview.clear()
+
+        assertNull(NovaMenuOpacityPreview.opacityPercent.value)
+        assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
+    }
+
+    @Test
+    fun darkTextNativeSurfacesRetainAContrastFloorAtZeroOpacity() {
+        assertEquals(
+            NovaMenuPreferences.MIN_READABILITY_SURFACE_ALPHA,
+            NovaMenuPreferences.readabilitySurfaceAlpha(0.94f, 0, usesDarkText = true),
+            0.001f
+        )
+        assertEquals(
+            0f,
+            NovaMenuPreferences.readabilitySurfaceAlpha(0.94f, 0, usesDarkText = false),
+            0.001f
+        )
+        assertEquals(0.94f, NovaMenuPreferences.readabilitySurfaceAlpha(0.94f, 100, true), 0.001f)
+    }
+
+    @Test
     fun adaptiveBlurPreservesTheDefaultAndStrengthensAsGlassClears() {
         assertEquals(0f, NovaMenuPreferences.blurRadiusDp(100), 0.001f)
         assertEquals(2.4f, NovaMenuPreferences.blurRadiusDp(90), 0.001f)
@@ -89,6 +124,23 @@ class NovaMenuPreferencesTest {
         assertEquals(0f, NovaSheetChrome.getSheetGlassAlpha(context), 0.001f)
         assertEquals(NovaMenuPreferences.MIN_READABILITY_SCRIM_ALPHA, NovaSheetChrome.getSheetScrimAlpha(context), 0.001f)
         assertEquals(0, Color.alpha(NovaSheetChrome.getSheetStrokeColor(context)))
+    }
+
+    @Test
+    fun streamUiResetFailsClosedWhenGivenAvailabilityFilteredDefinitions() {
+        val fullDefinitions = NovaSettingDefinitions.load(context)
+        val filteredDefinitions = fullDefinitions.copy(
+            settings = fullDefinitions.settings.filterNot { it.key == NovaMenuPreferences.KEY_OPACITY }
+        )
+        val prefs = context.getSharedPreferences("nova-menu-filtered-reset", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        val store = NovaSharedPreferencesSettingsStore(prefs)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { persistNovaStreamUiDefaults(store, filteredDefinitions) }
+        }
+        assertFalse(prefs.contains(NovaHudPreferences.KEY_OPACITY))
+        assertFalse(prefs.contains(NovaMenuPreferences.KEY_OPACITY))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
@@ -2,6 +2,7 @@ package com.papi.nova.ui
 
 import android.content.Context
 import android.graphics.Color
+import androidx.core.graphics.ColorUtils
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.preferences.NOVA_STREAM_UI_DEFAULT_UPDATES
@@ -17,6 +18,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -58,26 +60,35 @@ class NovaMenuPreferencesTest {
     }
 
     @Test
-    fun livePreviewIsProcessLocalAndNeverMutatesTheDurablePreference() {
+    fun livePreviewIsProcessLocalOwnershipSafeAndNeverMutatesTheDurablePreference() {
         val prefs = context.getSharedPreferences("nova-menu-preview", Context.MODE_PRIVATE)
         prefs.edit().clear().putInt(NovaMenuPreferences.KEY_OPACITY, 100).commit()
-        NovaMenuOpacityPreview.clear()
+        val firstOwner = NovaMenuOpacityPreview.newOwner()
+        val secondOwner = NovaMenuOpacityPreview.newOwner()
 
-        NovaMenuOpacityPreview.update(25)
+        NovaMenuOpacityPreview.update(firstOwner, 25)
 
         assertEquals(25, NovaMenuOpacityPreview.opacityPercent.value)
         assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
 
-        NovaMenuOpacityPreview.clear()
+        NovaMenuOpacityPreview.update(secondOwner, 64)
+        NovaMenuOpacityPreview.clear(firstOwner)
+
+        assertEquals(64, NovaMenuOpacityPreview.opacityPercent.value)
+        assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
+
+        NovaMenuOpacityPreview.clear(secondOwner)
 
         assertNull(NovaMenuOpacityPreview.opacityPercent.value)
         assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
     }
 
     @Test
-    fun darkTextNativeSurfacesRetainAContrastFloorAtZeroOpacity() {
+    fun darkTextContrastFloorsMeetWcagAgainstABlackScene() {
+        assertEquals(0.71f, NovaMenuPreferences.MIN_DARK_TEXT_SURFACE_ALPHA, 0.001f)
+        assertEquals(0.57f, NovaMenuPreferences.MIN_DARK_TEXT_SCRIM_ALPHA, 0.001f)
         assertEquals(
-            NovaMenuPreferences.MIN_READABILITY_SURFACE_ALPHA,
+            NovaMenuPreferences.MIN_DARK_TEXT_SURFACE_ALPHA,
             NovaMenuPreferences.readabilitySurfaceAlpha(0.94f, 0, usesDarkText = true),
             0.001f
         )
@@ -87,6 +98,30 @@ class NovaMenuPreferencesTest {
             0.001f
         )
         assertEquals(0.94f, NovaMenuPreferences.readabilitySurfaceAlpha(0.94f, 100, true), 0.001f)
+
+        val text = Color.rgb(0x1F, 0x2A, 0x35)
+        val portableSurface = Color.rgb(0xC4, 0xCD, 0xD8)
+        val nativeComposite = ColorUtils.compositeColors(
+            ColorUtils.setAlphaComponent(
+                portableSurface,
+                (NovaMenuPreferences.MIN_DARK_TEXT_SURFACE_ALPHA * 255f).toInt()
+            ),
+            Color.BLACK
+        )
+        val dialogBackdrop = ColorUtils.compositeColors(
+            ColorUtils.setAlphaComponent(
+                Color.WHITE,
+                (NovaMenuPreferences.MIN_DARK_TEXT_SCRIM_ALPHA * 255f).toInt()
+            ),
+            Color.BLACK
+        )
+        assertTrue(ColorUtils.calculateContrast(text, nativeComposite) >= 4.5)
+        assertTrue(ColorUtils.calculateContrast(text, dialogBackdrop) >= 4.5)
+        assertEquals(
+            NovaMenuPreferences.MIN_DARK_TEXT_SCRIM_ALPHA,
+            NovaMenuPreferences.readabilityScrimAlpha(0.58f, 0f, usesDarkText = true),
+            0.001f
+        )
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaMenuPreferencesTest.kt
@@ -1,0 +1,166 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.graphics.Color
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import com.papi.nova.preferences.NOVA_STREAM_UI_DEFAULT_UPDATES
+import com.papi.nova.preferences.NOVA_STREAM_UI_RESET_REMOVALS
+import com.papi.nova.preferences.NovaSettingDefinitions
+import com.papi.nova.preferences.NovaSettingValue
+import com.papi.nova.preferences.NovaSettingsRepository
+import com.papi.nova.preferences.persistNovaStreamUiDefaults
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaMenuPreferencesTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun sharedPreferencesDefaultReadWriteClampsAndScalesThemeAlpha() {
+        val prefs = context.getSharedPreferences("nova-menu-preferences-shared", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+
+        assertEquals(100, NovaMenuPreferences.readOpacityPercent(prefs))
+        assertEquals(listOf(0, 25, 64, 90, 100), NovaMenuPreferences.OPACITY_PRESETS)
+        assertEquals(0.62f, NovaMenuPreferences.scaleAlpha(0.62f, 100), 0.001f)
+        assertEquals(0.31f, NovaMenuPreferences.scaleAlpha(0.62f, 50), 0.001f)
+
+        NovaMenuPreferences.writeOpacityPercent(prefs, -10)
+
+        assertEquals(0, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 25))
+        assertEquals(0, NovaMenuPreferences.readOpacityPercent(prefs))
+        assertEquals(0.0f, NovaMenuPreferences.opacityScale(-10), 0.001f)
+
+        NovaMenuPreferences.writeOpacityPercent(prefs, 150)
+
+        assertEquals(100, prefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
+        assertEquals(100, NovaMenuPreferences.readOpacityPercent(prefs))
+        assertEquals(1.0f, NovaMenuPreferences.opacityScale(150), 0.001f)
+        assertEquals(0.58f, NovaMenuPreferences.readabilityScrimAlpha(0.58f, 100), 0.001f)
+        assertEquals(0.56f, NovaMenuPreferences.readabilityScrimAlpha(0.58f, 50), 0.001f)
+        assertEquals(NovaMenuPreferences.MIN_READABILITY_SCRIM_ALPHA, NovaMenuPreferences.readabilityScrimAlpha(0.58f, 0), 0.001f)
+        assertEquals(147, NovaMenuPreferences.alphaByte(0.58f, 100))
+        assertEquals(178, NovaMenuPreferences.alphaByte(0.70f, 100))
+        assertEquals(239, NovaMenuPreferences.alphaByte(0.94f, 100))
+        assertEquals(0, NovaMenuPreferences.alphaByte(0.94f, 0))
+    }
+
+    @Test
+    fun adaptiveBlurPreservesTheDefaultAndStrengthensAsGlassClears() {
+        assertEquals(0f, NovaMenuPreferences.blurRadiusDp(100), 0.001f)
+        assertEquals(2.4f, NovaMenuPreferences.blurRadiusDp(90), 0.001f)
+        assertEquals(8.64f, NovaMenuPreferences.blurRadiusDp(64), 0.001f)
+        assertEquals(18f, NovaMenuPreferences.blurRadiusDp(25), 0.001f)
+        assertEquals(24f, NovaMenuPreferences.blurRadiusDp(0), 0.001f)
+        assertEquals(0f, NovaMenuPreferences.blurRadiusDp(150), 0.001f)
+        assertEquals(24f, NovaMenuPreferences.blurRadiusDp(-10), 0.001f)
+    }
+
+    @Test
+    fun sharedSheetChromeScalesThemeGlassScrimAndBorder() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        prefs.edit().clear().commit()
+
+        NovaMenuPreferences.writeOpacityPercent(prefs, 100)
+        val fullGlassAlpha = NovaSheetChrome.getSheetGlassAlpha(context)
+        val fullStrokeAlpha = Color.alpha(NovaSheetChrome.getSheetStrokeColor(context))
+
+        NovaMenuPreferences.writeOpacityPercent(prefs, 50)
+
+        assertEquals(fullGlassAlpha * 0.5f, NovaSheetChrome.getSheetGlassAlpha(context), 0.001f)
+        assertEquals(
+            NovaMenuPreferences.readabilityScrimAlpha(NovaSheetChrome.SCRIM_ALPHA, 50),
+            NovaSheetChrome.getSheetScrimAlpha(context),
+            0.001f
+        )
+        assertEquals(fullStrokeAlpha * 0.5f, Color.alpha(NovaSheetChrome.getSheetStrokeColor(context)).toFloat(), 1.0f)
+
+        NovaMenuPreferences.writeOpacityPercent(prefs, 0)
+
+        assertEquals(0f, NovaSheetChrome.getSheetGlassAlpha(context), 0.001f)
+        assertEquals(NovaMenuPreferences.MIN_READABILITY_SCRIM_ALPHA, NovaSheetChrome.getSheetScrimAlpha(context), 0.001f)
+        assertEquals(0, Color.alpha(NovaSheetChrome.getSheetStrokeColor(context)))
+    }
+
+    @Test
+    fun durableStreamUiResetWritesEveryDefaultAsOneBatchAndRemovesHudPosition() = runBlocking {
+        val mirrorPrefs = context.getSharedPreferences("nova-menu-reset-mirror", Context.MODE_PRIVATE)
+        mirrorPrefs.edit()
+            .clear()
+            .putFloat("nova_polaris_hud_x", 0.33f)
+            .putFloat("nova_polaris_hud_y", 0.66f)
+            .commit()
+        val storeFile = File(context.filesDir, "nova-menu-reset-" + System.nanoTime() + ".preferences_pb")
+        val repository = NovaSettingsRepository.createForTest(
+            context = context,
+            mirrorPrefs = mirrorPrefs,
+            storeFile = storeFile
+        )
+        val definitions = NovaSettingDefinitions.load(context)
+        for ((key, expected) in NOVA_STREAM_UI_DEFAULT_UPDATES) {
+            val definition = definitions.require(key)
+            val stale = when (expected) {
+                is NovaSettingValue.BooleanValue -> NovaSettingValue.BooleanValue(!expected.value)
+                is NovaSettingValue.IntValue -> NovaSettingValue.IntValue(expected.value + 1)
+                is NovaSettingValue.StringValue -> NovaSettingValue.StringValue(expected.value + "_stale")
+                is NovaSettingValue.StringSetValue -> NovaSettingValue.StringSetValue(expected.value + "stale")
+            }
+            repository.set(definition, stale)
+        }
+
+        persistNovaStreamUiDefaults(repository, definitions)
+
+        val snapshot = repository.snapshot(definitions)
+        for ((key, expected) in NOVA_STREAM_UI_DEFAULT_UPDATES) {
+            assertEquals("DataStore reset mismatch for $key", expected, snapshot[key])
+            when (expected) {
+                is NovaSettingValue.BooleanValue -> assertEquals(expected.value, mirrorPrefs.getBoolean(key, !expected.value))
+                is NovaSettingValue.IntValue -> assertEquals(expected.value, mirrorPrefs.getInt(key, Int.MIN_VALUE))
+                is NovaSettingValue.StringValue -> assertEquals(expected.value, mirrorPrefs.getString(key, null))
+                is NovaSettingValue.StringSetValue -> assertEquals(expected.value, mirrorPrefs.getStringSet(key, null))
+            }
+        }
+        for (key in NOVA_STREAM_UI_RESET_REMOVALS) {
+            assertFalse("runtime reset key should be removed: $key", mirrorPrefs.contains(key))
+        }
+    }
+
+    @Test
+    fun repositoryWriteUpdatesDataStoreAndMirrorPrefs() = runBlocking {
+        val mirrorPrefs = context.getSharedPreferences("nova-menu-preferences-mirror", Context.MODE_PRIVATE)
+        mirrorPrefs.edit().clear().commit()
+        val storeFile = File(context.filesDir, "nova-menu-preferences-" + System.nanoTime() + ".preferences_pb")
+        val repository = NovaSettingsRepository.createForTest(
+            context = context,
+            mirrorPrefs = mirrorPrefs,
+            storeFile = storeFile
+        )
+        val definitions = NovaSettingDefinitions.load(context)
+        val definition = definitions.require(NovaMenuPreferences.KEY_OPACITY)
+
+        NovaMenuPreferences.writeOpacityPercent(repository, definition, 64)
+
+        assertEquals(64, mirrorPrefs.getInt(NovaMenuPreferences.KEY_OPACITY, 0))
+        assertEquals(
+            NovaSettingValue.IntValue(64),
+            repository.snapshot(definitions)[NovaMenuPreferences.KEY_OPACITY]
+        )
+
+        NovaMenuPreferences.writeOpacityPercent(repository, definition, -10)
+
+        assertEquals(0, mirrorPrefs.getInt(NovaMenuPreferences.KEY_OPACITY, 25))
+        assertEquals(
+            NovaSettingValue.IntValue(0),
+            repository.snapshot(definitions)[NovaMenuPreferences.KEY_OPACITY]
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -311,6 +311,28 @@ class NovaQuickMenuUiStateTest {
         assertEquals(NovaHudPreferences.OPACITY_PRESETS, state.hudOpacity.presets)
     }
 
+    @Test
+    fun commandCenterStateExposesMenuOpacityIndependentlyFromHud() {
+        val state = quickState(
+            status = status(),
+            hudShowing = false,
+            hudOpacityPercent = 25,
+            menuOpacityPercent = 64
+        )
+
+        assertFalse(state.hudOpacity.enabled)
+        assertEquals(64, state.menuOpacity.percent)
+        assertEquals(listOf(0, 25, 64, 90, 100), state.menuOpacity.presets)
+    }
+
+    @Test
+    fun commandCenterStateClampsNonPresetMenuOpacityValues() {
+        val state = quickState(status = status(), menuOpacityPercent = 150)
+
+        assertEquals(100, state.menuOpacity.percent)
+        assertEquals(NovaMenuPreferences.OPACITY_PRESETS, state.menuOpacity.presets)
+    }
+
     private fun quickState(
         status: PolarisSessionStatus?,
         apiAvailable: Boolean = true,
@@ -326,6 +348,7 @@ class NovaQuickMenuUiStateTest {
         currentGameUuid: String? = "game-1",
         hudShowing: Boolean = false,
         hudOpacityPercent: Int = 90,
+        menuOpacityPercent: Int = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT,
         fallbackTargetFps: Double = 60.0
     ) = NovaQuickMenuUiState.from(
         context = context,
@@ -344,6 +367,7 @@ class NovaQuickMenuUiStateTest {
         profilePreference = "quality",
         hudShowing = hudShowing,
         hudOpacityPercent = hudOpacityPercent,
+        menuOpacityPercent = menuOpacityPercent,
         perfOverlayEnabled = false,
         onscreenControllerEnabled = false,
         keyboardVisible = false,

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -360,9 +360,10 @@ class NovaThemeResourcesTest {
             .substringAfter("private fun NovaSliderDialog(")
             .substringBefore("private fun NovaTextDialog(")
 
-        assertTrue("Settings should preview Menu Opacity through the SharedPreferences mirror while dragging", settings.contains("onMenuOpacityPreview") && sliderDialog.contains("onValueChange = { nextValue ->"))
-        assertTrue("cancel should restore the original Menu Opacity preview", settings.contains("restoreMenuOpacityPreview"))
-        assertTrue("Save should still persist the final preview through the repository", sliderDialog.contains("onSave(definition, NovaSettingValue.IntValue(value.roundToInt()))"))
+        assertTrue("Settings should preview Menu Opacity through process-local state while dragging", settings.contains("NovaMenuOpacityPreview::update") && sliderDialog.contains("onValueChange = { nextValue ->"))
+        assertFalse("live preview must not write the durable SharedPreferences key", settings.contains("NovaMenuPreferences.writeOpacityPercent(prefs"))
+        assertTrue("cancel should clear the temporary Menu Opacity preview", settings.contains("NovaMenuOpacityPreview.clear()"))
+        assertTrue("Save should persist through the repository before clearing preview", sliderDialog.contains("onSave(definition, NovaSettingValue.IntValue(value.roundToInt()))"))
         assertFalse("default Material slider dialogs should not be unconditionally restyled at 100%", sliderDialog.contains("containerColor = surfaces.panel") || sliderDialog.contains("tonalElevation = 0.dp"))
     }
 
@@ -374,6 +375,7 @@ class NovaThemeResourcesTest {
         val settings = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
         val focusComponents = File("src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt").readText()
         val settingsViewModel = File("src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt").readText()
+        val streamSettings = File("src/main/java/com/papi/nova/preferences/StreamSettings.kt").readText()
         val settingsRepository = File("src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt").readText()
 
         assertTrue("session start/reconnect scrims should retain a contrast floor while honoring menu opacity", lifecycle.contains("NovaMenuPreferences.readabilityScrimAlpha(") && lifecycle.contains("scrimAlpha,"))
@@ -387,8 +389,11 @@ class NovaThemeResourcesTest {
         assertTrue("options fixed glass overrides should consume the menu opacity local", settings.contains("LocalNovaMenuOpacityScale.current"))
         assertTrue("shared focus components should scale panel glass while retaining focus rings", focusComponents.contains("LocalNovaMenuOpacityScale.current"))
         assertTrue("Stream UI reset should restore menu opacity to its compatibility default", settingsViewModel.contains("NovaMenuPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaMenuPreferences.DEFAULT_OPACITY_PERCENT)"))
-        assertTrue("Stream UI reset should remove stale HUD coordinates in the same batch", settingsViewModel.contains("NOVA_STREAM_UI_RESET_REMOVALS") && settingsViewModel.contains("store.updateAtomically(updates, NOVA_STREAM_UI_RESET_REMOVALS)"))
-        assertTrue("repository batch should update DataStore in one edit", settingsRepository.contains("override suspend fun updateAtomically(") && settingsRepository.contains("dataStore.edit { preferences ->"))
+        assertTrue("Stream UI reset should remove stale HUD coordinates in the same authoritative batch", settingsViewModel.contains("NOVA_STREAM_UI_RESET_REMOVALS") && settingsViewModel.contains("store.updateAtomically(updates, NOVA_STREAM_UI_RESET_REMOVALS)"))
+        assertTrue("reset construction should fail closed instead of silently skipping filtered definitions", settingsViewModel.contains("definitions.require(key) to value"))
+        assertTrue("Compose Settings should use canonical unfiltered definitions for resets", streamSettings.contains("resetDefinitions = canonicalDefinitions"))
+        assertTrue("repository batch should commit SharedPreferences once as the runtime authority", settingsRepository.contains("check(editor.commit())") && settingsRepository.contains("SharedPreferences is authoritative"))
+        assertTrue("DataStore should be repaired from the authoritative runtime mirror", settingsRepository.contains("reconcileDataStoreMirror") && settingsRepository.contains("canonicalDefinitions.settings"))
     }
 
     @Test
@@ -396,6 +401,7 @@ class NovaThemeResourcesTest {
         val blur = File("src/main/java/com/papi/nova/ui/NovaMenuBlur.kt").readText()
         val composeBlur = File("src/main/java/com/papi/nova/ui/compose/NovaMenuBackdropBlur.kt").readText()
         val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val quickMenuHost = File("src/main/java/com/papi/nova/ui/NovaQuickMenu.kt").readText()
         val quickMenu = File("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt").readText()
         val library = File("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt").readText()
         val settings = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
@@ -408,13 +414,15 @@ class NovaThemeResourcesTest {
         assertTrue("stale dialog listeners must not remove a newer binding", blur.contains("dialogBindings[view] !== binding") && blur.contains("dialogBindings[view] === binding"))
         assertTrue("releasing an owner should recompute the strongest remaining radius", blur.contains("state.ownerRadiiDp.remove(owner)") && blur.contains("state.ownerRadiiDp.values.maxOrNull()"))
         assertTrue("Compose drawers should lease the Activity backdrop and release only their own effect", composeBlur.contains("NovaMenuBlur.acquireActivityBackground") && composeBlur.contains("lease?.release()"))
+        assertTrue("Command Center must live in a separate Dialog window before leasing the Game backdrop", quickMenuHost.contains("val overlay = Dialog(game)") && quickMenuHost.contains("overlay.setContentView(composeView)"))
         assertTrue("Command Center should opt into adaptive backdrop blur", quickMenu.contains("NovaMenuBackdropBlur()"))
         assertTrue("Library drawers should blur only while a separate-window drawer is active", library.contains("if (activeOptionsSheet || activeSystemMenu)") && library.contains("NovaMenuBackdropBlur()"))
         assertFalse("same-window filter sheets must not blur their own controls through the Activity decor", library.contains("activeFilterSheet != null || activeOptionsSheet"))
         assertTrue("Settings editors should blur the underlying Settings surface", settings.contains("NovaMenuBackdropBlur()"))
         assertTrue("native dialog blur should start on window attach and clear on detach", blur.contains("onViewAttachedToWindow") && blur.contains("isAttachedToWindow") && blur.contains("onViewDetachedFromWindow"))
         assertTrue("native sheets and alerts should share the same adaptive blur contract", sheetChrome.contains("NovaMenuBlur.attachBehindDialog"))
-        assertTrue("native 100% glass should preserve legacy truncation rather than rounding up", sheetChrome.contains("NovaMenuPreferences.alphaByte(themedAlpha"))
+        assertTrue("dark-text native surfaces should retain a readability floor below 100%", sheetChrome.contains("NovaMenuPreferences.readabilitySurfaceAlpha") && sheetChrome.contains("ColorUtils.calculateLuminance"))
+        assertTrue("custom select dialogs should draw the theme-aware window contrast scrim only below compatibility opacity", settings.contains("NovaDialogContrastBackdrop()") && settings.contains("if (opacityScale < 1f)") && settings.contains("surfaces.backgroundScrim.toArgb()"))
         assertTrue("unfocused native action strokes should disappear with menu glass", sheetChrome.contains("strokeAccentBlend * menuOpacityScale"))
         assertTrue("focused and pressed native action strokes should remain as readability cues", sheetChrome.contains("if (preservesFocusCue)"))
         assertTrue("session startup should release leases on explicit dismissal and unexpected view detach", progress.contains("NovaMenuBlur.acquireChildren") && progress.contains("releaseBackgroundBlur") && progress.contains("releaseOnUnexpectedDetach"))

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -268,6 +268,23 @@ class NovaThemeResourcesTest {
 
 
     @Test
+    fun menuOpacityWiresSharedChromeWithoutCouplingNovaHud() {
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val composeTheme = File("src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt").readText()
+        val streamHud = File("src/main/java/com/papi/nova/ui/NovaStreamHud.kt").readText()
+
+        assertTrue("native sheet glass should read the shared menu opacity preference", sheetChrome.contains("NovaMenuPreferences.readOpacityPercent"))
+        assertTrue("native sheet scrims should expose a preference-scaled alpha", sheetChrome.contains("getSheetScrimAlpha"))
+        assertTrue("Compose menus should publish one menu opacity composition local", composeTheme.contains("LocalNovaMenuOpacityScale"))
+        assertTrue("Compose menu surfaces should receive the current opacity scale", composeTheme.contains("librarySurfaces(theme, menuOpacityScale)"))
+        assertTrue("Compose roots should observe saved menu opacity changes without requiring Activity recreation", composeTheme.contains("registerOnSharedPreferenceChangeListener") && composeTheme.contains("NovaMenuPreferences.KEY_OPACITY"))
+        assertTrue(
+            "NovaHUD must opt out of menu opacity so its own slider remains authoritative",
+            streamHud.contains("NovaComposeTheme(menuOpacityPercent = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT)")
+        )
+    }
+
+    @Test
     fun sessionQuitConfirmationUsesNovaGlassBottomSheetInsteadOfRawAlertDialog() {
         val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
         val spinnerDialog = File("src/main/java/com/papi/nova/utils/SpinnerDialog.kt").readText()
@@ -316,6 +333,108 @@ class NovaThemeResourcesTest {
         assertFalse("Startup retry path must not assume a legacy spinner exists", game.contains("spinner!!.setMessage(getResources().getString(R.string.unlocking_or_starting))"))
         assertTrue("Startup retry path should report host readiness through the verbose progress overlay", game.contains("novaProgressOverlay?.updateState(\"unlocking_or_starting\""))
     }
+    @Test
+    fun commandCenterExposesLiveMenuOpacityWithoutDependingOnNovaHud() {
+        val quickMenu = File("src/main/java/com/papi/nova/ui/NovaQuickMenu.kt").readText()
+        val content = File("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue("Command Center state should read the saved menu opacity", quickMenu.contains("menuOpacityPercent = NovaMenuPreferences.readOpacityPercent(prefs)"))
+        assertTrue("Command Center should expose a menu-opacity callback", quickMenu.contains("onMenuOpacityChange = { percent ->"))
+        assertTrue("the open Command Center should recompose from its live opacity state", quickMenu.contains("NovaComposeTheme(menuOpacityPercent = uiState.menuOpacity.percent)"))
+        assertTrue("Command Center content should render the independent menu opacity control", content.contains("NovaQuickMenuMenuOpacityControl"))
+        val menuOpacityControl = content
+            .substringAfter("private fun NovaQuickMenuMenuOpacityControl(")
+            .substringBefore("\n@Composable")
+        assertTrue("the rendered control should expose every preset from state", menuOpacityControl.contains("state.menuOpacity.presets.forEach"))
+        assertTrue("each rendered preset should dispatch the menu-opacity callback", menuOpacityControl.contains("callbacks.onMenuOpacityChange(percent)"))
+        assertTrue("rendered presets should retain controller-sized focus targets", menuOpacityControl.contains("minHeight = 44.dp"))
+        assertTrue("Command Center explicit glass constants should consume the menu opacity composition local", content.contains("LocalNovaMenuOpacityScale.current"))
+        assertTrue("Command Center should label the new control as Menu Opacity", strings.contains("<string name=\"nova_quick_menu_menu_opacity\">Menu Opacity</string>"))
+    }
+
+    @Test
+    fun settingsMenuOpacitySliderPreviewsLiveAndRestoresOnCancel() {
+        val settings = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+        val sliderDialog = settings
+            .substringAfter("private fun NovaSliderDialog(")
+            .substringBefore("private fun NovaTextDialog(")
+
+        assertTrue("Settings should preview Menu Opacity through the SharedPreferences mirror while dragging", settings.contains("onMenuOpacityPreview") && sliderDialog.contains("onValueChange = { nextValue ->"))
+        assertTrue("cancel should restore the original Menu Opacity preview", settings.contains("restoreMenuOpacityPreview"))
+        assertTrue("Save should still persist the final preview through the repository", sliderDialog.contains("onSave(definition, NovaSettingValue.IntValue(value.roundToInt()))"))
+        assertFalse("default Material slider dialogs should not be unconditionally restyled at 100%", sliderDialog.contains("containerColor = surfaces.panel") || sliderDialog.contains("tonalElevation = 0.dp"))
+    }
+
+    @Test
+    fun menuOpacityCoversLifecycleLibraryOptionsAndResetPaths() {
+        val lifecycle = File("src/main/java/com/papi/nova/ui/NovaStreamOverlayContent.kt").readText()
+        val library = File("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt").readText()
+        val gameDetail = File("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt").readText()
+        val settings = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+        val focusComponents = File("src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt").readText()
+        val settingsViewModel = File("src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt").readText()
+        val settingsRepository = File("src/main/java/com/papi/nova/preferences/NovaSettingsRepository.kt").readText()
+
+        assertTrue("session start/reconnect scrims should retain a contrast floor while honoring menu opacity", lifecycle.contains("NovaMenuPreferences.readabilityScrimAlpha(") && lifecycle.contains("scrimAlpha,"))
+        assertTrue("Compose library modal scrims should retain a contrast floor", library.contains("NovaMenuPreferences.readabilityScrimAlpha"))
+        assertTrue(
+            "both Library Options and System drawer scrims should use the readability floor",
+            library.split("NovaMenuPreferences.readabilityScrimAlpha(").size - 1 >= 3
+        )
+        assertTrue("Library fixed glass overrides should consume the menu opacity local", library.contains("LocalNovaMenuOpacityScale.current"))
+        assertTrue("game detail fixed glass overrides should consume the menu opacity local", gameDetail.contains("LocalNovaMenuOpacityScale.current"))
+        assertTrue("options fixed glass overrides should consume the menu opacity local", settings.contains("LocalNovaMenuOpacityScale.current"))
+        assertTrue("shared focus components should scale panel glass while retaining focus rings", focusComponents.contains("LocalNovaMenuOpacityScale.current"))
+        assertTrue("Stream UI reset should restore menu opacity to its compatibility default", settingsViewModel.contains("NovaMenuPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaMenuPreferences.DEFAULT_OPACITY_PERCENT)"))
+        assertTrue("Stream UI reset should remove stale HUD coordinates in the same batch", settingsViewModel.contains("NOVA_STREAM_UI_RESET_REMOVALS") && settingsViewModel.contains("store.updateAtomically(updates, NOVA_STREAM_UI_RESET_REMOVALS)"))
+        assertTrue("repository batch should update DataStore in one edit", settingsRepository.contains("override suspend fun updateAtomically(") && settingsRepository.contains("dataStore.edit { preferences ->"))
+    }
+
+    @Test
+    fun adaptiveMenuBlurTargetsOnlyBackdropContentAndFailsSoftBelowAndroid12() {
+        val blur = File("src/main/java/com/papi/nova/ui/NovaMenuBlur.kt").readText()
+        val composeBlur = File("src/main/java/com/papi/nova/ui/compose/NovaMenuBackdropBlur.kt").readText()
+        val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
+        val quickMenu = File("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt").readText()
+        val library = File("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt").readText()
+        val settings = File("src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt").readText()
+        val progress = File("src/main/java/com/papi/nova/ui/SessionProgressOverlay.kt").readText()
+        val reconnect = File("src/main/java/com/papi/nova/ui/ReconnectOverlay.kt").readText()
+
+        assertTrue("adaptive blur should use API 31 RenderEffect rather than optional cross-window blur", blur.contains("Build.VERSION_CODES.S") && blur.contains("RenderEffect.createBlurEffect"))
+        assertTrue("blur cleanup must be owner-scoped for overlapping overlays", blur.contains("class BlurLease") && blur.contains("ownerRadiiDp") && blur.contains("applyStrongestOwnedEffect"))
+        assertTrue("all View and dialog mutations should be main-thread confined", blur.contains("Looper.myLooper() == Looper.getMainLooper()") && blur.contains("requireMainThread()"))
+        assertTrue("stale dialog listeners must not remove a newer binding", blur.contains("dialogBindings[view] !== binding") && blur.contains("dialogBindings[view] === binding"))
+        assertTrue("releasing an owner should recompute the strongest remaining radius", blur.contains("state.ownerRadiiDp.remove(owner)") && blur.contains("state.ownerRadiiDp.values.maxOrNull()"))
+        assertTrue("Compose drawers should lease the Activity backdrop and release only their own effect", composeBlur.contains("NovaMenuBlur.acquireActivityBackground") && composeBlur.contains("lease?.release()"))
+        assertTrue("Command Center should opt into adaptive backdrop blur", quickMenu.contains("NovaMenuBackdropBlur()"))
+        assertTrue("Library drawers should blur only while a separate-window drawer is active", library.contains("if (activeOptionsSheet || activeSystemMenu)") && library.contains("NovaMenuBackdropBlur()"))
+        assertFalse("same-window filter sheets must not blur their own controls through the Activity decor", library.contains("activeFilterSheet != null || activeOptionsSheet"))
+        assertTrue("Settings editors should blur the underlying Settings surface", settings.contains("NovaMenuBackdropBlur()"))
+        assertTrue("native dialog blur should start on window attach and clear on detach", blur.contains("onViewAttachedToWindow") && blur.contains("isAttachedToWindow") && blur.contains("onViewDetachedFromWindow"))
+        assertTrue("native sheets and alerts should share the same adaptive blur contract", sheetChrome.contains("NovaMenuBlur.attachBehindDialog"))
+        assertTrue("native 100% glass should preserve legacy truncation rather than rounding up", sheetChrome.contains("NovaMenuPreferences.alphaByte(themedAlpha"))
+        assertTrue("unfocused native action strokes should disappear with menu glass", sheetChrome.contains("strokeAccentBlend * menuOpacityScale"))
+        assertTrue("focused and pressed native action strokes should remain as readability cues", sheetChrome.contains("if (preservesFocusCue)"))
+        assertTrue("session startup should release leases on explicit dismissal and unexpected view detach", progress.contains("NovaMenuBlur.acquireChildren") && progress.contains("releaseBackgroundBlur") && progress.contains("releaseOnUnexpectedDetach"))
+        assertTrue("reconnect should release leases on explicit dismissal and unexpected view detach", reconnect.contains("NovaMenuBlur.acquireChildren") && reconnect.contains("releaseBackgroundBlur") && reconnect.contains("releaseOnUnexpectedDetach"))
+    }
+
+    @Test
+    fun requiredNativeAlertsUseSharedOpacityAndBlurChrome() {
+        val gameDetail = File("src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt").readText()
+        val legacySlider = File("src/main/java/com/papi/nova/preferences/SeekBarPreference.kt").readText()
+        val sessionDialog = File("src/main/java/com/papi/nova/utils/Dialog.kt").readText()
+
+        val preflight = gameDetail
+            .substringAfter("private fun showPreflightReview(")
+            .substringBefore("private fun showDesktopSteamLaunchDecision(")
+        assertTrue("game-detail preflight should opt into opacity below 100 without restyling its compatibility default", preflight.contains("NovaSheetChrome.applyMenuOpacityToLegacyAlert"))
+        assertTrue("legacy sliders, including Menu & Drawer Opacity, should preserve default dialog chrome at 100%", legacySlider.contains("NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdDialog)"))
+        assertTrue("session termination/error alerts should preserve default dialog chrome at 100%", sessionDialog.contains("NovaSheetChrome.applyMenuOpacityToLegacyAlert(createdAlert)"))
+    }
+
     @Test
     fun legacyGameMenuUsesNovaGlassBottomSheetInsteadOfRawAlertList() {
         val source = File("src/main/java/com/papi/nova/GameMenu.kt").readText()

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -360,9 +360,9 @@ class NovaThemeResourcesTest {
             .substringAfter("private fun NovaSliderDialog(")
             .substringBefore("private fun NovaTextDialog(")
 
-        assertTrue("Settings should preview Menu Opacity through process-local state while dragging", settings.contains("NovaMenuOpacityPreview::update") && sliderDialog.contains("onValueChange = { nextValue ->"))
+        assertTrue("Settings should preview Menu Opacity through owner-scoped process-local state while dragging", settings.contains("NovaMenuOpacityPreview.update(owner, percent)") && settings.contains("NovaMenuOpacityPreview.newOwner()") && sliderDialog.contains("onValueChange = { nextValue ->"))
         assertFalse("live preview must not write the durable SharedPreferences key", settings.contains("NovaMenuPreferences.writeOpacityPercent(prefs"))
-        assertTrue("cancel should clear the temporary Menu Opacity preview", settings.contains("NovaMenuOpacityPreview.clear()"))
+        assertTrue("cancel and save should clear only the owning temporary preview", settings.contains("NovaMenuOpacityPreview::clear") && settings.contains("previewOwnerAtSave"))
         assertTrue("Save should persist through the repository before clearing preview", sliderDialog.contains("onSave(definition, NovaSettingValue.IntValue(value.roundToInt()))"))
         assertFalse("default Material slider dialogs should not be unconditionally restyled at 100%", sliderDialog.contains("containerColor = surfaces.panel") || sliderDialog.contains("tonalElevation = 0.dp"))
     }
@@ -400,6 +400,7 @@ class NovaThemeResourcesTest {
     fun adaptiveMenuBlurTargetsOnlyBackdropContentAndFailsSoftBelowAndroid12() {
         val blur = File("src/main/java/com/papi/nova/ui/NovaMenuBlur.kt").readText()
         val composeBlur = File("src/main/java/com/papi/nova/ui/compose/NovaMenuBackdropBlur.kt").readText()
+        val composeTheme = File("src/main/java/com/papi/nova/ui/compose/NovaComposeTheme.kt").readText()
         val sheetChrome = File("src/main/java/com/papi/nova/ui/NovaSheetChrome.kt").readText()
         val quickMenuHost = File("src/main/java/com/papi/nova/ui/NovaQuickMenu.kt").readText()
         val quickMenu = File("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt").readText()
@@ -421,7 +422,8 @@ class NovaThemeResourcesTest {
         assertTrue("Settings editors should blur the underlying Settings surface", settings.contains("NovaMenuBackdropBlur()"))
         assertTrue("native dialog blur should start on window attach and clear on detach", blur.contains("onViewAttachedToWindow") && blur.contains("isAttachedToWindow") && blur.contains("onViewDetachedFromWindow"))
         assertTrue("native sheets and alerts should share the same adaptive blur contract", sheetChrome.contains("NovaMenuBlur.attachBehindDialog"))
-        assertTrue("dark-text native surfaces should retain a readability floor below 100%", sheetChrome.contains("NovaMenuPreferences.readabilitySurfaceAlpha") && sheetChrome.contains("ColorUtils.calculateLuminance"))
+        assertTrue("dark-text native surfaces should retain a WCAG readability floor below 100%", sheetChrome.contains("NovaMenuPreferences.readabilitySurfaceAlpha") && sheetChrome.contains("ColorUtils.calculateLuminance"))
+        assertTrue("Compose contrast scrims should use the stronger dark-text floor", composeTheme.contains("usesDarkText = textPrimary.luminance() < 0.5f"))
         assertTrue("custom select dialogs should draw the theme-aware window contrast scrim only below compatibility opacity", settings.contains("NovaDialogContrastBackdrop()") && settings.contains("if (opacityScale < 1f)") && settings.contains("surfaces.backgroundScrim.toArgb()"))
         assertTrue("unfocused native action strokes should disappear with menu glass", sheetChrome.contains("strokeAccentBlend * menuOpacityScale"))
         assertTrue("focused and pressed native action strokes should remain as readability cues", sheetChrome.contains("if (preservesFocusCue)"))

--- a/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
@@ -54,7 +54,11 @@ class NovaLibrarySurfacesTest {
         val zero = colors.librarySurfaces(NovaThemeManager.THEME_PORTABLE_CHROME, menuOpacityScale = 0f)
 
         assertEquals(
-            NovaMenuPreferences.readabilityScrimAlpha(full.backgroundScrim.alpha, 50),
+            NovaMenuPreferences.readabilityScrimAlpha(
+                baseAlpha = full.backgroundScrim.alpha,
+                opacityScale = 0.5f,
+                usesDarkText = true
+            ),
             half.backgroundScrim.alpha,
             0.005f
         )
@@ -64,7 +68,7 @@ class NovaLibrarySurfacesTest {
         assertEquals(full.tileBorder.alpha * 0.5f, half.tileBorder.alpha, 0.005f)
         assertEquals(full.control.alpha * 0.5f, half.control.alpha, 0.005f)
         assertEquals(full.selectedControl.alpha * 0.5f, half.selectedControl.alpha, 0.005f)
-        assertEquals(NovaMenuPreferences.MIN_READABILITY_SCRIM_ALPHA, zero.backgroundScrim.alpha, 0.005f)
+        assertEquals(NovaMenuPreferences.MIN_DARK_TEXT_SCRIM_ALPHA, zero.backgroundScrim.alpha, 0.005f)
         assertEquals(Color.White, zero.backgroundScrim.copy(alpha = 1f))
         assertEquals(0f, zero.panel.alpha, 0.001f)
         assertEquals(0f, zero.control.alpha, 0.001f)

--- a/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/compose/NovaLibrarySurfacesTest.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui.compose
 
 import androidx.compose.ui.graphics.Color
+import com.papi.nova.ui.NovaMenuPreferences
 import com.papi.nova.ui.NovaSheetChrome
 import com.papi.nova.ui.NovaThemeManager
 import org.junit.Assert.assertEquals
@@ -43,6 +44,34 @@ class NovaLibrarySurfacesTest {
         assertEquals(0f, oled.backgroundScrim.alpha, 0.001f)
         assertEquals(base.accent, polaris.focusRing)
         assertEquals(Color.White, oled.onMedia)
+    }
+
+    @Test
+    fun menuOpacityScalesGlassSurfacesButPreservesFocusAndMediaReadability() {
+        val colors = portableChromeColors()
+        val full = colors.librarySurfaces(NovaThemeManager.THEME_PORTABLE_CHROME, menuOpacityScale = 1f)
+        val half = colors.librarySurfaces(NovaThemeManager.THEME_PORTABLE_CHROME, menuOpacityScale = 0.5f)
+        val zero = colors.librarySurfaces(NovaThemeManager.THEME_PORTABLE_CHROME, menuOpacityScale = 0f)
+
+        assertEquals(
+            NovaMenuPreferences.readabilityScrimAlpha(full.backgroundScrim.alpha, 50),
+            half.backgroundScrim.alpha,
+            0.005f
+        )
+        assertEquals(full.panel.alpha * 0.5f, half.panel.alpha, 0.005f)
+        assertEquals(full.panelBorder.alpha * 0.5f, half.panelBorder.alpha, 0.005f)
+        assertEquals(full.tile.alpha * 0.5f, half.tile.alpha, 0.005f)
+        assertEquals(full.tileBorder.alpha * 0.5f, half.tileBorder.alpha, 0.005f)
+        assertEquals(full.control.alpha * 0.5f, half.control.alpha, 0.005f)
+        assertEquals(full.selectedControl.alpha * 0.5f, half.selectedControl.alpha, 0.005f)
+        assertEquals(NovaMenuPreferences.MIN_READABILITY_SCRIM_ALPHA, zero.backgroundScrim.alpha, 0.005f)
+        assertEquals(Color.White, zero.backgroundScrim.copy(alpha = 1f))
+        assertEquals(0f, zero.panel.alpha, 0.001f)
+        assertEquals(0f, zero.control.alpha, 0.001f)
+        assertEquals(full.focusRing, zero.focusRing)
+        assertEquals(full.focusHalo, zero.focusHalo)
+        assertEquals(full.onMedia, zero.onMedia)
+        assertEquals(full.onMediaSecondary, zero.onMediaSecondary)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a global **Menu & Drawer Opacity** control that is independent from NovaHUD opacity.
- Apply the setting consistently across Command Center, Library options, settings, native dialogs/drawers, and session startup/reconnect/end chrome.
- Add automatic adaptive backdrop blur that increases as opacity decreases while keeping menu text, controls, and D-pad focus cues sharp.
- Preserve 100% opacity compatibility styling and fail soft without backdrop blur below Android 12.

## Behavior

- Opacity previews are process-local and owner-scoped: dragging previews live without changing durable storage, **Save** commits, and **Cancel** restores the persisted value.
- SharedPreferences remains the synchronous runtime authority; DataStore is maintained as a typed best-effort mirror.
- Command Center exposes live menu opacity without coupling it to NovaHUD visibility or opacity.
- Dark-text themes enforce contrast floors, including alpha-byte truncation, and retain at least WCAG 4.5:1 contrast in the tested worst case.
- Legacy preference dialogs release cached view/dialog references so opacity and blur chrome are recalculated when reopened.

## Adaptive blur curve

- 100% opacity → 0 dp blur
- 90% opacity → 2.4 dp blur
- 64% opacity → 8.64 dp blur
- 25% opacity → 18 dp blur
- 0% opacity → 24 dp blur

## Verification

Verified after rebasing directly onto the merged D-pad opacity baseline:

- Non-root unit tests: **878 passed**
- Root unit tests: **884 passed**
- Non-root and root lint: passed
- ARM64 non-root debug assembly: passed
- ARM64 non-root release assembly: passed
- ARM64 root release assembly: passed
- Public-surface, public-docs, and diff checks: passed
- Two independent exact-tree reviews found no Critical or Important issues
- Physical Android handheld verification covered live preview, Cancel, Save, relaunch persistence, restore-to-default, readable text/focus cues at 0%, and cleanup

The post-rebase source tree is identical to the reviewed and physically verified tree, and both release APK hashes are unchanged.

## Compatibility notes

- Backdrop blur is used on Android 12 and newer when supported.
- Older Android versions retain opacity behavior without requiring blur support.
- This PR does not change NovaHUD opacity semantics.
