### PR TITLE
chore(release): prepare Nova 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 1.3.2 - 2026-07-19
+
+Nova 1.3.2 adds adjustable menu and drawer glass, sharpens controller focus rendering, and delivers focused reliability fixes for companion displays, updater recovery, launch diagnostics, and verified host endpoint mobility.
+
+### Highlights
+
+- Adds an independent **Menu & Drawer Opacity** control from 0–100%, with live Settings and Command Center previews, readable 0% focus states, and automatic adaptive backdrop blur on Android 12 and newer.
+- Preserves the intended opacity of D-pad artwork instead of flattening asset transparency during rendering.
+- Keeps external-display companion controls owned by the active Game session through Android `Presentation` and removes stale controls after teardown.
+- Hardens APK download, validation, staging, and retry recovery without weakening package identity or signer verification.
+- Enriches launch diagnostics and classifies near-target stream health without presenting healthy small FPS variance as a failure.
+- Preserves certificate- and UUID-validated host routes across LAN and private-overlay address changes while keeping endpoint and host identity semantics separate.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.2 and versionCode 34.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus portable SHA-256 sidecars through the GitHub release workflow.
+
+### Validation notes
+
+- Final publication validation must use the tagged ARM64 release APK for package identity, Library, Menu & Drawer Opacity at 100%/25%/0%, adaptive-blur cleanup, preflight, live stream, physical controller and D-pad focus, Command Center, NovaHUD, updater, reconnect, and cleanup proof.
+- Physical Thor audio routing remains tracked separately and is not claimed fixed by this release.
+
 ## 1.3.1 - 2026-07-11
 
 Nova 1.3.1 is a focused follow-up to the matched Polaris 1.3 client release. It tightens Watch-stream ownership, keeps NovaHUD readable at Retroid-class widths, and makes the published checksum files portable for normal download-and-verify workflows.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ while you play, and what is safe to do when you leave.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v131) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v132) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -105,16 +105,18 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.3.1
+## Latest release: v1.3.2
 
-Nova v1.3.1 is a focused follow-up to the Polaris 1.3 client release: safer Watch-stream admission, cleaner NovaHUD presentation on Retroid-class displays, and portable checksum files for public APK verification.
+Nova v1.3.2 adds adjustable menu and drawer glass, clearer controller focus, and focused reliability improvements across companion displays, updater recovery, launch diagnostics, and verified host routes.
 
-- **Watch the real owner stream**: Nova offers Watch only for a live foreign-owned stream and requests the owner's active resolution and FPS profile instead of a mismatched viewer-local mode.
-- **Clearer NovaHUD modes**: Performance and Debug preserve the headline FPS, separate lower-priority detail metrics, and make the 0% opacity preset truly text-only.
-- **Three-digit FPS readability**: compact Debug HUD layouts keep values such as `114 TGT 120` visible by constraining stream metadata before the FPS lane ellipsizes.
-- **Portable checksums**: every public APK sidecar is generated with a relative filename so the documented `sha256sum -c` workflow works from a clean download directory.
-- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 33 keeps Obtainium and manual installs on a clean upgrade path.
-- **Release validation**: final publication validation must use the tagged ARM64 release APK for package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
+- **Adjustable menu glass**: Menu & Drawer Opacity runs independently from NovaHUD, previews live in Settings and Command Center, keeps 0% text and focus readable, and adds automatic backdrop blur on Android 12 and newer.
+- **Sharper D-pad rendering**: virtual-controller artwork keeps its intended asset transparency instead of being forced to full opacity.
+- **Safer companion controls**: external-display controls remain Game-owned, use Android `Presentation`, and are removed when their stream session ends instead of leaving stale controls behind.
+- **Recoverable updates**: interrupted APK downloads, stale staged files, validation failures, and retry flows recover without weakening package or signer checks.
+- **Clearer launch health**: richer launch diagnostics distinguish healthy near-target streams from real degraded states.
+- **Verified endpoint mobility**: paired hosts can retain validated routes as they move between LAN and private-overlay addresses without treating an address as host identity.
+- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 34 keeps Obtainium and manual installs on a clean upgrade path.
+- **Release validation**: final publication validation must use the tagged ARM64 release APK for menu opacity, blur cleanup, package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.1"
-        versionCode = 33
+        versionName "1.3.2"
+        versionCode = 34
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
@@ -22,20 +22,20 @@ class NovaUpdateInstallerSecurityTest {
     @Test
     fun downloadedApkValidationBlocksPackageSignatureAndDowngradeMismatches() {
         val release = NovaUpdateRelease(
-            tagName = "v1.3.2",
-            versionName = "1.3.2",
-            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.2",
+            tagName = "v1.3.3",
+            versionName = "1.3.3",
+            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.3",
             apkAssetName = "Nova-Android-arm64-v8a.apk",
-            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.2/Nova-Android-arm64-v8a.apk"
+            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.3/Nova-Android-arm64-v8a.apk"
         )
 
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 33L,
+                currentVersionCode = 34L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 34L,
+                downloadedVersionCode = 35L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Valid
@@ -44,10 +44,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 33L,
+                currentVersionCode = 34L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova.debug",
-                downloadedVersionCode = 34L,
+                downloadedVersionCode = 35L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -56,10 +56,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 33L,
+                currentVersionCode = 34L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 34L,
+                downloadedVersionCode = 35L,
                 downloadedSignerDigests = setOf("BB"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -68,10 +68,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 33L,
+                currentVersionCode = 34L,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 33L,
+                downloadedVersionCode = 34L,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid

--- a/fastlane/metadata/android/en-US/changelogs/34.txt
+++ b/fastlane/metadata/android/en-US/changelogs/34.txt
@@ -1,0 +1,6 @@
+Nova 1.3.2
+
+- Adds independent Menu & Drawer Opacity with live preview, readable 0% focus states, and adaptive blur on Android 12+.
+- Preserves intended D-pad artwork transparency.
+- Hardens companion-display teardown and updater recovery.
+- Improves launch diagnostics and verified host-route mobility.


### PR DESCRIPTION
## Summary

- Bump Android `versionName` to 1.3.2 and `versionCode` to 34.
- Update the changelog and README release summary for Menu & Drawer Opacity, adaptive blur, D-pad artwork transparency, and the existing 1.3.2 reliability fixes.
- Add the public Fastlane/Play changelog for versionCode 34.
- Advance updater-security test expectations from the current `1.3.2` / `34` release to the next hypothetical `1.3.3` / `35` update.

## Test plan

- [x] Non-root debug unit tests: 878 passed, 0 failed
- [x] Root debug unit tests: 884 passed, 0 failed
- [x] Non-root and root debug lint passed
- [x] Non-root and root release lint-vital passed
- [x] Moonlight native submodule verification passed
- [x] ARM64 non-root debug assembly passed
- [x] ARM64 non-root release assembly passed
- [x] ARM64 root release assembly passed
- [x] Retroid smoke-helper unit tests: 48 passed, 0 failed
- [x] APK metadata reports versionName 1.3.2, versionCode 34, and arm64-v8a
- [x] Public-surface and public-doc checks passed
- [x] `git diff --check` passed
- [x] Independent exact-head read-only review: no findings

## Release boundary

This PR prepares release metadata only. It does not tag or publish Nova 1.3.2, sign final release assets, publish store assets, deploy anything, or announce the release. Those remain separate validation and approval steps.
