### PR TITLE
fix(ui): adapt text and keep host actions reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Nova 1.3.2 adds adjustable menu and drawer glass, sharpens controller focus rend
 
 - Adds an independent **Menu & Drawer Opacity** control from 0–100%, with live Settings and Command Center previews, readable 0% focus states, and automatic adaptive backdrop blur on Android 12 and newer.
 - Defaults both **NovaHUD Opacity** and **Menu & Drawer Opacity** to 64%, keeps the controls independent, preserves existing saved values, and makes the 100% endpoint fully opaque.
+- Adds an in-app **Nova Text Size** control (80–130% relative to Android system text size) and keeps short-landscape host selection actions reachable with adaptive scrolling.
 - Preserves the intended opacity of D-pad artwork instead of flattening asset transparency during rendering.
 - Keeps external-display companion controls owned by the active Game session through Android `Presentation` and removes stale controls after teardown.
 - Hardens APK download, validation, staging, and retry recovery without weakening package identity or signer verification.

--- a/app/src/main/java/com/papi/nova/AppView.kt
+++ b/app/src/main/java/com/papi/nova/AppView.kt
@@ -21,7 +21,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -57,7 +56,7 @@ import java.io.StringReader
 import java.util.Locale
 import org.xmlpull.v1.XmlPullParserException
 
-class AppView : AppCompatActivity(), AdapterFragmentCallbacks {
+class AppView : NovaActivity(), AdapterFragmentCallbacks {
     private var appGridAdapter: AppGridAdapter? = null
     private var uuidString: String? = null
     private lateinit var shortcutHelper: ShortcutHelper

--- a/app/src/main/java/com/papi/nova/DebugInfoActivity.kt
+++ b/app/src/main/java/com/papi/nova/DebugInfoActivity.kt
@@ -16,11 +16,10 @@ import android.widget.Button
 import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import com.papi.nova.utils.DeviceUtils
 
 @Suppress("DEPRECATION")
-class DebugInfoActivity : AppCompatActivity(), View.OnClickListener {
+class DebugInfoActivity : NovaActivity(), View.OnClickListener {
     private lateinit var gamepadInfoText: TextView
     private var vibrator: Vibrator? = null
     private lateinit var vibratorButton: Button

--- a/app/src/main/java/com/papi/nova/EditProfileActivity.kt
+++ b/app/src/main/java/com/papi/nova/EditProfileActivity.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.ViewModelProvider
@@ -35,7 +34,7 @@ import com.papi.nova.ui.compose.NovaComposeTheme
 import com.papi.nova.utils.UiHelper
 import java.util.UUID
 
-class EditProfileActivity : AppCompatActivity() {
+class EditProfileActivity : NovaActivity() {
     private var profileUuid: String? = null
     private var currentProfile: SettingsProfile? = null
     private lateinit var inMemoryPrefs: InMemorySharedPreferences
@@ -180,7 +179,7 @@ class EditProfileActivity : AppCompatActivity() {
     private fun saveProfile() {
         val profileOptions = HashMap<String, Any>()
         for ((key, value) in inMemoryPrefs.all) {
-            if (value != null) {
+            if (value != null && NovaSettingsAvailability.shouldPersistProfileOverride(key)) {
                 profileOptions[key] = value
             }
         }
@@ -339,6 +338,7 @@ class EditProfileActivity : AppCompatActivity() {
 
             super.onCreatePreferences(savedInstanceState, rootKey)
 
+            findPreference<Preference>("nova_ui_font_scale_percent")?.isVisible = false
             findPreference<Preference>("option_reset_osc_preference")?.isVisible = false
             findPreference<Preference>("import_keyboard_file")?.isVisible = false
             findPreference<Preference>("export_keyboard_file")?.isVisible = false

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -126,7 +126,6 @@ import android.widget.Toast
 import android.widget.ImageButton
 import androidx.annotation.NonNull
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.PreferenceManager
 
@@ -153,7 +152,9 @@ import android.view.SurfaceView
 import android.view.ViewGroup
 
 
- class Game:AppCompatActivity(), SurfaceHolder.Callback, OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener, OnSystemUiVisibilityChangeListener, GameGestures, StreamContainer.InputCallbacks, ExternalControllerView.InputCallbacks, PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener {
+class Game : NovaActivity(), SurfaceHolder.Callback, OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener, OnSystemUiVisibilityChangeListener, GameGestures, StreamContainer.InputCallbacks, ExternalControllerView.InputCallbacks, PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener {
+    override fun shouldRecreateForFontScaleChange(): Boolean = false
+
 
 private val runtimeTasks:NovaRuntimeTasks = NovaRuntimeTasks(this, "Nova runtime")
 private var novaHud:com.papi.nova.ui.NovaStreamHud? = null

--- a/app/src/main/java/com/papi/nova/HelpActivity.kt
+++ b/app/src/main/java/com/papi/nova/HelpActivity.kt
@@ -9,12 +9,11 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
-import androidx.appcompat.app.AppCompatActivity
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.utils.SpinnerDialog
 
 @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
-class HelpActivity : AppCompatActivity() {
+class HelpActivity : NovaActivity() {
     private var loadingDialog: SpinnerDialog? = null
     private lateinit var webView: WebView
     private var backCallbackRegistered = false

--- a/app/src/main/java/com/papi/nova/NovaActivity.kt
+++ b/app/src/main/java/com/papi/nova/NovaActivity.kt
@@ -1,0 +1,71 @@
+package com.papi.nova
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.PreferenceManager
+import com.papi.nova.ui.NovaFontScalePreferences
+import kotlin.math.abs
+
+open class NovaActivity : AppCompatActivity() {
+    private var appliedScalePercent = NovaFontScalePreferences.DEFAULT_SCALE_PERCENT
+    private var appliedSystemFontScale = 1f
+    private var recreatePosted = false
+
+    private val fontScaleListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == NovaFontScalePreferences.KEY_SCALE_PERCENT) {
+            requestRecreateIfScaleChanged()
+        }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        appliedScalePercent = NovaFontScalePreferences.readScalePercent(newBase)
+        appliedSystemFontScale = NovaFontScalePreferences.readSystemFontScale(newBase)
+        super.attachBaseContext(
+            NovaFontScalePreferences.wrapContext(
+                context = newBase,
+                systemFontScale = appliedSystemFontScale,
+            )
+        )
+    }
+
+    override fun onStart() {
+        super.onStart()
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .registerOnSharedPreferenceChangeListener(fontScaleListener)
+        requestRecreateIfScaleChanged()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        requestRecreateIfScaleChanged()
+    }
+
+    override fun onStop() {
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .unregisterOnSharedPreferenceChangeListener(fontScaleListener)
+        super.onStop()
+    }
+
+    protected open fun shouldRecreateForFontScaleChange(): Boolean = true
+
+    private fun requestRecreateIfScaleChanged() {
+        val currentScalePercent = NovaFontScalePreferences.readScalePercent(this)
+        val currentSystemFontScale = NovaFontScalePreferences.readSystemFontScale(this)
+        val stale = currentScalePercent != appliedScalePercent ||
+            abs(currentSystemFontScale - appliedSystemFontScale) > FONT_SCALE_EPSILON
+        if (!stale || recreatePosted || !shouldRecreateForFontScaleChange()) return
+
+        recreatePosted = true
+        window.decorView.post {
+            recreatePosted = false
+            if (!isFinishing && !isDestroyed) {
+                recreate()
+            }
+        }
+    }
+
+    private companion object {
+        const val FONT_SCALE_EPSILON = 0.001f
+    }
+}

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -31,7 +31,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.lifecycle.ViewModelProvider
@@ -99,7 +98,7 @@ import javax.microedition.khronos.egl.EGLConfig
 import javax.microedition.khronos.opengles.GL10
 import org.xmlpull.v1.XmlPullParserException
 
-class PcView : AppCompatActivity(), AdapterFragmentCallbacks {
+class PcView : NovaActivity(), AdapterFragmentCallbacks {
     private val THEME_PICKER_GRID_GAP_DP = 8
     private var noPcFoundLayout: View? = null
     private lateinit var pcGridAdapter: PcGridAdapter

--- a/app/src/main/java/com/papi/nova/ProfilesActivity.kt
+++ b/app/src/main/java/com/papi/nova/ProfilesActivity.kt
@@ -3,7 +3,6 @@ package com.papi.nova
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -12,7 +11,7 @@ import com.papi.nova.profiles.ProfilesManager
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.utils.UiHelper
 
-class ProfilesActivity : AppCompatActivity(), ProfilesManager.ProfileChangeListener {
+class ProfilesActivity : NovaActivity(), ProfilesManager.ProfileChangeListener {
     private lateinit var adapter: ProfilesAdapter
     private lateinit var recyclerView: RecyclerView
     private lateinit var emptyState: View

--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
-import androidx.appcompat.app.AppCompatActivity
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.api.PolarisStreamDisplayMode
@@ -44,7 +43,7 @@ import java.util.Locale
 import java.util.Objects
 import java.util.UUID
 
-class ShortcutTrampoline : AppCompatActivity() {
+class ShortcutTrampoline : NovaActivity() {
     private lateinit var prefConfig: PreferenceConfiguration
     private var uuidString: String = ""
     private var app: NvApp? = null

--- a/app/src/main/java/com/papi/nova/preferences/AddComputerManually.kt
+++ b/app/src/main/java/com/papi/nova/preferences/AddComputerManually.kt
@@ -15,7 +15,7 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.NovaActivity
 import com.papi.nova.AppView
 import com.papi.nova.Game
 import com.papi.nova.PcView
@@ -36,7 +36,7 @@ import java.net.NetworkInterface
 import java.util.Collections
 import java.util.concurrent.LinkedBlockingQueue
 
-class AddComputerManually : AppCompatActivity() {
+class AddComputerManually : NovaActivity() {
     private lateinit var hostText: TextView
     private var managerBinder: ComputerManagerService.ComputerManagerBinder? = null
     private val computersToAdd = LinkedBlockingQueue<String>()

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsAvailability.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsAvailability.kt
@@ -19,7 +19,7 @@ object NovaSettingsAvailability {
     }
 
     fun filterForProfileEditor(definitions: NovaSettingsDefinitionSet): NovaSettingsDefinitionSet {
-        val settings = definitions.settings.filterNot { it.key in profileEditorHiddenKeys }
+        val settings = definitions.settings.filter { shouldPersistProfileOverride(it.key) }
         val visibleCategoryKeys = settings.mapTo(linkedSetOf()) { it.categoryKey }
         return definitions.copy(
             categories = definitions.categories.filter { it.key in visibleCategoryKeys },
@@ -115,7 +115,10 @@ object NovaSettingsAvailability {
         "checkbox_enable_keyboard"
     )
 
+    fun shouldPersistProfileOverride(key: String): Boolean = key !in profileEditorHiddenKeys
+
     private val profileEditorHiddenKeys = setOf(
+        "nova_ui_font_scale_percent",
         "option_reset_osc_preference",
         "nova_reset_stream_ui",
         "import_keyboard_file",

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -31,6 +31,7 @@ import android.view.WindowInsets
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.NovaActivity
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.FileProvider
 import androidx.fragment.app.DialogFragment
@@ -72,7 +73,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
-class StreamSettings : AppCompatActivity() {
+class StreamSettings : NovaActivity() {
     private lateinit var previousPrefs: PreferenceConfiguration
     private var previousDisplayPixelCount = 0
     private var prefsFragment: SettingsFragment? = null

--- a/app/src/main/java/com/papi/nova/ui/NovaFontScalePreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaFontScalePreferences.kt
@@ -1,0 +1,49 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import android.provider.Settings
+import androidx.preference.PreferenceManager
+
+object NovaFontScalePreferences {
+    const val KEY_SCALE_PERCENT = "nova_ui_font_scale_percent"
+    const val DEFAULT_SCALE_PERCENT = 100
+    const val MIN_SCALE_PERCENT = 80
+    const val MAX_SCALE_PERCENT = 130
+    const val SCALE_STEP_PERCENT = 1
+
+    fun readScalePercent(context: Context): Int {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val stored = runCatching {
+            prefs.getInt(KEY_SCALE_PERCENT, DEFAULT_SCALE_PERCENT)
+        }.getOrDefault(DEFAULT_SCALE_PERCENT)
+        return stored.coerceIn(MIN_SCALE_PERCENT, MAX_SCALE_PERCENT)
+    }
+
+    fun resolveFontScale(systemFontScale: Float, scalePercent: Int): Float {
+        val safeSystemScale = systemFontScale.takeIf { it.isFinite() && it > 0f } ?: 1f
+        val safePercent = scalePercent.coerceIn(MIN_SCALE_PERCENT, MAX_SCALE_PERCENT)
+        return safeSystemScale * (safePercent / 100f)
+    }
+
+    fun readSystemFontScale(context: Context): Float {
+        val fallback = context.applicationContext.resources.configuration.fontScale
+        return runCatching {
+            Settings.System.getFloat(
+                context.contentResolver,
+                Settings.System.FONT_SCALE,
+                fallback,
+            )
+        }.getOrDefault(fallback).takeIf { it.isFinite() && it > 0f } ?: 1f
+    }
+
+    fun wrapContext(
+        context: Context,
+        systemFontScale: Float = readSystemFontScale(context),
+    ): Context {
+        val configuration = Configuration(context.resources.configuration).apply {
+            fontScale = resolveFontScale(systemFontScale, readScalePercent(context))
+        }
+        return context.createConfigurationContext(configuration)
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -10,7 +10,7 @@ import android.widget.Toast
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.NovaActivity
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -151,7 +151,7 @@ private data class LibraryLoadResult(
     val activeSession: NovaLibraryActiveSessionUiState?
 )
 
-class NovaLibraryActivity : AppCompatActivity() {
+class NovaLibraryActivity : NovaActivity() {
 
     private lateinit var apiClient: PolarisApiClient
     private lateinit var streamHost: String

--- a/app/src/main/java/com/papi/nova/ui/NovaQrScanActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQrScanActivity.kt
@@ -5,13 +5,13 @@ import android.view.KeyEvent
 import com.journeyapps.barcodescanner.CaptureManager
 import com.journeyapps.barcodescanner.DecoratedBarcodeView
 import com.papi.nova.R
-import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.NovaActivity
 
 /**
  * Nova-themed QR code scanner activity.
  * Uses custom layout with branded viewfinder and instruction card.
  */
-class NovaQrScanActivity : AppCompatActivity() {
+class NovaQrScanActivity : NovaActivity() {
 
     private lateinit var capture: CaptureManager
     private lateinit var barcodeView: DecoratedBarcodeView

--- a/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.NovaActivity
 import com.papi.nova.PcView
 import com.papi.nova.R
 import com.papi.nova.preferences.AddComputerManually
@@ -12,7 +12,7 @@ import com.papi.nova.preferences.AddComputerManually
 /**
  * First-launch welcome screen. Shows once, then never again.
  */
-class NovaWelcomeActivity : AppCompatActivity() {
+class NovaWelcomeActivity : NovaActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         NovaThemeManager.applyTheme(this)

--- a/app/src/main/res/layout-land/activity_pc_view.xml
+++ b/app/src/main/res/layout-land/activity_pc_view.xml
@@ -19,11 +19,14 @@
         android:baselineAligned="false"
         android:orientation="horizontal">
 
-        <LinearLayout
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/dashboardCockpitRail"
             android:layout_width="@dimen/nova_dashboard_rail_width"
             android:layout_height="match_parent"
-            android:orientation="vertical"
+            android:clipToPadding="false"
+            android:descendantFocusability="afterDescendants"
+            android:fillViewport="true"
+            android:overScrollMode="ifContentScrolls"
             android:paddingStart="14dp"
             android:paddingTop="6dp"
             android:paddingEnd="14dp"
@@ -32,7 +35,7 @@
             <LinearLayout
                 android:id="@+id/pcViewHeader"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="vertical">
 
                 <LinearLayout
@@ -93,7 +96,8 @@
                     android:id="@+id/actionStartPolaris"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"
-                    android:layout_height="34dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="34dp"
                     android:layout_marginTop="8dp"
                     android:contentDescription="@string/pcview_quick_start_polaris"
                     android:insetTop="0dp"
@@ -116,7 +120,8 @@
                     android:id="@+id/profilesButton"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"
-                    android:layout_height="34dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="34dp"
                     android:layout_marginTop="5dp"
                     android:contentDescription="@string/pcview_quick_profiles"
                     android:insetTop="0dp"
@@ -139,7 +144,8 @@
                     android:id="@+id/actionTheme"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"
-                    android:layout_height="34dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="34dp"
                     android:layout_marginTop="5dp"
                     android:contentDescription="@string/pcview_quick_theme"
                     android:insetTop="0dp"
@@ -162,7 +168,8 @@
                     android:id="@+id/actionGithub"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"
-                    android:layout_height="34dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="34dp"
                     android:layout_marginTop="5dp"
                     android:contentDescription="@string/pcview_quick_github"
                     android:insetTop="0dp"
@@ -185,7 +192,8 @@
                     android:id="@+id/actionSettings"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"
-                    android:layout_height="34dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="34dp"
                     android:layout_marginTop="5dp"
                     android:contentDescription="@string/pcview_quick_settings"
                     android:insetTop="0dp"
@@ -207,7 +215,8 @@
                 <com.google.android.material.card.MaterialCardView
                     android:id="@+id/actionNovaUpdate"
                     android:layout_width="match_parent"
-                    android:layout_height="38dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="38dp"
                     android:layout_marginTop="5dp"
                     android:clickable="true"
                     android:contentDescription="@string/pcview_update_pill_content_current"
@@ -221,7 +230,8 @@
 
                     <LinearLayout
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="38dp"
                         android:gravity="center_vertical"
                         android:orientation="horizontal"
                         android:paddingStart="10dp"
@@ -291,7 +301,8 @@
                     <LinearLayout
                         android:id="@+id/dashboardModeSelector"
                         android:layout_width="match_parent"
-                        android:layout_height="34dp"
+                        android:layout_height="wrap_content"
+                        android:minHeight="34dp"
                         android:layout_marginTop="6dp"
                         android:contentDescription="@string/pcview_dashboard_mode_selector"
                         android:gravity="center_vertical"
@@ -300,8 +311,9 @@
                     <com.google.android.material.card.MaterialCardView
                         android:id="@+id/modeServers"
                         android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:minHeight="34dp"
                         android:layout_weight="1"
-                        android:layout_height="34dp"
                         android:clickable="true"
                         android:contentDescription="@string/pcview_mode_servers"
                         android:focusable="true"
@@ -314,7 +326,8 @@
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="34dp"
                             android:gravity="center"
                             android:orientation="horizontal"
                             android:paddingStart="6dp"
@@ -343,8 +356,9 @@
                     <com.google.android.material.card.MaterialCardView
                         android:id="@+id/modeLibrary"
                         android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:minHeight="34dp"
                         android:layout_weight="1"
-                        android:layout_height="34dp"
                         android:layout_marginStart="6dp"
                         android:clickable="true"
                         android:contentDescription="@string/pcview_mode_library"
@@ -358,7 +372,8 @@
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="34dp"
                             android:gravity="center"
                             android:orientation="horizontal"
                             android:paddingStart="6dp"
@@ -408,8 +423,9 @@
                         android:id="@+id/actionAddServer"
                         style="@style/Widget.MaterialComponents.Button"
                         android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:minHeight="34dp"
                         android:layout_weight="1"
-                        android:layout_height="34dp"
                         android:contentDescription="@string/pcview_quick_add_server"
                         android:insetTop="0dp"
                         android:insetBottom="0dp"
@@ -431,8 +447,9 @@
                         android:id="@+id/actionScanPair"
                         style="@style/Widget.MaterialComponents.Button"
                         android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:minHeight="34dp"
                         android:layout_weight="1"
-                        android:layout_height="34dp"
                         android:layout_marginStart="6dp"
                         android:contentDescription="@string/pcview_quick_scan_pair"
                         android:insetTop="0dp"
@@ -456,7 +473,8 @@
                 <TextView
                     android:id="@+id/topActionFocusLabel"
                     android:layout_width="match_parent"
-                    android:layout_height="14dp"
+                    android:layout_height="wrap_content"
+                    android:minHeight="14dp"
                     android:layout_marginTop="3dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center"
@@ -465,7 +483,7 @@
                     android:visibility="invisible"
                     tools:text="Settings" />
             </LinearLayout>
-        </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
 
         <LinearLayout
             android:id="@+id/dashboardContent"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -675,7 +675,7 @@
     <PreferenceCategory
         android:key="category_nova"
         android:title="Nova"
-        android:summary="Theme, auto-connect, Polaris integration"
+        android:summary="Theme, text size, auto-connect, Polaris integration"
         app:iconSpaceReserved="false">
         <Preference
             android:key="nova_app_version"
@@ -690,6 +690,17 @@
             android:entryValues="@array/nova_theme_values"
             android:defaultValue="polaris"
             app:iconSpaceReserved="false" />
+        <com.papi.nova.preferences.SeekBarPreference
+            android:key="nova_ui_font_scale_percent"
+            android:title="Nova Text Size"
+            android:summary="Scale Nova text relative to Android system text size"
+            android:dialogMessage="Scale Nova text relative to Android system text size"
+            android:defaultValue="100"
+            android:max="130"
+            android:text="%"
+            app:iconSpaceReserved="false"
+            seekbar:min="80"
+            seekbar:step="1" />
         <CheckBoxPreference
             android:key="nova_compose_settings_beta"
             android:title="Modern Settings"

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -122,6 +122,22 @@ class NovaSettingsDefinitionsTest {
     }
 
     @Test
+    fun novaTextSizeIsGlobalSystemRelativeInstantSlider() {
+        val definitions = NovaSettingDefinitions.load(context)
+        val textSize = definitions.require("nova_ui_font_scale_percent")
+
+        assertEquals("Nova Text Size", textSize.title)
+        assertEquals("category_nova", textSize.categoryKey)
+        assertEquals(NovaSettingType.Slider, textSize.type)
+        assertEquals(NovaSettingValue.IntValue(100), textSize.defaultValue)
+        assertEquals(80, textSize.min)
+        assertEquals(130, textSize.max)
+        assertEquals(1, textSize.step)
+        assertEquals("%", textSize.suffix)
+        assertEquals(NovaSettingApplyTiming.Instant, textSize.applyTiming)
+    }
+
+    @Test
     fun hudOpacityPreferenceIsAdjustableInstantSlider() {
         val definitions = NovaSettingDefinitions.load(context)
         val hudOpacity = definitions.require("nova_polaris_hud_opacity")
@@ -307,6 +323,7 @@ class NovaSettingsDefinitionsTest {
         assertFalse(keys.contains("import_keyboard_file"))
         assertFalse(keys.contains("export_keyboard_file"))
         assertFalse(keys.contains("import_special_button_file"))
+        assertFalse(keys.contains("nova_ui_font_scale_percent"))
     }
 
     private fun legacyPreferenceKeys(): Set<String> {

--- a/app/src/test/java/com/papi/nova/profiles/ProfilesActivityUiTest.kt
+++ b/app/src/test/java/com/papi/nova/profiles/ProfilesActivityUiTest.kt
@@ -2,20 +2,24 @@ package com.papi.nova.profiles
 
 import android.app.AlertDialog
 import android.content.Context
+import android.content.Intent
 import android.os.Looper
 import android.view.View
 import android.widget.ImageButton
 import android.widget.RadioButton
+import androidx.preference.Preference
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import com.papi.nova.EditProfileActivity
 import com.papi.nova.ProfilesActivity
 import com.papi.nova.R
 import com.papi.nova.TestLogSuppressor
+import com.papi.nova.preferences.NovaSettingsFeatureFlags
 import com.papi.nova.shadows.ShadowGameManager
 import com.papi.nova.shadows.ShadowMoonBridge
 import java.util.UUID
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -62,6 +66,66 @@ class ProfilesActivityUiTest {
 
         assertNotNull(activity)
         assertNotNull(activity.getInMemoryPrefs())
+    }
+
+    @Test
+    fun legacyProfileEditorHidesGlobalNovaTextSize() {
+        NovaSettingsFeatureFlags.setComposeSettingsEnabled(context, false)
+        val controller = Robolectric.buildActivity(EditProfileActivity::class.java)
+        try {
+            val activity = controller.setup().get()
+            activity.supportFragmentManager.executePendingTransactions()
+            val fragment = activity.supportFragmentManager
+                .findFragmentById(R.id.preferences_container) as EditProfileActivity.ProfilePreferenceFragment
+            val textSize = fragment.findPreference<Preference>("nova_ui_font_scale_percent")
+
+            assertNotNull(textSize)
+            assertFalse(textSize!!.isVisible)
+        } finally {
+            controller.destroy()
+            NovaSettingsFeatureFlags.setComposeSettingsEnabled(context, true)
+        }
+    }
+
+    @Test
+    fun profileSaveStripsGlobalTextSizeInBothEditorModes() {
+        try {
+            for (composeEnabled in listOf(true, false)) {
+                val profileId = UUID.randomUUID()
+                val contaminated = SettingsProfile(
+                    profileId,
+                    "Contaminated",
+                    System.currentTimeMillis(),
+                    System.currentTimeMillis(),
+                    mapOf(
+                        "nova_ui_font_scale_percent" to 130,
+                        "profile_test_marker" to "kept",
+                    ),
+                )
+                pm.add(contaminated)
+                NovaSettingsFeatureFlags.setComposeSettingsEnabled(context, composeEnabled)
+                val intent = Intent(context, EditProfileActivity::class.java)
+                    .putExtra("profileUuid", profileId.toString())
+                val controller = Robolectric.buildActivity(EditProfileActivity::class.java, intent)
+                try {
+                    val activity = controller.setup().get()
+                    EditProfileActivity::class.java.getDeclaredMethod("saveProfile").apply {
+                        isAccessible = true
+                    }.invoke(activity)
+
+                    val savedOptions = pm.getProfiles()
+                        .single { it.getUuid() == profileId }
+                        .getOptions()
+                        .orEmpty()
+                    assertFalse(savedOptions.containsKey("nova_ui_font_scale_percent"))
+                    assertEquals("kept", savedOptions["profile_test_marker"])
+                } finally {
+                    controller.destroy()
+                }
+            }
+        } finally {
+            NovaSettingsFeatureFlags.setComposeSettingsEnabled(context, true)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
@@ -40,9 +40,12 @@ class NovaDashboardRevampContractTest {
             assertTrue("${layout.path} should make Start Polaris a labeled pill", headerXml.contains("@string/pcview_quick_start_polaris"))
             assertTrue("${layout.path} should make Theme a labeled pill", headerXml.contains("@string/pcview_quick_theme"))
             assertTrue("${layout.path} should make GitHub a labeled pill", headerXml.contains("@string/pcview_quick_github"))
-            val expectedActionHeight = if (layout.path.contains("layout-land")) "34dp" else "@dimen/nova_dashboard_top_action_height"
+            val expectedActionHeight = if (layout.path.contains("layout-land")) "wrap_content" else "@dimen/nova_dashboard_top_action_height"
             val expectedActionRadius = if (layout.path.contains("layout-land")) "17dp" else "@dimen/nova_dashboard_top_action_radius"
             assertTrue("${layout.path} should use compact pilled top actions", headerXml.contains("""android:layout_height="$expectedActionHeight"""") && headerXml.contains("""app:cornerRadius="$expectedActionRadius""""))
+            if (layout.path.contains("layout-land")) {
+                assertTrue("landscape text actions should grow above their compact baseline", headerXml.contains("""android:minHeight="34dp"""))
+            }
         }
     }
 
@@ -161,6 +164,39 @@ class NovaDashboardRevampContractTest {
 
 
     @Test
+    fun shortLandscapeRailScrollsAndTextRowsGrowInsteadOfClipping() {
+        val landscape = File("src/main/res/layout-land/activity_pc_view.xml").readText()
+        val railStart = landscape.indexOf("@+id/dashboardCockpitRail")
+        val contentStart = landscape.indexOf("@+id/dashboardContent")
+        val railXml = landscape.substring(railStart, contentStart)
+        val railOpenTag = landscape.substring(landscape.lastIndexOf('<', railStart), landscape.indexOf('>', railStart) + 1)
+
+        assertTrue("short landscape rail should be a focus-aware vertical scroller", railOpenTag.contains("androidx.core.widget.NestedScrollView"))
+        assertTrue("rail should fill the viewport but still scroll overflowing actions", railOpenTag.contains("""android:fillViewport="true"""))
+        assertTrue("rail should scroll focused DPAD descendants into view", railOpenTag.contains("""android:descendantFocusability="afterDescendants"""))
+
+        val headerTag = railXml.substring(railXml.indexOf("@+id/pcViewHeader")).substringBefore('>')
+        assertTrue("scroll content height must be intrinsic", headerTag.contains("""android:layout_height="wrap_content"""))
+
+        listOf(
+            "@+id/actionStartPolaris",
+            "@+id/profilesButton",
+            "@+id/actionTheme",
+            "@+id/actionGithub",
+            "@+id/actionSettings",
+            "@+id/actionNovaUpdate",
+            "@+id/modeServers",
+            "@+id/modeLibrary",
+            "@+id/actionAddServer",
+            "@+id/actionScanPair",
+        ).forEach { id ->
+            val node = railXml.substring(railXml.indexOf(id)).substringBefore('>')
+            assertTrue("$id should grow vertically for scaled text", node.contains("""android:layout_height="wrap_content"""))
+            assertTrue("$id should retain a compact minimum target", node.contains("android:minHeight="))
+        }
+    }
+
+    @Test
     fun laneThreeServerLibraryModesRenderAsCompactSelector() {
         val layouts = listOf(
             File("src/main/res/layout/activity_pc_view.xml"),
@@ -209,7 +245,7 @@ class NovaDashboardRevampContractTest {
             if (layout.path.contains("layout-land")) {
                 assertTrue("${layout.path} setup row should fill the compact left rail", setupXml.contains("""android:layout_width="match_parent"""))
                 assertTrue("${layout.path} expanded setup actions should split into compact paired rail pills", setupXml.contains("""android:layout_width="0dp""") && setupXml.contains("android:layout_weight"))
-                assertTrue("${layout.path} setup actions should use compact rail pill sizing", setupXml.contains("""android:layout_height="34dp""") && setupXml.contains("""app:cornerRadius="17dp"""))
+                assertTrue("${layout.path} setup actions should retain compact minimums while growing for larger text", setupXml.contains("""android:layout_height="wrap_content""") && setupXml.contains("""android:minHeight="34dp""") && setupXml.contains("""app:cornerRadius="17dp"""))
             } else {
                 assertTrue("${layout.path} setup row should fill portrait width for large touch targets", setupXml.contains("""android:layout_width="match_parent"""))
                 assertTrue("${layout.path} setup actions should use shared pill tokens", setupXml.contains("@dimen/nova_dashboard_pill_height") && setupXml.contains("@dimen/nova_dashboard_pill_radius"))

--- a/app/src/test/java/com/papi/nova/ui/NovaFontScalePreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaFontScalePreferencesTest.kt
@@ -1,0 +1,125 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import android.os.Bundle
+import android.os.Looper
+import android.provider.Settings
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import com.papi.nova.NovaActivity
+import com.papi.nova.R
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaFontScalePreferencesTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun clearPreferences() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
+        Settings.System.putFloat(context.contentResolver, Settings.System.FONT_SCALE, 1.0f)
+    }
+
+    @Test
+    fun defaultsToSystemRelativeOneHundredPercent() {
+        assertEquals(100, NovaFontScalePreferences.readScalePercent(context))
+        assertEquals(1, NovaFontScalePreferences.SCALE_STEP_PERCENT)
+        assertEquals(1.15f, NovaFontScalePreferences.resolveFontScale(1.15f, 100), 0.001f)
+    }
+
+    @Test
+    fun clampsStoredScaleToSupportedRange() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        prefs.edit().putInt(NovaFontScalePreferences.KEY_SCALE_PERCENT, 40).commit()
+        assertEquals(80, NovaFontScalePreferences.readScalePercent(context))
+
+        prefs.edit().putInt(NovaFontScalePreferences.KEY_SCALE_PERCENT, 180).commit()
+        assertEquals(130, NovaFontScalePreferences.readScalePercent(context))
+    }
+
+    @Test
+    fun multipliesNovaScaleByAndroidSystemScale() {
+        assertEquals(0.92f, NovaFontScalePreferences.resolveFontScale(1.15f, 80), 0.001f)
+        assertEquals(1.30f, NovaFontScalePreferences.resolveFontScale(1.00f, 130), 0.001f)
+        assertEquals(1.69f, NovaFontScalePreferences.resolveFontScale(1.30f, 130), 0.001f)
+    }
+
+    @Test
+    fun wrapsResourcesWithTheResolvedScale() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        prefs.edit().putInt(NovaFontScalePreferences.KEY_SCALE_PERCENT, 80).commit()
+
+        val wrapped = NovaFontScalePreferences.wrapContext(context, systemFontScale = 1.25f)
+
+        assertEquals(1.0f, wrapped.resources.configuration.fontScale, 0.001f)
+    }
+
+    @Test
+    fun activeNovaActivityRecreatesAfterTheScalePreferenceChanges() {
+        Settings.System.putFloat(context.contentResolver, Settings.System.FONT_SCALE, 1.25f)
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        prefs.edit().putInt(NovaFontScalePreferences.KEY_SCALE_PERCENT, 80).commit()
+        val controller = Robolectric.buildActivity(RecordingNovaActivity::class.java).setup()
+        val activity = controller.get()
+        assertEquals(1.0f, activity.resources.configuration.fontScale, 0.001f)
+
+        prefs.edit().putInt(NovaFontScalePreferences.KEY_SCALE_PERCENT, 130).commit()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1, activity.recreateCalls)
+        controller.destroy()
+    }
+
+    @Test
+    fun userFacingActivitiesRouteThroughSharedScaledBase() {
+        val activities = listOf(
+            "src/main/java/com/papi/nova/AppView.kt",
+            "src/main/java/com/papi/nova/DebugInfoActivity.kt",
+            "src/main/java/com/papi/nova/EditProfileActivity.kt",
+            "src/main/java/com/papi/nova/Game.kt",
+            "src/main/java/com/papi/nova/HelpActivity.kt",
+            "src/main/java/com/papi/nova/PcView.kt",
+            "src/main/java/com/papi/nova/ProfilesActivity.kt",
+            "src/main/java/com/papi/nova/ShortcutTrampoline.kt",
+            "src/main/java/com/papi/nova/preferences/AddComputerManually.kt",
+            "src/main/java/com/papi/nova/preferences/StreamSettings.kt",
+            "src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt",
+            "src/main/java/com/papi/nova/ui/NovaQrScanActivity.kt",
+            "src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt",
+        )
+        activities.forEach { path ->
+            assertTrue("$path should inherit NovaActivity", File(path).readText().contains(": NovaActivity"))
+        }
+
+        val base = File("src/main/java/com/papi/nova/NovaActivity.kt").readText()
+        assertTrue(base.contains("override fun attachBaseContext"))
+        assertTrue(base.contains("NovaFontScalePreferences.wrapContext"))
+        assertTrue(base.contains("OnSharedPreferenceChangeListener"))
+        assertTrue(base.contains("override fun onResume()"))
+        assertTrue(base.contains("recreate()"))
+        assertTrue(File("src/main/java/com/papi/nova/Game.kt").readText().contains("shouldRecreateForFontScaleChange(): Boolean = false"))
+    }
+}
+
+private class RecordingNovaActivity : NovaActivity() {
+    var recreateCalls: Int = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(R.style.AppTheme)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun recreate() {
+        recreateCalls += 1
+    }
+}


### PR DESCRIPTION
## Summary

- add a global **Nova Text Size** control from 80–130% with a 100% default and 1% increments
- apply Nova text sizing relative to Android's system font scale across user-facing View and Compose activities without recreating an active stream
- make the short-landscape Host-selection rail scrollable and let text-bearing controls grow, keeping Add Server and Scan Pair reachable by touch and D-pad

## Behavior and compatibility

- existing installations remain at 100% unless the user changes the new setting
- invalid stored values clamp to the supported 80–130% range
- Nova Text Size stays global, is excluded from both Modern and legacy per-profile settings editors, and stale profile-scoped copies are removed on save
- non-stream activities recreate after a saved scale change; an active Game session keeps running and uses the new scale on its next launch
- the right Hosts pane remains stationary while only the left action rail scrolls
- collapsing and reopening the rail restores adaptive setup-action heights so enlarged labels remain fully visible

## Verification

- `git diff --check`
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `./gradlew -PnovaAbis=arm64-v8a -PlintFailOnError=true :app:testNonRoot_gameDebugUnitTest :app:lintNonRoot_gameDebug :app:lintVitalNonRoot_gameRelease :app:assembleNonRoot_gameDebug :app:assembleNonRoot_gameRelease`
- 918 unit tests passed; 0 failures, 0 errors, 0 skipped
- installed a debug build on a 1920×1080 Android 13 short-landscape AVD
- verified default and enlarged text, touch scrolling, D-pad traversal, and reachability of Add Server / Scan Pair
- verified collapse → expand at Android 130% text restores adaptive Add Server / Scan Pair heights with no clipping, then restored the AVD's original system scale

## Boundaries

This PR changes application UI behavior only. It does not tag, sign, publish, deploy, or announce a release.
