### PR TITLE
fix(ui): restore adaptive host action heights after rail expansion

### DIFF
--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -734,7 +734,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         addServer?.let { button ->
             val addParams = button.layoutParams as? LinearLayout.LayoutParams ?: return@let
             addParams.width = if (collapsed) LinearLayout.LayoutParams.MATCH_PARENT else 0
-            addParams.height = compactHeight
+            addParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT
             addParams.weight = if (collapsed) 0f else 1f
             addParams.marginStart = 0
             addParams.topMargin = 0
@@ -743,7 +743,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         scanPair?.let { button ->
             val scanParams = button.layoutParams as? LinearLayout.LayoutParams ?: return@let
             scanParams.width = if (collapsed) LinearLayout.LayoutParams.MATCH_PARENT else 0
-            scanParams.height = compactHeight
+            scanParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT
             scanParams.weight = if (collapsed) 0f else 1f
             scanParams.marginStart = if (collapsed) 0 else collapsedSpacing
             scanParams.topMargin = if (collapsed) collapsedSpacing else 0

--- a/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
@@ -319,6 +319,24 @@ class NovaDashboardRevampContractTest {
 
 
     @Test
+    fun expandingLandscapeRailRestoresAdaptiveSetupActionHeights() {
+        val source = File("src/main/java/com/papi/nova/PcView.kt").readText()
+
+        assertTrue(
+            "expanded Add Server must return to wrap_content for scaled or multiline text",
+            source.contains(
+                "addParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT"
+            ),
+        )
+        assertTrue(
+            "expanded Scan Pair must return to wrap_content for scaled or multiline text",
+            source.contains(
+                "scanParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT"
+            ),
+        )
+    }
+
+    @Test
     fun laneThreePointTwoLandscapeRailHasCollapsibleIconDrawerAnatomy() {
         val landscape = File("src/main/res/layout-land/activity_pc_view.xml").readText()
         val source = File("src/main/java/com/papi/nova/PcView.kt").readText()


### PR DESCRIPTION
## Summary

- restore `wrap_content` heights for Add Server and Scan Pair when the short-landscape Host rail expands
- keep the existing compact 34dp height while the rail is collapsed
- add a regression guard for the collapse → expand path

## Context

Follow-up to #152. Independent review found that the first implementation made the setup buttons adaptive in XML but the runtime collapse handler left them at a fixed height after reopening the rail. With enlarged text, that could reintroduce clipping after a collapse/expand cycle.

## Verification

- regression guard failed against the previous implementation and passed after this fix
- independent re-review passed with no security or logic findings
- `git diff --check origin/master...HEAD`
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `./gradlew -PnovaAbis=arm64-v8a -PlintFailOnError=true :app:testNonRoot_gameDebugUnitTest :app:lintNonRoot_gameDebug :app:lintVitalNonRoot_gameRelease :app:assembleNonRoot_gameDebug :app:assembleNonRoot_gameRelease`
  - 918 tests, 0 failures/errors/skips
  - strict debug lint passed
  - release vital lint passed
  - ARM64 debug/release assembly passed
- 1920×1080 Android AVD smoke at Android 130% text:
  - collapsed and reopened the Host rail
  - Add Server restored to 142px and Scan Pair to 103px
  - both labels remained fully visible; the Hosts pane stayed fixed
  - restored the AVD's original system text scale afterward

## Boundaries

This corrective PR does not tag, sign, publish, deploy, or announce a release.
