### PR TITLE
test(ui): cover adaptive host action heights behaviorally

### DIFF
--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -98,6 +98,9 @@ import javax.microedition.khronos.egl.EGLConfig
 import javax.microedition.khronos.opengles.GL10
 import org.xmlpull.v1.XmlPullParserException
 
+internal fun dashboardSetupActionHeight(collapsed: Boolean, compactHeight: Int): Int =
+    if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT
+
 class PcView : NovaActivity(), AdapterFragmentCallbacks {
     private val THEME_PICKER_GRID_GAP_DP = 8
     private var noPcFoundLayout: View? = null
@@ -734,7 +737,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         addServer?.let { button ->
             val addParams = button.layoutParams as? LinearLayout.LayoutParams ?: return@let
             addParams.width = if (collapsed) LinearLayout.LayoutParams.MATCH_PARENT else 0
-            addParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT
+            addParams.height = dashboardSetupActionHeight(collapsed, compactHeight)
             addParams.weight = if (collapsed) 0f else 1f
             addParams.marginStart = 0
             addParams.topMargin = 0
@@ -743,7 +746,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         scanPair?.let { button ->
             val scanParams = button.layoutParams as? LinearLayout.LayoutParams ?: return@let
             scanParams.width = if (collapsed) LinearLayout.LayoutParams.MATCH_PARENT else 0
-            scanParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT
+            scanParams.height = dashboardSetupActionHeight(collapsed, compactHeight)
             scanParams.weight = if (collapsed) 0f else 1f
             scanParams.marginStart = if (collapsed) 0 else collapsedSpacing
             scanParams.topMargin = if (collapsed) collapsedSpacing else 0

--- a/app/src/test/java/com/papi/nova/DashboardSetupActionLayoutTest.kt
+++ b/app/src/test/java/com/papi/nova/DashboardSetupActionLayoutTest.kt
@@ -1,0 +1,18 @@
+package com.papi.nova
+
+import android.widget.LinearLayout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardSetupActionLayoutTest {
+    @Test
+    fun setupActionHeightIsCompactWhenCollapsedAndAdaptiveWhenExpanded() {
+        val compactHeight = 34
+
+        assertEquals(compactHeight, dashboardSetupActionHeight(collapsed = true, compactHeight))
+        assertEquals(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            dashboardSetupActionHeight(collapsed = false, compactHeight),
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDashboardRevampContractTest.kt
@@ -318,23 +318,6 @@ class NovaDashboardRevampContractTest {
     }
 
 
-    @Test
-    fun expandingLandscapeRailRestoresAdaptiveSetupActionHeights() {
-        val source = File("src/main/java/com/papi/nova/PcView.kt").readText()
-
-        assertTrue(
-            "expanded Add Server must return to wrap_content for scaled or multiline text",
-            source.contains(
-                "addParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT"
-            ),
-        )
-        assertTrue(
-            "expanded Scan Pair must return to wrap_content for scaled or multiline text",
-            source.contains(
-                "scanParams.height = if (collapsed) compactHeight else LinearLayout.LayoutParams.WRAP_CONTENT"
-            ),
-        )
-    }
 
     @Test
     fun laneThreePointTwoLandscapeRailHasCollapsibleIconDrawerAnatomy() {


### PR DESCRIPTION
## Summary

- replace PR #153's Kotlin source-text assertion with a behavior-level unit test
- centralize collapsed/expanded Host setup-action height selection in one internal policy used by both Add Server and Scan Pair
- preserve existing runtime behavior: compact fixed height when collapsed, `WRAP_CONTENT` when expanded

## Why

PR #153 fixed a real post-expand clipping edge case, but its new regression test inspected Kotlin source text. Repository policy requires behavior contracts rather than source-shape tests. This follow-up keeps the functional fix intact while making the regression guard refactor-safe.

## Verification

- RED: the new behavior test failed to compile before the height policy seam existed
- GREEN: focused behavior test and dashboard contract suite passed
- 918 unit tests passed; 0 failures, 0 errors, 0 skipped
- strict lint and release vital lint passed
- ARM64 debug and unsigned release APK builds passed
- public repository hygiene passed
- independent read-only Codex review passed with no security or logic findings

One unrelated updater-recovery timing test failed once during an earlier full run, passed immediately in isolation, and the next full run passed all 918 tests.
