### PR TITLE
fix(dual-screen): retain Android 13 companion Back origin

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -227,6 +227,7 @@ private var cursorVisible:Boolean = false
 private var currentMouseModeIndex:Int = 0
 private var streamingDisplayId:Int = Display.DEFAULT_DISPLAY
 private var companionControlDisplayId:Int = INVALID_DISPLAY_ID
+private var companionControlHasWindowFocus:Boolean = false
 private var lastQuickMenuInteractionDisplayId:Int = INVALID_DISPLAY_ID
 private var isTopResumedActivity:Boolean = false
 private var externalDisplayControlPresentation:ExternalDisplayControlPresentation? = null
@@ -418,12 +419,31 @@ fun streamingDisplayIdForCompanion(): Int = streamingDisplayId
 
 private fun logGameDisplayFocus(hasWindowFocus:Boolean) {
 // Focus restoration after menu dismissal is not user input; keep provenance unchanged.
+if (hasWindowFocus)
+{
+companionControlHasWindowFocus = false
+}
 LimeLog.info(DisplayFocusTelemetry.game(streamingDisplayId, hasWindowFocus, isTopResumedActivity))
 }
 
 fun logCompanionDisplayFocus(displayId:Int, hasWindowFocus:Boolean) {
 // Presentation focus is lifecycle telemetry. Touch/key paths record real interaction origin.
 LimeLog.info(DisplayFocusTelemetry.companion(displayId, hasWindowFocus, isTopResumedActivity))
+}
+
+fun updateCompanionDisplayBackFocus(
+presentation:ExternalDisplayControlPresentation,
+displayId:Int,
+hasWindowFocus:Boolean,
+) {
+if (DualScreenQuickMenuPolicy.acceptsCompanionFocus(
+currentCompanionDisplayId = companionControlDisplayId.takeIf { it != INVALID_DISPLAY_ID },
+focusDisplayId = displayId,
+isCurrentPresentation = externalDisplayControlPresentation === presentation,
+))
+{
+companionControlHasWindowFocus = hasWindowFocus
+}
 }
 
 fun recordQuickMenuInteraction(displayId:Int) {
@@ -465,6 +485,7 @@ if (lastQuickMenuInteractionDisplayId == companionDisplayId)
 lastQuickMenuInteractionDisplayId = streamingDisplayId
 }
 companionControlDisplayId = INVALID_DISPLAY_ID
+companionControlHasWindowFocus = false
 if (shouldMigrateOpenMenu)
 {
 showQuickMenuOnStreamAfterCompanionClose()
@@ -473,6 +494,7 @@ showQuickMenuOnStreamAfterCompanionClose()
 }
 externalDisplayControlPresentation = presentation
 companionControlDisplayId = companionDisplayId
+companionControlHasWindowFocus = false
 try
 {
 presentation.show()
@@ -487,6 +509,7 @@ if (lastQuickMenuInteractionDisplayId == companionDisplayId)
 lastQuickMenuInteractionDisplayId = streamingDisplayId
 }
 companionControlDisplayId = INVALID_DISPLAY_ID
+companionControlHasWindowFocus = false
 LimeLog.warning("Nova: Android companion presentation unavailable display_id=$companionDisplayId")
 }
 }
@@ -1593,6 +1616,7 @@ if (lastQuickMenuInteractionDisplayId == companionControlDisplayId)
 lastQuickMenuInteractionDisplayId = streamingDisplayId
 }
 companionControlDisplayId = INVALID_DISPLAY_ID
+companionControlHasWindowFocus = false
 presentation?.dismissAfterCurrentCallback()
 if (shouldMigrateOpenMenu)
 {
@@ -3099,6 +3123,20 @@ if (keyboardTranslator!!.hasNormalizedMapping(event.getKeyCode(), deviceId)) 0.t
 return true
 }
 override fun onKeyUp(keyCode:Int, event:KeyEvent):Boolean {
+if (keyCode == KeyEvent.KEYCODE_BACK)
+{
+val eventSource:Int = event.getSource()
+val companionBackOrigin:Int? = DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+companionDisplayId = companionControlDisplayId.takeIf { it != INVALID_DISPLAY_ID },
+companionHasWindowFocus = companionControlHasWindowFocus,
+inputDeviceId = event.getDeviceId(),
+isMouseInput = eventSource == InputDevice.SOURCE_MOUSE || eventSource == InputDevice.SOURCE_MOUSE_RELATIVE,
+)
+if (companionBackOrigin != null && handleQuickMenuBackFromDisplay(companionBackOrigin))
+{
+return true
+}
+}
 return handleKeyUp(event) || super.onKeyUp(keyCode, event)
 }
 override fun handleKeyUp(event:KeyEvent):Boolean {

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -3131,8 +3131,11 @@ companionDisplayId = companionControlDisplayId.takeIf { it != INVALID_DISPLAY_ID
 companionHasWindowFocus = companionControlHasWindowFocus,
 inputDeviceId = event.getDeviceId(),
 isMouseInput = eventSource == InputDevice.SOURCE_MOUSE || eventSource == InputDevice.SOURCE_MOUSE_RELATIVE,
+ignoreSyntheticEvents = prefConfig!!.ignoreSynthEvents,
+sendMetaOnBack = prefConfig!!.backAsMeta,
 )
-if (companionBackOrigin != null && handleQuickMenuBackFromDisplay(companionBackOrigin))
+if (companionBackOrigin != null &&
+externalDisplayControlPresentation?.handleBackFromOwningGame() == true)
 {
 return true
 }

--- a/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
+++ b/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
@@ -54,9 +54,11 @@ object DualScreenQuickMenuPolicy {
         companionHasWindowFocus: Boolean,
         inputDeviceId: Int,
         isMouseInput: Boolean,
+        ignoreSyntheticEvents: Boolean = false,
+        sendMetaOnBack: Boolean = false,
     ): Int? {
         if (!companionHasWindowFocus || companionDisplayId == null) return null
-        if (inputDeviceId >= 0 || isMouseInput) return null
+        if (inputDeviceId >= 0 || isMouseInput || ignoreSyntheticEvents || sendMetaOnBack) return null
         return companionDisplayId
     }
 

--- a/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
+++ b/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
@@ -49,6 +49,25 @@ object DualScreenQuickMenuPolicy {
         return if (quickMenuOpen) BackAction.DISMISS else BackAction.SHOW
     }
 
+    fun legacyCompanionBackOrigin(
+        companionDisplayId: Int?,
+        companionHasWindowFocus: Boolean,
+        inputDeviceId: Int,
+        isMouseInput: Boolean,
+    ): Int? {
+        if (!companionHasWindowFocus || companionDisplayId == null) return null
+        if (inputDeviceId >= 0 || isMouseInput) return null
+        return companionDisplayId
+    }
+
+    fun acceptsCompanionFocus(
+        currentCompanionDisplayId: Int?,
+        focusDisplayId: Int,
+        isCurrentPresentation: Boolean,
+    ): Boolean {
+        return isCurrentPresentation && currentCompanionDisplayId == focusDisplayId
+    }
+
     fun openWithFallback(
         requestedSurface: Surface,
         showStream: () -> Unit,

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
@@ -252,6 +252,7 @@ class ExternalDisplayControlPresentation(
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         game.logCompanionDisplayFocus(display.displayId, hasFocus)
+        game.updateCompanionDisplayBackFocus(this, display.displayId, hasFocus)
         if (game.isFinishing) {
             dismissAfterCurrentCallback()
         }

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
@@ -260,11 +260,21 @@ class ExternalDisplayControlPresentation(
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
+        handleCompanionBack()
+    }
+
+    private fun handleCompanionBack() {
         if (game.isKeyboardLayoutVisible) {
             toggleFullKeyboard()
         } else if (!game.handleQuickMenuBackFromDisplay(display.displayId)) {
             cancel()
         }
+    }
+
+    fun handleBackFromOwningGame(): Boolean {
+        if (!isCompanionDisplayAvailable()) return false
+        handleCompanionBack()
+        return true
     }
 
     private fun initializeComponents() {

--- a/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
@@ -183,6 +183,34 @@ class DualScreenQuickMenuPolicyTest {
     }
 
     @Test
+    fun ignoredSyntheticBackKeepsExistingInputPreference() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+                ignoreSyntheticEvents = true,
+            ),
+        )
+    }
+
+    @Test
+    fun backAsMetaKeepsBalancedHostKeyPath() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+                sendMetaOnBack = true,
+            ),
+        )
+    }
+
+    @Test
     fun unfocusedCompanionKeepsExistingActivityPath() {
         assertEquals(
             null,

--- a/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
@@ -1,6 +1,8 @@
 package com.papi.nova.utils
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DualScreenQuickMenuPolicyTest {
@@ -138,6 +140,93 @@ class DualScreenQuickMenuPolicyTest {
         assertEquals(
             DualScreenQuickMenuPolicy.BackAction.PASS_THROUGH,
             DualScreenQuickMenuPolicy.backAction(backMenuEnabled = false, quickMenuOpen = false),
+        )
+    }
+
+    @Test
+    fun syntheticLegacyBackKeepsCompanionDisplayOrigin() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun physicalInputDeviceBackKeepsExistingControllerPath() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = 7,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun mouseGeneratedBackKeepsExistingRightClickPath() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = true,
+            ),
+        )
+    }
+
+    @Test
+    fun unfocusedCompanionKeepsExistingActivityPath() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                companionHasWindowFocus = false,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun legacyBackHasNoCompanionOriginAfterPresentationTeardown() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = null,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun currentPresentationCanUpdateCompanionFocus() {
+        assertTrue(
+            DualScreenQuickMenuPolicy.acceptsCompanionFocus(
+                currentCompanionDisplayId = companionDisplayId,
+                focusDisplayId = companionDisplayId,
+                isCurrentPresentation = true,
+            ),
+        )
+    }
+
+    @Test
+    fun stalePresentationCannotOverrideReplacementFocus() {
+        assertFalse(
+            DualScreenQuickMenuPolicy.acceptsCompanionFocus(
+                currentCompanionDisplayId = companionDisplayId,
+                focusDisplayId = companionDisplayId,
+                isCurrentPresentation = false,
+            ),
         )
     }
 


### PR DESCRIPTION
## Summary

- preserve Nova's deliberate application-wide predictive-Back opt-out and physical input-device `KEYCODE_BACK` behavior
- retain focus for the currently owned companion `Presentation` without treating focus alone as user interaction
- recover companion origin only when an actual synthetic, non-mouse legacy Back event arrives while that Presentation owns focus
- preserve `ignoreSynthEvents` and `backAsMeta`, including balanced Meta key-down/up
- reject stale focus callbacks from replaced Presentations and clear focus state on Game focus, failed show, dismissal, and display removal
- route escaped Back through the same companion handler as `Presentation.onBackPressed()`, preserving keyboard-first dismissal and disabled-shortcut cancellation
- keep existing Follow / Stream / Companion policy and deferred Presentation teardown intact

## Root cause

Nova intentionally keeps application-wide predictive Back disabled because enabling it breaks `KEYCODE_BACK` from input devices. Android 13 does not honor per-activity predictive-Back opt-in, so a normal window `OnBackInvokedCallback` cannot be used safely.

When Android 13 delivered companion navigation Back through the owning `Game` Activity, `Activity.onBackPressed()` had already discarded the originating window. Nova therefore assumed the stream display. The fix pairs an actual synthetic Back event with the current companion Presentation's owner-checked focus and forwards that event to the companion handler.

## Verification

- pre-fix API 33 reproduction: companion-targeted Back logged `origin_display_id=0 ... destination=stream`
- RED→GREEN policy coverage for synthetic companion Back, physical input, mouse Back, unfocused/removed companions, stale owners, ignored synthetic events, and Back-as-Meta
- Root JVM: 934 passed, 0 failures/errors/skips
- NonRoot_game JVM: 928 passed, 0 failures/errors/skips on a clean isolated rerun
- Root and NonRoot_game lint: passed with no current errors; existing baseline-filtered findings remain unchanged
- Root and NonRoot_game debug assembly: passed
- exact commit `05c168a5` x86_64 APK installed on API 33 RP6 virtual device
  - SHA-256 `132c73cf355b87404e0e028c937085864576494eef188b4f218c7b6684679905`
  - Control: `Game` display `0`, companion Presentation transient display `6`
  - companion Back: `origin_display_id=6 ... destination=companion`
  - menu window attached on display `6`
  - display removal: no fatal exception; Nova remained alive
- physical Thor left-edge routing remains the field gate: `physical_thor_follow_interaction_verified=false`

## Scope

- no manifest, settings/default, explicit pinning, version, signing, or release-metadata changes
- no predictive-Back opt-in
- no audio claim
