### PR TITLE
fix(dual-screen): route escaped Activity Back by origin

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -3128,6 +3128,7 @@ if (keyCode == KeyEvent.KEYCODE_BACK)
 val eventSource:Int = event.getSource()
 val companionBackOrigin:Int? = DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
 companionDisplayId = companionControlDisplayId.takeIf { it != INVALID_DISPLAY_ID },
+lastInteractionDisplayId = lastQuickMenuInteractionDisplayId.takeIf { it != INVALID_DISPLAY_ID },
 companionHasWindowFocus = companionControlHasWindowFocus,
 inputDeviceId = event.getDeviceId(),
 isMouseInput = eventSource == InputDevice.SOURCE_MOUSE || eventSource == InputDevice.SOURCE_MOUSE_RELATIVE,
@@ -5279,6 +5280,16 @@ else -> return false
 }
 }
 override fun onBackPressed() {
+val companionBackOrigin = DualScreenQuickMenuPolicy.escapedBackOrigin(
+companionDisplayId = companionControlDisplayId.takeIf { it != INVALID_DISPLAY_ID },
+lastInteractionDisplayId = lastQuickMenuInteractionDisplayId.takeIf { it != INVALID_DISPLAY_ID },
+companionHasWindowFocus = companionControlHasWindowFocus,
+)
+if (companionBackOrigin != null &&
+externalDisplayControlPresentation?.handleBackFromOwningGame() == true)
+{
+return
+}
 if (handleQuickMenuBackFromDisplay(streamingDisplayId))
 {
 return

--- a/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
+++ b/app/src/main/java/com/papi/nova/utils/DualScreenQuickMenuPolicy.kt
@@ -49,17 +49,38 @@ object DualScreenQuickMenuPolicy {
         return if (quickMenuOpen) BackAction.DISMISS else BackAction.SHOW
     }
 
+    /**
+     * Recovers companion origin when Android routes display-owned Back through [Game].
+     * API 33 can preserve either owner-checked window focus or an ACTION_DOWN interaction,
+     * depending on which legacy callback path receives the system gesture.
+     */
+    fun escapedBackOrigin(
+        companionDisplayId: Int?,
+        lastInteractionDisplayId: Int?,
+        companionHasWindowFocus: Boolean,
+    ): Int? {
+        if (companionDisplayId == null) return null
+
+        return companionDisplayId.takeIf {
+            companionHasWindowFocus || lastInteractionDisplayId == companionDisplayId
+        }
+    }
+
     fun legacyCompanionBackOrigin(
         companionDisplayId: Int?,
+        lastInteractionDisplayId: Int? = null,
         companionHasWindowFocus: Boolean,
         inputDeviceId: Int,
         isMouseInput: Boolean,
         ignoreSyntheticEvents: Boolean = false,
         sendMetaOnBack: Boolean = false,
     ): Int? {
-        if (!companionHasWindowFocus || companionDisplayId == null) return null
         if (inputDeviceId >= 0 || isMouseInput || ignoreSyntheticEvents || sendMetaOnBack) return null
-        return companionDisplayId
+        return escapedBackOrigin(
+            companionDisplayId = companionDisplayId,
+            lastInteractionDisplayId = lastInteractionDisplayId,
+            companionHasWindowFocus = companionHasWindowFocus,
+        )
     }
 
     fun acceptsCompanionFocus(

--- a/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/DualScreenQuickMenuPolicyTest.kt
@@ -144,12 +144,102 @@ class DualScreenQuickMenuPolicyTest {
     }
 
     @Test
+    fun escapedBackUsesCompanionInteractionAfterGameTakesWindowFocus() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.escapedBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = companionDisplayId,
+                companionHasWindowFocus = false,
+            ),
+        )
+    }
+
+    @Test
+    fun escapedBackUsesCurrentCompanionFocusWhenLastInteractionIsStream() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.escapedBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = streamDisplayId,
+                companionHasWindowFocus = true,
+            ),
+        )
+    }
+
+    @Test
+    fun escapedBackKeepsStreamInteractionWithoutCompanionFocus() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.escapedBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = streamDisplayId,
+                companionHasWindowFocus = false,
+            ),
+        )
+    }
+
+    @Test
+    fun escapedBackFallsBackToCompanionFocusWithoutRecordedInteraction() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.escapedBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = null,
+                companionHasWindowFocus = true,
+            ),
+        )
+    }
+
+    @Test
     fun syntheticLegacyBackKeepsCompanionDisplayOrigin() {
         assertEquals(
             companionDisplayId,
             DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
                 companionDisplayId = companionDisplayId,
                 companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun syntheticLegacyBackUsesRecordedCompanionInteractionWithoutFocus() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = companionDisplayId,
+                companionHasWindowFocus = false,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun syntheticLegacyBackUsesCurrentCompanionFocusWhenInteractionIsStream() {
+        assertEquals(
+            companionDisplayId,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = streamDisplayId,
+                companionHasWindowFocus = true,
+                inputDeviceId = -1,
+                isMouseInput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun syntheticLegacyBackKeepsStreamInteractionWithoutCompanionFocus() {
+        assertEquals(
+            null,
+            DualScreenQuickMenuPolicy.legacyCompanionBackOrigin(
+                companionDisplayId = companionDisplayId,
+                lastInteractionDisplayId = streamDisplayId,
+                companionHasWindowFocus = false,
                 inputDeviceId = -1,
                 isMouseInput = false,
             ),

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -420,6 +420,32 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
+    fun escapedBackRoutesCurrentCompanionSignalsBeforeStreamFallback() {
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val onKeyUp =
+            game.substringAfter("override fun onKeyUp(keyCode:Int, event:KeyEvent):Boolean")
+                .substringBefore("override fun handleKeyUp(event:KeyEvent):Boolean")
+        assertTrue(
+            "Synthetic Back must supply the recorded interaction alongside current focus",
+            onKeyUp.contains(
+                "lastInteractionDisplayId = lastQuickMenuInteractionDisplayId.takeIf { it != INVALID_DISPLAY_ID }",
+            ),
+        )
+
+        val activityBack =
+            game.substringAfter("override fun onBackPressed()")
+                .substringBefore("fun handleQuickMenuBackFromDisplay")
+        val originResolution = activityBack.indexOf("DualScreenQuickMenuPolicy.escapedBackOrigin(")
+        val interactionOrigin = activityBack.indexOf("lastQuickMenuInteractionDisplayId.takeIf")
+        val companionHandler = activityBack.indexOf("handleBackFromOwningGame()")
+        val streamFallback = activityBack.indexOf("handleQuickMenuBackFromDisplay(streamingDisplayId)")
+        assertTrue("Activity Back must resolve companion origin signals", originResolution >= 0)
+        assertTrue("Activity Back must pass the recorded interaction display alongside focus", interactionOrigin > originResolution)
+        assertTrue("Companion handling must follow origin resolution", companionHandler > interactionOrigin)
+        assertTrue("Stream handling must remain the fallback", streamFallback > companionHandler)
+    }
+
+    @Test
     fun presentationCancellationDefersDisplayRemovalAndBackTeardown() {
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()


### PR DESCRIPTION
## Summary

- combine owner-checked companion focus with Nova's recorded touch/key display when Android 13 forwards Back through the owning `Game` Activity
- route escaped Activity Back through the companion handler before falling back to the stream display
- preserve physical input-device Back, mouse Back, `ignoreSynthEvents`, Back-as-Meta, keyboard dismissal, and existing Follow / Stream / Companion policy

## Root cause

PR #156 recovered companion origin only on the synthetic `onKeyUp()` path. Thor field testing exercised the Activity `onBackPressed()` path, which still hardcoded the stream display after opening the top Quick Menu.

Android 13 can preserve either owner-checked companion focus or an `ACTION_DOWN` interaction depending on which legacy callback path receives the gesture. This follow-up accepts either current companion signal and falls back to the stream only when neither identifies the companion.

## Verification

- RED policy coverage for current companion focus with stale stream interaction, recorded companion interaction without focus, and stream interaction without companion focus
- RED source-wiring coverage for both synthetic `onKeyUp()` and Activity `onBackPressed()`
- Root JVM: 942 passed, 0 failures/errors/skips
- NonRoot_game JVM: 936 passed, 0 failures/errors/skips
- Root and NonRoot_game lint: passed with no current Error-severity findings; existing baseline-filtered findings remain unchanged
- Root and NonRoot_game debug assembly: passed for arm64-v8a, armeabi-v7a, and x86_64

## Field status

Physical Thor validation of this follow-up remains pending. The regression tests model the report's exact top → companion → top routing sequence, but they are not a substitute for the real Android 13 dual-screen gesture path.

Follow-up to #156 and [the field report](https://github.com/papi-ux/nova/pull/156#issuecomment-5036557925).
