### PR TITLE
Pin game launch action in detail sheet footer

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import android.widget.ScrollView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -19,15 +20,22 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -1206,102 +1214,132 @@ fun NovaGameDetailSheetContent(
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
     val verticalScroll = rememberScrollState()
+    val playFocusRequester = remember { FocusRequester() }
+    val detailsFocusRequester = remember { FocusRequester() }
 
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .fillMaxHeight()
             .clip(RoundedCornerShape(topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp, topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp))
             .background(surfaces.panel)
-            .verticalScroll(verticalScroll)
-            .padding(bottom = 16.dp)
     ) {
-        NovaSheetDragHandle(onDismiss = onSheetHandleDismiss)
+        NovaGameDetailScrollableContent(
+            scrollState = verticalScroll,
+            modifier = Modifier.weight(1f)
+        ) {
+            NovaSheetDragHandle(onDismiss = onSheetHandleDismiss)
 
-        GameDetailsPanel(
-            uiState = uiState,
-            lastPlayedText = lastPlayedText,
-            coverContentDescription = coverContentDescription,
-            coverLoader = coverLoader
-        )
+            GameDetailsPanel(
+                uiState = uiState,
+                lastPlayedText = lastPlayedText,
+                coverContentDescription = coverContentDescription,
+                coverLoader = coverLoader
+            )
 
-        LaunchControlsPanel(
-            uiState = uiState,
-            launchIntro = launchIntro,
-            launchModeTitle = launchModeTitle,
-            recommendedBadge = recommendedBadge,
+            LaunchControlsPanel(
+                uiState = uiState,
+                launchIntro = launchIntro,
+                launchModeTitle = launchModeTitle,
+                recommendedBadge = recommendedBadge,
+                launchOptionsLabel = launchOptionsLabel,
+                profilePreferenceLabel = profilePreferenceLabel,
+                profileSummary = optimizationState.profileSummary,
+                resetProfileLabel = resetProfileLabel,
+                resetProfileWorking = resetProfileWorking,
+                headlessModeLabel = headlessModeLabel,
+                virtualDisplayModeLabel = virtualDisplayModeLabel,
+                playFocusRequester = playFocusRequester,
+                detailsFocusRequester = detailsFocusRequester,
+                onLaunchOptions = onLaunchOptions,
+                onLaunchModeSelected = onLaunchModeSelected,
+                onProfilePreference = onProfilePreference,
+                onRetryHighFps = onRetryHighFps,
+                onResetProfile = onResetProfile
+            )
+
+            launchOptionsState?.let {
+                NovaLaunchOptionsSheet(
+                    state = it,
+                    onLaunch = onLaunchOptionSelected,
+                    onDismiss = onDismissLaunchOptions
+                )
+            }
+
+            profileOptionsState?.let {
+                NovaProfilePreferenceSheet(
+                    state = it,
+                    onSelected = onProfilePreferenceSelected,
+                    onDismiss = onDismissProfileOptions
+                )
+            }
+
+            SteamLaunchModeCard(
+                visible = uiState.showSteamLaunchMode,
+                label = steamLaunchLabel,
+                modeLabel = steamLaunchModeLabel,
+                caption = steamLaunchCaption,
+                warning = uiState.steamLaunchWarning,
+                onClick = onSteamLaunchMode
+            )
+
+            steamLaunchOptionsState?.let { state ->
+                NovaSteamLaunchModeSheet(
+                    state = state,
+                    onSelected = onSteamLaunchModeSelected,
+                    onDismiss = onDismissSteamLaunchModeOptions
+                )
+            }
+
+            if (mangoHudEnabled) {
+                MangoHudPassiveStatus(
+                    label = mangoHudStatusLabel,
+                    caption = mangoHudStatusCaption,
+                    warning = mangoHudWarning
+                )
+            }
+
+            optimizationState.ai?.let {
+                InsightCard(card = it)
+            }
+
+            optimizationState.stability?.let {
+                InsightCard(card = it)
+            }
+
+            NovaControllerHintBar(
+                hints = novaGameDetailControllerHints(),
+                compact = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 14.dp, end = 14.dp, top = 12.dp)
+            )
+        }
+
+        NovaGameDetailLaunchFooter(
             playLabel = playLabel,
-            launchOptionsLabel = launchOptionsLabel,
-            profilePreferenceLabel = profilePreferenceLabel,
-            profileSummary = optimizationState.profileSummary,
-            resetProfileLabel = resetProfileLabel,
-            resetProfileWorking = resetProfileWorking,
-            headlessModeLabel = headlessModeLabel,
-            virtualDisplayModeLabel = virtualDisplayModeLabel,
+            enabled = uiState.playEnabled,
             onPrimaryLaunch = onPrimaryLaunch,
-            onLaunchOptions = onLaunchOptions,
-            onLaunchModeSelected = onLaunchModeSelected,
-            onProfilePreference = onProfilePreference,
-            onRetryHighFps = onRetryHighFps,
-            onResetProfile = onResetProfile
-        )
-
-        launchOptionsState?.let {
-            NovaLaunchOptionsSheet(
-                state = it,
-                onLaunch = onLaunchOptionSelected,
-                onDismiss = onDismissLaunchOptions
-            )
-        }
-
-        profileOptionsState?.let {
-            NovaProfilePreferenceSheet(
-                state = it,
-                onSelected = onProfilePreferenceSelected,
-                onDismiss = onDismissProfileOptions
-            )
-        }
-
-        SteamLaunchModeCard(
-            visible = uiState.showSteamLaunchMode,
-            label = steamLaunchLabel,
-            modeLabel = steamLaunchModeLabel,
-            caption = steamLaunchCaption,
-            warning = uiState.steamLaunchWarning,
-            onClick = onSteamLaunchMode
-        )
-
-        steamLaunchOptionsState?.let { state ->
-            NovaSteamLaunchModeSheet(
-                state = state,
-                onSelected = onSteamLaunchModeSelected,
-                onDismiss = onDismissSteamLaunchModeOptions
-            )
-        }
-
-        if (mangoHudEnabled) {
-            MangoHudPassiveStatus(
-                label = mangoHudStatusLabel,
-                caption = mangoHudStatusCaption,
-                warning = mangoHudWarning
-            )
-        }
-
-        optimizationState.ai?.let {
-            InsightCard(card = it)
-        }
-
-        optimizationState.stability?.let {
-            InsightCard(card = it)
-        }
-
-        NovaControllerHintBar(
-            hints = novaGameDetailControllerHints(),
-            compact = true,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 14.dp, end = 14.dp, top = 12.dp)
+            playFocusRequester = playFocusRequester,
+            detailsFocusRequester = detailsFocusRequester,
+            contentInsets = WindowInsets.safeContent.only(WindowInsetsSides.Bottom)
         )
     }
+}
+
+@Composable
+private fun NovaGameDetailScrollableContent(
+    scrollState: ScrollState,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(bottom = 16.dp),
+        content = content
+    )
 }
 
 @Composable
@@ -1323,6 +1361,57 @@ private fun novaGameDetailControllerHints(): List<NovaControllerHint> = listOf(
         label = stringResource(R.string.nova_controller_hint_profile)
     )
 )
+
+@Composable
+internal fun NovaGameDetailLaunchFooter(
+    playLabel: String,
+    enabled: Boolean,
+    onPrimaryLaunch: () -> Unit,
+    playFocusRequester: FocusRequester,
+    detailsFocusRequester: FocusRequester,
+    contentInsets: WindowInsets,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+
+    LaunchedEffect(enabled) {
+        if (enabled) {
+            playFocusRequester.requestFocus()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(surfaces.panel)
+            .windowInsetsPadding(contentInsets)
+            .padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 18.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 1.dp, max = 1.dp)
+                .background(colors.divider.copy(alpha = 0.55f))
+        )
+        NovaActionButton(
+            text = playLabel,
+            onClick = onPrimaryLaunch,
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(playFocusRequester)
+                .focusProperties { up = detailsFocusRequester }
+                .padding(top = 6.dp),
+            enabled = enabled,
+            primary = true,
+            contentDescription = playLabel,
+            minHeight = 48.dp,
+            cornerRadius = 12.dp,
+            fontSize = 16.sp,
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)
+        )
+    }
+}
 
 @Composable
 private fun NovaDetailPanel(
@@ -1587,7 +1676,6 @@ private fun LaunchControlsPanel(
     launchIntro: String,
     launchModeTitle: String,
     recommendedBadge: String,
-    playLabel: String,
     launchOptionsLabel: String,
     profilePreferenceLabel: String,
     profileSummary: NovaLaunchProfileSummary?,
@@ -1595,7 +1683,8 @@ private fun LaunchControlsPanel(
     resetProfileWorking: Boolean,
     headlessModeLabel: String,
     virtualDisplayModeLabel: String,
-    onPrimaryLaunch: () -> Unit,
+    playFocusRequester: FocusRequester,
+    detailsFocusRequester: FocusRequester,
     onLaunchOptions: () -> Unit,
     onLaunchModeSelected: (String) -> Unit,
     onProfilePreference: () -> Unit,
@@ -1615,7 +1704,6 @@ private fun LaunchControlsPanel(
             launchIntro = launchIntro,
             launchModeTitle = launchModeTitle,
             recommendedBadge = recommendedBadge,
-            playLabel = playLabel,
             launchOptionsLabel = launchOptionsLabel,
             profilePreferenceLabel = profilePreferenceLabel,
             profileSummary = profileSummary,
@@ -1623,7 +1711,8 @@ private fun LaunchControlsPanel(
             resetProfileWorking = resetProfileWorking,
             headlessModeLabel = headlessModeLabel,
             virtualDisplayModeLabel = virtualDisplayModeLabel,
-            onPrimaryLaunch = onPrimaryLaunch,
+            playFocusRequester = playFocusRequester,
+            detailsFocusRequester = detailsFocusRequester,
             onLaunchOptions = onLaunchOptions,
             onLaunchModeSelected = onLaunchModeSelected,
             onProfilePreference = onProfilePreference,
@@ -1676,7 +1765,6 @@ private fun LaunchControls(
     launchIntro: String,
     launchModeTitle: String,
     recommendedBadge: String,
-    playLabel: String,
     launchOptionsLabel: String,
     profilePreferenceLabel: String,
     profileSummary: NovaLaunchProfileSummary?,
@@ -1684,7 +1772,8 @@ private fun LaunchControls(
     resetProfileWorking: Boolean,
     headlessModeLabel: String,
     virtualDisplayModeLabel: String,
-    onPrimaryLaunch: () -> Unit,
+    playFocusRequester: FocusRequester,
+    detailsFocusRequester: FocusRequester,
     onLaunchOptions: () -> Unit,
     onLaunchModeSelected: (String) -> Unit,
     onProfilePreference: () -> Unit,
@@ -1692,14 +1781,6 @@ private fun LaunchControls(
     onResetProfile: () -> Unit
 ) {
     val colors = LocalNovaComposeColors.current
-    val playFocusRequester = remember { FocusRequester() }
-    val detailsFocusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(uiState.playEnabled) {
-        if (uiState.playEnabled) {
-            playFocusRequester.requestFocus()
-        }
-    }
 
     Column {
         Row(
@@ -1767,23 +1848,6 @@ private fun LaunchControls(
                 playFocusRequester = playFocusRequester
             )
         }
-
-        NovaActionButton(
-            text = playLabel,
-            onClick = onPrimaryLaunch,
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(playFocusRequester)
-                .focusProperties { up = detailsFocusRequester }
-                .padding(top = 10.dp),
-            enabled = uiState.playEnabled,
-            primary = true,
-            contentDescription = playLabel,
-            minHeight = 50.dp,
-            cornerRadius = 12.dp,
-            fontSize = 16.sp,
-            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 12.dp)
-        )
 
         if (uiState.showLaunchOptionsButton || uiState.showVirtualUnavailableHint) {
             Row(

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1080,9 +1080,9 @@ class NovaComposeSourceGuardTest {
             "private fun GameDetailsPanel(",
             "@Composable\nprivate fun LaunchControlsPanel("
         )
-        val launchControls = detail.section(
-            "private fun LaunchControls(",
-            "@Composable\nprivate fun LaunchProfileSummaryInline("
+        val launchFooter = detail.section(
+            "internal fun NovaGameDetailLaunchFooter(",
+            "@Composable\nprivate fun NovaDetailPanel("
         )
         val launchModePill = detail.section(
             "private fun LaunchModeChoicePill(",
@@ -1105,8 +1105,8 @@ class NovaComposeSourceGuardTest {
                 detailsPanel.contains("fontSize = 22.sp")
         )
         assertTrue(
-            "primary launch and mode choice controls should stay compact enough to be visible together on Retroid first paint",
-            launchControls.contains("minHeight = 50.dp") &&
+            "pinned primary launch and mode choice controls should stay compact enough for Retroid landscape",
+            launchFooter.contains("minHeight = 48.dp") &&
                 launchModePill.contains("modifier = modifier.heightIn(min = 52.dp)")
         )
     }
@@ -1118,36 +1118,66 @@ class NovaComposeSourceGuardTest {
             "private fun LaunchControls(",
             "@Composable\nprivate fun LaunchProfileSummaryInline("
         )
+        val launchFooter = detail.section(
+            "internal fun NovaGameDetailLaunchFooter(",
+            "@Composable\nprivate fun NovaDetailPanel("
+        )
+        val sheetContent = detail.section(
+            "fun NovaGameDetailSheetContent(",
+            "@Composable\nprivate fun NovaGameDetailScrollableContent("
+        )
+        val scrollableContent = detail.section(
+            "private fun NovaGameDetailScrollableContent(",
+            "@Composable\nprivate fun novaGameDetailControllerHints("
+        )
+        val scrollBody = sheetContent.blockStartingAt("NovaGameDetailScrollableContent(")
 
         assertTrue(
-            "game detail should focus the primary play action when the sheet opens",
-            launchControls.contains("val playFocusRequester = remember { FocusRequester() }") &&
-                launchControls.contains("playFocusRequester.requestFocus()") &&
-                launchControls.contains(".focusRequester(playFocusRequester)")
+            "game detail should focus the pinned primary play action when the sheet opens",
+            sheetContent.contains("val playFocusRequester = remember { FocusRequester() }") &&
+                launchFooter.contains("playFocusRequester.requestFocus()") &&
+                launchFooter.contains(".focusRequester(playFocusRequester)")
         )
         assertTrue(
-            "game detail should wire an explicit controller focus route between Play and More details",
-            launchControls.contains("val detailsFocusRequester = remember { FocusRequester() }") &&
+            "game detail should preserve an explicit controller focus route between pinned Play and More details",
+            sheetContent.contains("val detailsFocusRequester = remember { FocusRequester() }") &&
                 launchControls.contains("detailsFocusRequester = detailsFocusRequester") &&
                 launchControls.contains("playFocusRequester = playFocusRequester") &&
-                launchControls.contains(".focusProperties { up = detailsFocusRequester }") &&
+                launchFooter.contains(".focusProperties { up = detailsFocusRequester }") &&
                 launchControls.contains(".focusProperties { down = playFocusRequester }")
         )
         assertTrue(
-            "game detail should make Play the full-width primary action before secondary tuning actions",
-            launchControls.section("text = playLabel", "enabled = uiState.playEnabled")
+            "the pinned footer should keep Play as a full-width primary action above the safe-content bottom inset",
+            launchFooter.section("text = playLabel", "enabled = enabled")
                 .contains(".fillMaxWidth()\n                .focusRequester(playFocusRequester)") &&
-                launchControls.indexOf("text = playLabel") < launchControls.indexOf("text = profilePreferenceLabel")
+                launchFooter.contains(".windowInsetsPadding(contentInsets)") &&
+                launchFooter.contains(".padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 18.dp)") &&
+                sheetContent.contains("contentInsets = WindowInsets.safeContent.only(WindowInsetsSides.Bottom)")
         )
         assertTrue(
-            "game detail should keep Play above mode choices and the longer launch profile summary",
-            launchControls.indexOf("text = playLabel") < launchControls.indexOf("LaunchModeChoicePill(") &&
-                launchControls.indexOf("text = playLabel") < launchControls.indexOf("LaunchProfileSummaryInline(")
+            "the game-detail root must remain bounded while the detail body owns the remaining height and vertical scrolling",
+            sheetContent.contains(".fillMaxHeight()") &&
+                sheetContent.contains("modifier = Modifier.weight(1f)") &&
+                scrollableContent.contains(".verticalScroll(scrollState)")
         )
         assertTrue(
-            "game detail should surface host/render limits before the primary launch action",
+            "the pinned Play footer must be composed after and outside the scrollable detail lambda",
+            scrollBody.contains("GameDetailsPanel(") &&
+                scrollBody.contains("LaunchControlsPanel(") &&
+                scrollBody.contains("NovaControllerHintBar(") &&
+                !scrollBody.contains("NovaGameDetailLaunchFooter(") &&
+                sheetContent.indexOf("NovaGameDetailLaunchFooter(") >
+                    sheetContent.indexOf(scrollBody) + scrollBody.length
+        )
+        assertFalse(
+            "the primary launch button must not remain inside the vertically scrolling launch-controls body",
+            launchControls.contains("text = playLabel") ||
+                launchControls.contains("onClick = onPrimaryLaunch")
+        )
+        assertTrue(
+            "game detail should keep host/render limits in the scrolling body above the pinned launch action",
             launchControls.contains("LaunchProfilePrimaryNotice(") &&
-                launchControls.indexOf("LaunchProfilePrimaryNotice(") < launchControls.indexOf("text = playLabel")
+                sheetContent.indexOf("LaunchControlsPanel(") < sheetContent.indexOf("NovaGameDetailLaunchFooter(")
         )
         assertTrue(
             "Heads up should explain evidence and the recommended next launch instead of showing one vague limited-by line",
@@ -2263,4 +2293,22 @@ class NovaComposeSourceGuardTest {
 
     private fun String.section(startMarker: String, endMarker: String): String =
         substring(indexOf(startMarker), indexOf(endMarker))
+
+    private fun String.blockStartingAt(startMarker: String): String {
+        val markerIndex = indexOf(startMarker)
+        require(markerIndex >= 0) { "Missing start marker: $startMarker" }
+        val openBrace = indexOf('{', markerIndex)
+        require(openBrace >= 0) { "Missing opening brace after: $startMarker" }
+        var depth = 0
+        for (index in openBrace until length) {
+            when (this[index]) {
+                '{' -> depth += 1
+                '}' -> {
+                    depth -= 1
+                    if (depth == 0) return substring(openBrace, index + 1)
+                }
+            }
+        }
+        error("Unbalanced block after: $startMarker")
+    }
 }


### PR DESCRIPTION
## Summary
- keep game identity, launch modes, profile information, secondary actions, and controller hints independently scrollable in the game-detail sheet
- pin the full-width primary Launch action in a compact footer with safe-content bottom insets and a 48dp minimum target
- preserve initial controller focus and bidirectional focus routing, with structural source guards for the bounded scrolling-body/footer contract

## Test plan
- [x] `./gradlew -PnovaAbis=x86_64 :app:testNonRoot_gameDebugUnitTest`
- [x] `./gradlew -PnovaAbis=x86_64 :app:compileNonRoot_gameDebugAndroidTestSources`
- [x] `./gradlew -PnovaAbis=x86_64 :app:lintNonRoot_gameDebug`
- [x] `./gradlew -PnovaAbis=x86_64 :app:assembleNonRoot_gameDebug`
- [x] RP6 landscape smoke at 1920x1080: Launch visible on first paint, scrollable detail body moved while CTA geometry remained stationary, and no stream was started
- [x] Exact-diff independent review passed with no security or logic findings

## Scope
- Android Compose game-detail layout only
- no launch, session, network, deployment, or release behavior changes
- Steam Deck capture waived for this Android-only change; Deck client files are unaffected
