### PR TITLE
docs(changelog): record PR #160 merge finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Release administration
+
+- Merged PR #160 ("chore(nova): integrate 1.3.2 Kanban-full smoke branch") into release/v1.3.2-opacity-prep on 2026-07-24, preserving the 1.3.2 package/version identity (versionName 1.3.2, versionCode 34, minSdk 21, targetSdk 36) and preserving canonical artifact naming.
+
 ## 1.3.2 - 2026-07-19
 
 Nova 1.3.2 adds adjustable menu and drawer glass, sharpens controller focus rendering, and delivers focused reliability fixes for companion displays, updater recovery, launch diagnostics, and verified host endpoint mobility.

--- a/fastlane/metadata/android/en-US/changelogs/34.txt
+++ b/fastlane/metadata/android/en-US/changelogs/34.txt
@@ -4,3 +4,4 @@ Nova 1.3.2
 - Preserves intended D-pad artwork transparency.
 - Hardens companion-display teardown and updater recovery.
 - Improves launch diagnostics and verified host-route mobility.
+- Improves merge-branch reliability and smoke validation for multi-display, menu drawer, and updater workflows.


### PR DESCRIPTION
## Summary

- Record finalization details for the merged PR #160 in release documentation and store notes in release-facing changelog files.
- This keeps release provenance synchronized for 1.3.2 without changing runtime behavior or package contents.

## Scope

- `CHANGELOG.md`: add a release administration entry for PR #160 merge.
- `fastlane/metadata/android/en-US/changelogs/34.txt`: add one release bullet for merge reliability and validation context.

## Validation

- Target package identity: `versionName 1.3.2`, `versionCode 34`, `minSdk 21`, `targetSdk 36`.
- Merge source merged previously into `release/v1.3.2-opacity-prep` (PR #160) and canonical artifact naming policy remains unchanged.
- CI was previously validated during the earlier merge workflow; this patch contains docs-only updates.

## Notes

- No executable code changes in this follow-up.
