### PR TITLE
Fix codec settings dialog crash on API 33

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -229,7 +229,6 @@
         <item name="android:windowBackground">@color/nova_dialog_bg</item>
         <item name="android:textColorPrimary">@color/nova_text_primary</item>
         <item name="android:textColorSecondary">@color/nova_text_secondary</item>
-        <item name="colorAccent">?attr/colorAccent</item>
         <item name="buttonBarPositiveButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/NovaDialogButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/NovaDialogButton</item>

--- a/app/src/test/java/com/papi/nova/ui/NovaAlertDialogThemeTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaAlertDialogThemeTest.kt
@@ -1,0 +1,39 @@
+package com.papi.nova.ui
+
+import android.content.DialogInterface
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.papi.nova.R
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NovaAlertDialogThemeTest {
+
+    @Test
+    fun settingsThemeInflatesListPreferenceDialogButtons() {
+        val controller = Robolectric.buildActivity(AppCompatActivity::class.java)
+        val activity = controller.get()
+        activity.setTheme(R.style.SettingsTheme)
+        controller.setup()
+
+        val dialog = AlertDialog.Builder(activity)
+            .setTitle("Change codec settings")
+            .setSingleChoiceItems(arrayOf("Automatic", "Prefer H.264"), 0, null)
+            .setPositiveButton(android.R.string.ok, null)
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+
+        dialog.show()
+
+        assertNotNull(dialog.getButton(DialogInterface.BUTTON_POSITIVE))
+        assertNotNull(dialog.getButton(DialogInterface.BUTTON_NEGATIVE))
+        dialog.dismiss()
+        controller.destroy()
+    }
+}


### PR DESCRIPTION
## Summary

- stop `NovaAlertDialog` from self-referencing `colorAccent`
- inherit the concrete accent from the active `SettingsTheme` variant
- add an API 33 Robolectric regression for AppCompat list-dialog button inflation

## Root cause

The legacy codec `ListPreference` opened under `SettingsTheme`, which forces `NovaAlertDialog`. That overlay declared:

```xml
<item name="colorAccent">?attr/colorAccent</item>
```

Material dialog buttons resolved `colorAccent` back through the same overlay and crashed with `InflateException` / `UnsupportedOperationException`. Removing the self-reference preserves each settings theme's concrete accent while allowing Material buttons to inflate normally.

## Verification

- TDD RED: restoring the removed item reproduces the API 33 `MaterialButton`/`colorAccent` crash
- TDD GREEN: focused dialog regression passes
- all six settings-theme variants resolve and inflate successfully in an independent API 33 probe
- `:app:testNonRoot_gameDebugUnitTest`: 937 tests, 0 failures/errors/skips
- `:app:lintNonRoot_gameDebug`: 0 fatal issues, 0 errors
- `:app:assembleNonRoot_gameDebug`: pass
- API 33 x86_64 emulator: codec selector opens, all choices render, and `Prefer H.264` persists
- H.264 end-to-end smoke: 1920×1080@60, hardware H.264 encode, audio, D-pad input, disconnect/resume, explicit end-session, and clean teardown

## Scope

This is a narrow theme-contract fix plus regression coverage. It does not change codec negotiation, streaming behavior, application IDs, or release signing.
