### PR TITLE
fix(ui): preserve server focus during polling

### DIFF
--- a/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/GenericGridAdapter.kt
@@ -37,7 +37,7 @@ abstract class GenericGridAdapter<T>(
         clickListener = listener
     }
 
-    fun setItems(items: List<T>?) {
+    open fun setItems(items: List<T>?) {
         itemList.clear()
         if (items != null) {
             itemList.addAll(items)

--- a/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
@@ -10,36 +10,181 @@ import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
 import com.papi.nova.PcViewModel
 import com.papi.nova.R
 import com.papi.nova.nvstream.http.ComputerDetails
 import com.papi.nova.nvstream.http.PairingManager
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.NovaThemeManager
+import java.util.IdentityHashMap
 import java.util.Locale
 
 class PcGridAdapter(
     context: Context,
     prefs: PreferenceConfiguration
 ) : GenericGridAdapter<PcViewModel.ComputerObject>(context, getLayoutIdForPreferences(prefs)) {
+    private val stableIdsByObject = IdentityHashMap<PcViewModel.ComputerObject, Long>()
+    private val uuidsByObject = IdentityHashMap<PcViewModel.ComputerObject, String>()
+    private val stableIdsByUuid = HashMap<String, Long>()
+    private val reservedStableIds = HashSet<Long>()
+    private val itemIds = ArrayList<Long>()
+    private var nextFallbackStableId = Long.MIN_VALUE
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(i: Int): Long = itemIds[i]
+
+    override fun setItems(items: List<PcViewModel.ComputerObject>?) {
+        val nextItems = normalizeItems(items.orEmpty())
+        val oldIds = itemIds.toList()
+        val newIds = assignStableIds(nextItems)
+
+        if (oldIds == newIds) {
+            itemList.clear()
+            itemList.addAll(nextItems)
+            itemIds.clear()
+            itemIds.addAll(newIds)
+            if (itemList.isNotEmpty()) {
+                notifyItemRangeChanged(0, itemList.size, SERVER_ROW_REFRESH_PAYLOAD)
+            }
+            return
+        }
+
+        val diff =
+            DiffUtil.calculateDiff(
+                object : DiffUtil.Callback() {
+                    override fun getOldListSize(): Int = oldIds.size
+
+                    override fun getNewListSize(): Int = newIds.size
+
+                    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                        oldIds[oldItemPosition] == newIds[newItemPosition]
+
+                    // ComputerObject instances are updated in place by PcViewModel, so retained
+                    // rows must rebind even when their identity and position stay the same.
+                    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = false
+
+                    override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any =
+                        SERVER_ROW_REFRESH_PAYLOAD
+                }
+            )
+
+        itemList.clear()
+        itemList.addAll(nextItems)
+        itemIds.clear()
+        itemIds.addAll(newIds)
+        diff.dispatchUpdatesTo(this)
+    }
+
+    private fun normalizeItems(items: List<PcViewModel.ComputerObject>): List<PcViewModel.ComputerObject> {
+        val seenObjects = IdentityHashMap<PcViewModel.ComputerObject, Boolean>(items.size)
+        val seenUuids = HashSet<String>(items.size)
+        return items.filter { computer ->
+            if (seenObjects.put(computer, true) != null) {
+                false
+            } else {
+                val uuid = computer.details.uuid.trim()
+                uuid.isEmpty() || seenUuids.add(uuid)
+            }
+        }
+    }
+
+    private fun assignStableIds(items: List<PcViewModel.ComputerObject>): List<Long> {
+        val assignedIds = HashSet<Long>(items.size)
+        return items.map { computer ->
+            val knownObjectId = stableIdsByObject[computer]
+            val id =
+                if (knownObjectId != null && knownObjectId !in assignedIds) {
+                    bindUuidIfAvailable(computer, knownObjectId)
+                    knownObjectId
+                } else {
+                    assignStableId(computer, assignedIds)
+                }
+            assignedIds.add(id)
+            id
+        }
+    }
+
+    private fun assignStableId(
+        computer: PcViewModel.ComputerObject,
+        assignedIds: Set<Long>,
+    ): Long {
+        val uuid = computer.details.uuid.trim()
+        val mappedUuidId = uuid.takeIf(String::isNotEmpty)?.let(stableIdsByUuid::get)
+        val id =
+            if (mappedUuidId != null && mappedUuidId !in assignedIds) {
+                mappedUuidId
+            } else if (uuid.isNotEmpty() && mappedUuidId == null) {
+                reserveUniqueId(stableServerId(uuid))
+            } else {
+                reserveFallbackId()
+            }
+
+        stableIdsByObject[computer] = id
+        updateUuidOwnership(computer, uuid, id)
+        return id
+    }
+
+    private fun bindUuidIfAvailable(computer: PcViewModel.ComputerObject, id: Long) {
+        val uuid = computer.details.uuid.trim()
+        updateUuidOwnership(computer, uuid, id)
+    }
+
+    private fun updateUuidOwnership(computer: PcViewModel.ComputerObject, uuid: String, id: Long) {
+        val previousUuid = uuidsByObject.put(computer, uuid)
+        if (!previousUuid.isNullOrEmpty() && previousUuid != uuid && stableIdsByUuid[previousUuid] == id) {
+            stableIdsByUuid.remove(previousUuid)
+        }
+
+        if (uuid.isNotEmpty() && uuid !in stableIdsByUuid) {
+            stableIdsByUuid[uuid] = id
+        }
+    }
+
+    private fun reserveFallbackId(): Long {
+        val id = reserveUniqueId(nextFallbackStableId)
+        nextFallbackStableId = id + 1
+        return id
+    }
+
+    private fun reserveUniqueId(candidate: Long): Long {
+        var id = candidate
+        while (!reservedStableIds.add(id)) {
+            id++
+        }
+        return id
+    }
+
     fun updateLayoutWithPreferences(context: Context, prefs: PreferenceConfiguration) {
         // This will trigger the view to reload with the new layout.
         setLayoutId(getLayoutIdForPreferences(prefs))
     }
 
     fun addComputer(computer: PcViewModel.ComputerObject) {
-        itemList.add(computer)
-        sortList()
-    }
-
-    private fun sortList() {
-        itemList.sortWith { lhs, rhs ->
+        val updatedItems = itemList.toMutableList()
+        updatedItems.add(computer)
+        updatedItems.sortWith { lhs, rhs ->
             lhs.details.name.lowercase(Locale.getDefault())
                 .compareTo(rhs.details.name.lowercase(Locale.getDefault()))
         }
+        setItems(updatedItems)
     }
 
-    fun removeComputer(computer: PcViewModel.ComputerObject): Boolean = itemList.remove(computer)
+    fun removeComputer(computer: PcViewModel.ComputerObject): Boolean {
+        val updatedItems = itemList.toMutableList()
+        if (!updatedItems.remove(computer)) {
+            return false
+        }
+        setItems(updatedItems)
+        return true
+    }
+
+    override fun clear() {
+        setItems(emptyList())
+    }
 
     /** Cached references for PcView-specific views (status dot + text). */
     private class PcViewHolder {
@@ -249,7 +394,17 @@ class PcGridAdapter(
 
     companion object {
         private const val TAG_PC_HOLDER = R.id.status_dot
+        private val SERVER_ROW_REFRESH_PAYLOAD = Any()
 
         private fun getLayoutIdForPreferences(prefs: PreferenceConfiguration): Int = R.layout.pc_grid_item
     }
+}
+
+private fun stableServerId(uuid: String): Long {
+    var hash = -3750763034362895579L
+    for (character in uuid) {
+        hash = hash xor character.code.toLong()
+        hash *= 1099511628211L
+    }
+    return hash
 }

--- a/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
+++ b/app/src/main/java/com/papi/nova/grid/PcGridAdapter.kt
@@ -11,6 +11,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
 import com.papi.nova.PcViewModel
 import com.papi.nova.R
 import com.papi.nova.nvstream.http.ComputerDetails
@@ -24,8 +25,9 @@ class PcGridAdapter(
     context: Context,
     prefs: PreferenceConfiguration
 ) : GenericGridAdapter<PcViewModel.ComputerObject>(context, getLayoutIdForPreferences(prefs)) {
-    private val stableIdsByObject = IdentityHashMap<PcViewModel.ComputerObject, Long>()
-    private val uuidsByObject = IdentityHashMap<PcViewModel.ComputerObject, String>()
+    // PcViewModel and ComputerDetails treat a nonblank UUID as the logical host identity.
+    // Object identity is only a provisional fallback until discovery supplies that UUID.
+    private val provisionalIdsByObject = IdentityHashMap<PcViewModel.ComputerObject, Long>()
     private val stableIdsByUuid = HashMap<String, Long>()
     private val reservedStableIds = HashSet<Long>()
     private val itemIds = ArrayList<Long>()
@@ -92,56 +94,24 @@ class PcGridAdapter(
         }
     }
 
-    private fun assignStableIds(items: List<PcViewModel.ComputerObject>): List<Long> {
-        val assignedIds = HashSet<Long>(items.size)
-        return items.map { computer ->
-            val knownObjectId = stableIdsByObject[computer]
-            val id =
-                if (knownObjectId != null && knownObjectId !in assignedIds) {
-                    bindUuidIfAvailable(computer, knownObjectId)
-                    knownObjectId
-                } else {
-                    assignStableId(computer, assignedIds)
-                }
-            assignedIds.add(id)
-            id
-        }
-    }
+    private fun assignStableIds(items: List<PcViewModel.ComputerObject>): List<Long> =
+        items.map(::stableIdFor)
 
-    private fun assignStableId(
-        computer: PcViewModel.ComputerObject,
-        assignedIds: Set<Long>,
-    ): Long {
+    private fun stableIdFor(computer: PcViewModel.ComputerObject): Long {
         val uuid = computer.details.uuid.trim()
-        val mappedUuidId = uuid.takeIf(String::isNotEmpty)?.let(stableIdsByUuid::get)
-        val id =
-            if (mappedUuidId != null && mappedUuidId !in assignedIds) {
-                mappedUuidId
-            } else if (uuid.isNotEmpty() && mappedUuidId == null) {
-                reserveUniqueId(stableServerId(uuid))
-            } else {
-                reserveFallbackId()
-            }
+        if (uuid.isEmpty()) {
+            return provisionalIdsByObject.getOrPut(computer, ::reserveFallbackId)
+        }
 
-        stableIdsByObject[computer] = id
-        updateUuidOwnership(computer, uuid, id)
+        val existingId = stableIdsByUuid[uuid]
+        if (existingId != null) {
+            provisionalIdsByObject.remove(computer)
+            return existingId
+        }
+
+        val id = provisionalIdsByObject.remove(computer) ?: reserveUniqueId(stableServerId(uuid))
+        stableIdsByUuid[uuid] = id
         return id
-    }
-
-    private fun bindUuidIfAvailable(computer: PcViewModel.ComputerObject, id: Long) {
-        val uuid = computer.details.uuid.trim()
-        updateUuidOwnership(computer, uuid, id)
-    }
-
-    private fun updateUuidOwnership(computer: PcViewModel.ComputerObject, uuid: String, id: Long) {
-        val previousUuid = uuidsByObject.put(computer, uuid)
-        if (!previousUuid.isNullOrEmpty() && previousUuid != uuid && stableIdsByUuid[previousUuid] == id) {
-            stableIdsByUuid.remove(previousUuid)
-        }
-
-        if (uuid.isNotEmpty() && uuid !in stableIdsByUuid) {
-            stableIdsByUuid[uuid] = id
-        }
     }
 
     private fun reserveFallbackId(): Long {
@@ -152,7 +122,7 @@ class PcGridAdapter(
 
     private fun reserveUniqueId(candidate: Long): Long {
         var id = candidate
-        while (!reservedStableIds.add(id)) {
+        while (id == RecyclerView.NO_ID || !reservedStableIds.add(id)) {
             id++
         }
         return id

--- a/app/src/test/java/com/papi/nova/grid/KotlinGridAdaptersMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/grid/KotlinGridAdaptersMigrationTest.kt
@@ -293,31 +293,79 @@ class KotlinGridAdaptersMigrationTest {
         val firstDuplicate = createComputerObject("duplicate-server")
         val secondDuplicate = createComputerObject("duplicate-server")
         adapter.setItems(listOf(firstDuplicate, secondDuplicate))
+        val duplicateId = adapter.getItemId(0)
 
         assertEquals("duplicate logical hosts must only appear once", 1, adapter.itemCount)
+
+        adapter.setItems(
+            listOf(
+                createComputerObject("duplicate-server"),
+                createComputerObject("duplicate-server"),
+            )
+        )
+
+        assertEquals("replacement duplicates must still normalize to one row", 1, adapter.itemCount)
+        assertEquals("the normalized logical host must keep its stable ID", duplicateId, adapter.getItemId(0))
+
+        val known = createComputerObject("known-server")
+        adapter.setItems(listOf(known))
+        val knownId = adapter.getItemId(0)
+        val provisional = createComputerObject("").apply { details.uuid = "" }
+        adapter.setItems(listOf(provisional))
+        val provisionalId = adapter.getItemId(0)
+
+        provisional.details.uuid = known.details.uuid
+        adapter.setItems(listOf(provisional, known))
+
+        assertEquals("discovery collisions must normalize to one logical host", 1, adapter.itemCount)
+        assertEquals("the known UUID must retain ownership of its stable ID", knownId, adapter.getItemId(0))
+        assertTrue("the provisional ID must not displace a known UUID", provisionalId != adapter.getItemId(0))
     }
 
     @Test
-    fun pcGridAdapterTransfersUuidOwnershipWithoutAliasingIds() {
+    fun pcGridAdapterKeepsStableIdsBoundToLogicalUuids() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val adapter = PcGridAdapter(context, PreferenceConfiguration())
-        val retained = createComputerObject("server-a")
-        adapter.setItems(listOf(retained))
-        val retainedId = adapter.getItemId(0)
+        val serverA = createComputerObject("server-a")
+        val serverB = createComputerObject("server-b")
+        adapter.setItems(listOf(serverA, serverB))
+        val serverAId = adapter.getItemId(0)
+        val serverBId = adapter.getItemId(1)
 
-        retained.details.uuid = "server-b"
-        adapter.setItems(listOf(retained))
+        serverA.details.uuid = "server-b-uuid"
+        adapter.setItems(listOf(serverA, serverB))
 
-        assertEquals("the retained row should keep its ID after UUID discovery", retainedId, adapter.getItemId(0))
+        assertEquals("duplicate UUID normalization should retain one logical server", 1, adapter.itemCount)
+        assertEquals("the retained logical server-b row must keep server-b's ID", serverBId, adapter.getItemId(0))
 
-        val replacementForOldUuid = createComputerObject("server-a")
-        adapter.setItems(listOf(replacementForOldUuid, retained))
+        val replacementA = createComputerObject("server-a")
+        val replacementB = createComputerObject("server-b")
+        adapter.setItems(listOf(replacementA, replacementB))
 
-        assertTrue(
-            "the old UUID must not remain aliased to the retained row ID",
-            adapter.getItemId(0) != retainedId,
-        )
-        assertEquals(retainedId, adapter.getItemId(1))
+        assertEquals("server-a must retain its UUID-owned ID", serverAId, adapter.getItemId(0))
+        assertEquals("server-b replacements must retain their UUID-owned ID", serverBId, adapter.getItemId(1))
+        assertTrue("logical UUIDs must never alias the same stable ID", adapter.getItemId(0) != adapter.getItemId(1))
+    }
+
+    @Test
+    fun pcGridAdapterTreatsNonblankUuidChangesAsNewLogicalServers() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val adapter = PcGridAdapter(context, PreferenceConfiguration())
+        val original = createComputerObject("server-a")
+        adapter.setItems(listOf(original))
+        val serverAId = adapter.getItemId(0)
+
+        original.details.uuid = "server-c-uuid"
+        adapter.setItems(listOf(original))
+        val serverCId = adapter.getItemId(0)
+
+        assertTrue("a different nonblank UUID must not inherit server-a's ID", serverAId != serverCId)
+
+        val replacementA = createComputerObject("server-a")
+        adapter.setItems(listOf(replacementA, original))
+
+        assertEquals(serverAId, adapter.getItemId(0))
+        assertEquals(serverCId, adapter.getItemId(1))
     }
 
     private fun createAdapter(): AppGridAdapter {

--- a/app/src/test/java/com/papi/nova/grid/KotlinGridAdaptersMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/grid/KotlinGridAdaptersMigrationTest.kt
@@ -177,9 +177,147 @@ class KotlinGridAdaptersMigrationTest {
 
         assertEquals(alpha, adapter.getItem(0))
         assertEquals(beta, adapter.getItem(1))
+        val betaId = adapter.getItemId(1)
         assertTrue(adapter.removeComputer(alpha))
         assertEquals(beta, adapter.getItem(0))
+        assertEquals(betaId, adapter.getItemId(0))
         assertFalse(adapter.removeComputer(alpha))
+
+        adapter.clear()
+        assertEquals(0, adapter.itemCount)
+        adapter.addComputer(beta)
+        assertEquals(betaId, adapter.getItemId(0))
+        assertTrue(adapter.removeComputer(beta))
+        assertEquals(0, adapter.itemCount)
+    }
+
+    @Test
+    fun pcGridAdapterRefreshesKnownServersWithoutReplacingWholeList() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val adapter = PcGridAdapter(context, PreferenceConfiguration())
+        val alpha = createComputerObject("server-alpha")
+        val beta = createComputerObject("server-beta")
+        adapter.setItems(listOf(alpha, beta))
+
+        var wholeListRefreshes = 0
+        var changedItems = 0
+        var payloadChanges = 0
+        adapter.registerAdapterDataObserver(
+            object : RecyclerView.AdapterDataObserver() {
+                override fun onChanged() {
+                    wholeListRefreshes++
+                }
+
+                override fun onItemRangeChanged(
+                    positionStart: Int,
+                    itemCount: Int,
+                    payload: Any?,
+                ) {
+                    changedItems += itemCount
+                    if (payload != null) {
+                        payloadChanges += itemCount
+                    }
+                }
+            }
+        )
+
+        val refreshedAlpha = createComputerObject("server-alpha").apply {
+            details.state = ComputerDetails.State.ONLINE
+        }
+        val refreshedBeta = createComputerObject("server-beta").apply {
+            details.state = ComputerDetails.State.OFFLINE
+        }
+        adapter.setItems(listOf(refreshedAlpha, refreshedBeta))
+
+        assertEquals("poll refresh should not replace every server row", 0, wholeListRefreshes)
+        assertEquals("retained rows should still rebind their latest status", 2, changedItems)
+        assertEquals("poll refresh should reuse existing focused holders", 2, payloadChanges)
+        assertEquals(refreshedAlpha, adapter.getItem(0))
+        assertEquals(refreshedBeta, adapter.getItem(1))
+    }
+
+    @Test
+    fun pcGridAdapterUsesServerIdentityForStableIds() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val adapter = PcGridAdapter(context, PreferenceConfiguration())
+        val alpha = createComputerObject("server-alpha")
+        val beta = createComputerObject("server-beta")
+        adapter.setItems(listOf(alpha, beta))
+        val alphaId = adapter.getItemId(0)
+        val betaId = adapter.getItemId(1)
+
+        val refreshedBeta = createComputerObject("server-beta")
+        val refreshedAlpha = createComputerObject("server-alpha")
+        adapter.setItems(listOf(refreshedBeta, refreshedAlpha))
+
+        assertTrue("server rows should advertise stable IDs", adapter.hasStableIds())
+        assertEquals(betaId, adapter.getItemId(0))
+        assertEquals(alphaId, adapter.getItemId(1))
+    }
+
+    @Test
+    fun pcGridAdapterKeepsFallbackIdsUniqueAndStable() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val adapter = PcGridAdapter(context, PreferenceConfiguration())
+        val firstBlank = createComputerObject("").apply {
+            details.uuid = ""
+            details.name = "Duplicate"
+        }
+        val secondBlank = createComputerObject("").apply {
+            details.uuid = ""
+            details.name = "Duplicate"
+        }
+        adapter.setItems(listOf(firstBlank, secondBlank))
+        val firstBlankId = adapter.getItemId(0)
+        val secondBlankId = adapter.getItemId(1)
+
+        assertTrue("blank UUID rows must still have unique IDs", firstBlankId != secondBlankId)
+
+        firstBlank.details.name = "Renamed"
+        firstBlank.details.uuid = "discovered-server"
+        adapter.setItems(listOf(firstBlank, secondBlank))
+
+        assertEquals("a retained provisional row must keep its ID after discovery", firstBlankId, adapter.getItemId(0))
+        assertEquals(secondBlankId, adapter.getItemId(1))
+
+        val repeatedBlank = createComputerObject("").apply { details.uuid = "" }
+        adapter.setItems(listOf(repeatedBlank, repeatedBlank))
+        val repeatedBlankId = adapter.getItemId(0)
+
+        assertEquals("the same row object must only appear once", 1, adapter.itemCount)
+
+        adapter.setItems(listOf(repeatedBlank, repeatedBlank))
+
+        assertEquals(repeatedBlankId, adapter.getItemId(0))
+
+        val firstDuplicate = createComputerObject("duplicate-server")
+        val secondDuplicate = createComputerObject("duplicate-server")
+        adapter.setItems(listOf(firstDuplicate, secondDuplicate))
+
+        assertEquals("duplicate logical hosts must only appear once", 1, adapter.itemCount)
+    }
+
+    @Test
+    fun pcGridAdapterTransfersUuidOwnershipWithoutAliasingIds() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val adapter = PcGridAdapter(context, PreferenceConfiguration())
+        val retained = createComputerObject("server-a")
+        adapter.setItems(listOf(retained))
+        val retainedId = adapter.getItemId(0)
+
+        retained.details.uuid = "server-b"
+        adapter.setItems(listOf(retained))
+
+        assertEquals("the retained row should keep its ID after UUID discovery", retainedId, adapter.getItemId(0))
+
+        val replacementForOldUuid = createComputerObject("server-a")
+        adapter.setItems(listOf(replacementForOldUuid, retained))
+
+        assertTrue(
+            "the old UUID must not remain aliased to the retained row ID",
+            adapter.getItemId(0) != retainedId,
+        )
+        assertEquals(retainedId, adapter.getItemId(1))
     }
 
     private fun createAdapter(): AppGridAdapter {


### PR DESCRIPTION
## Summary

- preserve server-row identity across periodic host polling instead of replacing the entire RecyclerView dataset
- bind each nonblank UUID permanently to one collision-checked stable ID; use object identity only as a provisional fallback while UUID is blank
- normalize duplicate logical hosts before diffing so every emitted RecyclerView ID remains unique
- force retained-row rebinds through a non-null payload so RecyclerView reuses the focused holder
- keep adapter IDs synchronized across add, remove, clear, replacement-object, blank-to-UUID, duplicate-UUID, and nonblank-UUID-change paths
- add regression coverage for wholesale refreshes, holder-reuse payloads, stable IDs, provisional IDs, UUID ownership collisions, and list mutators

Closes #164

## Testing

- [x] I tested the affected build, pairing, stream, input, or UI path.
  - `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug testNonRoot_gameDebugUnitTest` — 941 JVM tests, 0 failures/errors/skips
  - `python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight` — 51 tests passed
  - `./gradlew -PnovaAbis=arm64-v8a assembleNonRoot_gameDebug`
  - focused RED/GREEN coverage in `KotlinGridAdaptersMigrationTest`
- [ ] I tested on a real device or emulator when the change affects Android behavior.
  - No Android device was attached to pc-papi. The reporter's recording was used to correlate the periodic focus jumps with polling-driven adapter refreshes.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
  - No visual styling changed; the issue already includes a reproduction recording.
- [ ] I updated docs or release notes when user-facing behavior changed.
  - No documentation or release-note change is needed for this focused bug fix.

## Notes

- No changes to pairing, certificate handling, discovery, exported Android components, input event translation, or Moonlight-core integration.
- The ARM64 debug APK built successfully; SHA-256: `6fe7289ccc0b18f2bc6ba3bc3b2f7ce903cc8b4fcecaf3a2dca89ae0750ff1d2`.
