### PR TITLE
Fix companion controls when streaming to external display

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,6 +166,14 @@
             android:noHistory="true"
             android:resizeableActivity="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
+        <activity android:name=".utils.ExternalDisplayControlActivity"
+            android:exported="false"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:taskAffinity=""
+            android:resizeableActivity="true"
+            android:theme="@style/ExternalDisplayControllerTheme"/>
         <activity
             android:name=".preferences.StreamSettings"
             android:resizeableActivity="true"

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -53,8 +53,11 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.papi.nova.utils.Dialog
 import com.papi.nova.utils.DeviceUtils
 import com.papi.nova.utils.DisplayFocusTelemetry
+import com.papi.nova.utils.CompanionControlHostPolicy
 import com.papi.nova.utils.CompanionControlLifecyclePolicy
 import com.papi.nova.utils.DualScreenQuickMenuPolicy
+import com.papi.nova.utils.ExternalDisplayControlActivity
+import com.papi.nova.utils.ExternalDisplayControlHost
 import com.papi.nova.utils.ExternalDisplayControlPresentation
 import com.papi.nova.utils.GameDisplayLaunchTrampolineActivity
 import com.papi.nova.utils.MouseModeOption
@@ -231,7 +234,7 @@ private var companionControlDisplayId:Int = INVALID_DISPLAY_ID
 private var companionControlHasWindowFocus:Boolean = false
 private var lastQuickMenuInteractionDisplayId:Int = INVALID_DISPLAY_ID
 private var isTopResumedActivity:Boolean = false
-private var externalDisplayControlPresentation:ExternalDisplayControlPresentation? = null
+private var externalDisplayControlPresentation:ExternalDisplayControlHost? = null
 private var externalDisplayListener:DisplayManager.DisplayListener? = null
 @Volatile private var lastClientPresentationRefreshRate:Float = 0f
 @Volatile private var lastClientPresentationDisplayModeId:Int = 0
@@ -452,10 +455,19 @@ val companionDisplay:Display? = getCompanionControlDisplay()
 if (::prefConfig.isInitialized && prefConfig.enableFullExDisplay && companionDisplay != null)
 {
 val companionDisplayId:Int = companionDisplay.getDisplayId()
-val currentPresentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
-if (currentPresentation == null || !currentPresentation.isShowing || companionControlDisplayId != companionDisplayId)
+val currentPresentation:ExternalDisplayControlHost? = externalDisplayControlPresentation
+if (currentPresentation == null || !currentPresentation.isHostShowing() || companionControlDisplayId != companionDisplayId)
 {
 currentPresentation?.dismissAfterCurrentCallback()
+when (CompanionControlHostPolicy.select(companionDisplayId)) {
+CompanionControlHostPolicy.HostType.ACTIVITY -> {
+externalDisplayControlPresentation = null
+companionControlDisplayId = companionDisplayId
+companionControlHasWindowFocus = false
+ExternalDisplayControlActivity.launch(this, companionDisplayId)
+ExternalDisplayControlPresentation.ensureCompanionControlsNotification(this)
+}
+CompanionControlHostPolicy.HostType.PRESENTATION -> {
 val presentation = ExternalDisplayControlPresentation(this, companionDisplay)
 presentation.setOnDismissListener {
 if (externalDisplayControlPresentation === presentation)
@@ -494,6 +506,8 @@ companionControlHasWindowFocus = false
 LimeLog.warning("Nova: Android companion presentation unavailable display_id=$companionDisplayId")
 }
 }
+}
+}
 listenForExternalDisplayRemoval()
 }
 }
@@ -506,6 +520,40 @@ closeCompanionControls()
 return@runOnUiThread
 }
 launchCompanionControlsIfAvailable()
+}
+}
+
+fun attachExternalDisplayControlActivity(activity:ExternalDisplayControlActivity):Boolean {
+if (!CompanionControlLifecyclePolicy.canShow(isStreamActive, isFinishing(), isDestroyed))
+{
+return false
+}
+val companionDisplayId = getCompanionControlDisplay()?.displayId ?: return false
+if (companionDisplayId != Display.DEFAULT_DISPLAY)
+{
+return false
+}
+externalDisplayControlPresentation = activity
+companionControlDisplayId = companionDisplayId
+companionControlHasWindowFocus = false
+return true
+}
+
+fun detachExternalDisplayControlActivity(activity:ExternalDisplayControlActivity) {
+if (externalDisplayControlPresentation === activity)
+{
+val shouldMigrateOpenMenu = activity.shouldMigrateOpenMenuToStream(canMigrateCompanionMenuToStream())
+externalDisplayControlPresentation = null
+if (lastQuickMenuInteractionDisplayId == companionControlDisplayId)
+{
+lastQuickMenuInteractionDisplayId = streamingDisplayId
+}
+companionControlDisplayId = INVALID_DISPLAY_ID
+companionControlHasWindowFocus = false
+if (shouldMigrateOpenMenu)
+{
+showQuickMenuOnStreamAfterCompanionClose()
+}
 }
 }
 
@@ -1580,7 +1628,7 @@ LimeLog.info("Nova: Android companion quick menu migrated to stream after compan
 private fun closeCompanionControls(migrateOpenMenuToStream:Boolean = false) {
 NotificationManagerCompat.from(baseContext)
 .cancel(ExternalDisplayControlPresentation.SECONDARY_SCREEN_NOTIFICATION_ID)
-val presentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
+val presentation:ExternalDisplayControlHost? = externalDisplayControlPresentation
 val shouldMigrateOpenMenu = migrateOpenMenuToStream &&
 DualScreenQuickMenuPolicy.shouldMigrateCompanionMenu(
 presentation?.isGameMenuOpen() == true,
@@ -1706,7 +1754,7 @@ return
 keyBoardController!!.toggleVisibility()
 }
  fun toggleFullKeyboard() {
-if (externalDisplayControlPresentation?.isShowing == true)
+if (externalDisplayControlPresentation?.isHostShowing() == true)
 {
 externalDisplayControlPresentation?.toggleFullKeyboard()
 return
@@ -3439,7 +3487,7 @@ return null
 }
 }
 override fun toggleKeyboard() {
-if (externalDisplayControlPresentation?.isShowing == true)
+if (externalDisplayControlPresentation?.isHostShowing() == true)
 {
 externalDisplayControlPresentation?.toggleKeyboard()
 }
@@ -6237,8 +6285,8 @@ Handler(Looper.getMainLooper()).postDelayed({ GameDisplayLaunchTrampolineActivit
 overridePendingTransition(0, 0) }, 900)
 }
  fun quit() {
-val companionPresentation:ExternalDisplayControlPresentation? = externalDisplayControlPresentation
-?.takeIf { it.isShowing }
+val companionPresentation:ExternalDisplayControlHost? = externalDisplayControlPresentation
+?.takeIf { it.isHostShowing() }
 val context:Context = companionPresentation?.companionDialogContext ?: this
 
 val sheet = BottomSheetDialog(context)

--- a/app/src/main/java/com/papi/nova/utils/CompanionControlHostPolicy.kt
+++ b/app/src/main/java/com/papi/nova/utils/CompanionControlHostPolicy.kt
@@ -1,0 +1,19 @@
+package com.papi.nova.utils
+
+import android.view.Display
+
+object CompanionControlHostPolicy {
+    enum class HostType {
+        PRESENTATION,
+        ACTIVITY,
+    }
+
+    @JvmStatic
+    fun select(displayId: Int): HostType {
+        return if (displayId == Display.DEFAULT_DISPLAY) {
+            HostType.ACTIVITY
+        } else {
+            HostType.PRESENTATION
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt
@@ -1,0 +1,248 @@
+package com.papi.nova.utils
+
+import android.app.Activity
+import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.os.Bundle
+import android.os.IBinder
+import android.view.Display
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.view.Window
+import android.view.WindowManager
+import com.papi.nova.Game
+import com.papi.nova.R
+import com.papi.nova.StartExternalDisplayControlReceiver
+import com.papi.nova.binding.input.GameInputDevice
+
+class ExternalDisplayControlActivity : Activity(),
+    ExternalDisplayControlHost {
+
+    private lateinit var controller: ExternalDisplayControlController
+    private var owningGame: Game? = null
+    private var registeredWithGame = false
+    private var softKeyboardFocusLeaseActive = false
+    private var softKeyboardWasVisible = false
+
+    override val game: Game
+        get() = requireNotNull(owningGame ?: Game.instance)
+
+    override val controlDisplay: Display
+        get() {
+            val currentDisplay = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                this@ExternalDisplayControlActivity.getDisplay()
+            } else {
+                @Suppress("DEPRECATION")
+                windowManager.defaultDisplay
+            }
+            val displayManager = getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            return currentDisplay ?: requireNotNull(displayManager.getDisplay(Display.DEFAULT_DISPLAY))
+        }
+
+    override val hostContext: Context
+        get() = this
+
+    override val hostWindow: Window
+        get() = window
+
+    override val companionDialogContext: Context
+        get() = this
+
+    override val companionDialogWindowType: Int
+        get() = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
+
+    override fun companionDialogWindowToken(): IBinder? = window.decorView.windowToken
+
+    override fun setControllerContentView(view: View) {
+        setContentView(view)
+    }
+
+    override fun isHostShowing(): Boolean = !isFinishing && !isDestroyed
+
+    override fun dismissHost() {
+        finish()
+        overridePendingTransition(0, 0)
+    }
+
+    override fun cancelHost() {
+        finish()
+        overridePendingTransition(0, 0)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(R.style.ExternalDisplayControllerTheme)
+        window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+        super.onCreate(savedInstanceState)
+
+        val currentGame = Game.instance
+        if (currentGame == null || currentGame.isFinishing) {
+            finish()
+            overridePendingTransition(0, 0)
+            return
+        }
+        owningGame = currentGame
+
+        controller = ExternalDisplayControlController(this)
+        controller.onCreate()
+        if (!attachToOwningGameIfNeeded()) {
+            finish()
+            overridePendingTransition(0, 0)
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (!attachToOwningGameIfNeeded()) {
+            finish()
+            overridePendingTransition(0, 0)
+            return
+        }
+        if (::controller.isInitialized) {
+            controller.onStart()
+        }
+    }
+
+    override fun onStop() {
+        releaseSoftKeyboardFocus()
+        if (::controller.isInitialized) {
+            controller.onStop()
+        }
+        if (registeredWithGame) {
+            owningGame?.detachExternalDisplayControlActivity(this)
+            registeredWithGame = false
+        }
+        super.onStop()
+    }
+
+    private fun attachToOwningGameIfNeeded(): Boolean {
+        if (registeredWithGame) return true
+        val currentGame = owningGame ?: return false
+        if (currentGame.isFinishing || currentGame.isDestroyed) return false
+        if (!currentGame.attachExternalDisplayControlActivity(this)) return false
+        registeredWithGame = true
+        return true
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (::controller.isInitialized) {
+            controller.onWindowFocusChanged(hasFocus)
+        }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        if (::controller.isInitialized) {
+            controller.handleCompanionBack()
+        } else {
+            finish()
+            overridePendingTransition(0, 0)
+        }
+    }
+
+    override fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        return controller.onGenericMotionEvent(event)
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        return controller.onKeyDown(event)
+    }
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+        return controller.onKeyUp(event)
+    }
+
+    override fun onKeyMultiple(keyCode: Int, repeatCount: Int, event: KeyEvent): Boolean {
+        return controller.onKeyMultiple(keyCode, repeatCount, event)
+    }
+
+    override fun dismissAfterCurrentCallback() {
+        controller.dismissAfterCurrentCallback()
+    }
+
+    override fun handleBackFromOwningGame(): Boolean = controller.handleBackFromOwningGame()
+
+    override fun toggleZoomMode(callGame: Boolean) {
+        controller.toggleZoomMode(callGame)
+    }
+
+    override fun isCompanionDisplayAvailable(): Boolean {
+        return controller.isCompanionDisplayAvailable()
+    }
+
+    override fun shouldMigrateOpenMenuToStream(streamAvailable: Boolean): Boolean {
+        return controller.shouldMigrateOpenMenuToStream(streamAvailable)
+    }
+
+    override fun showGameMenuOnCompanion(device: GameInputDevice?): Boolean {
+        return controller.showGameMenuOnCompanion(device)
+    }
+
+    override fun hideGameMenu() {
+        controller.hideGameMenu()
+    }
+
+    override fun isGameMenuOpen(): Boolean {
+        return controller.isGameMenuOpen()
+    }
+
+    override fun prepareForSoftKeyboard() {
+        if (softKeyboardFocusLeaseActive) return
+        softKeyboardFocusLeaseActive = true
+        softKeyboardWasVisible = false
+        window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+    }
+
+    override fun onSoftKeyboardVisibilityChanged(imeVisible: Boolean) {
+        if (!softKeyboardFocusLeaseActive) return
+        if (imeVisible) {
+            softKeyboardWasVisible = true
+        } else if (softKeyboardWasVisible) {
+            releaseSoftKeyboardFocus()
+        }
+    }
+
+    override fun releaseSoftKeyboardFocus() {
+        if (!softKeyboardFocusLeaseActive) return
+        softKeyboardFocusLeaseActive = false
+        softKeyboardWasVisible = false
+        window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+    }
+
+    override fun toggleKeyboard() {
+        controller.toggleKeyboard()
+    }
+
+    override fun toggleFullKeyboard() {
+        controller.toggleFullKeyboard()
+    }
+
+    override fun toggleGameMenu() {
+        controller.toggleGameMenu()
+    }
+
+    companion object {
+        @JvmStatic
+        fun launch(game: Game, displayId: Int) {
+            val intent = Intent(game, ExternalDisplayControlActivity::class.java)
+                .addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_NO_ANIMATION or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val options = ActivityOptions.makeBasic()
+                options.setLaunchDisplayId(displayId)
+                game.startActivity(intent, options.toBundle())
+            } else {
+                game.startActivity(intent)
+            }
+            game.overridePendingTransition(0, 0)
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt
@@ -1,0 +1,545 @@
+package com.papi.nova.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.view.inputmethod.InputMethodManager
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.LinearLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import com.papi.nova.GameMenu
+import com.papi.nova.LimeLog
+import com.papi.nova.R
+import com.papi.nova.StartExternalDisplayControlReceiver
+import com.papi.nova.binding.input.GameInputDevice
+import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardLayoutController
+import com.papi.nova.preferences.PreferenceConfiguration
+import com.papi.nova.ui.ExternalControllerView
+
+private const val SOFT_KEYBOARD_SHOW_MAX_ATTEMPTS = 3
+private const val SOFT_KEYBOARD_SHOW_RETRY_MILLIS = 100L
+private const val SOFT_KEYBOARD_VISIBILITY_TIMEOUT_MILLIS = 1_500L
+
+class ExternalDisplayControlController(
+    private val host: ExternalDisplayControlHost,
+) : View.OnKeyListener,
+    KeyBoardLayoutController.ViewCallbacks {
+
+    private val game = host.game
+    private val display = host.controlDisplay
+    private val context = host.hostContext
+    private val controllerWindow = host.hostWindow
+
+    private lateinit var prefConfig: PreferenceConfiguration
+    private lateinit var rootLayout: ExternalControllerView
+    private lateinit var zoomButton: ImageButton
+    private var keyBoardLayoutController: KeyBoardLayoutController? = null
+
+    private var isKeyboardVisible = false
+    private var softKeyboardShowPending = false
+    private var softKeyboardShowAttempts = 0
+    private var softKeyboardShowAccepted = false
+    private var softKeyboardWasVisible = false
+    private var transientStateDisposed = false
+    private var dismissalRequestedByNova = false
+    private var menuOpenAtDisposal = false
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var dimScreenRunnable = Runnable {}
+    private var originalBrightness = -1f
+
+    private var gameMenu: GameMenu? = null
+
+    fun onCreate() {
+        prefConfig = PreferenceConfiguration.readPreferences(context)
+        initViews()
+    }
+
+    private fun initViews() {
+        val windowInsetsController = WindowCompat.getInsetsController(controllerWindow, controllerWindow.decorView)
+
+        windowInsetsController.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+
+        windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        windowInsetsController.hide(WindowInsetsCompat.Type.navigationBars())
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowCompat.setDecorFitsSystemWindows(controllerWindow, false)
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(controllerWindow.decorView) { view, insets ->
+            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+            if (softKeyboardShowAccepted) {
+                if (imeVisible) {
+                    softKeyboardWasVisible = true
+                    host.onSoftKeyboardVisibilityChanged(true)
+                } else if (softKeyboardWasVisible) {
+                    host.onSoftKeyboardVisibilityChanged(false)
+                    softKeyboardShowAccepted = false
+                    softKeyboardWasVisible = false
+                }
+            }
+            updateKeyboardVisibility(
+                imeVisible ||
+                    (keyBoardLayoutController != null && keyBoardLayoutController!!.isKeyboardVisible()),
+            )
+            ViewCompat.onApplyWindowInsets(view, insets)
+        }
+
+        initializeComponents()
+        createProgrammaticUI()
+        initTouchEventHandling()
+        setupInactivityTimeoutForBrightness()
+        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initTouchEventHandling() {
+        rootLayout.setOnTouchListener { view, event ->
+            handleUserActivity()
+            game.handleMotionEvent(view, event)
+            true
+        }
+    }
+
+    fun onStart() {
+        transientStateDisposed = false
+        dismissalRequestedByNova = false
+        menuOpenAtDisposal = false
+        resetInactivityTimer()
+        if (game.isFinishing) {
+            dismissAfterCurrentCallback()
+        }
+    }
+
+    fun dismissAfterCurrentCallback() {
+        dismissalRequestedByNova = true
+        transientStateDisposed = true
+        handler.post {
+            if (host.isHostShowing()) {
+                host.dismissHost()
+            }
+        }
+    }
+
+    fun cancel() {
+        dismissalRequestedByNova = true
+        transientStateDisposed = true
+        handler.post {
+            if (host.isHostShowing()) {
+                host.cancelHost()
+            }
+        }
+    }
+
+    private fun disposeTransientState() {
+        menuOpenAtDisposal = menuOpenAtDisposal || gameMenu?.isMenuOpen() == true
+        transientStateDisposed = true
+        gameMenu?.hideMenu()
+        handler.removeCallbacksAndMessages(null)
+        restoreBrightnessIfNeeded()
+    }
+
+    fun disposeAfterFailedShow() {
+        dismissalRequestedByNova = true
+        disposeTransientState()
+    }
+
+    fun onStop() {
+        cancelPendingSoftKeyboardShow()
+        softKeyboardShowAccepted = false
+        softKeyboardWasVisible = false
+        host.releaseSoftKeyboardFocus()
+        disposeTransientState()
+    }
+
+    override fun onKeyboardControllerVisibilityChange(visible: Boolean) {
+        updateKeyboardVisibility(visible)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setupInactivityTimeoutForBrightness() {
+        originalBrightness = controllerWindow.attributes.screenBrightness
+
+        dimScreenRunnable = Runnable {
+            if (
+                CompanionScreenDimmingPolicy.shouldDimNow(
+                    keyboardVisible = isKeyboardVisible,
+                    quickMenuOpen = gameMenu?.isMenuOpen() == true,
+                )
+            ) {
+                val layout = controllerWindow.attributes
+                layout.screenBrightness = 0.0f
+                controllerWindow.attributes = layout
+            } else {
+                resetInactivityTimer()
+            }
+        }
+
+        resetInactivityTimer()
+    }
+
+    private fun updateKeyboardVisibility(visible: Boolean) {
+        if (isKeyboardVisible != visible) {
+            isKeyboardVisible = visible
+            if (isKeyboardVisible) {
+                handler.removeCallbacks(dimScreenRunnable)
+                restoreBrightnessIfNeeded()
+            } else {
+                resetInactivityTimer()
+            }
+        }
+    }
+
+    private fun restoreBrightnessIfNeeded() {
+        val layout = controllerWindow.attributes
+        if (layout.screenBrightness == 0.0f) {
+            layout.screenBrightness = originalBrightness
+            controllerWindow.attributes = layout
+        }
+    }
+
+    private fun handleUserActivity() {
+        if (transientStateDisposed) return
+        restoreBrightnessIfNeeded()
+        resetInactivityTimer()
+    }
+
+    private fun resetInactivityTimer() {
+        handler.removeCallbacks(dimScreenRunnable)
+        if (!isKeyboardVisible) {
+            CompanionScreenDimmingPolicy.delayMillis(prefConfig.companionScreenDimTimeoutSeconds)?.let { delay ->
+                handler.postDelayed(dimScreenRunnable, delay)
+            }
+        }
+    }
+
+    fun onWindowFocusChanged(hasFocus: Boolean) {
+        game.logCompanionDisplayFocus(display.displayId, hasFocus)
+        if (hasFocus) {
+            showPendingSoftKeyboardIfReady()
+        }
+        if (game.isFinishing) {
+            dismissAfterCurrentCallback()
+        }
+    }
+
+    fun handleCompanionBack() {
+        if (game.isKeyboardLayoutVisible) {
+            toggleFullKeyboard()
+        } else if (!game.handleQuickMenuBackFromDisplay(display.displayId)) {
+            cancel()
+        }
+    }
+
+    fun handleBackFromOwningGame(): Boolean {
+        if (!isCompanionDisplayAvailable()) return false
+        handleCompanionBack()
+        return true
+    }
+
+    private fun initializeComponents() {
+        gameMenu = GameMenu(
+            game,
+            host.companionDialogContext,
+            host.companionDialogWindowType,
+            host::companionDialogWindowToken,
+        ).also {
+            it.setOnMenuDismissedListener(::handleUserActivity)
+        }
+    }
+
+    fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        game.recordQuickMenuInteraction(display.displayId)
+        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        return game.onGenericMotionEvent(event)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onKey(view: View, keyCode: Int, keyEvent: KeyEvent): Boolean {
+        game.recordQuickMenuInteraction(display.displayId)
+        if (keyEvent.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        }
+        return when (keyEvent.action) {
+            KeyEvent.ACTION_DOWN -> game.handleKeyDown(keyEvent)
+            KeyEvent.ACTION_UP -> game.handleKeyUp(keyEvent)
+            KeyEvent.ACTION_MULTIPLE -> game.handleKeyMultiple(keyEvent)
+            else -> false
+        }
+    }
+
+    fun onKeyDown(event: KeyEvent): Boolean {
+        game.recordQuickMenuInteraction(display.displayId)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        }
+        return game.onKeyDown(event.keyCode, event)
+    }
+
+    fun onKeyUp(event: KeyEvent): Boolean {
+        game.recordQuickMenuInteraction(display.displayId)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        }
+        return game.onKeyUp(event.keyCode, event)
+    }
+
+    fun onKeyMultiple(keyCode: Int, repeatCount: Int, event: KeyEvent): Boolean {
+        game.recordQuickMenuInteraction(display.displayId)
+        if (event.deviceId >= 0) {
+            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
+        }
+        return game.onKeyMultiple(keyCode, repeatCount, event)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun createProgrammaticUI() {
+        rootLayout = ExternalControllerView(context)
+        rootLayout.layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        rootLayout.isFocusable = true
+        rootLayout.isFocusableInTouchMode = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            rootLayout.isFocusedByDefault = true
+        }
+
+        rootLayout.setInputCallbacks(game)
+        rootLayout.setCommitTextEnabled(prefConfig.enableCommitText)
+
+        host.setControllerContentView(rootLayout)
+
+        val topLeftButtons = createButtonContainer(Gravity.TOP or Gravity.START)
+        topLeftButtons.isFocusable = false
+        zoomButton = createImageButton(R.drawable.ic_zoom_toggle) { toggleZoomMode(true) }
+        if (game.isZoomModeEnabled) {
+            zoomButton.alpha = 1.0f
+        } else {
+            zoomButton.alpha = 0.5f
+        }
+        topLeftButtons.addView(zoomButton)
+        rootLayout.addView(topLeftButtons)
+
+        val topRightButtons = createButtonContainer(Gravity.TOP or Gravity.END)
+        topRightButtons.isFocusable = false
+        topRightButtons.addView(createImageButton(R.drawable.ic_menu_external) { showGameMenu() })
+        topRightButtons.addView(createImageButton(R.drawable.ic_close_external) { dismissAfterCurrentCallback() })
+        rootLayout.addView(topRightButtons)
+
+        val bottomLeftButton = createButtonContainer(Gravity.BOTTOM or Gravity.START)
+        bottomLeftButton.isFocusable = false
+        bottomLeftButton.addView(createImageButton(R.drawable.ic_android_keyboard) { _toggleKeyboard() })
+        rootLayout.addView(bottomLeftButton)
+
+        val bottomRightButton = createButtonContainer(Gravity.BOTTOM or Gravity.END)
+        bottomRightButton.isFocusable = false
+        bottomRightButton.addView(createImageButton(R.drawable.ic_fullscreen_keyboard) { _toggleFullKeyboard() })
+        rootLayout.addView(bottomRightButton)
+    }
+
+    private fun _toggleKeyboard() {
+        LimeLog.info("Toggling keyboard overlay on ExternalDisplayControlController")
+        val inputManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val imeVisible =
+            ViewCompat.getRootWindowInsets(rootLayout)
+                ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+        if (imeVisible) {
+            cancelPendingSoftKeyboardShow()
+            softKeyboardShowAccepted = false
+            softKeyboardWasVisible = false
+            inputManager.hideSoftInputFromWindow(rootLayout.windowToken, 0)
+            host.releaseSoftKeyboardFocus()
+            return
+        }
+
+        host.prepareForSoftKeyboard()
+        softKeyboardShowPending = true
+        softKeyboardShowAttempts = 0
+        softKeyboardShowAccepted = false
+        softKeyboardWasVisible = false
+        rootLayout.requestFocus()
+        handler.postDelayed(::showPendingSoftKeyboardIfReady, SOFT_KEYBOARD_SHOW_RETRY_MILLIS)
+    }
+
+    private fun isSoftKeyboardVisible(): Boolean =
+        ViewCompat.getRootWindowInsets(rootLayout)
+            ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+
+    private fun cancelPendingSoftKeyboardShow() {
+        softKeyboardShowPending = false
+        softKeyboardShowAttempts = 0
+    }
+
+    private fun showPendingSoftKeyboardIfReady() {
+        if (!softKeyboardShowPending) return
+        if (!rootLayout.hasWindowFocus()) {
+            softKeyboardShowAttempts += 1
+            if (softKeyboardShowAttempts < SOFT_KEYBOARD_SHOW_MAX_ATTEMPTS) {
+                handler.postDelayed(::showPendingSoftKeyboardIfReady, SOFT_KEYBOARD_SHOW_RETRY_MILLIS)
+            } else {
+                cancelPendingSoftKeyboardShow()
+                host.releaseSoftKeyboardFocus()
+            }
+            return
+        }
+        rootLayout.post(::tryShowPendingSoftKeyboard)
+    }
+
+    private fun tryShowPendingSoftKeyboard() {
+        if (!softKeyboardShowPending) return
+        if (!rootLayout.hasWindowFocus()) {
+            showPendingSoftKeyboardIfReady()
+            return
+        }
+        rootLayout.requestFocus()
+        val inputManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        if (inputManager.showSoftInput(rootLayout, InputMethodManager.SHOW_IMPLICIT)) {
+            softKeyboardShowAccepted = true
+            softKeyboardWasVisible = false
+            cancelPendingSoftKeyboardShow()
+            handler.postDelayed(
+                {
+                    if (!isSoftKeyboardVisible()) {
+                        softKeyboardShowAccepted = false
+                        softKeyboardWasVisible = false
+                        host.releaseSoftKeyboardFocus()
+                    }
+                },
+                SOFT_KEYBOARD_VISIBILITY_TIMEOUT_MILLIS,
+            )
+            return
+        }
+
+        softKeyboardShowAttempts += 1
+        if (softKeyboardShowAttempts < SOFT_KEYBOARD_SHOW_MAX_ATTEMPTS) {
+            handler.postDelayed(::showPendingSoftKeyboardIfReady, SOFT_KEYBOARD_SHOW_RETRY_MILLIS)
+        } else {
+            cancelPendingSoftKeyboardShow()
+            host.releaseSoftKeyboardFocus()
+        }
+    }
+
+    private fun initFullKeyboard(prefConfig: PreferenceConfiguration) {
+        keyBoardLayoutController = KeyBoardLayoutController(rootLayout, context, prefConfig).also {
+            it.setViewCallbacks(this)
+            it.refreshLayout()
+            it.show()
+        }
+    }
+
+    private fun _toggleFullKeyboard() {
+        val controller = keyBoardLayoutController
+        if (controller == null) {
+            initFullKeyboard(prefConfig)
+            return
+        }
+        controller.toggleVisibility()
+    }
+
+    fun toggleZoomMode(callGame: Boolean) {
+        if (callGame) {
+            game.toggleZoomMode()
+        } else {
+            zoomButton.alpha = if (game.isZoomModeEnabled) 1.0f else 0.5f
+        }
+    }
+
+    fun showGameMenu() {
+        game.showGameMenuFromDisplay(display.displayId, null)
+    }
+
+    fun isCompanionDisplayAvailable(): Boolean {
+        return host.isHostShowing() && display.isValid && !transientStateDisposed
+    }
+
+    fun shouldMigrateOpenMenuToStream(streamAvailable: Boolean): Boolean {
+        return DualScreenQuickMenuPolicy.shouldMigrateCompanionMenu(
+            menuWasOpen = menuOpenAtDisposal || gameMenu?.isMenuOpen() == true,
+            dismissalRequestedByNova = dismissalRequestedByNova,
+            streamAvailable = streamAvailable,
+        )
+    }
+
+    fun showGameMenuOnCompanion(device: GameInputDevice?): Boolean {
+        if (!isCompanionDisplayAvailable()) return false
+
+        return try {
+            handleUserActivity()
+            gameMenu?.showMenu(device)
+            gameMenu?.isMenuOpen() == true
+        } catch (e: RuntimeException) {
+            LimeLog.warning(
+                "Nova: Android companion quick menu unavailable display_id=${display.displayId} " +
+                    "exception=${e.javaClass.simpleName}"
+            )
+            runCatching { gameMenu?.hideMenu() }
+            false
+        }
+    }
+
+    fun hideGameMenu() {
+        runCatching { gameMenu?.hideMenu() }
+            .onFailure { error ->
+                LimeLog.warning(
+                    "Nova: Android companion quick menu dismiss failed display_id=${display.displayId} " +
+                        "exception=${error.javaClass.simpleName}"
+                )
+            }
+    }
+
+    fun isGameMenuOpen(): Boolean {
+        return gameMenu?.isMenuOpen() == true
+    }
+
+    private fun createButtonContainer(gravity: Int): LinearLayout {
+        return LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setGravity(gravity)
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                gravity,
+            )
+        }
+    }
+
+    private fun createImageButton(imageResourceId: Int, listener: View.OnClickListener): ImageButton {
+        return ImageButton(context).apply {
+            setImageResource(imageResourceId)
+            setBackgroundColor(Color.TRANSPARENT)
+            setOnClickListener(listener)
+            layoutParams = LinearLayout.LayoutParams(dpToPx(56), dpToPx(56))
+        }
+    }
+
+    private fun dpToPx(dp: Int): Int {
+        return (dp * context.resources.displayMetrics.density).toInt()
+    }
+
+    fun toggleKeyboard() {
+        _toggleKeyboard()
+    }
+
+    fun toggleFullKeyboard() {
+        _toggleFullKeyboard()
+    }
+
+    fun toggleGameMenu() {
+        showGameMenu()
+    }
+}

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlHost.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlHost.kt
@@ -1,0 +1,40 @@
+package com.papi.nova.utils
+
+import android.content.Context
+import android.os.IBinder
+import android.view.Display
+import android.view.View
+import android.view.Window
+import com.papi.nova.Game
+import com.papi.nova.binding.input.GameInputDevice
+
+interface ExternalDisplayControlHost {
+    val game: Game
+    val controlDisplay: Display
+    val hostContext: Context
+    val hostWindow: Window
+
+    val companionDialogContext: Context
+    val companionDialogWindowType: Int
+
+    fun companionDialogWindowToken(): IBinder?
+    fun setControllerContentView(view: View)
+    fun isHostShowing(): Boolean
+    fun dismissHost()
+    fun cancelHost()
+    fun dismissAfterCurrentCallback()
+    fun handleBackFromOwningGame(): Boolean
+    fun toggleZoomMode(callGame: Boolean)
+    fun isCompanionDisplayAvailable(): Boolean
+    fun shouldMigrateOpenMenuToStream(streamAvailable: Boolean): Boolean
+    fun showGameMenuOnCompanion(device: GameInputDevice?): Boolean
+    fun hideGameMenu()
+    fun isGameMenuOpen(): Boolean
+    fun toggleKeyboard()
+    fun toggleFullKeyboard()
+    fun toggleGameMenu()
+
+    fun prepareForSoftKeyboard() = Unit
+    fun onSoftKeyboardVisibilityChanged(imeVisible: Boolean) = Unit
+    fun releaseSoftKeyboardFocus() = Unit
+}

--- a/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
+++ b/app/src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt
@@ -1,7 +1,6 @@
 package com.papi.nova.utils
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -10,75 +9,44 @@ import android.app.Presentation
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.view.Display
-import android.view.Gravity
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
-import android.view.inputmethod.InputMethodManager
-import android.widget.FrameLayout
-import android.widget.ImageButton
-import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import com.papi.nova.Game
-import com.papi.nova.GameMenu
-import com.papi.nova.LimeLog
 import com.papi.nova.R
 import com.papi.nova.StartExternalDisplayControlReceiver
 import com.papi.nova.binding.input.GameInputDevice
-import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardLayoutController
-import com.papi.nova.preferences.PreferenceConfiguration
-import com.papi.nova.ui.ExternalControllerView
 
 /**
- * Game-owned controller surface rendered on the derived companion display without creating
- * another Activity/task that can become Android's top-resumed audio owner.
+ * Game-owned controller surface rendered on a presentation-capable companion display.
  */
 class ExternalDisplayControlPresentation(
-    private val game: Game,
-    display: Display,
-) : Presentation(game, display, R.style.ExternalDisplayControllerTheme),
-    View.OnKeyListener,
-    KeyBoardLayoutController.ViewCallbacks {
+    override val game: Game,
+    override val controlDisplay: Display,
+) : Presentation(game, controlDisplay, R.style.ExternalDisplayControllerTheme),
+    ExternalDisplayControlHost {
 
-    private lateinit var prefConfig: PreferenceConfiguration
+    private lateinit var controller: ExternalDisplayControlController
 
-    private lateinit var rootLayout: ExternalControllerView
-    private lateinit var zoomButton: ImageButton
-    private var keyBoardLayoutController: KeyBoardLayoutController? = null
+    override val hostContext: Context
+        get() = context
 
-    private var isKeyboardVisible = false
-    private var transientStateDisposed = false
-    private var dismissalRequestedByNova = false
-    private var menuOpenAtDisposal = false
-
-    private val handler = Handler(Looper.getMainLooper())
-    private var dimScreenRunnable = Runnable {}
-    private var originalBrightness = -1f // -1 = use system default
-
-    private var gameMenu: GameMenu? = null
-    private val presentationWindow: Window
+    override val hostWindow: Window
         get() = requireNotNull(window)
 
-    val companionDialogContext: Context by lazy {
+    override val companionDialogContext: Context by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            game.createDisplayContext(display).createWindowContext(
+            game.createDisplayContext(controlDisplay).createWindowContext(
                 WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG,
                 null,
             )
@@ -87,404 +55,119 @@ class ExternalDisplayControlPresentation(
         }
     }
 
-    val companionDialogWindowType: Int
+    override val companionDialogWindowType: Int
         get() = WindowManager.LayoutParams.TYPE_APPLICATION_ATTACHED_DIALOG
 
-    fun companionDialogWindowToken(): IBinder? = presentationWindow.decorView.windowToken
+    override fun companionDialogWindowToken(): IBinder? = hostWindow.decorView.windowToken
+
+    override fun setControllerContentView(view: View) {
+        setContentView(view)
+    }
+
+    override fun isHostShowing(): Boolean = isShowing
+
+    override fun dismissHost() {
+        dismiss()
+    }
+
+    override fun cancelHost() {
+        super.cancel()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        prefConfig = PreferenceConfiguration.readPreferences(context)
-        initViews()
-    }
-
-    private fun initViews() {
-        val windowInsetsController = WindowCompat.getInsetsController(presentationWindow, presentationWindow.decorView)
-
-        windowInsetsController.systemBarsBehavior =
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-
-        windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
-        windowInsetsController.hide(WindowInsetsCompat.Type.navigationBars())
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            WindowCompat.setDecorFitsSystemWindows(presentationWindow, false)
-            ViewCompat.setOnApplyWindowInsetsListener(presentationWindow.decorView) { view, insets ->
-                val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-                updateKeyboardVisibility(
-                    imeVisible ||
-                        (keyBoardLayoutController != null && keyBoardLayoutController!!.isKeyboardVisible()),
-                )
-                ViewCompat.onApplyWindowInsets(view, insets)
-            }
-        }
-
-        initializeComponents()
-        createProgrammaticUI()
-        initTouchEventHandling()
-        setupInactivityTimeoutForBrightness()
-        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
-    private fun initTouchEventHandling() {
-        rootLayout.setOnTouchListener { view, event ->
-            handleUserActivity()
-            game.handleMotionEvent(view, event)
-            true
-        }
+        controller = ExternalDisplayControlController(this)
+        controller.onCreate()
     }
 
     override fun onStart() {
         super.onStart()
-        transientStateDisposed = false
-        dismissalRequestedByNova = false
-        menuOpenAtDisposal = false
-        resetInactivityTimer()
-        if (game.isFinishing) {
-            dismissAfterCurrentCallback()
-        }
+        controller.onStart()
     }
 
-    fun dismissAfterCurrentCallback() {
-        dismissalRequestedByNova = true
-        transientStateDisposed = true
-        handler.post {
-            if (isShowing) {
-                dismiss()
-            }
-        }
+    override fun dismissAfterCurrentCallback() {
+        controller.dismissAfterCurrentCallback()
     }
 
     override fun cancel() {
-        dismissalRequestedByNova = true
-        transientStateDisposed = true
-        handler.post {
-            cancelNow()
-        }
-    }
-
-    private fun cancelNow() {
-        if (isShowing) {
-            super.cancel()
-        }
-    }
-
-    private fun disposeTransientState() {
-        menuOpenAtDisposal = menuOpenAtDisposal || gameMenu?.isMenuOpen() == true
-        transientStateDisposed = true
-        gameMenu?.hideMenu()
-        handler.removeCallbacksAndMessages(null)
-        restoreBrightnessIfNeeded()
+        controller.cancel()
     }
 
     fun disposeAfterFailedShow() {
-        dismissalRequestedByNova = true
-        disposeTransientState()
+        controller.disposeAfterFailedShow()
     }
 
     override fun onStop() {
-        disposeTransientState()
+        controller.onStop()
         super.onStop()
-    }
-
-    override fun onKeyboardControllerVisibilityChange(visible: Boolean) {
-        updateKeyboardVisibility(visible)
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
-    private fun setupInactivityTimeoutForBrightness() {
-        originalBrightness = presentationWindow.attributes.screenBrightness
-
-        dimScreenRunnable = Runnable {
-            if (
-                CompanionScreenDimmingPolicy.shouldDimNow(
-                    keyboardVisible = isKeyboardVisible,
-                    quickMenuOpen = gameMenu?.isMenuOpen() == true,
-                )
-            ) {
-                val layout = presentationWindow.attributes
-                layout.screenBrightness = 0.0f
-                presentationWindow.attributes = layout
-            } else {
-                resetInactivityTimer()
-            }
-        }
-
-        resetInactivityTimer()
-    }
-
-    private fun updateKeyboardVisibility(visible: Boolean) {
-        if (isKeyboardVisible != visible) {
-            isKeyboardVisible = visible
-            if (isKeyboardVisible) {
-                handler.removeCallbacks(dimScreenRunnable)
-                restoreBrightnessIfNeeded()
-            } else {
-                resetInactivityTimer()
-            }
-        }
-    }
-
-    private fun restoreBrightnessIfNeeded() {
-        val layout = presentationWindow.attributes
-        if (layout.screenBrightness == 0.0f) {
-            layout.screenBrightness = originalBrightness
-            presentationWindow.attributes = layout
-        }
-    }
-
-    private fun handleUserActivity() {
-        if (transientStateDisposed) return
-        restoreBrightnessIfNeeded()
-        resetInactivityTimer()
-    }
-
-    private fun resetInactivityTimer() {
-        handler.removeCallbacks(dimScreenRunnable)
-        if (!isKeyboardVisible) {
-            CompanionScreenDimmingPolicy.delayMillis(prefConfig.companionScreenDimTimeoutSeconds)?.let { delay ->
-                handler.postDelayed(dimScreenRunnable, delay)
-            }
-        }
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        game.logCompanionDisplayFocus(display.displayId, hasFocus)
-        if (game.isFinishing) {
-            dismissAfterCurrentCallback()
-        }
+        controller.onWindowFocusChanged(hasFocus)
     }
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
-        handleCompanionBack()
+        controller.handleCompanionBack()
     }
 
-    private fun handleCompanionBack() {
-        if (game.isKeyboardLayoutVisible) {
-            toggleFullKeyboard()
-        } else if (!game.handleQuickMenuBackFromDisplay(display.displayId)) {
-            cancel()
-        }
-    }
-
-    fun handleBackFromOwningGame(): Boolean {
-        if (!isCompanionDisplayAvailable()) return false
-        handleCompanionBack()
-        return true
-    }
-
-    private fun initializeComponents() {
-        gameMenu = GameMenu(game, companionDialogContext, companionDialogWindowType, ::companionDialogWindowToken).also {
-            it.setOnMenuDismissedListener(::handleUserActivity)
-        }
-    }
+    override fun handleBackFromOwningGame(): Boolean = controller.handleBackFromOwningGame()
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {
-        game.recordQuickMenuInteraction(display.displayId)
-        StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-        return game.onGenericMotionEvent(event)
-    }
-
-    @Suppress("DEPRECATION")
-    override fun onKey(view: View, keyCode: Int, keyEvent: KeyEvent): Boolean {
-        game.recordQuickMenuInteraction(display.displayId)
-        if (keyEvent.deviceId >= 0) {
-            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-        }
-        return when (keyEvent.action) {
-            KeyEvent.ACTION_DOWN -> game.handleKeyDown(keyEvent)
-            KeyEvent.ACTION_UP -> game.handleKeyUp(keyEvent)
-            KeyEvent.ACTION_MULTIPLE -> game.handleKeyMultiple(keyEvent)
-            else -> false
-        }
+        return controller.onGenericMotionEvent(event)
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        game.recordQuickMenuInteraction(display.displayId)
-        if (event.deviceId >= 0) {
-            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-        }
-        return game.onKeyDown(keyCode, event)
+        return controller.onKeyDown(event)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        game.recordQuickMenuInteraction(display.displayId)
-        if (event.deviceId >= 0) {
-            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-        }
-        return game.onKeyUp(keyCode, event)
+        return controller.onKeyUp(event)
     }
 
     override fun onKeyMultiple(keyCode: Int, repeatCount: Int, event: KeyEvent): Boolean {
-        game.recordQuickMenuInteraction(display.displayId)
-        if (event.deviceId >= 0) {
-            StartExternalDisplayControlReceiver.requestFocusToGameActivity(false)
-        }
-        return game.onKeyMultiple(keyCode, repeatCount, event)
+        return controller.onKeyMultiple(keyCode, repeatCount, event)
     }
 
-    @SuppressLint("ClickableViewAccessibility")
-    private fun createProgrammaticUI() {
-        rootLayout = ExternalControllerView(context)
-        rootLayout.layoutParams = ViewGroup.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.MATCH_PARENT,
-        )
-        rootLayout.isFocusable = true
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            rootLayout.isFocusedByDefault = true
-        }
-
-        rootLayout.setInputCallbacks(game)
-        rootLayout.setCommitTextEnabled(prefConfig.enableCommitText)
-
-        setContentView(rootLayout)
-
-        val topLeftButtons = createButtonContainer(Gravity.TOP or Gravity.START)
-        topLeftButtons.isFocusable = false
-        zoomButton = createImageButton(R.drawable.ic_zoom_toggle) { toggleZoomMode(true) }
-        if (game.isZoomModeEnabled) {
-            zoomButton.alpha = 1.0f
-        } else {
-            zoomButton.alpha = 0.5f
-        }
-        topLeftButtons.addView(zoomButton)
-        rootLayout.addView(topLeftButtons)
-
-        val topRightButtons = createButtonContainer(Gravity.TOP or Gravity.END)
-        topRightButtons.isFocusable = false
-        topRightButtons.addView(createImageButton(R.drawable.ic_menu_external) { showGameMenu() })
-        topRightButtons.addView(createImageButton(R.drawable.ic_close_external) { dismissAfterCurrentCallback() })
-        rootLayout.addView(topRightButtons)
-
-        val bottomLeftButton = createButtonContainer(Gravity.BOTTOM or Gravity.START)
-        bottomLeftButton.isFocusable = false
-        bottomLeftButton.addView(createImageButton(R.drawable.ic_android_keyboard) { _toggleKeyboard() })
-        rootLayout.addView(bottomLeftButton)
-
-        val bottomRightButton = createButtonContainer(Gravity.BOTTOM or Gravity.END)
-        bottomRightButton.isFocusable = false
-        bottomRightButton.addView(createImageButton(R.drawable.ic_fullscreen_keyboard) { _toggleFullKeyboard() })
-        rootLayout.addView(bottomRightButton)
-    }
-
-    @Suppress("DEPRECATION")
-    private fun _toggleKeyboard() {
-        LimeLog.info("Toggling keyboard overlay on ExternalDisplayControlPresentation")
-        val inputManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        inputManager.toggleSoftInput(0, 0)
-    }
-
-    private fun initFullKeyboard(prefConfig: PreferenceConfiguration) {
-        keyBoardLayoutController = KeyBoardLayoutController(rootLayout, context, prefConfig).also {
-            it.setViewCallbacks(this)
-            it.refreshLayout()
-            it.show()
-        }
-    }
-
-    private fun _toggleFullKeyboard() {
-        val controller = keyBoardLayoutController
-        if (controller == null) {
-            initFullKeyboard(prefConfig)
-            return
-        }
-        controller.toggleVisibility()
-    }
-
-    fun toggleZoomMode(callGame: Boolean) {
-        if (callGame) {
-            game.toggleZoomMode()
-        } else {
-            zoomButton.alpha = if (game.isZoomModeEnabled) 1.0f else 0.5f
-        }
+    override fun toggleZoomMode(callGame: Boolean) {
+        controller.toggleZoomMode(callGame)
     }
 
     fun showGameMenu() {
-        game.showGameMenuFromDisplay(display.displayId, null)
+        controller.showGameMenu()
     }
 
-    fun isCompanionDisplayAvailable(): Boolean {
-        return isShowing && display.isValid && !transientStateDisposed
+    override fun isCompanionDisplayAvailable(): Boolean {
+        return controller.isCompanionDisplayAvailable()
     }
 
-    fun shouldMigrateOpenMenuToStream(streamAvailable: Boolean): Boolean {
-        return DualScreenQuickMenuPolicy.shouldMigrateCompanionMenu(
-            menuWasOpen = menuOpenAtDisposal || gameMenu?.isMenuOpen() == true,
-            dismissalRequestedByNova = dismissalRequestedByNova,
-            streamAvailable = streamAvailable,
-        )
+    override fun shouldMigrateOpenMenuToStream(streamAvailable: Boolean): Boolean {
+        return controller.shouldMigrateOpenMenuToStream(streamAvailable)
     }
 
-    fun showGameMenuOnCompanion(device: GameInputDevice?): Boolean {
-        if (!isCompanionDisplayAvailable()) return false
-
-        return try {
-            handleUserActivity()
-            gameMenu?.showMenu(device)
-            gameMenu?.isMenuOpen() == true
-        } catch (e: RuntimeException) {
-            LimeLog.warning(
-                "Nova: Android companion quick menu unavailable display_id=${display.displayId} " +
-                    "exception=${e.javaClass.simpleName}"
-            )
-            runCatching { gameMenu?.hideMenu() }
-            false
-        }
+    override fun showGameMenuOnCompanion(device: GameInputDevice?): Boolean {
+        return controller.showGameMenuOnCompanion(device)
     }
 
-    fun hideGameMenu() {
-        runCatching { gameMenu?.hideMenu() }
-            .onFailure { error ->
-                LimeLog.warning(
-                    "Nova: Android companion quick menu dismiss failed display_id=${display.displayId} " +
-                        "exception=${error.javaClass.simpleName}"
-                )
-            }
+    override fun hideGameMenu() {
+        controller.hideGameMenu()
     }
 
-    fun isGameMenuOpen(): Boolean {
-        return gameMenu?.isMenuOpen() == true
+    override fun isGameMenuOpen(): Boolean {
+        return controller.isGameMenuOpen()
     }
 
-    private fun createButtonContainer(gravity: Int): LinearLayout {
-        return LinearLayout(context).apply {
-            orientation = LinearLayout.HORIZONTAL
-            setGravity(gravity)
-            layoutParams = FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                gravity,
-            )
-        }
+    override fun toggleKeyboard() {
+        controller.toggleKeyboard()
     }
 
-    private fun createImageButton(imageResourceId: Int, listener: View.OnClickListener): ImageButton {
-        return ImageButton(context).apply {
-            setImageResource(imageResourceId)
-            setBackgroundColor(Color.TRANSPARENT)
-            setOnClickListener(listener)
-            layoutParams = LinearLayout.LayoutParams(dpToPx(56), dpToPx(56))
-        }
+    override fun toggleFullKeyboard() {
+        controller.toggleFullKeyboard()
     }
 
-    private fun dpToPx(dp: Int): Int {
-        return (dp * context.resources.displayMetrics.density).toInt()
-    }
-
-    fun toggleKeyboard() {
-        _toggleKeyboard()
-    }
-
-    fun toggleFullKeyboard() {
-        _toggleFullKeyboard()
-    }
-
-    fun toggleGameMenu() {
-        showGameMenu()
+    override fun toggleGameMenu() {
+        controller.toggleGameMenu()
     }
 
     companion object {

--- a/app/src/test/java/com/papi/nova/utils/CompanionControlHostPolicyTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/CompanionControlHostPolicyTest.kt
@@ -1,0 +1,23 @@
+package com.papi.nova.utils
+
+import android.view.Display
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompanionControlHostPolicyTest {
+    @Test
+    fun defaultDisplayUsesActivityFallback() {
+        assertEquals(
+            CompanionControlHostPolicy.HostType.ACTIVITY,
+            CompanionControlHostPolicy.select(Display.DEFAULT_DISPLAY),
+        )
+    }
+
+    @Test
+    fun nonDefaultDisplayUsesPresentationHost() {
+        assertEquals(
+            CompanionControlHostPolicy.HostType.PRESENTATION,
+            CompanionControlHostPolicy.select(Display.DEFAULT_DISPLAY + 1),
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/utils/DefaultDisplayCompanionActivityGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/DefaultDisplayCompanionActivityGuardTest.kt
@@ -1,0 +1,62 @@
+package com.papi.nova.utils
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultDisplayCompanionActivityGuardTest {
+    @Test
+    fun activityReattachesAfterLifecycleRestart() {
+        val activity = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt").readText()
+        val game = File("src/main/java/com/papi/nova/Game.kt").readText()
+        val onStart = activity.substringAfter("override fun onStart()").substringBefore("override fun onStop()")
+        val attachHelper = activity.substringAfter("private fun attachToOwningGameIfNeeded()")
+        val gameAttach =
+            game.substringAfter("fun attachExternalDisplayControlActivity")
+                .substringBefore("fun detachExternalDisplayControlActivity")
+
+        assertTrue(onStart.contains("attachToOwningGameIfNeeded()"))
+        assertTrue(attachHelper.contains("attachExternalDisplayControlActivity(this)"))
+        assertTrue(attachHelper.contains("registeredWithGame = true"))
+        assertTrue("Game must re-resolve the current companion route after transient detach", gameAttach.contains("getCompanionControlDisplay()"))
+        assertTrue("Successful reattachment must restore the resolved companion display ID", gameAttach.contains("companionControlDisplayId = companionDisplayId"))
+    }
+
+    @Test
+    fun activityLeasesFocusOnlyWhileImeIsVisible() {
+        val activity = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlActivity.kt").readText()
+        val controller = File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
+        val prepare = activity.substringAfter("override fun prepareForSoftKeyboard()").substringBefore("override fun onSoftKeyboardVisibilityChanged")
+        val release = activity.substringAfter("override fun onSoftKeyboardVisibilityChanged").substringBefore("override fun closeFromGame")
+        val compactKeyboard = controller.substringAfter("private fun _toggleKeyboard()").substringBefore("private fun initFullKeyboard")
+
+        assertTrue(prepare.contains("window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)"))
+        assertTrue(release.contains("window.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)"))
+        assertTrue(release.contains("requestFocusToGameActivity(false)"))
+        assertTrue(compactKeyboard.contains("host.prepareForSoftKeyboard()"))
+        assertTrue("The companion input root must accept focus after a touchscreen keyboard tap", controller.contains("rootLayout.isFocusableInTouchMode = true"))
+        assertTrue(controller.contains("host.onSoftKeyboardVisibilityChanged("))
+        val insetsHandling =
+            controller.substringAfter("ViewCompat.setOnApplyWindowInsetsListener")
+                .substringBefore("initializeComponents()")
+        assertTrue("IME inset callbacks must not release an unaccepted show request", insetsHandling.contains("if (softKeyboardShowAccepted)"))
+        assertTrue(controller.contains("WindowInsetsCompat.Type.ime()"))
+        assertTrue("IME show must wait for the Activity window-focus callback", controller.contains("softKeyboardShowPending"))
+        val focusChanged =
+            controller.substringAfter("fun onWindowFocusChanged(hasFocus: Boolean)")
+                .substringBefore("fun handleCompanionBack()")
+        assertTrue(focusChanged.contains("showPendingSoftKeyboardIfReady()"))
+        val focusWait =
+            controller.substringAfter("private fun showPendingSoftKeyboardIfReady()")
+                .substringBefore("private fun tryShowPendingSoftKeyboard()")
+        assertTrue("No-focus waits must consume the bounded retry budget", focusWait.contains("softKeyboardShowAttempts += 1"))
+        assertTrue("No-focus waits must retry instead of returning forever", focusWait.contains("handler.postDelayed"))
+        assertTrue("Exhausted no-focus waits must restore Game focus", focusWait.contains("host.releaseSoftKeyboardFocus()"))
+        val postedShow =
+            controller.substringAfter("private fun tryShowPendingSoftKeyboard()")
+                .substringBefore("private fun initFullKeyboard")
+        assertTrue("Focus lost after posting must re-enter the bounded wait path", postedShow.substringBefore("rootLayout.requestFocus()").contains("showPendingSoftKeyboardIfReady()"))
+        assertFalse(controller.contains("toggleSoftInput("))
+    }
+}

--- a/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/NovaExternalDisplayRoutingSourceGuardTest.kt
@@ -192,20 +192,23 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     fun companionDialogsAttachToTheLivePresentationWindowToken() {
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
         val gameMenu = File("src/main/java/com/papi/nova/GameMenu.kt").readText()
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
 
         assertTrue(presentation.contains("TYPE_APPLICATION_ATTACHED_DIALOG"))
         assertTrue(presentation.contains("createWindowContext("))
-        assertTrue(presentation.contains("presentationWindow.decorView.windowToken"))
+        assertTrue(presentation.contains("hostWindow.decorView.windowToken"))
         assertFalse(
             "A second TYPE_PRESENTATION window reuses the wrong WindowContext token and crashes",
             presentation.contains("presentationWindow.attributes.type")
         )
         assertTrue(
-            presentation.contains(
+            controller.contains(
                 "GameMenu(game, companionDialogContext, companionDialogWindowType, ::companionDialogWindowToken)"
-            )
+            ) ||
+                controller.contains("host.companionDialogContext")
         )
         assertTrue(gameMenu.contains("private val dialogWindowTokenProvider: (() -> IBinder?)? = null"))
         assertTrue(gameMenu.contains("window.setType(windowType)"))
@@ -245,7 +248,7 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     }
 
     @Test
-    fun companionControlsAreGameOwnedPresentationInsteadOfManifestActivity() {
+    fun companionControlsUsePresentationForSecondaryDisplaysAndActivityForDefaultDisplay() {
         val presentationFile =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt")
         val activityFile =
@@ -253,15 +256,52 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val manifest = File("src/main/AndroidManifest.xml").readText()
 
-        assertTrue("Companion controls should have a Presentation source", presentationFile.exists())
+        assertTrue("Companion controls should retain a Presentation source", presentationFile.exists())
         val presentation = presentationFile.readText()
         assertTrue(presentation.contains("class ExternalDisplayControlPresentation"))
-        assertTrue(presentation.contains("Presentation(game, display"))
-        assertTrue(game.contains("private var externalDisplayControlPresentation"))
-        assertTrue(game.contains("ExternalDisplayControlPresentation(this, companionDisplay"))
-        assertFalse("The obsolete companion Activity source should be removed", activityFile.exists())
+        assertTrue(presentation.contains("Presentation(game, controlDisplay"))
+        assertTrue(
+            "Game should retain the Presentation path for presentation-capable companion displays",
+            game.contains("ExternalDisplayControlPresentation(this, companionDisplay")
+        )
+
+        assertTrue(
+            "Display.DEFAULT_DISPLAY cannot host TYPE_PRESENTATION, so a fallback Activity source is required",
+            activityFile.exists()
+        )
+        val activity = activityFile.readText()
+        assertTrue(activity.contains("class ExternalDisplayControlActivity"))
+        assertTrue(activity.contains("ExternalDisplayControlController(this)"))
+        assertTrue(activity.contains("attachExternalDisplayControlActivity(this)"))
+        assertTrue(
+            "The default-display fallback must not steal Game focus/audio ownership",
+            activity.contains("WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE")
+        )
+        val activityOnCreate = activity.substringAfter("override fun onCreate").substringBefore("override fun onStart")
+        val notFocusable = activityOnCreate.indexOf("WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE")
+        val controlCreation = activityOnCreate.indexOf("ExternalDisplayControlController(this)")
+        assertTrue(
+            "The fallback Activity must be non-focusable before control creation",
+            notFocusable >= 0 && controlCreation > notFocusable
+        )
+        assertTrue(
+            "Game must route companion displays through the tested host-selection policy",
+            game.contains("when (CompanionControlHostPolicy.select(companionDisplayId))")
+        )
+        assertTrue(
+            "The Activity policy branch must launch the default-display fallback",
+            game.contains("CompanionControlHostPolicy.HostType.ACTIVITY") &&
+                game.contains("ExternalDisplayControlActivity.launch(this, companionDisplayId)")
+        )
+        assertTrue(activity.contains("options.setLaunchDisplayId(displayId)"))
+        assertTrue(activity.contains("Intent.FLAG_ACTIVITY_NEW_TASK"))
+        assertTrue(manifest.contains(".utils.ExternalDisplayControlActivity"))
+        assertTrue(manifest.contains("android:launchMode=\"singleInstance\""))
+        assertTrue(manifest.contains("android:taskAffinity=\"\""))
+        assertTrue(manifest.contains("android:exported=\"false\""))
+        assertTrue(manifest.contains("android:noHistory=\"true\""))
         assertFalse(
-            "A Game-owned Presentation must not be registered as an Activity",
+            "A Game-owned Presentation must never be registered as an Activity",
             manifest.contains("ExternalDisplayControlPresentation")
         )
     }
@@ -271,6 +311,8 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
         val showBlock =
             game.substringAfter("val presentation = ExternalDisplayControlPresentation")
                 .substringBefore("listenForExternalDisplayRemoval()")
@@ -280,11 +322,15 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         assertTrue("Failed show must explicitly dispose partial Presentation state", dispose >= 0)
         assertTrue("Disposal must happen before Game clears its owner reference", clearReference > dispose)
         val transientDisposal =
-            presentation.substringAfter("private fun disposeTransientState()")
+            controller.substringAfter("private fun disposeTransientState()")
                 .substringBefore("fun disposeAfterFailedShow()")
         val failedShowDisposal =
-            presentation.substringAfter("fun disposeAfterFailedShow()")
+            controller.substringAfter("fun disposeAfterFailedShow()")
                 .substringBefore("override fun onStop()")
+                .ifEmpty {
+                    controller.substringAfter("fun disposeAfterFailedShow()")
+                        .substringBefore("fun onStop()")
+                }
         assertTrue(transientDisposal.contains("handler.removeCallbacksAndMessages(null)"))
         assertTrue(
             "Failed-show disposal must invoke the real transient-state cleanup",
@@ -297,13 +343,15 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
         val launchBlock =
             game.substringAfter("presentation.show()").substringBefore("catch (e:WindowManager.InvalidDisplayException)")
         val permissionBlock =
             game.substringAfter("override fun onRequestPermissionsResult(")
                 .substringBefore("override fun onNewIntent(")
         val compactPermissionBlock = permissionBlock.replace(Regex("""\s+"""), " ")
-        val initViews = presentation.substringAfter("private fun initViews()").substringBefore("private fun initTouchEventHandling()")
+        val initViews = controller.substringAfter("private fun initViews()").substringBefore("private fun initTouchEventHandling()")
 
         assertTrue(
             launchBlock.contains(
@@ -358,27 +406,29 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
 
         assertTrue(
             "Presentation teardown needs one deferred dismissal entrypoint",
             presentation.contains("fun dismissAfterCurrentCallback()"),
         )
         val deferredDismiss =
-            presentation.substringAfter("fun dismissAfterCurrentCallback()")
-                .substringBefore("override fun onStop()")
+            controller.substringAfter("fun dismissAfterCurrentCallback()")
+                .substringBefore("fun cancel()")
         val post = deferredDismiss.indexOf("handler.post")
-        val showingGuard = deferredDismiss.indexOf("if (isShowing)", post)
-        val dismiss = deferredDismiss.indexOf("dismiss()", showingGuard)
+        val showingGuard = deferredDismiss.indexOf("if (host.isHostShowing())", post)
+        val dismiss = deferredDismiss.indexOf("host.dismissHost()", showingGuard)
         assertTrue("dismissal must be posted beyond the active ViewRoot callback", post >= 0)
         assertTrue("a stale posted callback must not dismiss an already-hidden Presentation", showingGuard > post)
         assertTrue("dismissal must happen only after the showing-state guard", dismiss > showingGuard)
 
         val onStart =
-            presentation.substringAfter("override fun onStart()")
-                .substringBefore("private fun disposeTransientState()")
+            controller.substringAfter("fun onStart()")
+                .substringBefore("fun dismissAfterCurrentCallback()")
         val focusChanged =
-            presentation.substringAfter("override fun onWindowFocusChanged(hasFocus: Boolean)")
-                .substringBefore("@Deprecated")
+            controller.substringAfter("fun onWindowFocusChanged(hasFocus: Boolean)")
+                .substringBefore("fun handleCompanionBack()")
         assertTrue(onStart.contains("dismissAfterCurrentCallback()"))
         assertTrue(focusChanged.contains("dismissAfterCurrentCallback()"))
 
@@ -414,7 +464,7 @@ class NovaExternalDisplayRoutingSourceGuardTest {
 
         val directDismissCalls = Regex("""(?<![\w.])dismiss\(\)""").findAll(presentation).count()
         assertTrue(
-            "all Presentation-owned teardown must flow through the deferred helper; found $directDismissCalls direct calls",
+            "Presentation-owned teardown must keep one host dismiss implementation; found $directDismissCalls direct calls",
             directDismissCalls == 1,
         )
     }
@@ -449,27 +499,26 @@ class NovaExternalDisplayRoutingSourceGuardTest {
     fun presentationCancellationDefersDisplayRemovalAndBackTeardown() {
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
 
         assertTrue(
             "Presentation must override inherited cancel() used by display removal and Back",
             presentation.contains("override fun cancel()"),
         )
         val cancel =
-            presentation.substringAfter("override fun cancel()")
-                .substringBefore("private fun cancelNow()")
-        assertTrue("inherited cancellation must post beyond the active framework callback", cancel.contains("handler.post"))
-        assertTrue("the posted cancellation must delegate to one framework-cancel helper", cancel.contains("cancelNow()"))
-
-        val cancelNow =
-            presentation.substringAfter("private fun cancelNow()")
+            controller.substringAfter("fun cancel()")
                 .substringBefore("private fun disposeTransientState()")
-        val showingGuard = cancelNow.indexOf("if (isShowing)")
-        val frameworkCancel = cancelNow.indexOf("super.cancel()", showingGuard)
+        assertTrue("inherited cancellation must post beyond the active framework callback", cancel.contains("handler.post"))
+        assertTrue("the posted cancellation must delegate to the host cancel helper", cancel.contains("host.cancelHost()"))
+
+        val showingGuard = cancel.indexOf("if (host.isHostShowing())")
+        val frameworkCancel = cancel.indexOf("host.cancelHost()", showingGuard)
         assertTrue("stale cancellation must not act on an already-hidden Presentation", showingGuard >= 0)
         assertTrue("framework cancellation must run only after the showing-state guard", frameworkCancel > showingGuard)
 
         val backPressed =
-            presentation.substringAfter("override fun onBackPressed()")
+            controller.substringAfter("fun handleCompanionBack()")
                 .substringBefore("private fun initializeComponents()")
         assertTrue("Back teardown must use the deferred cancellation override", backPressed.contains("cancel()"))
         assertFalse("Back must not re-enter synchronous Dialog.onBackPressed teardown", backPressed.contains("super.onBackPressed()"))
@@ -523,6 +572,8 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         val game = File("src/main/java/com/papi/nova/Game.kt").readText()
         val presentation =
             File("src/main/java/com/papi/nova/utils/ExternalDisplayControlPresentation.kt").readText()
+        val controller =
+            File("src/main/java/com/papi/nova/utils/ExternalDisplayControlController.kt").readText()
 
         assertTrue("Shared focus telemetry formatter must exist", telemetryFile.exists())
         val telemetry = telemetryFile.readText()
@@ -556,8 +607,8 @@ class NovaExternalDisplayRoutingSourceGuardTest {
         )
 
         val presentationFocus =
-            presentation.substringAfter("override fun onWindowFocusChanged(hasFocus: Boolean)")
-                .substringBefore("@Deprecated")
+            controller.substringAfter("fun onWindowFocusChanged(hasFocus: Boolean)")
+                .substringBefore("fun handleCompanionBack()")
         assertTrue(
             presentationFocus.contains(
                 "game.logCompanionDisplayFocus(display.displayId, hasFocus)",


### PR DESCRIPTION
## Summary

- route companion controls to an isolated Activity when the companion target is Android's default display
- retain the existing Game-owned `Presentation` path for true secondary displays
- share companion UI, Quick Menu, keyboard, dimming, zoom, and teardown behavior through one controller
- reattach the Activity after lifecycle restart and temporarily lease window focus only while Android's compact IME is active

Addresses #157. Physical AYN Thor confirmation remains pending, so this PR intentionally does not auto-close the issue.

## Root cause

When Nova streams Game to the selected external display, the desired companion destination becomes `Display.DEFAULT_DISPLAY`. Android `Presentation` only supports presentation-capable secondary displays, so trying to use it for display 0 leaves ordinary/stale Nova UI there instead of companion controls.

## Candidate

- commit: `256fd93bc8265c7655587998e32ac549f78c851e`
- tree: `b14414653c7d414ebd68b42377d13b651393eb0c`
- ARM64 field APK SHA-256: `a2d4d792d39b4e5d86ae18016c5f2636afa38e97f048d1e0f58578410f12ccf4`

## Verification

- `946` JVM tests passed, `0` failed/skipped
- `48` Nova Retroid smoke tests passed
- `3` native-submodule preflight tests passed
- `lintNonRoot_gameDebug` passed
- ARM64 `assembleNonRoot_gameDebug` passed
- `git diff --check` passed
- changed-payload security scan: zero findings; no newly exported component

## API 33 Thor emulator

- external target: Game on display 2; isolated companion Activity on display 0
- primary target: Game full-screen on display 0; companion `Presentation` on display 2
- Quick Menu opened through display-targeted touch on the Activity host
- notification-permission interruption retained the companion surface
- compact IME targeted the Activity on display 0 at 2s and 5s with `ExternalControllerView` served
- Back hid the IME and restored `FLAG_NOT_FOCUSABLE` plus Game focus ownership
- optional commit-text mode served Nova's custom non-null `BaseInputConnection` with `TYPE_CLASS_TEXT`
- final IME replay passed all runtime assertions with a stable Polaris host PID

## Field validation pending

No physical AYN Thor was available locally. The ARM64 field APK is built from the reviewed commit; a Thor tester should verify both display-target permutations, companion Quick Menu/keyboard input, and transitions during an active stream before issue closure.
