### PR TITLE
feat(android): add Spotlight Row and adaptive controller chrome

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
@@ -16,8 +16,11 @@ import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.unit.Density
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -32,6 +35,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.math.abs
 
 @RunWith(AndroidJUnit4::class)
 class NovaLibrarySpotlightRowComposeTest {
@@ -119,6 +123,57 @@ class NovaLibrarySpotlightRowComposeTest {
         composeRule.runOnIdle { restoreFocusGameId = "charlie" }
 
         waitForFocus(composeRule.onNode(hasContentDescription("Charlie", substring = true)))
+    }
+
+    @Test
+    fun touchSwipeReportsTheCardNearestTheViewportCenter() {
+        val games = listOf(
+            game("alpha", "Alpha", "steam"),
+            game("bravo", "Bravo", "epic"),
+            game("charlie", "Charlie", "gog"),
+            game("delta", "Delta", "steam")
+        )
+        val focusedGameId = AtomicReference<String?>(null)
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                Box(Modifier.fillMaxSize()) {
+                    NovaLibrarySpotlightRow(
+                        games = games,
+                        apiClient = apiClient,
+                        isLandscape = true,
+                        restoreFocusGameId = "bravo",
+                        showPosterTitles = true,
+                        onGameFocused = { focusedGameId.set(it.id) },
+                        onOpenDetail = {}
+                    )
+                }
+            }
+        }
+
+        val bravo = composeRule.onNode(hasContentDescription("Bravo", substring = true))
+        bravo.assertIsDisplayed()
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { focusedGameId.set(null) }
+
+        bravo.performTouchInput { swipeLeft(durationMillis = 800) }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) { focusedGameId.get() != null }
+        val viewportCenterX = composeRule.onRoot().fetchSemanticsNode().boundsInRoot.center.x
+        val centeredGameId = games.mapNotNull { game ->
+            runCatching {
+                composeRule.onNode(
+                    hasContentDescription(game.name, substring = true)
+                ).fetchSemanticsNode().boundsInRoot
+            }.getOrNull()?.let { bounds ->
+                game.id to abs(bounds.center.x - viewportCenterX)
+            }
+        }.minByOrNull { (_, distance) -> distance }?.first
+
+        assertEquals(centeredGameId, focusedGameId.get())
+        assertEquals("charlie", centeredGameId)
     }
 
     @Test

--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
@@ -1,0 +1,96 @@
+package com.papi.nova.ui
+
+import android.view.KeyEvent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.shared.polaris.model.PolarisGame
+import com.papi.nova.ui.compose.NovaComposeTheme
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NovaLibrarySpotlightRowComposeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun spotlightRestoresFocusNavigatesAndActivatesTheCenteredGame() {
+        val games = listOf(
+            game("alpha", "Alpha", "steam"),
+            game("bravo", "Bravo", "epic"),
+            game("charlie", "Charlie", "gog")
+        )
+        val openedGameId = AtomicReference<String?>(null)
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                Box(Modifier.fillMaxSize()) {
+                    NovaLibrarySpotlightRow(
+                        games = games,
+                        apiClient = apiClient,
+                        isLandscape = true,
+                        restoreFocusGameId = "bravo",
+                        showPosterTitles = true,
+                        onGameFocused = {},
+                        onOpenDetail = { openedGameId.set(it.id) }
+                    )
+                }
+            }
+        }
+
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_DOWN)
+        instrumentation.waitForIdleSync()
+        val bravo = composeRule.onNode(hasContentDescription("Bravo", substring = true))
+        bravo.assertIsDisplayed().assertHasClickAction()
+        waitForFocus(bravo)
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_RIGHT)
+        instrumentation.waitForIdleSync()
+        val charlie = composeRule.onNode(hasContentDescription("Charlie", substring = true))
+        charlie.assertIsDisplayed().assertHasClickAction()
+        waitForFocus(charlie)
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_CENTER)
+        instrumentation.waitForIdleSync()
+        assertEquals("charlie", openedGameId.get())
+
+        instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_LEFT)
+        instrumentation.waitForIdleSync()
+        waitForFocus(bravo)
+    }
+
+    private fun waitForFocus(node: androidx.compose.ui.test.SemanticsNodeInteraction) {
+        composeRule.waitUntil(timeoutMillis = 2_000) {
+            runCatching {
+                node.assertIsFocused()
+                true
+            }.getOrDefault(false)
+        }
+        node.assertIsFocused()
+    }
+
+    private fun game(id: String, name: String, source: String): PolarisGame = PolarisGame(
+        id = id,
+        name = name,
+        source = source,
+        launcherSource = source,
+        category = "fast_action",
+        genres = listOf("Action")
+    )
+}

--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLibrarySpotlightRowComposeTest.kt
@@ -3,12 +3,22 @@ package com.papi.nova.ui
 import android.view.KeyEvent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.unit.Density
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -17,6 +27,8 @@ import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.ui.compose.NovaComposeTheme
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -73,6 +85,166 @@ class NovaLibrarySpotlightRowComposeTest {
         instrumentation.sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_LEFT)
         instrumentation.waitForIdleSync()
         waitForFocus(bravo)
+    }
+
+    @Test
+    fun changingTheRestoreTargetMovesFocusWithoutChangingTheGameList() {
+        val games = listOf(
+            game("alpha", "Alpha", "steam"),
+            game("bravo", "Bravo", "epic"),
+            game("charlie", "Charlie", "gog")
+        )
+        var restoreFocusGameId by mutableStateOf("alpha")
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                NovaLibrarySpotlightRow(
+                    games = games,
+                    apiClient = apiClient,
+                    isLandscape = true,
+                    restoreFocusGameId = restoreFocusGameId,
+                    showPosterTitles = true,
+                    onGameFocused = {},
+                    onOpenDetail = {}
+                )
+            }
+        }
+
+        enterSpotlightRow()
+        val alpha = composeRule.onNode(hasContentDescription("Alpha", substring = true))
+        waitForFocus(alpha)
+
+        composeRule.runOnIdle { restoreFocusGameId = "charlie" }
+
+        waitForFocus(composeRule.onNode(hasContentDescription("Charlie", substring = true)))
+    }
+
+    @Test
+    fun accessibilityActivationSelectsTheGameBeforeOpeningDetails() {
+        val games = listOf(
+            game("alpha", "Alpha", "steam"),
+            game("bravo", "Bravo", "epic")
+        )
+        val focusedGameId = AtomicReference<String?>(null)
+        val openedGameId = AtomicReference<String?>(null)
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                NovaLibrarySpotlightRow(
+                    games = games,
+                    apiClient = apiClient,
+                    isLandscape = true,
+                    restoreFocusGameId = "alpha",
+                    showPosterTitles = true,
+                    onGameFocused = { focusedGameId.set(it.id) },
+                    onOpenDetail = { openedGameId.set(it.id) }
+                )
+            }
+        }
+
+        composeRule.onNode(hasContentDescription("Bravo", substring = true)).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals("bravo", focusedGameId.get())
+            assertEquals("bravo", openedGameId.get())
+        }
+    }
+
+    @Test
+    fun twoXFontScaleKeepsTheFocusedTitleScaledAndUnclipped() {
+        val title = "Control Ultimate Edition"
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            val deviceDensity = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(deviceDensity.density, fontScale = 2f)
+            ) {
+                NovaComposeTheme {
+                    NovaLibrarySpotlightRow(
+                        games = listOf(
+                            game("control", title, "epic").copy(
+                                hdrSupported = true,
+                                lastLaunched = 1L
+                            )
+                        ),
+                        apiClient = apiClient,
+                        isLandscape = true,
+                        restoreFocusGameId = "control",
+                        showPosterTitles = true,
+                        onGameFocused = {},
+                        onOpenDetail = {},
+                        coverLoader = { _, _ -> }
+                    )
+                }
+            }
+        }
+
+        enterSpotlightRow()
+        waitForFocus(composeRule.onNode(hasContentDescription(title, substring = true)))
+        val textNode = composeRule.onNodeWithText("Control Ultimate", substring = true, useUnmergedTree = true)
+        val layoutResults = mutableListOf<androidx.compose.ui.text.TextLayoutResult>()
+        textNode.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action ->
+            action(layoutResults)
+        }
+
+        assertEquals(21f, layoutResults.single().layoutInput.style.fontSize.value, 0.01f)
+        assertFalse(layoutResults.single().hasVisualOverflow)
+
+        val metadataResults = mutableListOf<androidx.compose.ui.text.TextLayoutResult>()
+        val metadata = composeRule.onNodeWithText("Epic · Fast action", useUnmergedTree = true)
+        metadata.assertIsDisplayed()
+        metadata.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(metadataResults) }
+        val metadataResult = metadataResults.single()
+        assertFalse(
+            "metadata overflow lines=${metadataResult.lineCount} size=${metadataResult.size} width=${metadataResult.multiParagraph.width} height=${metadataResult.multiParagraph.height} ellipsized=${(0 until metadataResult.lineCount).any(metadataResult::isLineEllipsized)}",
+            metadataResult.hasVisualOverflow
+        )
+        val hdr = composeRule.onNodeWithText("HDR", useUnmergedTree = true)
+        val recent = composeRule.onNodeWithText("Recent", useUnmergedTree = true)
+        hdr.assertIsDisplayed()
+        recent.assertIsDisplayed()
+        val titleTop = textNode.fetchSemanticsNode().boundsInRoot.top
+        val hdrBottom = hdr.fetchSemanticsNode().boundsInRoot.bottom
+        val recentBottom = recent.fetchSemanticsNode().boundsInRoot.bottom
+        assertTrue(hdrBottom <= titleTop)
+        assertTrue(recentBottom <= titleTop)
+    }
+
+    @Test
+    fun missingArtworkStillExposesReadableFallbackAndLaunchPath() {
+        val openedGameId = AtomicReference<String?>(null)
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                NovaLibrarySpotlightRow(
+                    games = listOf(game("offline", "", "offline")),
+                    apiClient = apiClient,
+                    isLandscape = true,
+                    restoreFocusGameId = "offline",
+                    showPosterTitles = true,
+                    onGameFocused = {},
+                    onOpenDetail = { openedGameId.set(it.id) },
+                    coverLoader = { _, _ -> }
+                )
+            }
+        }
+
+        val fallback = composeRule.onNode(hasContentDescription("Unknown game", substring = true))
+        fallback.assertIsDisplayed().assertHasClickAction().performClick()
+        composeRule.runOnIdle { assertEquals("offline", openedGameId.get()) }
+    }
+
+    private fun enterSpotlightRow() {
+        InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_DPAD_DOWN)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
     private fun waitForFocus(node: androidx.compose.ui.test.SemanticsNodeInteraction) {

--- a/app/src/main/java/com/papi/nova/ui/NovaControllerHintChromeState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaControllerHintChromeState.kt
@@ -1,0 +1,24 @@
+package com.papi.nova.ui
+
+enum class NovaControllerHintChromeEvent {
+    BROWSE_INTENT,
+    IDLE,
+    LAYOUT_CHANGED,
+    HELP_REQUESTED,
+    EXPLICIT_REVEAL
+}
+
+data class NovaControllerHintChromeState(
+    val visible: Boolean = true
+) {
+    fun reduce(event: NovaControllerHintChromeEvent): NovaControllerHintChromeState {
+        val nextVisible = when (event) {
+            NovaControllerHintChromeEvent.BROWSE_INTENT -> false
+            NovaControllerHintChromeEvent.IDLE,
+            NovaControllerHintChromeEvent.LAYOUT_CHANGED,
+            NovaControllerHintChromeEvent.HELP_REQUESTED,
+            NovaControllerHintChromeEvent.EXPLICIT_REVEAL -> true
+        }
+        return if (visible == nextVisible) this else copy(visible = nextVisible)
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaControllerHintChromeState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaControllerHintChromeState.kt
@@ -1,7 +1,13 @@
 package com.papi.nova.ui
 
+enum class NovaLibraryInputMode {
+    CONTROLLER,
+    TOUCH
+}
+
 enum class NovaControllerHintChromeEvent {
-    BROWSE_INTENT,
+    CONTROLLER_INPUT,
+    TOUCH_INPUT,
     IDLE,
     LAYOUT_CHANGED,
     HELP_REQUESTED,
@@ -9,16 +15,29 @@ enum class NovaControllerHintChromeEvent {
 }
 
 data class NovaControllerHintChromeState(
-    val visible: Boolean = true
+    val visible: Boolean = true,
+    val lastInputMode: NovaLibraryInputMode? = null
 ) {
     fun reduce(event: NovaControllerHintChromeEvent): NovaControllerHintChromeState {
-        val nextVisible = when (event) {
-            NovaControllerHintChromeEvent.BROWSE_INTENT -> false
+        return when (event) {
+            NovaControllerHintChromeEvent.CONTROLLER_INPUT -> reduceInput(NovaLibraryInputMode.CONTROLLER)
+            NovaControllerHintChromeEvent.TOUCH_INPUT -> reduceInput(NovaLibraryInputMode.TOUCH)
             NovaControllerHintChromeEvent.IDLE,
             NovaControllerHintChromeEvent.LAYOUT_CHANGED,
             NovaControllerHintChromeEvent.HELP_REQUESTED,
-            NovaControllerHintChromeEvent.EXPLICIT_REVEAL -> true
+            NovaControllerHintChromeEvent.EXPLICIT_REVEAL -> {
+                if (visible) this else copy(visible = true)
+            }
         }
-        return if (visible == nextVisible) this else copy(visible = nextVisible)
+    }
+
+    private fun reduceInput(inputMode: NovaLibraryInputMode): NovaControllerHintChromeState {
+        val changedMode = lastInputMode != null && lastInputMode != inputMode
+        val nextVisible = changedMode
+        return if (visible == nextVisible && lastInputMode == inputMode) {
+            this
+        } else {
+            copy(visible = nextVisible, lastInputMode = inputMode)
+        }
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -432,7 +432,7 @@ class NovaLibraryActivity : NovaActivity() {
                 event.action == MotionEvent.ACTION_MOVE &&
                 event.hasControllerBrowseMotion()
         val handled = super.dispatchGenericMotionEvent(event)
-        if (hasBrowseIntent) {
+        if (handled && hasBrowseIntent) {
             registerSuccessfulLibraryInput(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
         }
         return handled

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -4,10 +4,17 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
+import android.view.InputDevice
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.widget.ImageView
 import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.core.tween
 import androidx.activity.OnBackPressedCallback
 import com.papi.nova.NovaActivity
@@ -144,6 +151,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
+import kotlin.math.abs
 
 private data class LibraryLoadResult(
     val games: List<PolarisGame>,
@@ -179,7 +187,9 @@ class NovaLibraryActivity : NovaActivity() {
     private var activeSystemMenu by mutableStateOf(false)
     private var lastFocusedGameId by mutableStateOf<String?>(null)
     private var lastFocusedPrimaryFilter by mutableStateOf(NovaLibraryPrimaryFilter.ALL)
+    private var controllerHintChromeState by mutableStateOf(NovaControllerHintChromeState())
     private var activeSessionRefreshJob: Job? = null
+    private var controllerHintIdleJob: Job? = null
     private var appliedTheme: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -239,6 +249,7 @@ class NovaLibraryActivity : NovaActivity() {
                         activeFilterSheet = activeFilterSheet,
                         activeOptionsSheet = activeOptionsSheet,
                         activeSystemMenu = activeSystemMenu,
+                        controllerHintsVisible = controllerHintChromeState.visible,
                         restoreFocusGameId = lastFocusedGameId,
                         restoreFocusPrimaryFilter = lastFocusedPrimaryFilter,
                         onBack = ::finishWithTransition,
@@ -262,9 +273,7 @@ class NovaLibraryActivity : NovaActivity() {
                         onSortMode = { sortMode ->
                             updateLibraryOptions { it.copy(sortMode = sortMode) }
                         },
-                        onLayoutMode = { layoutMode ->
-                            updateLibraryOptions { it.copy(layoutMode = layoutMode) }
-                        },
+                        onLayoutMode = ::selectLibraryLayoutMode,
                         onPosterTitlesVisible = { showPosterTitles ->
                             updateLibraryOptions { it.copy(showPosterTitles = showPosterTitles) }
                         },
@@ -333,6 +342,11 @@ class NovaLibraryActivity : NovaActivity() {
         NovaLibraryPreferences.persistOptions(libraryPreferences(), nextState)
     }
 
+    private fun selectLibraryLayoutMode(layoutMode: NovaLibraryLayoutMode) {
+        updateLibraryOptions { it.copy(layoutMode = layoutMode) }
+        revealControllerHints(NovaControllerHintChromeEvent.LAYOUT_CHANGED)
+    }
+
     private fun updateLibraryFilterState(nextState: NovaLibraryFilterState) {
         val normalized = NovaLibraryPreferences.normalizeFilterState(nextState)
         filterState = normalized
@@ -343,6 +357,7 @@ class NovaLibraryActivity : NovaActivity() {
     override fun onResume() {
         super.onResume()
         if (recreateForThemeChangeIfNeeded()) return
+        revealControllerHints(NovaControllerHintChromeEvent.EXPLICIT_REVEAL)
         if (::apiClient.isInitialized && !isInitialLoading) {
             if (consumeLocalSessionEndSignal()) {
                 activeSession = null
@@ -379,6 +394,16 @@ class NovaLibraryActivity : NovaActivity() {
                 true
             }
             KeyEvent.KEYCODE_BUTTON_Y -> cycleLibraryLayoutMode()
+            KeyEvent.KEYCODE_HELP,
+            KeyEvent.KEYCODE_INFO,
+            KeyEvent.KEYCODE_F1 -> {
+                revealControllerHints(NovaControllerHintChromeEvent.HELP_REQUESTED)
+                true
+            }
+            KeyEvent.KEYCODE_BUTTON_SELECT -> {
+                revealControllerHints(NovaControllerHintChromeEvent.EXPLICIT_REVEAL)
+                true
+            }
             KeyEvent.KEYCODE_MENU, KeyEvent.KEYCODE_BUTTON_START -> {
                 if (!activeSystemMenu) openLibrarySystemMenu()
                 true
@@ -387,12 +412,53 @@ class NovaLibraryActivity : NovaActivity() {
         }
     }
 
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.action == KeyEvent.ACTION_DOWN && event.keyCode in CONTROLLER_BROWSE_KEYS) {
+            registerControllerBrowseIntent()
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        val isJoystick = event.source and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+        if (isJoystick && event.action == MotionEvent.ACTION_MOVE && event.hasControllerBrowseMotion()) {
+            registerControllerBrowseIntent()
+        }
+        return super.dispatchGenericMotionEvent(event)
+    }
+
+    private fun MotionEvent.hasControllerBrowseMotion(): Boolean {
+        return CONTROLLER_BROWSE_AXES.any { axis ->
+            abs(getAxisValue(axis)) >= CONTROLLER_AXIS_INTENT_THRESHOLD
+        }
+    }
+
+    private fun registerControllerBrowseIntent() {
+        if (hasActiveLibraryOverlay) return
+        controllerHintChromeState = controllerHintChromeState.reduce(
+            NovaControllerHintChromeEvent.BROWSE_INTENT
+        )
+        controllerHintIdleJob?.cancel()
+        controllerHintIdleJob = lifecycleScope.launch {
+            delay(CONTROLLER_HINT_IDLE_REVEAL_MS)
+            controllerHintChromeState = controllerHintChromeState.reduce(
+                NovaControllerHintChromeEvent.IDLE
+            )
+        }
+    }
+
+    private fun revealControllerHints(event: NovaControllerHintChromeEvent) {
+        controllerHintIdleJob?.cancel()
+        controllerHintIdleJob = null
+        controllerHintChromeState = controllerHintChromeState.reduce(event)
+    }
+
     private fun cycleLibraryLayoutMode(): Boolean {
         if (activeOptionsSheet || activeSystemMenu || activeFilterSheet != null) {
             return false
         }
         val nextMode = optionsState.layoutMode.next()
-        updateLibraryOptions { it.copy(layoutMode = nextMode) }
+        selectLibraryLayoutMode(nextMode)
         Toast.makeText(
             this,
             getString(R.string.nova_library_layout_toast_format, getString(layoutModeLabelRes(nextMode))),
@@ -404,6 +470,8 @@ class NovaLibraryActivity : NovaActivity() {
     override fun onStop() {
         activeSessionRefreshJob?.cancel()
         activeSessionRefreshJob = null
+        controllerHintIdleJob?.cancel()
+        controllerHintIdleJob = null
         detailSheet?.dismissAllowingStateLoss()
         detailSheet = null
         super.onStop()
@@ -904,6 +972,7 @@ class NovaLibraryActivity : NovaActivity() {
         activeFilterSheet: LibraryFilterSheet?,
         activeOptionsSheet: Boolean,
         activeSystemMenu: Boolean,
+        controllerHintsVisible: Boolean,
         restoreFocusGameId: String?,
         restoreFocusPrimaryFilter: NovaLibraryPrimaryFilter,
         onBack: () -> Unit,
@@ -938,6 +1007,7 @@ class NovaLibraryActivity : NovaActivity() {
         }
         val configuration = LocalConfiguration.current
         val isLandscape = configuration.screenWidthDp > configuration.screenHeightDp
+        val spotlightMode = model.optionsState.layoutMode == NovaLibraryLayoutMode.SPOTLIGHT
         val showLandscapeControlRail = NovaLibraryUiStateMapper.showLandscapeControlRail()
         val columns = NovaLibraryUiStateMapper.gridColumnsForScreen(
             configuration.screenWidthDp,
@@ -945,16 +1015,17 @@ class NovaLibraryActivity : NovaActivity() {
             model.optionsState.layoutMode
         )
         val railWidth = NovaLibraryUiStateMapper.railWidthDp(configuration.screenWidthDp).dp
-        val showLandscapeRecentRail = NovaLibraryUiStateMapper.showLandscapeRecentRail(
-            screenHeightDp = configuration.screenHeightDp,
-            heroReason = model.hero.reason,
-            recentCount = model.recentGames.size
-        )
+        val showLandscapeRecentRail = !spotlightMode &&
+            NovaLibraryUiStateMapper.showLandscapeRecentRail(
+                screenHeightDp = configuration.screenHeightDp,
+                heroReason = model.hero.reason,
+                recentCount = model.recentGames.size
+            )
         val colors = LocalNovaComposeColors.current
         val surfaces = LocalNovaLibrarySurfaces.current
         val controllerHintBarBottomPadding = NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape).dp
         val controllerHintBarLandscapeStartPadding = if (isLandscape && showLandscapeControlRail) railWidth + 10.dp else 0.dp
-        val restoreFocusGameInRecent = restoreFocusGameId != null &&
+        val restoreFocusGameInRecent = !spotlightMode && restoreFocusGameId != null &&
             model.recentGames.any { it.id == restoreFocusGameId }
         val focusedBackdropGame = remember(
             model.filteredGames,
@@ -1014,27 +1085,29 @@ class NovaLibraryActivity : NovaActivity() {
                                 onOpenOptions = onOpenOptions,
                                 onOpenSystemMenu = onOpenSystemMenu
                             )
-                            NovaLibraryHomeHero(
-                                hero = model.hero,
-                                compact = true,
-                                apiClient = apiClient,
-                                onPrimaryAction = {
-                                    when (model.hero.primaryAction) {
-                                        NovaLibraryHeroPrimaryAction.RESUME,
-                                        NovaLibraryHeroPrimaryAction.WATCH -> activeSession?.let(onResumeSession)
-                                        NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
-                                        NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
-                                        NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
-                                    }
-                                },
-                                onSecondaryAction = {
-                                    when (model.hero.secondaryAction) {
-                                        NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
-                                        null -> Unit
-                                    }
-                                },
-                                onGameFocused = onGameFocused
-                            )
+                            if (!spotlightMode || activeSession != null) {
+                                NovaLibraryHomeHero(
+                                    hero = model.hero,
+                                    compact = true,
+                                    apiClient = apiClient,
+                                    onPrimaryAction = {
+                                        when (model.hero.primaryAction) {
+                                            NovaLibraryHeroPrimaryAction.RESUME,
+                                            NovaLibraryHeroPrimaryAction.WATCH -> activeSession?.let(onResumeSession)
+                                            NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
+                                            NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
+                                            NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
+                                        }
+                                    },
+                                    onSecondaryAction = {
+                                        when (model.hero.secondaryAction) {
+                                            NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
+                                            null -> Unit
+                                        }
+                                    },
+                                    onGameFocused = onGameFocused
+                                )
+                            }
                             NovaLibraryContent(
                                 modifier = Modifier.weight(1f),
                                 model = model,
@@ -1082,28 +1155,30 @@ class NovaLibraryActivity : NovaActivity() {
                                 onOpenOptions = onOpenOptions,
                                 onOpenSystemMenu = onOpenSystemMenu
                             )
-                            NovaLibraryHomeHero(
-                                hero = model.hero,
-                                compact = false,
-                                apiClient = apiClient,
-                                onPrimaryAction = {
-                                    when (model.hero.primaryAction) {
-                                        NovaLibraryHeroPrimaryAction.RESUME,
-                                        NovaLibraryHeroPrimaryAction.WATCH -> activeSession?.let(onResumeSession)
-                                        NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
-                                        NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
-                                        NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
-                                    }
-                                },
-                                onSecondaryAction = {
-                                    when (model.hero.secondaryAction) {
-                                        NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
-                                        null -> Unit
-                                    }
-                                },
-                                onGameFocused = onGameFocused
-                            )
-                            if (model.recentGames.isNotEmpty()) {
+                            if (!spotlightMode || activeSession != null) {
+                                NovaLibraryHomeHero(
+                                    hero = model.hero,
+                                    compact = false,
+                                    apiClient = apiClient,
+                                    onPrimaryAction = {
+                                        when (model.hero.primaryAction) {
+                                            NovaLibraryHeroPrimaryAction.RESUME,
+                                            NovaLibraryHeroPrimaryAction.WATCH -> activeSession?.let(onResumeSession)
+                                            NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
+                                            NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
+                                            NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
+                                        }
+                                    },
+                                    onSecondaryAction = {
+                                        when (model.hero.secondaryAction) {
+                                            NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
+                                            null -> Unit
+                                        }
+                                    },
+                                    onGameFocused = onGameFocused
+                                )
+                            }
+                            if (!spotlightMode && model.recentGames.isNotEmpty()) {
                                 NovaLibraryRecentRail(
                                     games = model.recentGames,
                                     apiClient = apiClient,
@@ -1134,14 +1209,28 @@ class NovaLibraryActivity : NovaActivity() {
                         }
                     }
                 }
-                NovaControllerHintBar(
-                    hints = novaLibraryControllerHints(isLandscape),
-                    compact = isLandscape,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(start = controllerHintBarLandscapeStartPadding)
-                        .fillMaxWidth()
-                )
+                AnimatedVisibility(
+                    visible = controllerHintsVisible,
+                    modifier = Modifier.align(Alignment.BottomCenter),
+                    enter = fadeIn(tween(durationMillis = CONTROLLER_HINT_ANIMATION_MS)) +
+                        slideInVertically(
+                            animationSpec = tween(durationMillis = CONTROLLER_HINT_ANIMATION_MS),
+                            initialOffsetY = { it / 2 }
+                        ),
+                    exit = fadeOut(tween(durationMillis = CONTROLLER_HINT_ANIMATION_MS)) +
+                        slideOutVertically(
+                            animationSpec = tween(durationMillis = CONTROLLER_HINT_ANIMATION_MS),
+                            targetOffsetY = { it / 2 }
+                        )
+                ) {
+                    NovaControllerHintBar(
+                        hints = novaLibraryControllerHints(isLandscape),
+                        compact = isLandscape,
+                        modifier = Modifier
+                            .padding(start = controllerHintBarLandscapeStartPadding)
+                            .fillMaxWidth()
+                    )
+                }
             }
 
             when {
@@ -2215,6 +2304,16 @@ class NovaLibraryActivity : NovaActivity() {
                         NovaLibraryRecoveryState(
                             recoveryState = emptyRecoveryState,
                             onAction = onRecoveryAction
+                        )
+                    } else if (layoutMode == NovaLibraryLayoutMode.SPOTLIGHT) {
+                        NovaLibrarySpotlightRow(
+                            games = model.filteredGames,
+                            apiClient = apiClient,
+                            isLandscape = isLandscape,
+                            restoreFocusGameId = restoreFocusGameId,
+                            showPosterTitles = model.optionsState.showPosterTitles,
+                            onGameFocused = onGameFocused,
+                            onOpenDetail = onOpenDetail
                         )
                     } else {
                         LazyVerticalGrid(
@@ -3560,6 +3659,7 @@ class NovaLibraryActivity : NovaActivity() {
         NovaLibraryLayoutMode.GRID -> R.string.nova_library_options_layout_grid
         NovaLibraryLayoutMode.COMPACT_GRID -> R.string.nova_library_options_layout_compact_grid
         NovaLibraryLayoutMode.LIST -> R.string.nova_library_options_layout_list
+        NovaLibraryLayoutMode.SPOTLIGHT -> R.string.nova_library_options_layout_spotlight
     }
 
     @Composable
@@ -3567,6 +3667,7 @@ class NovaLibraryActivity : NovaActivity() {
         NovaLibraryLayoutMode.GRID -> stringResource(R.string.nova_library_options_layout_grid_hint)
         NovaLibraryLayoutMode.COMPACT_GRID -> stringResource(R.string.nova_library_options_layout_compact_grid_hint)
         NovaLibraryLayoutMode.LIST -> stringResource(R.string.nova_library_options_layout_list_hint)
+        NovaLibraryLayoutMode.SPOTLIGHT -> stringResource(R.string.nova_library_options_layout_spotlight_hint)
     }
 
     private fun filterCount(filter: NovaLibraryPrimaryFilter, model: NovaLibraryUiModel): Int {
@@ -3615,6 +3716,27 @@ class NovaLibraryActivity : NovaActivity() {
         const val EXTRA_PC_UUID = "pc_uuid"
         const val EXTRA_SERVER_COMMANDS = "server_commands"
         const val EXTRA_SERVER_CERT = "server_cert"
+        private const val CONTROLLER_HINT_IDLE_REVEAL_MS = 4_000L
+        private const val CONTROLLER_HINT_ANIMATION_MS = 180
+        private const val CONTROLLER_AXIS_INTENT_THRESHOLD = 0.35f
+        private val CONTROLLER_BROWSE_KEYS = setOf(
+            KeyEvent.KEYCODE_DPAD_UP,
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            KeyEvent.KEYCODE_DPAD_LEFT,
+            KeyEvent.KEYCODE_DPAD_RIGHT,
+            KeyEvent.KEYCODE_MOVE_HOME,
+            KeyEvent.KEYCODE_MOVE_END
+        )
+        private val CONTROLLER_BROWSE_AXES = intArrayOf(
+            MotionEvent.AXIS_X,
+            MotionEvent.AXIS_Y,
+            MotionEvent.AXIS_HAT_X,
+            MotionEvent.AXIS_HAT_Y,
+            MotionEvent.AXIS_Z,
+            MotionEvent.AXIS_RZ,
+            MotionEvent.AXIS_RX,
+            MotionEvent.AXIS_RY
+        )
         private val ACTIVE_SESSION_RESUME_REFRESH_DELAYS_MS = longArrayOf(1500L, 2000L, 3000L, 5000L, 8000L)
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -95,6 +95,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -413,18 +414,36 @@ class NovaLibraryActivity : NovaActivity() {
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.action == KeyEvent.ACTION_DOWN && event.keyCode in CONTROLLER_BROWSE_KEYS) {
-            registerControllerBrowseIntent()
+        val handled = super.dispatchKeyEvent(event)
+        if (
+            handled &&
+            event.action == KeyEvent.ACTION_DOWN &&
+            event.keyCode in CONTROLLER_BROWSE_KEYS
+        ) {
+            registerSuccessfulLibraryInput(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
         }
-        return super.dispatchKeyEvent(event)
+        return handled
     }
 
     override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
         val isJoystick = event.source and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
-        if (isJoystick && event.action == MotionEvent.ACTION_MOVE && event.hasControllerBrowseMotion()) {
-            registerControllerBrowseIntent()
+        val hasBrowseIntent =
+            isJoystick &&
+                event.action == MotionEvent.ACTION_MOVE &&
+                event.hasControllerBrowseMotion()
+        val handled = super.dispatchGenericMotionEvent(event)
+        if (hasBrowseIntent) {
+            registerSuccessfulLibraryInput(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
         }
-        return super.dispatchGenericMotionEvent(event)
+        return handled
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        val handled = super.dispatchTouchEvent(event)
+        if (handled && event.actionMasked == MotionEvent.ACTION_UP) {
+            registerSuccessfulLibraryInput(NovaControllerHintChromeEvent.TOUCH_INPUT)
+        }
+        return handled
     }
 
     private fun MotionEvent.hasControllerBrowseMotion(): Boolean {
@@ -433,11 +452,9 @@ class NovaLibraryActivity : NovaActivity() {
         }
     }
 
-    private fun registerControllerBrowseIntent() {
+    private fun registerSuccessfulLibraryInput(event: NovaControllerHintChromeEvent) {
         if (hasActiveLibraryOverlay) return
-        controllerHintChromeState = controllerHintChromeState.reduce(
-            NovaControllerHintChromeEvent.BROWSE_INTENT
-        )
+        controllerHintChromeState = controllerHintChromeState.reduce(event)
         controllerHintIdleJob?.cancel()
         controllerHintIdleJob = lifecycleScope.launch {
             delay(CONTROLLER_HINT_IDLE_REVEAL_MS)
@@ -1007,7 +1024,8 @@ class NovaLibraryActivity : NovaActivity() {
         }
         val configuration = LocalConfiguration.current
         val isLandscape = configuration.screenWidthDp > configuration.screenHeightDp
-        val spotlightMode = model.optionsState.layoutMode == NovaLibraryLayoutMode.SPOTLIGHT
+        val largeText = LocalDensity.current.fontScale >= 1.5f
+        val spotlightMode = model.optionsState.layoutMode == NovaLibraryLayoutMode.SPOTLIGHT_ROW
         val showLandscapeControlRail = NovaLibraryUiStateMapper.showLandscapeControlRail()
         val columns = NovaLibraryUiStateMapper.gridColumnsForScreen(
             configuration.screenWidthDp,
@@ -1039,6 +1057,15 @@ class NovaLibraryActivity : NovaActivity() {
                 ?: model.hero.game
                 ?: model.filteredGames.firstOrNull()
                 ?: model.recentGames.firstOrNull()
+        }
+        val controllerHints = novaLibraryControllerHints(isLandscape)
+        val visibleControllerHints = if (largeText) {
+            controllerHints.filterIndexed { index, _ -> index in LARGE_TEXT_HINT_INDICES }
+        } else {
+            controllerHints
+        }
+        val controllerHintDescription = controllerHints.joinToString(separator = " · ") { hint ->
+            "${hint.key} ${hint.label}"
         }
 
         Box(
@@ -1224,8 +1251,9 @@ class NovaLibraryActivity : NovaActivity() {
                         )
                 ) {
                     NovaControllerHintBar(
-                        hints = novaLibraryControllerHints(isLandscape),
+                        hints = visibleControllerHints,
                         compact = isLandscape,
+                        semanticsDescription = controllerHintDescription,
                         modifier = Modifier
                             .padding(start = controllerHintBarLandscapeStartPadding)
                             .fillMaxWidth()
@@ -1655,6 +1683,8 @@ class NovaLibraryActivity : NovaActivity() {
     ) {
         val colors = LocalNovaComposeColors.current
         val surfaces = LocalNovaLibrarySurfaces.current
+        val largeText = LocalDensity.current.fontScale >= 1.5f
+        val optionsDescription = stringResource(R.string.nova_library_options_title)
         val hostLabel = serverName?.takeIf { it.isNotBlank() } ?: serverHost
         val shape = RoundedCornerShape(18.dp)
 
@@ -1669,7 +1699,12 @@ class NovaLibraryActivity : NovaActivity() {
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             NovaActionButton(
-                text = stringResource(R.string.nova_library_options_title),
+                text = if (largeText) {
+                    stringResource(R.string.nova_controller_hint_options)
+                } else {
+                    optionsDescription
+                },
+                contentDescription = optionsDescription,
                 onClick = onOpenOptions,
                 primary = true,
                 minHeight = 34.dp,
@@ -2305,7 +2340,7 @@ class NovaLibraryActivity : NovaActivity() {
                             recoveryState = emptyRecoveryState,
                             onAction = onRecoveryAction
                         )
-                    } else if (layoutMode == NovaLibraryLayoutMode.SPOTLIGHT) {
+                    } else if (layoutMode == NovaLibraryLayoutMode.SPOTLIGHT_ROW) {
                         NovaLibrarySpotlightRow(
                             games = model.filteredGames,
                             apiClient = apiClient,
@@ -3659,7 +3694,7 @@ class NovaLibraryActivity : NovaActivity() {
         NovaLibraryLayoutMode.GRID -> R.string.nova_library_options_layout_grid
         NovaLibraryLayoutMode.COMPACT_GRID -> R.string.nova_library_options_layout_compact_grid
         NovaLibraryLayoutMode.LIST -> R.string.nova_library_options_layout_list
-        NovaLibraryLayoutMode.SPOTLIGHT -> R.string.nova_library_options_layout_spotlight
+        NovaLibraryLayoutMode.SPOTLIGHT_ROW -> R.string.nova_library_options_layout_spotlight
     }
 
     @Composable
@@ -3667,7 +3702,7 @@ class NovaLibraryActivity : NovaActivity() {
         NovaLibraryLayoutMode.GRID -> stringResource(R.string.nova_library_options_layout_grid_hint)
         NovaLibraryLayoutMode.COMPACT_GRID -> stringResource(R.string.nova_library_options_layout_compact_grid_hint)
         NovaLibraryLayoutMode.LIST -> stringResource(R.string.nova_library_options_layout_list_hint)
-        NovaLibraryLayoutMode.SPOTLIGHT -> stringResource(R.string.nova_library_options_layout_spotlight_hint)
+        NovaLibraryLayoutMode.SPOTLIGHT_ROW -> stringResource(R.string.nova_library_options_layout_spotlight_hint)
     }
 
     private fun filterCount(filter: NovaLibraryPrimaryFilter, model: NovaLibraryUiModel): Int {
@@ -3719,6 +3754,7 @@ class NovaLibraryActivity : NovaActivity() {
         private const val CONTROLLER_HINT_IDLE_REVEAL_MS = 4_000L
         private const val CONTROLLER_HINT_ANIMATION_MS = 180
         private const val CONTROLLER_AXIS_INTENT_THRESHOLD = 0.35f
+        private val LARGE_TEXT_HINT_INDICES = setOf(0, 1, 3)
         private val CONTROLLER_BROWSE_KEYS = setOf(
             KeyEvent.KEYCODE_DPAD_UP,
             KeyEvent.KEYCODE_DPAD_DOWN,

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryPreferences.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryPreferences.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 object NovaLibraryPreferences {
     private const val SORT_MODE_PREF = "nova_library_sort_mode"
     private const val LAYOUT_MODE_PREF = "nova_library_layout_mode"
+    private const val LEGACY_SPOTLIGHT_LAYOUT_MODE = "SPOTLIGHT"
     private const val POSTER_TITLES_PREF = "nova_library_poster_titles"
     private const val FILTER_PRIMARY_PREF = "nova_library_filter_primary"
     private const val FILTER_SOURCE_PREF = "nova_library_filter_source"
@@ -14,7 +15,7 @@ object NovaLibraryPreferences {
     fun loadOptions(prefs: SharedPreferences): NovaLibraryOptionsState {
         return NovaLibraryOptionsState(
             sortMode = prefs.enumValue(SORT_MODE_PREF, NovaLibrarySortMode.LIBRARY_ORDER),
-            layoutMode = prefs.enumValue(LAYOUT_MODE_PREF, NovaLibraryLayoutMode.GRID),
+            layoutMode = prefs.libraryLayoutMode(),
             showPosterTitles = prefs.getBoolean(POSTER_TITLES_PREF, true)
         )
     }
@@ -83,6 +84,14 @@ object NovaLibraryPreferences {
                 )
                 else -> NovaLibraryFilterState()
             }
+        }
+    }
+
+    private fun SharedPreferences.libraryLayoutMode(): NovaLibraryLayoutMode {
+        return if (getString(LAYOUT_MODE_PREF, null) == LEGACY_SPOTLIGHT_LAYOUT_MODE) {
+            NovaLibraryLayoutMode.SPOTLIGHT_ROW
+        } else {
+            enumValue(LAYOUT_MODE_PREF, NovaLibraryLayoutMode.GRID)
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
@@ -1,0 +1,391 @@
+package com.papi.nova.ui
+
+import android.graphics.Color
+import android.widget.ImageView
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.ui.res.stringResource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.papi.nova.R
+import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.shared.polaris.model.PolarisGame
+import com.papi.nova.ui.compose.LocalNovaComposeColors
+import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.NovaFocusMotionSpec
+import com.papi.nova.ui.compose.novaFocusMotion
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+@Composable
+internal fun NovaLibrarySpotlightRow(
+    games: List<PolarisGame>,
+    apiClient: PolarisApiClient,
+    isLandscape: Boolean,
+    restoreFocusGameId: String?,
+    showPosterTitles: Boolean,
+    onGameFocused: (PolarisGame) -> Unit,
+    onOpenDetail: (PolarisGame) -> Unit,
+    coverLoader: (ImageView, PolarisGame) -> Unit = { view, game ->
+        apiClient.loadCoverInto(view, game)
+    }
+) {
+    val gameIds = remember(games) { games.map { it.id } }
+    val initialIndex = remember(gameIds) {
+        NovaLibraryUiStateMapper.spotlightRestoreIndex(gameIds, restoreFocusGameId)
+    }
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialIndex)
+    val focusRequesters = remember(gameIds) { List(games.size) { FocusRequester() } }
+    val scope = rememberCoroutineScope()
+    val largeText = LocalDensity.current.fontScale >= 1.5f
+
+    LaunchedEffect(gameIds, initialIndex) {
+        if (games.isEmpty()) return@LaunchedEffect
+        repeat(SPOTLIGHT_FOCUS_REQUEST_ATTEMPTS) {
+            withFrameNanos { }
+            val accepted = runCatching {
+                focusRequesters[initialIndex].requestFocus()
+            }.getOrDefault(false)
+            if (accepted) return@LaunchedEffect
+            delay(SPOTLIGHT_FOCUS_RETRY_DELAY_MS)
+        }
+    }
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val availableWidthDp = maxWidth.value.toInt()
+        val cardWidthDp = NovaLibraryUiStateMapper.spotlightCardWidthDp(
+            availableWidthDp = availableWidthDp,
+            isLandscape = isLandscape
+        )
+        val desiredCardHeightDp = NovaLibraryUiStateMapper.spotlightCardHeightDp(
+            cardWidthDp = cardWidthDp,
+            isLandscape = isLandscape,
+            largeText = largeText
+        )
+        val cardHeightDp = NovaLibraryUiStateMapper.spotlightConstrainedCardHeightDp(
+            desiredHeightDp = desiredCardHeightDp,
+            availableHeightDp = maxHeight.value.toInt()
+        )
+        val horizontalPaddingDp = NovaLibraryUiStateMapper.spotlightHorizontalContentPaddingDp(
+            availableWidthDp = availableWidthDp,
+            cardWidthDp = cardWidthDp
+        )
+
+        LazyRow(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = horizontalPaddingDp.dp,
+                end = horizontalPaddingDp.dp,
+                top = 12.dp,
+                bottom = 14.dp
+            ),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            itemsIndexed(
+                items = games,
+                key = { _, game -> game.id },
+                contentType = { _, _ -> "spotlight-game" }
+            ) { index, game ->
+                NovaLibrarySpotlightCard(
+                    game = game,
+                    cardWidthDp = cardWidthDp,
+                    cardHeightDp = cardHeightDp,
+                    largeText = largeText,
+                    showPosterTitles = showPosterTitles,
+                    focusRequester = focusRequesters[index],
+                    onFocused = {
+                        onGameFocused(game)
+                        scope.launch { listState.animateScrollToItem(index) }
+                    },
+                    onNavigate = { delta ->
+                        val nextIndex = NovaLibraryUiStateMapper.spotlightAdjacentIndex(
+                            currentIndex = index,
+                            delta = delta,
+                            itemCount = games.size
+                        )
+                        if (nextIndex != index) {
+                            scope.launch {
+                                listState.animateScrollToItem(nextIndex)
+                                withFrameNanos { }
+                                runCatching { focusRequesters[nextIndex].requestFocus() }
+                            }
+                        }
+                        true
+                    },
+                    coverLoader = coverLoader,
+                    onOpenDetail = { onOpenDetail(game) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaLibrarySpotlightCard(
+    game: PolarisGame,
+    cardWidthDp: Int,
+    cardHeightDp: Int,
+    largeText: Boolean,
+    showPosterTitles: Boolean,
+    focusRequester: FocusRequester,
+    onFocused: () -> Unit,
+    onNavigate: (Int) -> Boolean,
+    coverLoader: (ImageView, PolarisGame) -> Unit,
+    onOpenDetail: () -> Unit
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val shape = RoundedCornerShape(22.dp)
+    val title = game.name.ifBlank { stringResource(R.string.nova_library_unknown_game) }
+    val detailsLabel = stringResource(R.string.nova_library_card_action_details)
+    val recentLabel = stringResource(R.string.nova_library_filter_recent)
+    val source = spotlightLabel(game.source)
+    val category = spotlightLabel(game.category)
+    val metadata = buildList {
+        add(source)
+        add(category)
+        if (largeText && game.hdrSupported) add("HDR")
+        if (largeText && game.lastLaunched > 0) add(recentLabel)
+    }.filter { it.isNotBlank() }.distinct().joinToString(" · ")
+    var focused by remember(game.id) { mutableStateOf(false) }
+    val cardAlpha by animateFloatAsState(
+        targetValue = if (focused) 1f else 0.68f,
+        animationSpec = tween(durationMillis = 150),
+        label = "NovaSpotlightCardAlpha"
+    )
+    val accessibilityLabel = buildString {
+        append(title)
+        if (metadata.isNotBlank()) append(". ").append(metadata)
+        if (game.hdrSupported && !largeText) append(". HDR")
+        append(". ").append(detailsLabel)
+    }
+
+    Box(
+        modifier = Modifier
+            .width(cardWidthDp.dp)
+            .height(cardHeightDp.dp)
+            .alpha(cardAlpha)
+            .novaFocusMotion(
+                focused = focused,
+                focusedScale = NovaFocusMotionSpec.CardFocusedScale
+            )
+            .focusRequester(focusRequester)
+            .onFocusChanged { state ->
+                focused = state.isFocused
+                if (state.isFocused) onFocused()
+            }
+            .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                when (event.key) {
+                    Key.DirectionLeft -> onNavigate(-1)
+                    Key.DirectionRight -> onNavigate(1)
+                    else -> false
+                }
+            }
+            .semantics {
+                role = Role.Button
+                contentDescription = accessibilityLabel
+            }
+            .combinedClickable(
+                role = Role.Button,
+                onClick = onOpenDetail,
+                onLongClick = onOpenDetail
+            )
+            .clip(shape)
+            .background(if (focused) colors.accent else surfaces.tileBorder)
+            .padding(if (focused) 3.dp else 1.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(surfaces.mediaPlaceholder)
+        ) {
+            Text(
+                text = title.take(1).uppercase(Locale.US),
+                color = colors.accent.copy(alpha = 0.40f),
+                fontSize = if (largeText) 72.sp else 58.sp,
+                fontWeight = FontWeight.Black,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        AndroidView(
+            factory = { context ->
+                ImageView(context).apply {
+                    scaleType = ImageView.ScaleType.CENTER_CROP
+                    setBackgroundColor(Color.TRANSPARENT)
+                    isFocusable = false
+                    isClickable = false
+                    importantForAccessibility = android.view.View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                }
+            },
+            update = { view ->
+                view.scaleType = ImageView.ScaleType.CENTER_CROP
+                view.setBackgroundColor(Color.TRANSPARENT)
+                view.alpha = 1f
+                view.contentDescription = null
+                coverLoader(view, game)
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+
+        if (!largeText) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (game.hdrSupported) {
+                    NovaSpotlightPill(text = "HDR", emphasized = focused)
+                }
+                if (game.lastLaunched > 0) {
+                    NovaSpotlightPill(text = recentLabel, emphasized = false)
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(if (largeText) 164.dp else 128.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        0f to surfaces.mediaScrimBottom.copy(alpha = 0f),
+                        0.30f to surfaces.mediaScrimBottom.copy(alpha = 0.66f),
+                        1f to surfaces.mediaScrimBottom.copy(alpha = 0.98f)
+                    )
+                )
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(
+                    horizontal = if (largeText) 14.dp else 18.dp,
+                    vertical = if (largeText) 10.dp else 14.dp
+                ),
+            verticalArrangement = Arrangement.spacedBy(if (largeText) 2.dp else 3.dp)
+        ) {
+            if (showPosterTitles || focused) {
+                Text(
+                    text = title,
+                    color = surfaces.onMedia,
+                    fontSize = if (largeText) 10.sp else if (focused) 21.sp else 17.sp,
+                    fontWeight = if (focused) FontWeight.Bold else FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            if (metadata.isNotBlank()) {
+                Text(
+                    text = metadata,
+                    color = surfaces.onMediaSecondary,
+                    fontSize = if (largeText) 8.sp else 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+    }
+}
+
+@Composable
+private fun NovaSpotlightPill(text: String, emphasized: Boolean) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val shape = RoundedCornerShape(999.dp)
+    Text(
+        text = text,
+        color = if (emphasized) colors.onAccent else surfaces.onMedia,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+        modifier = Modifier
+            .clip(shape)
+            .background(
+                if (emphasized) colors.accent.copy(alpha = 0.94f)
+                else surfaces.mediaScrimBottom.copy(alpha = 0.64f)
+            )
+            .border(
+                BorderStroke(
+                    1.dp,
+                    if (emphasized) colors.accent else surfaces.onMedia.copy(alpha = 0.24f)
+                ),
+                shape
+            )
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    )
+}
+
+private fun spotlightLabel(value: String?): String {
+    return value
+        ?.substringAfterLast('/')
+        ?.substringAfterLast(':')
+        ?.replace('_', ' ')
+        ?.replace('-', ' ')
+        ?.trim()
+        ?.replaceFirstChar { char ->
+            if (char.isLowerCase()) char.titlecase(Locale.US) else char.toString()
+        }
+        .orEmpty()
+}
+
+private const val SPOTLIGHT_FOCUS_REQUEST_ATTEMPTS = 6
+private const val SPOTLIGHT_FOCUS_RETRY_DELAY_MS = 32L

--- a/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
@@ -5,9 +5,11 @@ import android.widget.ImageView
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -31,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -64,9 +67,13 @@ import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
 import com.papi.nova.ui.compose.NovaFocusMotionSpec
 import com.papi.nova.ui.compose.novaFocusMotion
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import java.util.Locale
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun NovaLibrarySpotlightRow(
     games: List<PolarisGame>,
@@ -81,16 +88,18 @@ internal fun NovaLibrarySpotlightRow(
     }
 ) {
     val gameIds = remember(games) { games.map { it.id } }
-    val initialIndex = remember(gameIds) {
+    val initialIndex = remember(gameIds, restoreFocusGameId) {
         NovaLibraryUiStateMapper.spotlightRestoreIndex(gameIds, restoreFocusGameId)
     }
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialIndex)
+    val snapFlingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
     val focusRequesters = remember(gameIds) { List(games.size) { FocusRequester() } }
     val scope = rememberCoroutineScope()
     val largeText = LocalDensity.current.fontScale >= 1.5f
 
     LaunchedEffect(gameIds, initialIndex) {
         if (games.isEmpty()) return@LaunchedEffect
+        listState.scrollToItem(initialIndex)
         repeat(SPOTLIGHT_FOCUS_REQUEST_ATTEMPTS) {
             withFrameNanos { }
             val accepted = runCatching {
@@ -101,11 +110,22 @@ internal fun NovaLibrarySpotlightRow(
         }
     }
 
+    LaunchedEffect(gameIds, listState) {
+        snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
+            .drop(1)
+            .filter { scrolling -> !scrolling }
+            .collect {
+                games.getOrNull(listState.firstVisibleItemIndex)?.let(onGameFocused)
+            }
+    }
+
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val availableWidthDp = maxWidth.value.toInt()
         val cardWidthDp = NovaLibraryUiStateMapper.spotlightCardWidthDp(
             availableWidthDp = availableWidthDp,
-            isLandscape = isLandscape
+            isLandscape = isLandscape,
+            largeText = largeText
         )
         val desiredCardHeightDp = NovaLibraryUiStateMapper.spotlightCardHeightDp(
             cardWidthDp = cardWidthDp,
@@ -123,6 +143,7 @@ internal fun NovaLibrarySpotlightRow(
 
         LazyRow(
             state = listState,
+            flingBehavior = snapFlingBehavior,
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
                 start = horizontalPaddingDp.dp,
@@ -165,7 +186,11 @@ internal fun NovaLibrarySpotlightRow(
                         true
                     },
                     coverLoader = coverLoader,
-                    onOpenDetail = { onOpenDetail(game) }
+                    onOpenDetail = {
+                        onGameFocused(game)
+                        scope.launch { listState.animateScrollToItem(index) }
+                        onOpenDetail(game)
+                    }
                 )
             }
         }
@@ -189,6 +214,7 @@ private fun NovaLibrarySpotlightCard(
     val surfaces = LocalNovaLibrarySurfaces.current
     val shape = RoundedCornerShape(22.dp)
     val title = game.name.ifBlank { stringResource(R.string.nova_library_unknown_game) }
+    val displayTitle = spotlightDisplayTitle(title, largeText)
     val detailsLabel = stringResource(R.string.nova_library_card_action_details)
     val recentLabel = stringResource(R.string.nova_library_filter_recent)
     val source = spotlightLabel(game.source)
@@ -196,8 +222,6 @@ private fun NovaLibrarySpotlightCard(
     val metadata = buildList {
         add(source)
         add(category)
-        if (largeText && game.hdrSupported) add("HDR")
-        if (largeText && game.lastLaunched > 0) add(recentLabel)
     }.filter { it.isNotBlank() }.distinct().joinToString(" · ")
     var focused by remember(game.id) { mutableStateOf(false) }
     val cardAlpha by animateFloatAsState(
@@ -208,7 +232,8 @@ private fun NovaLibrarySpotlightCard(
     val accessibilityLabel = buildString {
         append(title)
         if (metadata.isNotBlank()) append(". ").append(metadata)
-        if (game.hdrSupported && !largeText) append(". HDR")
+        if (game.hdrSupported) append(". HDR")
+        if (game.lastLaunched > 0) append(". ").append(recentLabel)
         append(". ").append(detailsLabel)
     }
 
@@ -280,27 +305,25 @@ private fun NovaLibrarySpotlightCard(
             modifier = Modifier.fillMaxSize()
         )
 
-        if (!largeText) {
-            Row(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (game.hdrSupported) {
-                    NovaSpotlightPill(text = "HDR", emphasized = focused)
-                }
-                if (game.lastLaunched > 0) {
-                    NovaSpotlightPill(text = recentLabel, emphasized = false)
-                }
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(if (largeText) 8.dp else 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(if (largeText) 4.dp else 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (game.hdrSupported) {
+                NovaSpotlightPill(text = "HDR", emphasized = focused)
+            }
+            if (game.lastLaunched > 0) {
+                NovaSpotlightPill(text = recentLabel, emphasized = false)
             }
         }
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(if (largeText) 164.dp else 128.dp)
+                .height(if (largeText) 216.dp else 128.dp)
                 .align(Alignment.BottomCenter)
                 .background(
                     Brush.verticalGradient(
@@ -317,28 +340,31 @@ private fun NovaLibrarySpotlightCard(
                 .fillMaxWidth()
                 .padding(
                     horizontal = if (largeText) 14.dp else 18.dp,
-                    vertical = if (largeText) 10.dp else 14.dp
+                    vertical = if (largeText) 4.dp else 14.dp
                 ),
             verticalArrangement = Arrangement.spacedBy(if (largeText) 2.dp else 3.dp)
         ) {
             if (showPosterTitles || focused) {
                 Text(
-                    text = title,
+                    text = displayTitle,
                     color = surfaces.onMedia,
-                    fontSize = if (largeText) 10.sp else if (focused) 21.sp else 17.sp,
+                    fontSize = if (focused) 21.sp else 17.sp,
                     fontWeight = if (focused) FontWeight.Bold else FontWeight.SemiBold,
+                    minLines = if (largeText) 2 else 1,
                     maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
             if (metadata.isNotBlank()) {
                 Text(
                     text = metadata,
                     color = surfaces.onMediaSecondary,
-                    fontSize = if (largeText) 8.sp else 12.sp,
+                    fontSize = 12.sp,
                     fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    maxLines = if (largeText) 2 else 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }
@@ -355,6 +381,7 @@ private fun NovaSpotlightPill(text: String, emphasized: Boolean) {
         text = text,
         color = if (emphasized) colors.onAccent else surfaces.onMedia,
         fontSize = 10.sp,
+        lineHeight = 10.sp,
         fontWeight = FontWeight.Bold,
         maxLines = 1,
         modifier = Modifier
@@ -372,6 +399,16 @@ private fun NovaSpotlightPill(text: String, emphasized: Boolean) {
             )
             .padding(horizontal = 8.dp, vertical = 3.dp)
     )
+}
+
+internal fun spotlightDisplayTitle(title: String, largeText: Boolean): String {
+    if (!largeText || title.length <= 20 || '\n' in title) return title
+    val midpoint = title.length / 2
+    val breakIndex = title.indices
+        .filter { index -> title[index] == ' ' }
+        .minByOrNull { index -> kotlin.math.abs(index - midpoint) }
+        ?: return title
+    return title.substring(0, breakIndex) + "\n" + title.substring(breakIndex + 1)
 }
 
 private fun spotlightLabel(value: String?): String {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import java.util.Locale
+import kotlin.math.abs
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -116,7 +117,14 @@ internal fun NovaLibrarySpotlightRow(
             .drop(1)
             .filter { scrolling -> !scrolling }
             .collect {
-                games.getOrNull(listState.firstVisibleItemIndex)?.let(onGameFocused)
+                val layoutInfo = listState.layoutInfo
+                val viewportCenter = (
+                    layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset
+                ) / 2f
+                val centeredIndex = layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                    abs(item.offset + item.size / 2f - viewportCenter)
+                }?.index
+                centeredIndex?.let(games::getOrNull)?.let(onGameFocused)
             }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -2,6 +2,7 @@ package com.papi.nova.ui
 
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.api.PolarisSessionStatus
+import kotlin.math.roundToInt
 
 enum class NovaLibraryPrimaryFilter {
     ALL,
@@ -33,12 +34,14 @@ enum class NovaLibrarySortMode {
 enum class NovaLibraryLayoutMode {
     GRID,
     COMPACT_GRID,
-    LIST;
+    LIST,
+    SPOTLIGHT;
 
     fun next(): NovaLibraryLayoutMode = when (this) {
         GRID -> COMPACT_GRID
         COMPACT_GRID -> LIST
-        LIST -> GRID
+        LIST -> SPOTLIGHT
+        SPOTLIGHT -> GRID
     }
 }
 
@@ -784,7 +787,57 @@ object NovaLibraryUiStateMapper {
             NovaLibraryLayoutMode.GRID -> baseColumns
             NovaLibraryLayoutMode.COMPACT_GRID -> (baseColumns + 1).coerceAtMost(6)
             NovaLibraryLayoutMode.LIST -> 1
+            NovaLibraryLayoutMode.SPOTLIGHT -> 1
         }
+    }
+
+    fun spotlightCardWidthDp(availableWidthDp: Int, isLandscape: Boolean): Int {
+        val fraction = if (isLandscape) 0.58f else 0.84f
+        val configuredMin = if (isLandscape) 320 else 260
+        val configuredMax = if (isLandscape) 520 else 420
+        val safeMax = minOf(configuredMax, (availableWidthDp - 32).coerceAtLeast(1))
+        val safeMin = minOf(configuredMin, safeMax)
+        return (availableWidthDp * fraction).roundToInt().coerceIn(safeMin, safeMax)
+    }
+
+    fun spotlightHorizontalContentPaddingDp(
+        availableWidthDp: Int,
+        cardWidthDp: Int
+    ): Int = ((availableWidthDp - cardWidthDp) / 2).coerceAtLeast(12)
+
+    fun spotlightCardHeightDp(
+        cardWidthDp: Int,
+        isLandscape: Boolean,
+        largeText: Boolean
+    ): Int {
+        val ratio = when {
+            isLandscape && largeText -> 0.68f
+            isLandscape -> 0.60f
+            largeText -> 0.90f
+            else -> 0.80f
+        }
+        val minimum = if (isLandscape) 220 else 240
+        val maximum = if (isLandscape) 360 else 420
+        return (cardWidthDp * ratio).roundToInt().coerceIn(minimum, maximum)
+    }
+
+    fun spotlightConstrainedCardHeightDp(
+        desiredHeightDp: Int,
+        availableHeightDp: Int,
+        verticalContentPaddingDp: Int = 26
+    ): Int {
+        val viewportHeight = (availableHeightDp - verticalContentPaddingDp).coerceAtLeast(180)
+        return desiredHeightDp.coerceAtMost(viewportHeight)
+    }
+
+    fun spotlightRestoreIndex(gameIds: List<String>, restoreGameId: String?): Int {
+        if (gameIds.isEmpty() || restoreGameId == null) return 0
+        return gameIds.indexOf(restoreGameId).takeIf { it >= 0 } ?: 0
+    }
+
+    fun spotlightAdjacentIndex(currentIndex: Int, delta: Int, itemCount: Int): Int {
+        if (itemCount <= 0) return 0
+        return (currentIndex + delta).coerceIn(0, itemCount - 1)
     }
 
     fun recentRailCardWidthDp(
@@ -815,6 +868,7 @@ object NovaLibraryUiStateMapper {
             NovaLibraryLayoutMode.COMPACT_GRID -> 112
             NovaLibraryLayoutMode.GRID -> if (isLandscape) 156 else 168
             NovaLibraryLayoutMode.LIST -> 88
+            NovaLibraryLayoutMode.SPOTLIGHT -> if (isLandscape) 290 else 300
         }
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -35,13 +35,13 @@ enum class NovaLibraryLayoutMode {
     GRID,
     COMPACT_GRID,
     LIST,
-    SPOTLIGHT;
+    SPOTLIGHT_ROW;
 
     fun next(): NovaLibraryLayoutMode = when (this) {
         GRID -> COMPACT_GRID
         COMPACT_GRID -> LIST
-        LIST -> SPOTLIGHT
-        SPOTLIGHT -> GRID
+        LIST -> SPOTLIGHT_ROW
+        SPOTLIGHT_ROW -> GRID
     }
 }
 
@@ -787,13 +787,27 @@ object NovaLibraryUiStateMapper {
             NovaLibraryLayoutMode.GRID -> baseColumns
             NovaLibraryLayoutMode.COMPACT_GRID -> (baseColumns + 1).coerceAtMost(6)
             NovaLibraryLayoutMode.LIST -> 1
-            NovaLibraryLayoutMode.SPOTLIGHT -> 1
+            NovaLibraryLayoutMode.SPOTLIGHT_ROW -> 1
         }
     }
 
-    fun spotlightCardWidthDp(availableWidthDp: Int, isLandscape: Boolean): Int {
-        val fraction = if (isLandscape) 0.58f else 0.84f
-        val configuredMin = if (isLandscape) 320 else 260
+    fun spotlightCardWidthDp(
+        availableWidthDp: Int,
+        isLandscape: Boolean,
+        largeText: Boolean = false
+    ): Int {
+        val fraction = when {
+            isLandscape && largeText -> 0.72f
+            isLandscape -> 0.58f
+            largeText -> 0.92f
+            else -> 0.84f
+        }
+        val configuredMin = when {
+            isLandscape && largeText -> 352
+            isLandscape -> 320
+            largeText -> 300
+            else -> 260
+        }
         val configuredMax = if (isLandscape) 520 else 420
         val safeMax = minOf(configuredMax, (availableWidthDp - 32).coerceAtLeast(1))
         val safeMin = minOf(configuredMin, safeMax)
@@ -868,7 +882,7 @@ object NovaLibraryUiStateMapper {
             NovaLibraryLayoutMode.COMPACT_GRID -> 112
             NovaLibraryLayoutMode.GRID -> if (isLandscape) 156 else 168
             NovaLibraryLayoutMode.LIST -> 88
-            NovaLibraryLayoutMode.SPOTLIGHT -> if (isLandscape) 290 else 300
+            NovaLibraryLayoutMode.SPOTLIGHT_ROW -> if (isLandscape) 290 else 300
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,8 @@
     <string name="nova_library_options_layout_compact_grid_hint">More games on screen for fast controller sweeps.</string>
     <string name="nova_library_options_layout_list">List</string>
     <string name="nova_library_options_layout_list_hint">One-column rows for quick title scanning.</string>
+    <string name="nova_library_options_layout_spotlight">Spotlight row</string>
+    <string name="nova_library_options_layout_spotlight_hint">Center the focused game with adjacent titles ready on either side.</string>
     <string name="nova_library_options_poster_titles_title">Poster titles</string>
     <string name="nova_library_options_poster_titles_show">Show titles</string>
     <string name="nova_library_options_poster_titles_show_hint">Keep the readable title bar on poster cards.</string>
@@ -296,6 +298,7 @@
     <string name="nova_library_error_hint">Check Polaris and try again.</string>
     <string name="nova_library_error_action_manage">Manage server</string>
     <string name="nova_library_card_action_details">Details</string>
+    <string name="nova_library_unknown_game">Unknown game</string>
     <string name="nova_library_meta_last_played">Played %1$s</string>
     <string name="nova_library_meta_ready_to_play">Ready to play</string>
     <string name="nova_library_launch_mode_title">Launch Mode</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -494,7 +494,7 @@ class NovaComposeSourceGuardTest {
             "private fun NovaLibraryLandscapeToolbar("
         )
 
-        val landscape = screen.section("if (isLandscape) {", "} else {")
+        val landscape = screen.blockStartingAt("if (isLandscape) {")
 
         assertTrue(
             "landscape library should promote the hero before grid content so the picker remains visible on Retroid",
@@ -1636,7 +1636,7 @@ class NovaComposeSourceGuardTest {
                 libraryScreen.contains("NovaLibraryLandscapeToolbar(") &&
                 libraryScreen.contains(".padding(bottom = controllerHintBarBottomPadding)") &&
                 libraryScreen.contains("NovaControllerHintBar(") &&
-                libraryScreen.contains("hints = novaLibraryControllerHints(isLandscape)") &&
+                libraryScreen.contains("hints = visibleControllerHints") &&
                 libraryScreen.contains("modifier = Modifier") &&
                 libraryScreen.contains(".align(Alignment.BottomCenter)") &&
                 libraryScreen.contains(".padding(start = controllerHintBarLandscapeStartPadding)") &&

--- a/app/src/test/java/com/papi/nova/ui/NovaControllerHintChromeStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaControllerHintChromeStateTest.kt
@@ -10,7 +10,7 @@ class NovaControllerHintChromeStateTest {
         val initial = NovaControllerHintChromeState()
 
         assertTrue(initial.visible)
-        assertFalse(initial.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT).visible)
+        assertFalse(initial.reduce(NovaControllerHintChromeEvent.CONTROLLER_INPUT).visible)
     }
 
     @Test
@@ -26,9 +26,23 @@ class NovaControllerHintChromeStateTest {
     @Test
     fun repeatedVisibilityEventsAreIdempotent() {
         val visible = NovaControllerHintChromeState()
-        val hidden = visible.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT)
+        val hidden = visible.reduce(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
 
-        assertFalse(hidden.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT).visible)
+        assertFalse(hidden.reduce(NovaControllerHintChromeEvent.CONTROLLER_INPUT).visible)
         assertTrue(visible.reduce(NovaControllerHintChromeEvent.IDLE).visible)
+    }
+
+    @Test
+    fun changingBetweenControllerAndTouchRestoresHintsBeforeRepeatedInputCollapsesThem() {
+        val controllerHidden = NovaControllerHintChromeState()
+            .reduce(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
+        val touchModeRevealed = controllerHidden.reduce(NovaControllerHintChromeEvent.TOUCH_INPUT)
+        val touchHidden = touchModeRevealed.reduce(NovaControllerHintChromeEvent.TOUCH_INPUT)
+        val controllerModeRevealed = touchHidden.reduce(NovaControllerHintChromeEvent.CONTROLLER_INPUT)
+
+        assertFalse(controllerHidden.visible)
+        assertTrue(touchModeRevealed.visible)
+        assertFalse(touchHidden.visible)
+        assertTrue(controllerModeRevealed.visible)
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaControllerHintChromeStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaControllerHintChromeStateTest.kt
@@ -1,0 +1,34 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaControllerHintChromeStateTest {
+    @Test
+    fun hintsStartVisibleAndBrowsingIntentCollapsesThem() {
+        val initial = NovaControllerHintChromeState()
+
+        assertTrue(initial.visible)
+        assertFalse(initial.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT).visible)
+    }
+
+    @Test
+    fun idleLayoutHelpAndExplicitRevealRestoreHints() {
+        val hidden = NovaControllerHintChromeState(visible = false)
+
+        assertTrue(hidden.reduce(NovaControllerHintChromeEvent.IDLE).visible)
+        assertTrue(hidden.reduce(NovaControllerHintChromeEvent.LAYOUT_CHANGED).visible)
+        assertTrue(hidden.reduce(NovaControllerHintChromeEvent.HELP_REQUESTED).visible)
+        assertTrue(hidden.reduce(NovaControllerHintChromeEvent.EXPLICIT_REVEAL).visible)
+    }
+
+    @Test
+    fun repeatedVisibilityEventsAreIdempotent() {
+        val visible = NovaControllerHintChromeState()
+        val hidden = visible.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT)
+
+        assertFalse(hidden.reduce(NovaControllerHintChromeEvent.BROWSE_INTENT).visible)
+        assertTrue(visible.reduce(NovaControllerHintChromeEvent.IDLE).visible)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
@@ -60,7 +60,8 @@ class NovaLibraryActivitySourceTest {
         assertTrue(source.contains("KeyEvent.KEYCODE_BUTTON_Y"))
         assertTrue(source.contains("cycleLibraryLayoutMode()"))
         assertTrue(source.contains("activeOptionsSheet || activeSystemMenu || activeFilterSheet != null"))
-        assertTrue(source.contains("updateLibraryOptions { it.copy(layoutMode = nextMode) }"))
+        assertTrue(source.contains("selectLibraryLayoutMode(nextMode)"))
+        assertTrue(source.contains("revealControllerHints(NovaControllerHintChromeEvent.LAYOUT_CHANGED)"))
         assertTrue(hints.contains("R.string.nova_controller_hint_y"))
         assertTrue(hints.contains("R.string.nova_controller_hint_layout"))
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
@@ -46,6 +46,18 @@ class NovaLibraryPreferencesTest {
     }
 
     @Test
+    fun persistsSpotlightAsAnOptionalLibraryLayout() {
+        val prefs = freshPrefs("nova-library-prefs-spotlight")
+        val options = NovaLibraryOptionsState(
+            layoutMode = NovaLibraryLayoutMode.SPOTLIGHT
+        )
+
+        NovaLibraryPreferences.persistOptions(prefs, options)
+
+        assertEquals(options, NovaLibraryPreferences.loadOptions(prefs))
+    }
+
+    @Test
     fun persistsMoreFiltersAndClearsThemBackToAll() {
         val prefs = freshPrefs("nova-library-prefs-more")
         val category = NovaLibraryFilterState(

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
@@ -58,6 +58,19 @@ class NovaLibraryPreferencesTest {
     }
 
     @Test
+    fun migratesCandidateEraSpotlightLayoutWithoutResettingToGrid() {
+        val prefs = freshPrefs("nova-library-prefs-spotlight-migration")
+        prefs.edit()
+            .putString("nova_library_layout_mode", "SPOTLIGHT")
+            .commit()
+
+        assertEquals(
+            NovaLibraryLayoutMode.SPOTLIGHT_ROW,
+            NovaLibraryPreferences.loadOptions(prefs).layoutMode
+        )
+    }
+
+    @Test
     fun persistsMoreFiltersAndClearsThemBackToAll() {
         val prefs = freshPrefs("nova-library-prefs-more")
         val category = NovaLibraryFilterState(

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryPreferencesTest.kt
@@ -49,7 +49,7 @@ class NovaLibraryPreferencesTest {
     fun persistsSpotlightAsAnOptionalLibraryLayout() {
         val prefs = freshPrefs("nova-library-prefs-spotlight")
         val options = NovaLibraryOptionsState(
-            layoutMode = NovaLibraryLayoutMode.SPOTLIGHT
+            layoutMode = NovaLibraryLayoutMode.SPOTLIGHT_ROW
         )
 
         NovaLibraryPreferences.persistOptions(prefs, options)

--- a/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
@@ -1,0 +1,67 @@
+package com.papi.nova.ui
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaLibrarySpotlightSourceTest {
+    private fun read(path: String): String = File(path).readText()
+
+    @Test
+    fun spotlightIsARealLibraryRenderingModeWithoutChangingExistingCardModes() {
+        val activity = read("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+        val spotlight = read("src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt")
+
+        assertTrue(activity.contains("layoutMode == NovaLibraryLayoutMode.SPOTLIGHT"))
+        assertTrue(activity.contains("NovaLibrarySpotlightRow("))
+        assertTrue(activity.contains("NovaLibraryLayoutMode.SPOTLIGHT -> R.string.nova_library_options_layout_spotlight"))
+        assertTrue(spotlight.contains("LazyRow("))
+        assertTrue(spotlight.contains("itemsIndexed("))
+        assertTrue(spotlight.contains("key = { _, game -> game.id }"))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightCardWidthDp("))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightHorizontalContentPaddingDp("))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightCardHeightDp("))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightConstrainedCardHeightDp("))
+    }
+
+    @Test
+    fun spotlightUsesRealArtworkAccessibleCardsAndDeterministicFocusRestoration() {
+        val spotlight = read("src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt")
+
+        assertTrue(spotlight.contains("apiClient.loadCoverInto(view, game)"))
+        assertTrue(spotlight.contains("coverLoader(view, game)"))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightRestoreIndex("))
+        assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightAdjacentIndex("))
+        assertTrue(spotlight.contains("rememberLazyListState("))
+        assertTrue(spotlight.contains("FocusRequester()"))
+        assertTrue(spotlight.contains("repeat(SPOTLIGHT_FOCUS_REQUEST_ATTEMPTS)"))
+        assertTrue(spotlight.contains("SPOTLIGHT_FOCUS_RETRY_DELAY_MS"))
+        assertTrue(spotlight.contains(".onPreviewKeyEvent"))
+        assertTrue(spotlight.contains("Key.DirectionLeft"))
+        assertTrue(spotlight.contains("Key.DirectionRight"))
+        assertTrue(spotlight.contains(".semantics"))
+        assertTrue(spotlight.contains("contentDescription = accessibilityLabel"))
+        assertTrue(spotlight.contains("showPosterTitles || focused"))
+        assertTrue(spotlight.contains("LocalDensity.current.fontScale >= 1.5f"))
+    }
+
+    @Test
+    fun adaptiveControllerChromeObservesInputWithoutStealingNavigation() {
+        val activity = read("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+
+        assertTrue(activity.contains("private var controllerHintChromeState by mutableStateOf(NovaControllerHintChromeState())"))
+        assertTrue(activity.contains("override fun dispatchKeyEvent(event: KeyEvent): Boolean"))
+        assertTrue(activity.contains("registerControllerBrowseIntent()"))
+        assertTrue(activity.contains("override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean"))
+        assertTrue(activity.contains("InputDevice.SOURCE_JOYSTICK"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.BROWSE_INTENT"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.IDLE"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.LAYOUT_CHANGED"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.HELP_REQUESTED"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.EXPLICIT_REVEAL"))
+        assertTrue(activity.contains("controllerHintChromeState.visible"))
+        assertTrue(activity.contains("AnimatedVisibility("))
+        assertTrue(activity.contains("visible = controllerHintsVisible"))
+        assertTrue(activity.contains("return super.dispatchGenericMotionEvent(event)"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
@@ -35,6 +35,9 @@ class NovaLibrarySpotlightSourceTest {
         assertTrue(spotlight.contains("remember(gameIds, restoreFocusGameId)"))
         assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightAdjacentIndex("))
         assertTrue(spotlight.contains("rememberLazyListState("))
+        assertTrue(spotlight.contains("layoutInfo.viewportStartOffset"))
+        assertTrue(spotlight.contains("layoutInfo.visibleItemsInfo.minByOrNull"))
+        assertFalse(spotlight.contains("games.getOrNull(listState.firstVisibleItemIndex)"))
         assertTrue(spotlight.contains("FocusRequester()"))
         assertTrue(spotlight.contains("repeat(SPOTLIGHT_FOCUS_REQUEST_ATTEMPTS)"))
         assertTrue(spotlight.contains("SPOTLIGHT_FOCUS_RETRY_DELAY_MS"))
@@ -69,6 +72,11 @@ class NovaLibrarySpotlightSourceTest {
         assertTrue(activity.contains("AnimatedVisibility("))
         assertTrue(activity.contains("visible = controllerHintsVisible"))
         assertTrue(activity.contains("val handled = super.dispatchGenericMotionEvent(event)"))
+        val genericMotionDispatch = activity.substring(
+            activity.indexOf("override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean"),
+            activity.indexOf("override fun dispatchTouchEvent(event: MotionEvent): Boolean")
+        )
+        assertTrue(genericMotionDispatch.contains("if (handled && hasBrowseIntent)"))
         assertTrue(activity.contains("return handled"))
     }
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibrarySpotlightSourceTest.kt
@@ -1,6 +1,7 @@
 package com.papi.nova.ui
 
 import java.io.File
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -12,9 +13,9 @@ class NovaLibrarySpotlightSourceTest {
         val activity = read("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
         val spotlight = read("src/main/java/com/papi/nova/ui/NovaLibrarySpotlightRow.kt")
 
-        assertTrue(activity.contains("layoutMode == NovaLibraryLayoutMode.SPOTLIGHT"))
+        assertTrue(activity.contains("layoutMode == NovaLibraryLayoutMode.SPOTLIGHT_ROW"))
         assertTrue(activity.contains("NovaLibrarySpotlightRow("))
-        assertTrue(activity.contains("NovaLibraryLayoutMode.SPOTLIGHT -> R.string.nova_library_options_layout_spotlight"))
+        assertTrue(activity.contains("NovaLibraryLayoutMode.SPOTLIGHT_ROW -> R.string.nova_library_options_layout_spotlight"))
         assertTrue(spotlight.contains("LazyRow("))
         assertTrue(spotlight.contains("itemsIndexed("))
         assertTrue(spotlight.contains("key = { _, game -> game.id }"))
@@ -31,6 +32,7 @@ class NovaLibrarySpotlightSourceTest {
         assertTrue(spotlight.contains("apiClient.loadCoverInto(view, game)"))
         assertTrue(spotlight.contains("coverLoader(view, game)"))
         assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightRestoreIndex("))
+        assertTrue(spotlight.contains("remember(gameIds, restoreFocusGameId)"))
         assertTrue(spotlight.contains("NovaLibraryUiStateMapper.spotlightAdjacentIndex("))
         assertTrue(spotlight.contains("rememberLazyListState("))
         assertTrue(spotlight.contains("FocusRequester()"))
@@ -43,6 +45,8 @@ class NovaLibrarySpotlightSourceTest {
         assertTrue(spotlight.contains("contentDescription = accessibilityLabel"))
         assertTrue(spotlight.contains("showPosterTitles || focused"))
         assertTrue(spotlight.contains("LocalDensity.current.fontScale >= 1.5f"))
+        assertFalse(spotlight.contains("fontSize = if (largeText) 10.sp"))
+        assertFalse(spotlight.contains("fontSize = if (largeText) 8.sp"))
     }
 
     @Test
@@ -51,10 +55,12 @@ class NovaLibrarySpotlightSourceTest {
 
         assertTrue(activity.contains("private var controllerHintChromeState by mutableStateOf(NovaControllerHintChromeState())"))
         assertTrue(activity.contains("override fun dispatchKeyEvent(event: KeyEvent): Boolean"))
-        assertTrue(activity.contains("registerControllerBrowseIntent()"))
+        assertTrue(activity.contains("registerSuccessfulLibraryInput(NovaControllerHintChromeEvent.CONTROLLER_INPUT)"))
         assertTrue(activity.contains("override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean"))
+        assertTrue(activity.contains("override fun dispatchTouchEvent(event: MotionEvent): Boolean"))
         assertTrue(activity.contains("InputDevice.SOURCE_JOYSTICK"))
-        assertTrue(activity.contains("NovaControllerHintChromeEvent.BROWSE_INTENT"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.CONTROLLER_INPUT"))
+        assertTrue(activity.contains("NovaControllerHintChromeEvent.TOUCH_INPUT"))
         assertTrue(activity.contains("NovaControllerHintChromeEvent.IDLE"))
         assertTrue(activity.contains("NovaControllerHintChromeEvent.LAYOUT_CHANGED"))
         assertTrue(activity.contains("NovaControllerHintChromeEvent.HELP_REQUESTED"))
@@ -62,6 +68,16 @@ class NovaLibrarySpotlightSourceTest {
         assertTrue(activity.contains("controllerHintChromeState.visible"))
         assertTrue(activity.contains("AnimatedVisibility("))
         assertTrue(activity.contains("visible = controllerHintsVisible"))
-        assertTrue(activity.contains("return super.dispatchGenericMotionEvent(event)"))
+        assertTrue(activity.contains("val handled = super.dispatchGenericMotionEvent(event)"))
+        assertTrue(activity.contains("return handled"))
     }
+    @Test
+    fun largeTextToolbarKeepsEssentialHintsVisibleAndFullSemantics() {
+        val activity = read("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+
+        assertTrue(activity.contains("LARGE_TEXT_HINT_INDICES"))
+        assertTrue(activity.contains("semanticsDescription = controllerHintDescription"))
+        assertTrue(activity.contains("R.string.nova_controller_hint_options"))
+    }
+
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -571,6 +571,14 @@ class NovaLibraryUiStateTest {
                 layoutMode = NovaLibraryLayoutMode.LIST
             )
         )
+        assertEquals(
+            1,
+            NovaLibraryUiStateMapper.gridColumnsForScreen(
+                widthDp = 833,
+                isLandscape = true,
+                layoutMode = NovaLibraryLayoutMode.SPOTLIGHT
+            )
+        )
         assertEquals(156, NovaLibraryUiStateMapper.gameCardHeightDp(NovaLibraryLayoutMode.GRID, isLandscape = true))
         assertEquals(112, NovaLibraryUiStateMapper.gameCardHeightDp(NovaLibraryLayoutMode.COMPACT_GRID, isLandscape = true))
         assertEquals(88, NovaLibraryUiStateMapper.gameCardHeightDp(NovaLibraryLayoutMode.LIST, isLandscape = true))
@@ -580,15 +588,83 @@ class NovaLibraryUiStateTest {
     fun libraryLayoutModesCycleForTheYShortcut() {
         assertEquals(NovaLibraryLayoutMode.COMPACT_GRID, NovaLibraryLayoutMode.GRID.next())
         assertEquals(NovaLibraryLayoutMode.LIST, NovaLibraryLayoutMode.COMPACT_GRID.next())
-        assertEquals(NovaLibraryLayoutMode.GRID, NovaLibraryLayoutMode.LIST.next())
+        assertEquals(NovaLibraryLayoutMode.SPOTLIGHT, NovaLibraryLayoutMode.LIST.next())
+        assertEquals(NovaLibraryLayoutMode.GRID, NovaLibraryLayoutMode.SPOTLIGHT.next())
         assertEquals(
             listOf(
                 NovaLibraryLayoutMode.GRID,
                 NovaLibraryLayoutMode.COMPACT_GRID,
-                NovaLibraryLayoutMode.LIST
+                NovaLibraryLayoutMode.LIST,
+                NovaLibraryLayoutMode.SPOTLIGHT
             ),
             NovaLibraryLayoutMode.entries
         )
+    }
+
+    @Test
+    fun spotlightMetricsCenterTheFocusedGameAndScaleForLargeText() {
+        val thorWidth = NovaLibraryUiStateMapper.spotlightCardWidthDp(
+            availableWidthDp = 833,
+            isLandscape = true
+        )
+        val phoneWidth = NovaLibraryUiStateMapper.spotlightCardWidthDp(
+            availableWidthDp = 430,
+            isLandscape = false
+        )
+
+        assertEquals(483, thorWidth)
+        assertEquals(361, phoneWidth)
+        assertEquals(
+            175,
+            NovaLibraryUiStateMapper.spotlightHorizontalContentPaddingDp(
+                availableWidthDp = 833,
+                cardWidthDp = thorWidth
+            )
+        )
+        assertEquals(
+            290,
+            NovaLibraryUiStateMapper.spotlightCardHeightDp(
+                cardWidthDp = thorWidth,
+                isLandscape = true,
+                largeText = false
+            )
+        )
+        assertEquals(
+            328,
+            NovaLibraryUiStateMapper.spotlightCardHeightDp(
+                cardWidthDp = thorWidth,
+                isLandscape = true,
+                largeText = true
+            )
+        )
+        assertEquals(
+            284,
+            NovaLibraryUiStateMapper.spotlightConstrainedCardHeightDp(
+                desiredHeightDp = 328,
+                availableHeightDp = 310
+            )
+        )
+        assertEquals(
+            290,
+            NovaLibraryUiStateMapper.spotlightConstrainedCardHeightDp(
+                desiredHeightDp = 290,
+                availableHeightDp = 400
+            )
+        )
+    }
+
+    @Test
+    fun spotlightFocusRestorationAndAdjacentNavigationAreDeterministic() {
+        val gameIds = listOf("alpha", "bravo", "charlie")
+
+        assertEquals(1, NovaLibraryUiStateMapper.spotlightRestoreIndex(gameIds, "bravo"))
+        assertEquals(0, NovaLibraryUiStateMapper.spotlightRestoreIndex(gameIds, "missing"))
+        assertEquals(0, NovaLibraryUiStateMapper.spotlightRestoreIndex(gameIds, null))
+        assertEquals(0, NovaLibraryUiStateMapper.spotlightRestoreIndex(emptyList(), "bravo"))
+        assertEquals(0, NovaLibraryUiStateMapper.spotlightAdjacentIndex(0, -1, gameIds.size))
+        assertEquals(1, NovaLibraryUiStateMapper.spotlightAdjacentIndex(0, 1, gameIds.size))
+        assertEquals(2, NovaLibraryUiStateMapper.spotlightAdjacentIndex(2, 1, gameIds.size))
+        assertEquals(1, NovaLibraryUiStateMapper.spotlightAdjacentIndex(2, -1, gameIds.size))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -576,7 +576,7 @@ class NovaLibraryUiStateTest {
             NovaLibraryUiStateMapper.gridColumnsForScreen(
                 widthDp = 833,
                 isLandscape = true,
-                layoutMode = NovaLibraryLayoutMode.SPOTLIGHT
+                layoutMode = NovaLibraryLayoutMode.SPOTLIGHT_ROW
             )
         )
         assertEquals(156, NovaLibraryUiStateMapper.gameCardHeightDp(NovaLibraryLayoutMode.GRID, isLandscape = true))
@@ -588,14 +588,14 @@ class NovaLibraryUiStateTest {
     fun libraryLayoutModesCycleForTheYShortcut() {
         assertEquals(NovaLibraryLayoutMode.COMPACT_GRID, NovaLibraryLayoutMode.GRID.next())
         assertEquals(NovaLibraryLayoutMode.LIST, NovaLibraryLayoutMode.COMPACT_GRID.next())
-        assertEquals(NovaLibraryLayoutMode.SPOTLIGHT, NovaLibraryLayoutMode.LIST.next())
-        assertEquals(NovaLibraryLayoutMode.GRID, NovaLibraryLayoutMode.SPOTLIGHT.next())
+        assertEquals(NovaLibraryLayoutMode.SPOTLIGHT_ROW, NovaLibraryLayoutMode.LIST.next())
+        assertEquals(NovaLibraryLayoutMode.GRID, NovaLibraryLayoutMode.SPOTLIGHT_ROW.next())
         assertEquals(
             listOf(
                 NovaLibraryLayoutMode.GRID,
                 NovaLibraryLayoutMode.COMPACT_GRID,
                 NovaLibraryLayoutMode.LIST,
-                NovaLibraryLayoutMode.SPOTLIGHT
+                NovaLibraryLayoutMode.SPOTLIGHT_ROW
             ),
             NovaLibraryLayoutMode.entries
         )
@@ -607,12 +607,24 @@ class NovaLibraryUiStateTest {
             availableWidthDp = 833,
             isLandscape = true
         )
+        val thorLargeTextWidth = NovaLibraryUiStateMapper.spotlightCardWidthDp(
+            availableWidthDp = 833,
+            isLandscape = true,
+            largeText = true
+        )
+        val compactThorLargeTextWidth = NovaLibraryUiStateMapper.spotlightCardWidthDp(
+            availableWidthDp = 472,
+            isLandscape = true,
+            largeText = true
+        )
         val phoneWidth = NovaLibraryUiStateMapper.spotlightCardWidthDp(
             availableWidthDp = 430,
             isLandscape = false
         )
 
         assertEquals(483, thorWidth)
+        assertEquals(520, thorLargeTextWidth)
+        assertEquals(352, compactThorLargeTextWidth)
         assertEquals(361, phoneWidth)
         assertEquals(
             175,
@@ -992,6 +1004,19 @@ class NovaLibraryUiStateTest {
                 PolarisSessionStatus(state = "idle", game = "Indy", gameId = 777)
             )
         )
+    }
+
+    @Test
+    fun largeTextSpotlightTitlesWrapAtNaturalWordBoundaries() {
+        assertEquals(
+            "Control Ultimate\nEdition",
+            spotlightDisplayTitle("Control Ultimate Edition", largeText = true)
+        )
+        assertEquals(
+            "Control Ultimate Edition",
+            spotlightDisplayTitle("Control Ultimate Edition", largeText = false)
+        )
+        assertEquals("Alan Wake 2", spotlightDisplayTitle("Alan Wake 2", largeText = true))
     }
 
     private fun game(


### PR DESCRIPTION
## Summary

Closes #169.

- add an optional, persisted **Spotlight Row** beside Grid, Compact Grid, and List
- center the active game with adjacent peeks, stable ID keys, existing artwork loading, readable fallbacks, and source/category/HDR/recent metadata
- restore focus by stable game ID, including restore-target changes without list mutation
- keep Android focus as the sole D-pad/keyboard movement authority
- resolve settled touch selection from the visible item nearest viewport center rather than `firstVisibleItemIndex`
- synchronize touch/accessibility activation with selection before opening details
- collapse controller hints only after successfully handled key or generic-motion browsing; ignore unhandled joystick noise
- migrate candidate-era persisted `SPOTLIGHT` values to `SPOTLIGHT_ROW`
- preserve genuine Android scaled typography through responsive geometry and two-line word-boundary wrapping instead of shrinking source text
- preserve Grid/List behavior, Material You/OLED appearance, filters, options, artwork fallback, and activation semantics

## Exact candidate

- Commit: `b82070fcb67b7b4a0f0543d70cef6b6789e4b880`
- Tree: `9f5d35f8126bdbbd8e803fc9d492d85686cb1f8d`
- Parent: `f91dfe639074a912a203857e08b0ac76158db809`
- Base: `8ee5257b868220ac45cb1bd5dd5e53102f0f82ca`

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1,030 tests, 0 failures/errors/skips
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebugAndroidTest`
- [x] direct API 33 Thor `NovaLibrarySpotlightRowComposeTest` — 6/6 passed
- [x] real swipe assertion compares callback ID with the actual card nearest viewport center
- [x] Material You light and OLED dark screenshot review
- [x] real Activity Android 2× and OLED + Android 2× screenshot review
- [x] real Grid and List regression screenshot review
- [x] modified-file secret/truncation/debug/capture scan: zero hits
- [x] `git diff --check`
- [x] temporary capture tests, fixture asset/server, and TLS material removed before commit
- [x] exact-commit engineering review — APPROVE
- [x] exact-commit UX/accessibility review — APPROVE
- [x] exact-commit adversarial state/input review — APPROVE after verdict-only redispatch
- [x] physical AYN Thor QA explicitly waived for merge of exact `b82070fc` / tree `9f5d35f8` only; not performed and not waived for v1.3.3 release

### Broader API 33 harness baseline

The full Thor suite stalls at a pre-existing Activity Compose idle boundary. Untouched exact base `8ee5257b` also stalls in `NovaLibraryActivityComposeTest` on Thor. On RP6, untouched base reproduces the two historical `Test Server` visibility failures. Historical exact-base testing also reproduced the existing Polaris Sync visibility failure.

The broad suite is not claimed green. The issue-specific exact-candidate API 33 class is green, and the Thor stall is reproduced on untouched base.

## QA artifact

- `Nova-issue169-b82070fc-arm64-v8a-debug.apk`
- Package `com.papi.nova.debug`
- Version `1.3.2 (34)`
- ABI `arm64-v8a`
- Size `30,201,173` bytes
- SHA-256 `157a69592b304912d96170abb7b558687f76240acb9ce72163b3b76874719064`

The QA APK is a debug artifact, not the signed v1.3.3 release artifact.

Physical AYN Thor QA was not performed and was explicitly waived for **merging exact commit `b82070fcb67b7b4a0f0543d70cef6b6789e4b880` / tree `9f5d35f8126bdbbd8e803fc9d492d85686cb1f8d` only**. It is not represented as passed. The waiver does not cover a successor or v1.3.3 release/signing/tag/publication/deployment; physical OLED, controller, touch, routing, reconnect, lifecycle, and teardown validation remain release debt.
