### PR TITLE
chore(release): prepare Nova 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,36 @@
 
 ## Unreleased
 
-### Release administration
+## 1.3.3 - 2026-07-30
 
-- Merged PR #160 ("chore(nova): integrate 1.3.2 Kanban-full smoke branch") into release/v1.3.2-opacity-prep on 2026-07-24, preserving the 1.3.2 package/version identity (versionName 1.3.2, versionCode 34, minSdk 21, targetSdk 36) and preserving canonical artifact naming.
+Nova 1.3.3 turns the Library and dual-screen experience into a controller-first command surface. It adds Spotlight Row, explicit Follow / Stream / Companion display roles, the Thor companion command deck, broader Material You semantics, and focused navigation, lifecycle, and API 33 reliability fixes.
+
+### Highlights
+
+- Adds **Spotlight Row** as a fourth persisted Library mode beside Grid, Compact Grid, and List, with centered artwork, adjacent-card peeks, stable-ID focus restoration, touch snapping, readable offline fallbacks, and adaptive controller guidance.
+- Adds a visual **Follow / Stream / Companion** role composer that previews display assignments, applies changes explicitly, survives hotplug safely, and reuses Nova's existing display-routing authority.
+- Ships the **Thor companion command deck** on the non-stream display while preserving keyboard, Quick Menu, touchpad, controller-focus, lifecycle, and teardown behavior.
+- Applies **Material You** and OLED-aware semantic surfaces across system bars, dialogs, settings, Library chrome, focus states, and companion controls.
+- Keeps controller focus stable while server state refreshes, fixes the API 33 codec-settings dialog crash, and strengthens display-ID reconciliation, stream geometry, server removal, polling, manual-add, and active-session cleanup.
+- Adds a distinct **Modern** Settings action and clearer **Manage** server action without changing card activation semantics.
+
+### Compatibility and behavior
+
+- Preserves Grid, Compact Grid, and List; Spotlight Row remains optional.
+- Preserves Android scaled text rather than shrinking source typography at large font scales, including a two-line Spotlight title and complete accessibility semantics.
+- Keeps Android focus/navigation as the only movement authority; adaptive chrome observes successfully handled input without consuming or duplicating navigation.
+- Preserves minSdk 21, targetSdk 36, existing database and routing authorities, Moonlight-compatible hosts, Polaris integration, artwork fallbacks, and signed in-place upgrades.
+- Issue #127 remains separate; its current workaround is **Screen Launch → Top Screen**, not Auto.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.3 and versionCode 35.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus portable SHA-256 sidecars through the GitHub release workflow.
+
+### Validation notes
+
+- Final publication requires the exact tagged ARM64 APK to pass package/version and signer continuity checks plus physical AYN Thor validation for OLED appearance, real D-pad/shoulder/touch behavior, both Stream/Companion directions, reconnect/focus, active-session command-deck lifecycle, teardown, and recovery.
+- Roadmap issue #115 remains the release hardware-evidence umbrella until that physical matrix is recorded; merged child issues #169, #170, and #171 are not themselves proof of release validation.
 
 ## 1.3.2 - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ while you play, and what is safe to do when you leave.
 [![License](https://img.shields.io/github/license/papi-ux/nova?style=for-the-badge&color=4c5265&labelColor=1a1a2e)](LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/papi-ux/nova?style=for-the-badge&color=4ade80&labelColor=1a1a2e&label=latest)](https://github.com/papi-ux/nova/releases/latest)
 
-[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v132) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
+[Why Nova](#why-nova) · [Feature Matrix](#feature-matrix) · [Quick Start](#quick-start) · [Latest Release](#latest-release-v133) · [Install](#install) · [Compatibility](#compatibility) · [Launch Modes](#launch-modes-in-plain-english) · [Tour](#tour) · [Polaris](#use-with-polaris) · [Support](#support-and-bug-reports) · [FAQ](#faq) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md)
 
 **Support**: [Issues](https://github.com/papi-ux/nova/issues) · [Discussions](https://github.com/papi-ux/nova/discussions)
 
@@ -107,18 +107,19 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.3.2
+## Latest release: v1.3.3
 
-Nova v1.3.2 adds adjustable menu and drawer glass, clearer controller focus, and focused reliability improvements across companion displays, updater recovery, launch diagnostics, and verified host routes.
+Nova v1.3.3 adds an optional Spotlight Row, explicit dual-display roles, and a Thor companion command deck while tightening Material You, controller focus, large-text behavior, and display/session reliability.
 
-- **Adjustable menu glass**: Menu & Drawer Opacity runs independently from NovaHUD, previews live in Settings and Command Center, keeps 0% text and focus readable, and adds automatic backdrop blur on Android 12 and newer.
-- **Sharper D-pad rendering**: virtual-controller artwork keeps its intended asset transparency instead of being forced to full opacity.
-- **Safer companion controls**: external-display controls remain Game-owned, use Android `Presentation`, and are removed when their stream session ends instead of leaving stale controls behind.
-- **Recoverable updates**: interrupted APK downloads, stale staged files, validation failures, and retry flows recover without weakening package or signer checks.
-- **Clearer launch health**: richer launch diagnostics distinguish healthy near-target streams from real degraded states.
-- **Verified endpoint mobility**: paired hosts can retain validated routes as they move between LAN and private-overlay addresses without treating an address as host identity.
-- **Release packaging**: public GitHub Releases ship signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 checksums. VersionCode 34 keeps Obtainium and manual installs on a clean upgrade path.
-- **Release validation**: final publication validation must use the tagged ARM64 release APK for menu opacity, blur cleanup, package identity, Library, preflight, live stream, physical controls, Command Center, NovaHUD, and cleanup smoke evidence.
+- **Spotlight Row**: choose a centered, artwork-forward fourth Library mode with adjacent-card peeks, stable focus restoration, touch snapping, offline fallbacks, and adaptive controller hints.
+- **Display roles**: assign Follow, Stream, and Companion visually, preview Swap safely, and apply changes without creating a second routing authority.
+- **Thor command deck**: keep keyboard, Quick Menu, touchpad, and useful session controls on the non-stream display with controller/touch focus and lifecycle-aware teardown.
+- **Material You and OLED**: semantic surfaces, system bars, dialogs, settings, focus states, Library chrome, and companion controls now follow the selected theme more consistently.
+- **Controller and accessibility polish**: server focus survives polling; Spotlight uses genuine Android text scaling, meaningful two-line titles, complete semantics, and handled-input-only chrome transitions.
+- **Reliability**: fixes the API 33 codec-settings crash and strengthens display reconciliation, target-aware stream geometry, server removal/polling, manual add, and active-session cleanup.
+- **Compatibility**: preserves Grid, Compact Grid, List, existing routing and persistence authorities, minSdk 21, targetSdk 36, Polaris integration, Moonlight-compatible hosts, and signed in-place upgrades.
+- **Release packaging**: signed ARM64, ARMv7, and x86_64 APKs ship with portable SHA-256 sidecars. VersionCode 35 keeps Obtainium and manual installs on a clean upgrade path.
+- **Release validation**: final publication requires the tagged ARM64 APK to pass signer/package checks and the complete physical AYN Thor dual-display, OLED, controller, touch, reconnect, lifecycle, and teardown matrix. Issue #127 remains separate; use **Screen Launch → Top Screen**, not Auto.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.2"
-        versionCode = 34
+        versionName "1.3.3"
+        versionCode = 35
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -21,6 +21,7 @@ class NovaReleaseMetadataTest {
             root,
             "fastlane/metadata/android/en-US/changelogs/35.txt"
         )
+        val storeNotesBody = storeNotes.readText().trimEnd()
 
         assertTrue(build.contains("versionName \"1.3.3\""))
         assertTrue(build.contains("versionCode = 35"))
@@ -29,6 +30,10 @@ class NovaReleaseMetadataTest {
         assertTrue(readme.contains("VersionCode 35"))
         assertFalse(readme.contains("## Latest release: v1.3.2"))
         assertTrue(storeNotes.isFile)
-        assertTrue(storeNotes.readText().startsWith("Nova 1.3.3\n"))
+        assertTrue(
+            "Google Play release notes must be at most 500 Unicode characters",
+            storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
+        )
+        assertTrue(storeNotesBody.startsWith("Nova 1.3.3"))
     }
 }

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -1,0 +1,34 @@
+package com.papi.nova
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaReleaseMetadataTest {
+    private fun repoRoot(): File {
+        return generateSequence(File(".").canonicalFile) { it.parentFile }
+            .first { candidate -> File(candidate, "app/build.gradle").isFile }
+    }
+
+    @Test
+    fun versionNameCodeAndPublicReleaseMetadataStayConsistent() {
+        val root = repoRoot()
+        val build = File(root, "app/build.gradle").readText()
+        val changelog = File(root, "CHANGELOG.md").readText()
+        val readme = File(root, "README.md").readText()
+        val storeNotes = File(
+            root,
+            "fastlane/metadata/android/en-US/changelogs/35.txt"
+        )
+
+        assertTrue(build.contains("versionName \"1.3.3\""))
+        assertTrue(build.contains("versionCode = 35"))
+        assertTrue(changelog.contains("## 1.3.3 - 2026-07-30"))
+        assertTrue(readme.contains("## Latest release: v1.3.3"))
+        assertTrue(readme.contains("VersionCode 35"))
+        assertFalse(readme.contains("## Latest release: v1.3.2"))
+        assertTrue(storeNotes.isFile)
+        assertTrue(storeNotes.readText().startsWith("Nova 1.3.3\n"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaUpdateInstallerSecurityTest.kt
@@ -1,5 +1,6 @@
 package com.papi.nova.preferences
 
+import com.papi.nova.BuildConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,21 +22,25 @@ class NovaUpdateInstallerSecurityTest {
 
     @Test
     fun downloadedApkValidationBlocksPackageSignatureAndDowngradeMismatches() {
+        val currentVersionCode = BuildConfig.VERSION_CODE.toLong()
+        val downloadedVersionCode = currentVersionCode + 1L
+        val currentMajor = BuildConfig.VERSION_NAME.substringBefore('.').toIntOrNull() ?: 0
+        val releaseVersionName = "${currentMajor + 1}.0.0"
         val release = NovaUpdateRelease(
-            tagName = "v1.3.3",
-            versionName = "1.3.3",
-            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v1.3.3",
+            tagName = "v$releaseVersionName",
+            versionName = releaseVersionName,
+            releaseUrl = "https://github.com/papi-ux/nova/releases/tag/v$releaseVersionName",
             apkAssetName = "Nova-Android-arm64-v8a.apk",
-            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v1.3.3/Nova-Android-arm64-v8a.apk"
+            apkDownloadUrl = "https://github.com/papi-ux/nova/releases/download/v$releaseVersionName/Nova-Android-arm64-v8a.apk"
         )
 
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 34L,
+                currentVersionCode = currentVersionCode,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 35L,
+                downloadedVersionCode = downloadedVersionCode,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Valid
@@ -44,10 +49,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 34L,
+                currentVersionCode = currentVersionCode,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova.debug",
-                downloadedVersionCode = 35L,
+                downloadedVersionCode = downloadedVersionCode,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -56,10 +61,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 34L,
+                currentVersionCode = currentVersionCode,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 35L,
+                downloadedVersionCode = downloadedVersionCode,
                 downloadedSignerDigests = setOf("BB"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid
@@ -68,10 +73,10 @@ class NovaUpdateInstallerSecurityTest {
         assertTrue(
             NovaUpdateInstaller.validateDownloadedApkMetadata(
                 expectedPackageName = "com.papi.nova",
-                currentVersionCode = 34L,
+                currentVersionCode = currentVersionCode,
                 currentSignerDigests = setOf("AA"),
                 downloadedPackageName = "com.papi.nova",
-                downloadedVersionCode = 34L,
+                downloadedVersionCode = currentVersionCode,
                 downloadedSignerDigests = setOf("AA"),
                 release = release
             ) is NovaUpdateInstallValidation.Invalid

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,0 +1,7 @@
+Nova 1.3.3
+
+- Adds an optional Spotlight Row with centered artwork, touch snapping, stable focus restoration, large-text support, and adaptive controller hints.
+- Adds explicit Follow / Stream / Companion display roles and a Thor companion command deck.
+- Applies Material You and OLED-aware semantic surfaces more consistently.
+- Preserves controller focus during polling and fixes the API 33 codec-settings dialog crash.
+- Hardens display routing, stream geometry, server lifecycle, reconnect, and teardown behavior.

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,6 +1,6 @@
 Nova 1.3.3
 
-- Adds an optional Spotlight Row with centered artwork, touch snapping, stable focus restoration, large-text support, and adaptive controller hints.
+- Adds optional Spotlight Row with centered artwork, touch snapping, stable focus, large-text support, and controller hints.
 - Adds explicit Follow / Stream / Companion display roles and a Thor companion command deck.
 - Applies Material You and OLED-aware semantic surfaces more consistently.
 - Preserves controller focus during polling and fixes the API 33 codec-settings dialog crash.


### PR DESCRIPTION
## Summary

Prepare Nova v1.3.3 (35) from the exact merged v1.3.3 feature train.

This release adds Spotlight Row, explicit Follow / Stream / Companion display roles, the Thor companion command deck, broader Material You/OLED semantics, and focused navigation, lifecycle, update, and API 33 reliability fixes.

## Release identity

- versionName: `1.3.3`
- versionCode: `35`
- minSdk: `21` (unchanged)
- targetSdk: `36` (unchanged)
- Base master: `961aaa32e8dc66ca8964c6bd34f8c9bd08daf393`
- Release-prep candidate: `b430169aa342c838016764b86c6ac64239e4d665`

## Changes

- Add the v1.3.3 CHANGELOG and README latest-release sections.
- Add Fastlane changelog 35.
- Add a release-metadata consistency contract.
- Make the update-installer security fixture version-independent so release version bumps do not turn its valid future-update case into an equal-version rejection.

Production installer behavior is unchanged by this release-prep commit.

## Verification

- [x] 1,031 JVM tests; zero failures/errors/skips
- [x] Debug lint with fail-on-error
- [x] Release lint with fail-on-error
- [x] Debug assembly
- [x] Release assembly
- [x] AndroidTest assembly
- [x] Helper/onboarding Python suites
- [x] Public docs check
- [x] Public surface check
- [x] `git diff --check`
- [x] Signed ARM64 RC reports `com.papi.nova` `1.3.3 (35)` and ARM64 only
- [x] v1/v2/v3 signatures verified with signer continuity to published v1.3.2
- [x] Emulator signed in-place upgrade `34 → 35` and launch smoke
- [x] Exact-candidate Android release review — APPROVE
- [x] Exact-candidate security/release-integrity review — APPROVE
- [x] Exact-candidate release-notes/product review — APPROVE
- [ ] Full physical AYN Thor release QA — **NOT PERFORMED; explicitly waived for exact `b430169a` / tree `58e2ed0c` only (not a PASS)**

## Release gate

Issue #115 remains the physical Thor evidence umbrella. Physical validation was **not performed**; the user explicitly waived it for releasing exact commit `b430169a` / tree `58e2ed0c` only. This waiver is not a PASS and becomes invalid if the source tree or release artifact content changes. Publication still requires exact-head green CI and explicit release authorization.

Issue #127 remains separate. Its current workaround is **Screen Launch → Top Screen**, not Auto.

Closes #115 only after the physical matrix and tagged-asset verification are recorded.
