### PR TITLE
Integrate Polaris custom artwork presentation

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailSheetComposeTest.kt
@@ -93,6 +93,19 @@ class NovaGameDetailSheetComposeTest {
                         onRetryHighFps = {},
                         onResetProfile = {},
                         onSteamLaunchMode = {},
+                        artworkState = NovaArtworkCorrectionState(),
+                        onRefreshArtwork = {},
+                        onSearchArtwork = {},
+                        onApplyArtwork = { _, _ -> },
+                        onClearArtwork = {},
+                        onLogoTransform = { _, _, _ -> },
+                        candidatePreviewLoader = { _, _ -> },
+                        logoAvailable = false,
+                        logoPresentationKey = "",
+                        logoLoader = {},
+                        iconAvailable = false,
+                        iconPresentationKey = "",
+                        iconLoader = {},
                         coverLoader = {}
                     )
                 }

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -1,7 +1,6 @@
 package com.papi.nova.api
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.content.Context
 import com.papi.nova.binding.PlatformBinding
 import android.widget.ImageView
@@ -22,6 +21,8 @@ import okhttp3.Request
 import java.io.ByteArrayInputStream
 import org.json.JSONObject
 import java.net.Proxy
+import java.net.URI
+import java.net.URLDecoder
 import java.security.KeyStore
 import java.security.Principal
 import java.security.PrivateKey
@@ -57,11 +58,14 @@ class PolarisApiClient @JvmOverloads constructor(
         this(context, serverAddress, httpsPort, decodeCertificate(serverCertDer))
 
     @JvmField val client: OkHttpClient
+    private val artworkHttpClient: OkHttpClient
     private var apiKeyManager: X509KeyManager? = null
     private var apiTrustManager: X509TrustManager? = null
     private val resolvedHttpsPort = if (httpsPort > 0) httpsPort else 47984
     private val baseUrl = "https://$serverAddress:$resolvedHttpsPort/polaris/v1"
     private val webBaseUrl = "https://$serverAddress:$WEB_UI_HTTPS_PORT"
+    private val artworkDiskCache = PolarisArtworkDiskCache(context.applicationContext, serverAddress, resolvedHttpsPort)
+    private val artworkResolveOnce = ArtworkResolveOnce<PolarisGame.ArtworkManifest>()
     private val imageScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(1))
     private val coverCache = object : LruCache<String, Bitmap>(32 * 1024 * 1024) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
@@ -76,6 +80,101 @@ class PolarisApiClient @JvmOverloads constructor(
             if (serverCertDer == null) return null
             return CertificateFactory.getInstance("X.509")
                 .generateCertificate(ByteArrayInputStream(serverCertDer)) as X509Certificate
+        }
+
+        @JvmStatic
+        internal fun buildArtworkHttpClient(base: OkHttpClient): OkHttpClient =
+            base.newBuilder()
+                .followRedirects(false)
+                .followSslRedirects(false)
+                .build()
+
+        private val SAFE_GAME_ID = Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,255}")
+
+        @JvmStatic
+        fun isSafeArtworkGameId(gameId: String): Boolean =
+            SAFE_GAME_ID.matches(gameId) && gameId != "." && gameId != ".."
+
+        @JvmStatic
+        fun resolveManifestPath(host: String, port: Int, path: String): String? =
+            resolveHostRelativePath(host, port, path, requiredPrefix = "/polaris/v1/")
+
+        private fun resolveLegacyCoverPath(host: String, port: Int, path: String): String? =
+            resolveHostRelativePath(host, port, path, requiredPrefix = "/")
+
+        private fun resolveHostRelativePath(
+            host: String,
+            port: Int,
+            path: String,
+            requiredPrefix: String,
+        ): String? {
+            val candidate = path.trim()
+            if (candidate.isEmpty() || !candidate.startsWith("/") || candidate.startsWith("//") || '\\' in candidate) return null
+            if (port !in 1..65535) return null
+            return try {
+                val uri = URI(candidate)
+                if (uri.isAbsolute || uri.rawAuthority != null || uri.rawFragment != null) return null
+                val rawPath = uri.rawPath ?: return null
+                if (!rawPath.startsWith(requiredPrefix)) return null
+                var decodedPath = rawPath
+                repeat(4) {
+                    val decoded = URLDecoder.decode(decodedPath.replace("+", "%2B"), Charsets.UTF_8.name())
+                    if (decoded != decodedPath) decodedPath = decoded
+                }
+                if ('\\' in decodedPath || !decodedPath.startsWith(requiredPrefix)) return null
+                if (decodedPath.split('/').any { it == "." || it == ".." }) return null
+                val normalizedHost = host.trim().removePrefix("[").removeSuffix("]")
+                val base = okhttp3.HttpUrl.Builder()
+                    .scheme("https")
+                    .host(normalizedHost)
+                    .port(port)
+                    .build()
+                val resolved = base.resolve(candidate) ?: return null
+                if (resolved.scheme != "https" || resolved.host != base.host || resolved.port != port) return null
+                if (!resolved.encodedPath.startsWith(requiredPrefix)) return null
+                resolved.toString()
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        @JvmStatic
+        fun selectArtworkUrl(
+            host: String,
+            port: Int,
+            game: PolarisGame,
+            kind: String = PolarisGame.ARTWORK_KIND_POSTER,
+        ): String? {
+            val normalizedKind = kind.trim().lowercase()
+            game.artworkAsset(normalizedKind)
+                ?.takeIf { it.cached }
+                ?.let { resolveManifestPath(host, port, it.url) }
+                ?.let { return it }
+            if (normalizedKind != PolarisGame.ARTWORK_KIND_POSTER) return null
+
+            val legacy = game.coverUrl.trim()
+            if (legacy.startsWith("/")) {
+                resolveLegacyCoverPath(host, port, legacy)?.let { return it }
+            }
+            if (!isSafeArtworkGameId(game.id)) return null
+            return resolveManifestPath(host, port, "/polaris/v1/games/${game.id}/cover")
+        }
+
+        @JvmStatic
+        fun parseArtworkResolveResponse(json: JSONObject): PolarisGame.ArtworkManifest? {
+            val manifest = when {
+                json.has("assets") -> json
+                json.optJSONObject("artwork") != null -> json.optJSONObject("artwork")
+                json.optJSONObject("game")?.optJSONObject("artwork") != null ->
+                    json.optJSONObject("game")?.optJSONObject("artwork")
+                json.optJSONObject("data")?.optJSONObject("artwork") != null ->
+                    json.optJSONObject("data")?.optJSONObject("artwork")
+                else -> json.optJSONObject("data")
+                    ?.optJSONObject("game")
+                    ?.optJSONObject("artwork")
+            } ?: return null
+            if (!manifest.has("assets")) return null
+            return PolarisGameJsonAdapter.parseArtworkManifest(manifest)
         }
 
         @JvmStatic
@@ -734,6 +833,7 @@ class PolarisApiClient @JvmOverloads constructor(
 			LimeLog.warning("Nova: Failed to initialize Polaris API TLS client: ${errorMessage(e)}")
 			createBasicClient()
 		}
+        artworkHttpClient = buildArtworkHttpClient(client)
     }
 
     private fun createClientWithCryptoProvider(cryptoProvider: LimelightCryptoProvider): OkHttpClient {
@@ -754,18 +854,18 @@ class PolarisApiClient @JvmOverloads constructor(
             override fun getServerAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? = null
         }
 
-		val trustManager = createPinnedServerTrustManager()
-		apiKeyManager = keyManager
-		apiTrustManager = trustManager
-		val sslContext = SSLContext.getInstance("TLS").apply {
-			init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
-		}
+        val trustManager = createPinnedServerTrustManager()
+        apiKeyManager = keyManager
+        apiTrustManager = trustManager
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
+        }
 
-		return OkHttpClient.Builder()
-			.sslSocketFactory(sslContext.socketFactory, trustManager)
-			.hostnameVerifier { hostname, session ->
-				isPinnedServerCertificate(session) ||
-					HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)
+        return OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .hostnameVerifier { hostname, session ->
+                isPinnedServerCertificate(session) ||
+                    HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)
             }
             .connectionPool(ConnectionPool(0, 1, TimeUnit.MILLISECONDS))
             .protocols(listOf(Protocol.HTTP_1_1))
@@ -779,10 +879,10 @@ class PolarisApiClient @JvmOverloads constructor(
     private fun createPinnedServerTrustManager(): X509TrustManager {
         val defaultTrustManager = getDefaultTrustManager()
 
-		return object : X509TrustManager {
-			override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
-				throw IllegalStateException("Should never be called")
-			}
+        return object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
+                throw IllegalStateException("Should never be called")
+            }
 
             override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
                 try {
@@ -846,6 +946,12 @@ class PolarisApiClient @JvmOverloads constructor(
 			.header("Connection", "close")
 			.build()
 	).execute()
+
+    private fun executeArtwork(request: Request) = artworkHttpClient.newCall(
+        request.newBuilder()
+            .header("Connection", "close")
+            .build()
+    ).execute()
 
     private fun executeGetWithRetry(request: Request, attempts: Int = 3): okhttp3.Response {
         var lastError: Exception? = null
@@ -992,32 +1098,65 @@ class PolarisApiClient @JvmOverloads constructor(
     }
 
     /**
-     * Get the cover art URL for a game (full HTTPS URL).
+     * Get the legacy cover art URL for a game. Unsafe IDs fail closed.
      */
-	fun getCoverUrl(gameId: String): String {
-		return "https://$serverAddress:$resolvedHttpsPort/polaris/v1/games/$gameId/cover"
-	}
+    fun getCoverUrl(gameId: String): String =
+        if (isSafeArtworkGameId(gameId)) {
+            resolveManifestPath(serverAddress, resolvedHttpsPort, "/polaris/v1/games/$gameId/cover").orEmpty()
+        } else ""
 
-    fun getPreferredCoverUrl(game: PolarisGame): String {
-        val coverUrl = game.coverUrl.trim()
-        return when {
-            coverUrl.isEmpty() -> getCoverUrl(game.id)
-            coverUrl.startsWith("https://") || coverUrl.startsWith("http://") -> coverUrl
-			coverUrl.startsWith("/") -> "https://$serverAddress:$resolvedHttpsPort$coverUrl"
-            else -> getCoverUrl(game.id)
-        }
-    }
+    fun getPreferredCoverUrl(game: PolarisGame): String =
+        selectArtworkUrl(serverAddress, resolvedHttpsPort, game, PolarisGame.ARTWORK_KIND_POSTER).orEmpty()
 
     fun clearCoverCache() {
         coverCache.evictAll()
     }
 
+    fun resolveArtwork(gameId: String, force: Boolean = false): PolarisGame.ArtworkManifest? {
+        if (!isSafeArtworkGameId(gameId)) return null
+        if (force) artworkResolveOnce.invalidate(gameId)
+        return artworkResolveOnce.resolve(gameId) {
+            try {
+                val request = Request.Builder()
+                    .url("$baseUrl/games/$gameId/artwork/resolve")
+                    .post(okhttp3.RequestBody.create("application/json".toMediaTypeOrNull(), "{}"))
+                    .build()
+                execute(request).use { response ->
+                    if (!response.isSuccessful) return@resolve null
+                    val body = response.body?.string().orEmpty()
+                    if (body.isBlank()) null else parseArtworkResolveResponse(JSONObject(body))
+                }
+            } catch (e: Exception) {
+                LimeLog.warning("Nova: artwork resolve failed for $gameId: ${errorMessage(e)}")
+                null
+            }
+        }
+    }
+
+
     fun loadCoverInto(view: ImageView, game: PolarisGame) {
-        val cacheKey = "polaris-cover:${game.id}:${game.coverUrl}"
-        val imageUrl = getPreferredCoverUrl(game)
+        loadArtworkInto(view, game, PolarisGame.ARTWORK_KIND_POSTER)
+    }
+
+    fun loadArtworkInto(view: ImageView, game: PolarisGame, kind: String) {
+        val normalizedKind = kind.trim().lowercase()
+        val manifestAsset = game.artworkAsset(normalizedKind)?.takeIf { it.cached }
+        val manifestUrl = manifestAsset?.let {
+            resolveManifestPath(serverAddress, resolvedHttpsPort, it.url)
+        }
+        val usesManifest = manifestUrl != null
+        val imageUrl = manifestUrl
+            ?: selectArtworkUrl(serverAddress, resolvedHttpsPort, game, normalizedKind)
+        val revision = if (usesManifest) game.artwork?.revision.orEmpty() else ""
+        val cacheKey = if (usesManifest) {
+            "polaris-artwork:${game.id}:$normalizedKind:$revision:$manifestUrl"
+        } else {
+            "polaris-cover:${game.id}:${game.coverUrl}"
+        }
 
         view.tag = cacheKey
         view.setImageResource(R.drawable.nova_cover_placeholder)
+        if (imageUrl == null) return
 
         coverCache.get(cacheKey)?.let { cached ->
             view.setImageBitmap(cached)
@@ -1025,58 +1164,72 @@ class PolarisApiClient @JvmOverloads constructor(
         }
 
         imageScope.launch {
-            val bitmap = fetchCoverBitmap(imageUrl)
+            val exactDisk = if (usesManifest) {
+                artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = false)
+            } else null
+            val bitmap = exactDisk ?: run {
+                val fetched = fetchArtwork(imageUrl)
+                if (fetched != null) {
+                    if (usesManifest) {
+                        artworkDiskCache.store(
+                            game.id,
+                            normalizedKind,
+                            revision,
+                            fetched.bytes,
+                            fetched.mimeType,
+                        )
+                    }
+                    fetched.bitmap
+                } else if (usesManifest) {
+                    artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = true)
+                } else null
+            }
             withContext(Dispatchers.Main) {
-                if (view.tag != cacheKey) {
-                    return@withContext
-                }
-
+                if (view.tag != cacheKey) return@withContext
                 if (bitmap != null) {
                     coverCache.put(cacheKey, bitmap)
                     view.setImageBitmap(bitmap)
                 } else {
                     view.setImageResource(R.drawable.nova_cover_placeholder)
-                    LimeLog.warning("Nova: cover load failed for ${game.name}")
+                    LimeLog.warning("Nova: $normalizedKind artwork load failed for ${game.name}")
                 }
             }
         }
     }
 
-    private fun fetchCoverBitmap(url: String): Bitmap? {
+    private data class FetchedArtwork(val bytes: ByteArray, val mimeType: String, val bitmap: Bitmap)
+
+    private fun fetchArtwork(url: String): FetchedArtwork? {
         repeat(3) { attempt ->
             try {
-                val request = Request.Builder()
-                    .url(url)
-                    .header("Connection", "close")
-                    .build()
-                execute(request).use { response ->
+                val request = Request.Builder().url(url).header("Connection", "close").build()
+                executeArtwork(request).use { response ->
                     if (!response.isSuccessful) {
                         LimeLog.warning("Nova: cover request failed [$url] code=${response.code}")
                         return null
                     }
-
-                    val bytes = response.body?.bytes() ?: return null
-                    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, BitmapFactory.Options().apply {
-                        inPreferredConfig = Bitmap.Config.ARGB_8888
-                        inScaled = false
-                    })
-                    if (bitmap != null) {
-                        return bitmap
+                    val body = response.body ?: return null
+                    val mimeType = response.header("Content-Type") ?: body.contentType()?.toString()
+                    if (!PolarisArtworkDiskCache.isSupportedImageMime(mimeType)) {
+                        LimeLog.warning("Nova: cover MIME rejected [$url] type=${mimeType ?: "missing"}")
+                        return null
                     }
-
+                    val contentLength = body.contentLength()
+                    if (contentLength > PolarisArtworkDiskCache.MAX_IMAGE_BYTES) return null
+                    val bytes = body.byteStream().use {
+                        PolarisArtworkDiskCache.readBounded(it, PolarisArtworkDiskCache.MAX_IMAGE_BYTES)
+                    } ?: return null
+                    if (!PolarisArtworkDiskCache.hasSupportedImageSignature(bytes, mimeType)) return null
+                    val bitmap = PolarisArtworkDiskCache.decodeBounded(bytes)
+                    if (bitmap != null) return FetchedArtwork(bytes, mimeType.orEmpty(), bitmap)
                     LimeLog.warning("Nova: cover decode failed [$url] bytes=${bytes.size}")
-                }
-
-                if (attempt < 2) {
-                    Thread.sleep((attempt + 1) * 150L)
+                    return null
                 }
             } catch (e: Exception) {
-                if (attempt == 2) {
-                    LimeLog.warning("Nova: cover fetch failed [$url]: ${errorMessage(e)}")
-                }
+                if (attempt == 2) LimeLog.warning("Nova: cover fetch failed [$url]: ${errorMessage(e)}")
+                if (attempt < 2) Thread.sleep((attempt + 1) * 150L)
             }
         }
-
         return null
     }
 

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -18,7 +18,11 @@ import okhttp3.Protocol
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.io.ByteArrayInputStream
+import java.io.IOException
+import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 import java.net.Proxy
 import java.net.URI
@@ -43,6 +47,16 @@ import javax.net.ssl.X509KeyManager
 import javax.net.ssl.X509TrustManager
 import androidx.collection.LruCache
 
+data class PolarisArtworkMatchCandidate(
+    val provider: String,
+    val providerGameId: String,
+    val title: String,
+    val steamAppid: String? = null,
+    val releaseYear: Int? = null,
+    val confidence: Double = 0.0,
+    val posterPreviewUrl: String? = null,
+)
+
 /**
  * HTTP client for Polaris REST API on the nvhttp port (47984).
  * Uses the same client certificate as Moonlight pairing.
@@ -58,7 +72,6 @@ class PolarisApiClient @JvmOverloads constructor(
         this(context, serverAddress, httpsPort, decodeCertificate(serverCertDer))
 
     @JvmField val client: OkHttpClient
-    private val artworkHttpClient: OkHttpClient
     private var apiKeyManager: X509KeyManager? = null
     private var apiTrustManager: X509TrustManager? = null
     private val resolvedHttpsPort = if (httpsPort > 0) httpsPort else 47984
@@ -87,17 +100,131 @@ class PolarisApiClient @JvmOverloads constructor(
             base.newBuilder()
                 .followRedirects(false)
                 .followSslRedirects(false)
+                .callTimeout(ARTWORK_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(ARTWORK_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .build()
 
+        @JvmStatic
+        internal fun buildArtworkHttpClientForCall(baseForCall: () -> OkHttpClient): OkHttpClient =
+            buildArtworkHttpClient(baseForCall())
+
+        @JvmStatic
+        internal fun parseArtworkJsonBytes(bytes: ByteArray): JSONObject? {
+            val text = bytes.toString(Charsets.UTF_8)
+            if (text.isBlank()) return null
+            return try {
+                JSONObject(text)
+            } catch (_: JSONException) {
+                throw IOException("invalid artwork JSON")
+            }
+        }
+
         private val SAFE_GAME_ID = Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,255}")
+        private val CANDIDATE_PREVIEW_PATH = Regex(
+            "^/polaris/v1/games/[A-Za-z0-9][A-Za-z0-9._-]{0,255}/artwork/candidate/[0-9a-f]{32}/poster$",
+        )
+        private val PROVIDER_GAME_ID = Regex("[1-9][0-9]{0,19}")
+        private val STEAM_APP_ID = Regex("[1-9][0-9]{0,9}")
+        private val ARTWORK_KINDS = listOf("poster", "hero", "logo", "icon")
+        private const val MAX_ARTWORK_JSON_BYTES = 1024 * 1024
+        private const val ARTWORK_REQUEST_TIMEOUT_SECONDS = 120L
+
+        private fun sanitizedCandidateTitle(value: String): String? {
+            val title = value.trim()
+            if (title.isEmpty() || title.toByteArray(Charsets.UTF_8).size > 160) return null
+            if (title.any { it.code < 0x20 || it.code in 0x7f..0x9f }) return null
+            return title
+        }
 
         @JvmStatic
         fun isSafeArtworkGameId(gameId: String): Boolean =
             SAFE_GAME_ID.matches(gameId) && gameId != "." && gameId != ".."
 
         @JvmStatic
+        fun artworkPresentationKey(game: PolarisGame, kind: String): String {
+            val normalizedKind = kind.trim().lowercase()
+            val asset = game.artworkAsset(normalizedKind)?.takeIf { it.cached }
+            return if (asset != null) {
+                "manifest:${game.id}:$normalizedKind:${game.artwork?.revision.orEmpty()}:${asset.url}"
+            } else {
+                "legacy:${game.id}:${game.coverUrl}"
+            }
+        }
+
+        @JvmStatic
+        fun isTrustedCandidatePreviewUrl(url: String, host: String, port: Int): Boolean {
+            if (port !in 1..65535) return false
+            val uri = runCatching { URI(url) }.getOrNull() ?: return false
+            val pairedHost = host.trim().removePrefix("[").removeSuffix("]")
+            if (uri.scheme != "https" || uri.rawUserInfo != null || uri.rawQuery != null || uri.rawFragment != null) return false
+            if (!uri.host.orEmpty().equals(pairedHost, ignoreCase = true) || uri.port != port) return false
+            return CANDIDATE_PREVIEW_PATH.matches(uri.rawPath.orEmpty())
+        }
+
+        @JvmStatic
+        internal fun artworkRequestLogLabel(url: String): String {
+            val path = runCatching { URI(url).rawPath.orEmpty() }.getOrDefault("")
+            return when {
+                CANDIDATE_PREVIEW_PATH.matches(path) -> "candidate-preview"
+                path.startsWith("/polaris/v1/games/") && path.contains("/artwork/") -> "manifest-artwork"
+                else -> "legacy-cover"
+            }
+        }
+
+        @JvmStatic
         fun resolveManifestPath(host: String, port: Int, path: String): String? =
             resolveHostRelativePath(host, port, path, requiredPrefix = "/polaris/v1/")
+
+        @JvmStatic
+        fun parseArtworkCandidates(json: JSONObject, gameId: String, host: String, port: Int): List<PolarisArtworkMatchCandidate> {
+            if (!isSafeArtworkGameId(gameId)) return emptyList()
+            val status = json.opt("status")
+            if (status !is Boolean || !status) {
+                throw IOException("invalid artwork candidate search response")
+            }
+            val values = json.optJSONArray("candidates")
+                ?: throw IOException("invalid artwork candidate search response")
+            return (0 until values.length()).asSequence()
+                .mapNotNull { index -> values.optJSONObject(index)?.let { parseArtworkCandidate(it, gameId, host, port) } }
+                .distinctBy { "${it.provider}:${it.providerGameId}" }
+                .take(5)
+                .toList()
+        }
+
+        @JvmStatic
+        fun buildArtworkMatchBody(candidate: PolarisArtworkMatchCandidate, kinds: List<String>): JSONObject {
+            require(candidate.provider == "steamgriddb")
+            require(PROVIDER_GAME_ID.matches(candidate.providerGameId))
+            val title = requireNotNull(sanitizedCandidateTitle(candidate.title))
+            require(candidate.steamAppid == null || STEAM_APP_ID.matches(candidate.steamAppid))
+            val selectedKinds = kinds.map { it.trim().lowercase() }
+            require(selectedKinds.isNotEmpty() && selectedKinds.size <= ARTWORK_KINDS.size)
+            require(selectedKinds.distinct().size == selectedKinds.size && selectedKinds.all { it in ARTWORK_KINDS })
+            return JSONObject().apply {
+                put("provider", "steamgriddb")
+                put("provider_game_id", candidate.providerGameId)
+                put("title", title)
+                candidate.steamAppid?.let { put("steam_appid", it) }
+                put("kinds", JSONArray(selectedKinds))
+            }
+        }
+
+        private fun parseArtworkCandidate(item: JSONObject, gameId: String, host: String, port: Int): PolarisArtworkMatchCandidate? {
+            if (item.optString("provider") != "steamgriddb") return null
+            val providerGameId = item.optString("provider_game_id")
+            if (!PROVIDER_GAME_ID.matches(providerGameId)) return null
+            val title = sanitizedCandidateTitle(item.optString("title")) ?: return null
+            val steamAppid = item.optString("steam_appid").takeIf { STEAM_APP_ID.matches(it) }
+            val releaseYear = item.optInt("release_year", 0).takeIf { it in 1970..2100 }
+            val confidence = item.optDouble("confidence", 0.0).takeIf { it.isFinite() }?.coerceIn(0.0, 1.0) ?: 0.0
+            val previewPath = item.optJSONObject("preview")?.optString("poster").orEmpty()
+            val prefix = "/polaris/v1/games/$gameId/artwork/candidate/"
+            val token = previewPath.removePrefix(prefix).removeSuffix("/poster")
+            val previewUrl = previewPath.takeIf {
+                it.startsWith(prefix) && it.endsWith("/poster") && Regex("[0-9a-f]{32}").matches(token)
+            }?.let { resolveManifestPath(host, port, it) }
+            return PolarisArtworkMatchCandidate("steamgriddb", providerGameId, title, steamAppid, releaseYear, confidence, previewUrl)
+        }
 
         private fun resolveLegacyCoverPath(host: String, port: Int, path: String): String? =
             resolveHostRelativePath(host, port, path, requiredPrefix = "/")
@@ -833,7 +960,6 @@ class PolarisApiClient @JvmOverloads constructor(
 			LimeLog.warning("Nova: Failed to initialize Polaris API TLS client: ${errorMessage(e)}")
 			createBasicClient()
 		}
-        artworkHttpClient = buildArtworkHttpClient(client)
     }
 
     private fun createClientWithCryptoProvider(cryptoProvider: LimelightCryptoProvider): OkHttpClient {
@@ -947,7 +1073,7 @@ class PolarisApiClient @JvmOverloads constructor(
 			.build()
 	).execute()
 
-    private fun executeArtwork(request: Request) = artworkHttpClient.newCall(
+    private fun executeArtwork(request: Request) = buildArtworkHttpClientForCall(::clientForCall).newCall(
         request.newBuilder()
             .header("Connection", "close")
             .build()
@@ -1112,6 +1238,12 @@ class PolarisApiClient @JvmOverloads constructor(
         coverCache.evictAll()
     }
 
+    private fun parseBoundedArtworkJson(body: okhttp3.ResponseBody): JSONObject? {
+        if (body.contentLength() > MAX_ARTWORK_JSON_BYTES) return null
+        val bytes = PolarisArtworkDiskCache.readBounded(body.byteStream(), MAX_ARTWORK_JSON_BYTES) ?: return null
+        return parseArtworkJsonBytes(bytes)
+    }
+
     fun resolveArtwork(gameId: String, force: Boolean = false): PolarisGame.ArtworkManifest? {
         if (!isSafeArtworkGameId(gameId)) return null
         if (force) artworkResolveOnce.invalidate(gameId)
@@ -1121,10 +1253,9 @@ class PolarisApiClient @JvmOverloads constructor(
                     .url("$baseUrl/games/$gameId/artwork/resolve")
                     .post(okhttp3.RequestBody.create("application/json".toMediaTypeOrNull(), "{}"))
                     .build()
-                execute(request).use { response ->
+                executeArtwork(request).use { response ->
                     if (!response.isSuccessful) return@resolve null
-                    val body = response.body?.string().orEmpty()
-                    if (body.isBlank()) null else parseArtworkResolveResponse(JSONObject(body))
+                    response.body.let(::parseBoundedArtworkJson)?.let(::parseArtworkResolveResponse)
                 }
             } catch (e: Exception) {
                 LimeLog.warning("Nova: artwork resolve failed for $gameId: ${errorMessage(e)}")
@@ -1133,6 +1264,80 @@ class PolarisApiClient @JvmOverloads constructor(
         }
     }
 
+
+    fun searchArtworkCandidates(gameId: String, query: String): List<PolarisArtworkMatchCandidate> {
+        if (!isSafeArtworkGameId(gameId)) return emptyList()
+        val sanitizedQuery = sanitizedCandidateTitle(query) ?: return emptyList()
+        return try {
+            val url = "$baseUrl/games/$gameId/artwork/candidates".toHttpUrl().newBuilder()
+                .addQueryParameter("query", sanitizedQuery)
+                .build()
+            executeArtwork(Request.Builder().url(url).build()).use { response ->
+                if (!response.isSuccessful) throw IOException("artwork candidate search HTTP ${response.code}")
+                val json = parseBoundedArtworkJson(response.body)
+                    ?: throw IOException("artwork candidate search returned an invalid response")
+                parseArtworkCandidates(json, gameId, serverAddress, resolvedHttpsPort)
+            }
+        } catch (e: Exception) {
+            LimeLog.warning("Nova: artwork candidate search failed for $gameId: ${errorMessage(e)}")
+            throw e
+        }
+    }
+
+    fun applyArtworkMatch(
+        gameId: String,
+        candidate: PolarisArtworkMatchCandidate,
+        kinds: List<String> = ARTWORK_KINDS,
+    ): PolarisGame.ArtworkManifest? {
+        if (!isSafeArtworkGameId(gameId)) return null
+        val body = runCatching { buildArtworkMatchBody(candidate, kinds) }.getOrNull() ?: return null
+        val request = Request.Builder()
+            .url("$baseUrl/games/$gameId/artwork/match")
+            .post(okhttp3.RequestBody.create("application/json".toMediaTypeOrNull(), body.toString()))
+            .build()
+        return executeArtworkManifestMutation(gameId, request, "apply")
+    }
+
+    fun clearArtworkOverride(gameId: String): PolarisGame.ArtworkManifest? {
+        if (!isSafeArtworkGameId(gameId)) return null
+        val request = Request.Builder()
+            .url("$baseUrl/games/$gameId/artwork/override")
+            .delete()
+            .build()
+        return executeArtworkManifestMutation(gameId, request, "clear")
+    }
+
+    private fun executeArtworkManifestMutation(gameId: String, request: Request, operation: String): PolarisGame.ArtworkManifest? {
+        return try {
+            executeArtwork(request).use { response ->
+                if (!response.isSuccessful) return null
+                val json = parseBoundedArtworkJson(response.body)
+                val manifest = json?.let(::parseArtworkResolveResponse)
+                if (manifest != null) {
+                    artworkResolveOnce.invalidate(gameId)
+                    clearCoverCache()
+                }
+                manifest
+            }
+        } catch (e: Exception) {
+            LimeLog.warning("Nova: artwork $operation failed for $gameId: ${errorMessage(e)}")
+            null
+        }
+    }
+
+    fun loadArtworkCandidatePreviewInto(view: ImageView, candidate: PolarisArtworkMatchCandidate) {
+        val url = candidate.posterPreviewUrl ?: return
+        if (!isTrustedCandidatePreviewUrl(url, serverAddress, resolvedHttpsPort)) return
+        val cacheKey = "polaris-artwork-preview:$url"
+        view.tag = cacheKey
+        view.setImageResource(R.drawable.nova_cover_placeholder)
+        imageScope.launch {
+            val fetched = fetchArtwork(url) ?: return@launch
+            withContext(Dispatchers.Main) {
+                if (view.tag == cacheKey) view.setImageBitmap(fetched.bitmap)
+            }
+        }
+    }
 
     fun loadCoverInto(view: ImageView, game: PolarisGame) {
         loadArtworkInto(view, game, PolarisGame.ARTWORK_KIND_POSTER)
@@ -1200,18 +1405,19 @@ class PolarisApiClient @JvmOverloads constructor(
     private data class FetchedArtwork(val bytes: ByteArray, val mimeType: String, val bitmap: Bitmap)
 
     private fun fetchArtwork(url: String): FetchedArtwork? {
+        val requestClass = artworkRequestLogLabel(url)
         repeat(3) { attempt ->
             try {
                 val request = Request.Builder().url(url).header("Connection", "close").build()
                 executeArtwork(request).use { response ->
                     if (!response.isSuccessful) {
-                        LimeLog.warning("Nova: cover request failed [$url] code=${response.code}")
+                        LimeLog.warning("Nova: artwork request failed [$requestClass] code=${response.code}")
                         return null
                     }
                     val body = response.body ?: return null
                     val mimeType = response.header("Content-Type") ?: body.contentType()?.toString()
                     if (!PolarisArtworkDiskCache.isSupportedImageMime(mimeType)) {
-                        LimeLog.warning("Nova: cover MIME rejected [$url] type=${mimeType ?: "missing"}")
+                        LimeLog.warning("Nova: artwork MIME rejected [$requestClass] type=${mimeType ?: "missing"}")
                         return null
                     }
                     val contentLength = body.contentLength()
@@ -1222,11 +1428,13 @@ class PolarisApiClient @JvmOverloads constructor(
                     if (!PolarisArtworkDiskCache.hasSupportedImageSignature(bytes, mimeType)) return null
                     val bitmap = PolarisArtworkDiskCache.decodeBounded(bytes)
                     if (bitmap != null) return FetchedArtwork(bytes, mimeType.orEmpty(), bitmap)
-                    LimeLog.warning("Nova: cover decode failed [$url] bytes=${bytes.size}")
+                    LimeLog.warning("Nova: artwork decode failed [$requestClass] bytes=${bytes.size}")
                     return null
                 }
             } catch (e: Exception) {
-                if (attempt == 2) LimeLog.warning("Nova: cover fetch failed [$url]: ${errorMessage(e)}")
+                if (attempt == 2) {
+                    LimeLog.warning("Nova: artwork fetch failed [$requestClass]: ${e.javaClass.simpleName}")
+                }
                 if (attempt < 2) Thread.sleep((attempt + 1) * 150L)
             }
         }

--- a/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
@@ -3,9 +3,13 @@ package com.papi.nova.api
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.system.Os
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.FutureTask
@@ -15,13 +19,23 @@ internal class PolarisArtworkDiskCache(
     context: Context,
     private val host: String,
     private val port: Int,
+    private val cacheRoot: File = File(context.cacheDir, "polaris-artwork"),
+    private val maxCacheBytes: Long = MAX_CACHE_BYTES,
+    private val maxCacheEntries: Int = MAX_CACHE_ENTRIES,
+    private val replaceFile: (File, File) -> Boolean = Companion::atomicReplace,
 ) {
+    init {
+        require(maxCacheBytes > 0L)
+        require(maxCacheEntries > 0)
+    }
+
     private val cacheDir = File(
-        context.cacheDir,
-        "polaris-artwork/${sha256(listOf(host.trim().lowercase(), port.toString()))}",
+        cacheRoot,
+        sha256(listOf(host.trim().lowercase(), port.toString())),
     )
 
     fun load(gameId: String, kind: String, revision: String, allowStale: Boolean): Bitmap? {
+        if (revision.isBlank()) return null
         val exact = cacheFile(gameId, kind, revision)
         val candidates = buildList {
             if (exact.isFile) add(exact)
@@ -38,14 +52,20 @@ internal class PolarisArtworkDiskCache(
                 file.inputStream().buffered().use { readBounded(it, MAX_IMAGE_BYTES) }
             }.getOrNull()
             val bitmap = bytes?.let(::decodeBounded)
-            if (bitmap != null) return bitmap
-            file.delete()
+            if (bitmap != null) {
+                synchronized(CACHE_LOCK) {
+                    if (file.isFile) file.setLastModified(System.currentTimeMillis())
+                }
+                return bitmap
+            }
+            synchronized(CACHE_LOCK) { file.delete() }
         }
         return null
     }
 
     fun store(gameId: String, kind: String, revision: String, bytes: ByteArray, mimeType: String?): File? {
         if (
+            revision.isBlank() ||
             bytes.isEmpty() ||
             bytes.size > MAX_IMAGE_BYTES ||
             !isSupportedImageMime(mimeType) ||
@@ -54,41 +74,84 @@ internal class PolarisArtworkDiskCache(
         val decoded = decodeBounded(bytes) ?: return null
         decoded.recycle()
 
-        if (!cacheDir.exists() && !cacheDir.mkdirs()) return null
+        if (!cacheDir.isDirectory && !cacheDir.mkdirs() && !cacheDir.isDirectory) return null
         val target = cacheFile(gameId, kind, revision)
         val temp = File(cacheDir, "${target.name}.${TEMP_SEQUENCE.incrementAndGet()}.tmp")
-        val backup = File(cacheDir, "${target.name}.bak")
         return try {
-            temp.outputStream().buffered().use { output ->
+            FileOutputStream(temp).use { output ->
                 output.write(bytes)
                 output.flush()
+                output.fd.sync()
             }
-            backup.delete()
-            if (target.exists() && !target.renameTo(backup)) return null
-            if (!temp.renameTo(target)) {
-                if (backup.exists()) backup.renameTo(target)
-                return null
+            synchronized(WRITER_LOCK) {
+                if (!replaceFile(temp, target)) return null
+                cacheFilesForTest(gameId, kind).filterNot { it == target }.forEach(File::delete)
+                enforceGlobalBudget(pinned = target)
             }
-            backup.delete()
-            cacheFilesForTest(gameId, kind).filterNot { it == target }.forEach(File::delete)
             target
         } catch (_: Exception) {
-            if (!target.exists() && backup.exists()) backup.renameTo(target)
             null
         } finally {
             temp.delete()
-            if (target.exists()) backup.delete()
         }
     }
 
     fun clear() {
-        cacheDir.deleteRecursively()
+        synchronized(WRITER_LOCK) { cacheDir.deleteRecursively() }
     }
 
     internal fun cacheFilesForTest(gameId: String, kind: String): List<File> {
         val prefix = "${scopeKey(gameId, kind)}."
         return cacheDir.listFiles()
             ?.filter { it.isFile && it.name.startsWith(prefix) && it.name.endsWith(FILE_SUFFIX) }
+            .orEmpty()
+    }
+
+    internal fun rawCacheFilesForTest(): List<File> =
+        cacheDir.listFiles()?.filter(File::isFile).orEmpty()
+
+    private fun enforceGlobalBudget(pinned: File) {
+        val files = globalCacheFiles()
+        var totalBytes = files.sumOf(File::length)
+        var totalEntries = files.size
+        if (totalBytes <= maxCacheBytes && totalEntries <= maxCacheEntries) return
+
+        val evictionOrder = files
+            .asSequence()
+            .filterNot { it == pinned }
+            .sortedWith(compareBy<File>(File::lastModified).thenBy { it.absolutePath })
+            .toList()
+        for (candidate in evictionOrder) {
+            if (totalBytes <= maxCacheBytes && totalEntries <= maxCacheEntries) break
+            val size = candidate.length()
+            if (candidate.delete()) {
+                totalBytes = (totalBytes - size).coerceAtLeast(0L)
+                totalEntries -= 1
+            }
+        }
+        cacheRoot.listFiles()
+            ?.filter {
+                OWNED_HOST_DIRECTORY.matches(it.name) &&
+                    Files.isDirectory(it.toPath(), LinkOption.NOFOLLOW_LINKS) &&
+                    it.listFiles().isNullOrEmpty()
+            }
+            ?.forEach(File::delete)
+    }
+
+    private fun globalCacheFiles(): List<File> {
+        if (!Files.isDirectory(cacheRoot.toPath(), LinkOption.NOFOLLOW_LINKS)) return emptyList()
+        return cacheRoot.listFiles()
+            ?.asSequence()
+            ?.filter {
+                OWNED_HOST_DIRECTORY.matches(it.name) &&
+                    Files.isDirectory(it.toPath(), LinkOption.NOFOLLOW_LINKS)
+            }
+            ?.flatMap { directory -> directory.listFiles()?.asSequence() ?: emptySequence() }
+            ?.filter {
+                OWNED_CACHE_FILE.matches(it.name) &&
+                    Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS)
+            }
+            ?.toList()
             .orEmpty()
     }
 
@@ -101,10 +164,16 @@ internal class PolarisArtworkDiskCache(
 
     companion object {
         const val MAX_IMAGE_BYTES = 8 * 1024 * 1024
+        const val MAX_CACHE_BYTES = 96L * 1024L * 1024L
+        const val MAX_CACHE_ENTRIES = 128
         private const val MAX_IMAGE_DIMENSION = 8_192
         private const val MAX_IMAGE_PIXELS = 32L * 1024L * 1024L
         private const val FILE_SUFFIX = ".image"
+        private val OWNED_HOST_DIRECTORY = Regex("^[0-9a-f]{64}$")
+        private val OWNED_CACHE_FILE = Regex("^[0-9a-f]{64}\\.[0-9a-f]{64}\\.image$")
         private val TEMP_SEQUENCE = AtomicLong()
+        private val CACHE_LOCK = Any()
+        private val WRITER_LOCK = Any()
         private val SUPPORTED_IMAGE_MIMES = setOf(
             "image/png",
             "image/jpeg",
@@ -112,6 +181,13 @@ internal class PolarisArtworkDiskCache(
             "image/webp",
             "image/gif",
         )
+
+        @JvmStatic
+        internal fun atomicReplace(from: File, to: File): Boolean {
+            runCatching { Os.rename(from.absolutePath, to.absolutePath) }
+            if (!from.exists() && to.isFile) return true
+            return from.renameTo(to) && !from.exists() && to.isFile
+        }
 
         @JvmStatic
         fun cacheKey(host: String, port: Int, gameId: String, kind: String, revision: String): String =

--- a/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
@@ -8,8 +8,6 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
-import java.nio.file.Files
-import java.nio.file.LinkOption
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.FutureTask
@@ -132,28 +130,32 @@ internal class PolarisArtworkDiskCache(
         cacheRoot.listFiles()
             ?.filter {
                 OWNED_HOST_DIRECTORY.matches(it.name) &&
-                    Files.isDirectory(it.toPath(), LinkOption.NOFOLLOW_LINKS) &&
+                    isRealDirectory(it) &&
                     it.listFiles().isNullOrEmpty()
             }
             ?.forEach(File::delete)
     }
 
     private fun globalCacheFiles(): List<File> {
-        if (!Files.isDirectory(cacheRoot.toPath(), LinkOption.NOFOLLOW_LINKS)) return emptyList()
+        if (!isRealDirectory(cacheRoot)) return emptyList()
         return cacheRoot.listFiles()
             ?.asSequence()
             ?.filter {
-                OWNED_HOST_DIRECTORY.matches(it.name) &&
-                    Files.isDirectory(it.toPath(), LinkOption.NOFOLLOW_LINKS)
+                OWNED_HOST_DIRECTORY.matches(it.name) && isRealDirectory(it)
             }
             ?.flatMap { directory -> directory.listFiles()?.asSequence() ?: emptySequence() }
             ?.filter {
-                OWNED_CACHE_FILE.matches(it.name) &&
-                    Files.isRegularFile(it.toPath(), LinkOption.NOFOLLOW_LINKS)
+                OWNED_CACHE_FILE.matches(it.name) && isRealFile(it)
             }
             ?.toList()
             .orEmpty()
     }
+
+    private fun isRealDirectory(file: File): Boolean =
+        file.isDirectory && runCatching { file.canonicalFile == file.absoluteFile }.getOrDefault(false)
+
+    private fun isRealFile(file: File): Boolean =
+        file.isFile && runCatching { file.canonicalFile == file.absoluteFile }.getOrDefault(false)
 
     private fun cacheFile(gameId: String, kind: String, revision: String): File {
         return File(cacheDir, "${scopeKey(gameId, kind)}.${cacheKey(host, port, gameId, kind, revision)}$FILE_SUFFIX")

--- a/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
@@ -1,0 +1,222 @@
+package com.papi.nova.api
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.FutureTask
+import java.util.concurrent.atomic.AtomicLong
+
+internal class PolarisArtworkDiskCache(
+    context: Context,
+    private val host: String,
+    private val port: Int,
+) {
+    private val cacheDir = File(
+        context.cacheDir,
+        "polaris-artwork/${sha256(listOf(host.trim().lowercase(), port.toString()))}",
+    )
+
+    fun load(gameId: String, kind: String, revision: String, allowStale: Boolean): Bitmap? {
+        val exact = cacheFile(gameId, kind, revision)
+        val candidates = buildList {
+            if (exact.isFile) add(exact)
+            if (allowStale) {
+                cacheFilesForTest(gameId, kind)
+                    .asSequence()
+                    .filterNot { it == exact }
+                    .sortedByDescending(File::lastModified)
+                    .forEach(::add)
+            }
+        }
+        for (file in candidates) {
+            val bytes = runCatching {
+                file.inputStream().buffered().use { readBounded(it, MAX_IMAGE_BYTES) }
+            }.getOrNull()
+            val bitmap = bytes?.let(::decodeBounded)
+            if (bitmap != null) return bitmap
+            file.delete()
+        }
+        return null
+    }
+
+    fun store(gameId: String, kind: String, revision: String, bytes: ByteArray, mimeType: String?): File? {
+        if (
+            bytes.isEmpty() ||
+            bytes.size > MAX_IMAGE_BYTES ||
+            !isSupportedImageMime(mimeType) ||
+            !hasSupportedImageSignature(bytes, mimeType)
+        ) return null
+        val decoded = decodeBounded(bytes) ?: return null
+        decoded.recycle()
+
+        if (!cacheDir.exists() && !cacheDir.mkdirs()) return null
+        val target = cacheFile(gameId, kind, revision)
+        val temp = File(cacheDir, "${target.name}.${TEMP_SEQUENCE.incrementAndGet()}.tmp")
+        val backup = File(cacheDir, "${target.name}.bak")
+        return try {
+            temp.outputStream().buffered().use { output ->
+                output.write(bytes)
+                output.flush()
+            }
+            backup.delete()
+            if (target.exists() && !target.renameTo(backup)) return null
+            if (!temp.renameTo(target)) {
+                if (backup.exists()) backup.renameTo(target)
+                return null
+            }
+            backup.delete()
+            cacheFilesForTest(gameId, kind).filterNot { it == target }.forEach(File::delete)
+            target
+        } catch (_: Exception) {
+            if (!target.exists() && backup.exists()) backup.renameTo(target)
+            null
+        } finally {
+            temp.delete()
+            if (target.exists()) backup.delete()
+        }
+    }
+
+    fun clear() {
+        cacheDir.deleteRecursively()
+    }
+
+    internal fun cacheFilesForTest(gameId: String, kind: String): List<File> {
+        val prefix = "${scopeKey(gameId, kind)}."
+        return cacheDir.listFiles()
+            ?.filter { it.isFile && it.name.startsWith(prefix) && it.name.endsWith(FILE_SUFFIX) }
+            .orEmpty()
+    }
+
+    private fun cacheFile(gameId: String, kind: String, revision: String): File {
+        return File(cacheDir, "${scopeKey(gameId, kind)}.${cacheKey(host, port, gameId, kind, revision)}$FILE_SUFFIX")
+    }
+
+    private fun scopeKey(gameId: String, kind: String): String =
+        sha256(listOf(host.trim().lowercase(), port.toString(), gameId, kind.trim().lowercase()))
+
+    companion object {
+        const val MAX_IMAGE_BYTES = 8 * 1024 * 1024
+        private const val MAX_IMAGE_DIMENSION = 8_192
+        private const val MAX_IMAGE_PIXELS = 32L * 1024L * 1024L
+        private const val FILE_SUFFIX = ".image"
+        private val TEMP_SEQUENCE = AtomicLong()
+        private val SUPPORTED_IMAGE_MIMES = setOf(
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/webp",
+            "image/gif",
+        )
+
+        @JvmStatic
+        fun cacheKey(host: String, port: Int, gameId: String, kind: String, revision: String): String =
+            sha256(listOf(host.trim().lowercase(), port.toString(), gameId, kind.trim().lowercase(), revision))
+
+        @JvmStatic
+        fun readBounded(input: InputStream, maxBytes: Int): ByteArray? {
+            if (maxBytes < 0) return null
+            val output = ByteArrayOutputStream(minOf(maxBytes, 32 * 1024))
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                if (read == 0) continue
+                total += read
+                if (total > maxBytes) return null
+                output.write(buffer, 0, read)
+            }
+            return output.toByteArray()
+        }
+
+        @JvmStatic
+        fun decodeBounded(bytes: ByteArray): Bitmap? {
+            if (bytes.isEmpty() || bytes.size > MAX_IMAGE_BYTES) return null
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            if (runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds) }.isFailure) return null
+            val width = bounds.outWidth
+            val height = bounds.outHeight
+            if (width !in 1..MAX_IMAGE_DIMENSION || height !in 1..MAX_IMAGE_DIMENSION) return null
+            if (width.toLong() * height.toLong() > MAX_IMAGE_PIXELS) return null
+            return runCatching {
+                BitmapFactory.decodeByteArray(
+                    bytes,
+                    0,
+                    bytes.size,
+                    BitmapFactory.Options().apply {
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                        inScaled = false
+                    },
+                )
+            }.getOrNull()
+        }
+
+        @JvmStatic
+        fun isSupportedImageMime(value: String?): Boolean {
+            val normalized = value?.substringBefore(';')?.trim()?.lowercase().orEmpty()
+            return normalized in SUPPORTED_IMAGE_MIMES
+        }
+
+        @JvmStatic
+        fun hasSupportedImageSignature(bytes: ByteArray, mimeType: String?): Boolean {
+            fun startsWith(vararg expected: Int): Boolean =
+                bytes.size >= expected.size && expected.indices.all { bytes[it].toInt() and 0xff == expected[it] }
+
+            return when (mimeType?.substringBefore(';')?.trim()?.lowercase()) {
+                "image/png" -> startsWith(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
+                "image/jpeg", "image/jpg" -> startsWith(0xff, 0xd8, 0xff)
+                "image/gif" -> startsWith(0x47, 0x49, 0x46, 0x38) && bytes.size >= 6 &&
+                    (bytes.copyOfRange(0, 6).contentEquals("GIF87a".toByteArray()) ||
+                        bytes.copyOfRange(0, 6).contentEquals("GIF89a".toByteArray()))
+                "image/webp" -> bytes.size >= 12 && startsWith(0x52, 0x49, 0x46, 0x46) &&
+                    bytes.copyOfRange(8, 12).contentEquals("WEBP".toByteArray())
+                else -> false
+            }
+        }
+
+        private fun sha256(parts: List<String>): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            parts.forEach { part ->
+                val bytes = part.toByteArray(Charsets.UTF_8)
+                digest.update(byteArrayOf(
+                    (bytes.size ushr 24).toByte(),
+                    (bytes.size ushr 16).toByte(),
+                    (bytes.size ushr 8).toByte(),
+                    bytes.size.toByte(),
+                ))
+                digest.update(bytes)
+            }
+            return digest.digest().joinToString("") { "%02x".format(it) }
+        }
+    }
+}
+
+internal class ArtworkResolveOnce<T> {
+    private val resolutions = ConcurrentHashMap<String, FutureTask<T?>>()
+
+    fun resolve(key: String, resolver: () -> T?): T? {
+        val candidate = FutureTask(resolver)
+        val task = resolutions.putIfAbsent(key, candidate) ?: candidate.also { it.run() }
+        return try {
+            val result = task.get()
+            if (result == null) resolutions.remove(key, task)
+            result
+        } catch (e: java.util.concurrent.ExecutionException) {
+            resolutions.remove(key, task)
+            throw (e.cause ?: e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        }
+    }
+
+    fun invalidate(key: String) {
+        val task = resolutions[key] ?: return
+        if (task.isDone) resolutions.remove(key, task)
+    }
+}

--- a/app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt
@@ -46,8 +46,75 @@ object PolarisGameJsonAdapter {
             mangohud = json.optBoolean("mangohud", false),
             hdrSupported = json.optBoolean("hdr_supported", false),
             launchMode = launchMode,
-            steamLaunch = steamLaunch
+            steamLaunch = steamLaunch,
+            artwork = parseArtworkManifest(json.optJSONObject("artwork"))
         )
+    }
+
+    @JvmStatic
+    internal fun parseArtworkManifest(json: JSONObject?): PolarisGame.ArtworkManifest? {
+        if (json == null) return null
+        val assets = json.optJSONObject("assets")
+        val match = json.optJSONObject("match")?.let { matchJson ->
+            PolarisGame.ArtworkMatch(
+                source = matchJson.optString("source", ""),
+                providerGameId = matchJson.optString("provider_game_id", ""),
+                title = matchJson.optString("title", ""),
+                confidence = finiteDouble(matchJson, "confidence", 0.0).coerceIn(0.0, 1.0),
+                manual = matchJson.optBoolean("manual", false)
+            )
+        }
+        val override = json.optJSONObject("override")?.let { overrideJson ->
+            val transform = overrideJson.optJSONObject("logo_transform")?.let { transformJson ->
+                PolarisGame.ArtworkLogoTransform(
+                    x = finiteDouble(transformJson, "x", 0.5).coerceIn(0.0, 1.0),
+                    y = finiteDouble(transformJson, "y", 0.5).coerceIn(0.0, 1.0),
+                    scale = finiteDouble(transformJson, "scale", 1.0).coerceIn(0.25, 4.0)
+                )
+            }
+            PolarisGame.ArtworkOverride(
+                active = overrideJson.optBoolean("active", false),
+                kinds = fetchStringArray(overrideJson.optJSONArray("kinds")),
+                logoTransform = transform
+            )
+        }
+        return PolarisGame.ArtworkManifest(
+            version = json.optInt("version", 1).takeIf { it > 0 } ?: 1,
+            revision = json.opt("revision") as? String ?: "",
+            state = json.optString("state", "partial").ifBlank { "partial" },
+            match = match,
+            cachedAt = json.optLong("cached_at", 0).coerceAtLeast(0),
+            assets = PolarisGame.ArtworkAssets(
+                poster = parseArtworkAsset(assets?.optJSONObject("poster")),
+                hero = parseArtworkAsset(assets?.optJSONObject("hero")),
+                logo = parseArtworkAsset(assets?.optJSONObject("logo")),
+                icon = parseArtworkAsset(assets?.optJSONObject("icon")),
+                screenshots = parseArtworkAssets(assets?.optJSONArray("screenshots")),
+                trailer = parseArtworkAsset(assets?.optJSONObject("trailer"))
+            ),
+            override = override
+        )
+    }
+
+    private fun parseArtworkAssets(array: JSONArray?): List<PolarisGame.ArtworkAsset> {
+        if (array == null) return emptyList()
+        return (0 until array.length()).mapNotNull { index ->
+            parseArtworkAsset(array.optJSONObject(index))
+        }
+    }
+
+    private fun finiteDouble(json: JSONObject, key: String, fallback: Double): Double {
+        return json.optDouble(key, fallback).takeIf { it.isFinite() } ?: fallback
+    }
+
+    private fun parseArtworkAsset(json: JSONObject?): PolarisGame.ArtworkAsset? {
+        if (json == null) return null
+        return PolarisGame.ArtworkAsset(
+            url = json.opt("url") as? String ?: "",
+            source = json.opt("source") as? String ?: "",
+            mimeType = json.opt("mime_type") as? String ?: "",
+            cached = json.optBoolean("cached", false)
+        ).takeIf { it.url.isNotBlank() }
     }
 
     @JvmStatic

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailSheet.kt
@@ -15,10 +15,12 @@ import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -29,7 +31,9 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
@@ -40,6 +44,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -51,6 +56,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -75,6 +81,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.papi.nova.LimeLog
 import com.papi.nova.R
 import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.api.PolarisArtworkMatchCandidate
 import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.api.PolarisStreamDisplayMode
 import com.papi.nova.shared.polaris.model.PolarisGame
@@ -90,6 +97,7 @@ import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaFocusableCard
 import com.papi.nova.utils.DeviceUtils
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -109,6 +117,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
     private var defaultToVirtualDisplay: Boolean = false
     private var clientSettings: PolarisClientSettings? = null
     private var onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, JSONObject?) -> Unit)? = null
+    private var onGameUpdated: ((PolarisGame) -> Unit)? = null
 
     companion object {
         fun newInstance(
@@ -116,6 +125,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
             apiClient: PolarisApiClient,
             defaultToVirtualDisplay: Boolean,
             clientSettings: PolarisClientSettings?,
+            onGameUpdated: (PolarisGame) -> Unit,
             onLaunch: (PolarisGame, Boolean, Boolean, Boolean, String, JSONObject?) -> Unit
         ): NovaGameDetailSheet {
             return NovaGameDetailSheet().apply {
@@ -123,6 +133,7 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                 this.apiClient = apiClient
                 this.defaultToVirtualDisplay = defaultToVirtualDisplay
                 this.clientSettings = clientSettings
+                this.onGameUpdated = onGameUpdated
                 this.onLaunch = onLaunch
             }
         }
@@ -166,9 +177,22 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
         var launchOptionsState by mutableStateOf<NovaLaunchOptionsState?>(null)
         var profileOptionsState by mutableStateOf<NovaProfilePreferenceOptionsState?>(null)
         var steamLaunchOptionsState by mutableStateOf<NovaSteamLaunchModeOptionsState?>(null)
+        var artworkState by mutableStateOf(loadArtworkState(game))
 
         fun refreshUiState(preference: String = profilePreference) {
             uiState = buildUiState(currentGame, preference)
+        }
+
+        fun acceptArtwork(manifest: PolarisGame.ArtworkManifest) {
+            currentGame = currentGame.copy(artwork = manifest)
+            refreshUiState()
+            artworkState = artworkState.copy(
+                working = false,
+                error = null,
+                overrideActive = manifest.override?.active == true,
+                candidates = emptyList()
+            )
+            onGameUpdated?.invoke(currentGame)
         }
 
         fun loadOptimization(preference: String, usesVirtualDisplay: Boolean = uiState.playUsesVirtualDisplay) {
@@ -444,6 +468,71 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
                     onDismissSteamLaunchModeOptions = {
                         steamLaunchOptionsState = null
                     },
+                    artworkState = artworkState,
+                    onRefreshArtwork = {
+                        artworkState = artworkState.copy(working = true, error = null)
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            val manifest = withContext(Dispatchers.IO) { apiClient.resolveArtwork(currentGame.id, force = true) }
+                            if (manifest != null) acceptArtwork(manifest)
+                            else artworkState = artworkState.copy(working = false, error = getString(R.string.nova_artwork_refresh_failed))
+                        }
+                    },
+                    onSearchArtwork = { query ->
+                        artworkState = artworkState.copy(working = true, error = null)
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            try {
+                                val candidates = withContext(Dispatchers.IO) {
+                                    apiClient.searchArtworkCandidates(currentGame.id, query)
+                                }
+                                artworkState = artworkState.copy(
+                                    working = false,
+                                    candidates = candidates,
+                                    error = if (candidates.isEmpty()) getString(R.string.nova_artwork_no_matches) else null,
+                                )
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (_: Exception) {
+                                artworkState = artworkState.copy(
+                                    working = false,
+                                    candidates = emptyList(),
+                                    error = getString(R.string.nova_artwork_search_failed),
+                                )
+                            }
+                        }
+                    },
+                    onApplyArtwork = { candidate, kinds ->
+                        artworkState = artworkState.copy(working = true, error = null)
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            val manifest = withContext(Dispatchers.IO) { apiClient.applyArtworkMatch(currentGame.id, candidate, kinds) }
+                            if (manifest != null) acceptArtwork(manifest)
+                            else artworkState = artworkState.copy(working = false, error = getString(R.string.nova_artwork_apply_failed))
+                        }
+                    },
+                    onClearArtwork = {
+                        artworkState = artworkState.copy(working = true, error = null)
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            val manifest = withContext(Dispatchers.IO) { apiClient.clearArtworkOverride(currentGame.id) }
+                            if (manifest != null) acceptArtwork(manifest)
+                            else artworkState = artworkState.copy(working = false, error = getString(R.string.nova_artwork_clear_failed))
+                        }
+                    },
+                    onLogoTransform = { scale, x, y ->
+                        artworkState = artworkState.copy(logoScale = scale, logoX = x, logoY = y)
+                        saveArtworkTransform(currentGame.id, scale, x, y)
+                    },
+                    candidatePreviewLoader = apiClient::loadArtworkCandidatePreviewInto,
+                    heroAvailable = currentGame.heroArtwork?.cached == true,
+                    heroPresentationKey = PolarisApiClient.artworkPresentationKey(currentGame, PolarisGame.ARTWORK_KIND_HERO),
+                    heroLoader = { imageView -> apiClient.loadArtworkInto(imageView, currentGame, PolarisGame.ARTWORK_KIND_HERO) },
+                    heroContentDescription = getString(R.string.nova_artwork_hero_content_description, currentGame.name),
+                    logoAvailable = currentGame.logoArtwork?.cached == true,
+                    logoPresentationKey = PolarisApiClient.artworkPresentationKey(currentGame, PolarisGame.ARTWORK_KIND_LOGO),
+                    logoLoader = { imageView -> apiClient.loadArtworkInto(imageView, currentGame, PolarisGame.ARTWORK_KIND_LOGO) },
+                    logoContentDescription = getString(R.string.nova_artwork_logo_content_description, currentGame.name),
+                    iconAvailable = currentGame.iconArtwork?.cached == true,
+                    iconPresentationKey = PolarisApiClient.artworkPresentationKey(currentGame, PolarisGame.ARTWORK_KIND_ICON),
+                    iconLoader = { imageView -> apiClient.loadArtworkInto(imageView, currentGame, PolarisGame.ARTWORK_KIND_ICON) },
+                    iconContentDescription = getString(R.string.nova_artwork_icon_content_description, currentGame.name),
                     coverLoader = { imageView ->
                         apiClient.loadCoverInto(imageView, currentGame)
                     }
@@ -469,6 +558,25 @@ class NovaGameDetailSheet : BottomSheetDialogFragment() {
 
     private fun saveProfilePreference(game: PolarisGame, preference: String) {
         AutoQualityProfilePreferences.save(requireContext(), game.name, preference)
+    }
+
+    private fun loadArtworkState(game: PolarisGame): NovaArtworkCorrectionState {
+        val defaults = NovaArtworkCorrectionState.from(game)
+        val prefs = requireContext().getSharedPreferences("nova_artwork", 0)
+        val key = "logo_${game.id}_"
+        return defaults.copy(
+            logoScale = prefs.getFloat("${key}scale", defaults.logoScale).coerceIn(0.25f, 4f),
+            logoX = prefs.getFloat("${key}x", defaults.logoX).coerceIn(0f, 1f),
+            logoY = prefs.getFloat("${key}y", defaults.logoY).coerceIn(0f, 1f),
+        )
+    }
+
+    private fun saveArtworkTransform(gameId: String, scale: Float, x: Float, y: Float) {
+        requireContext().getSharedPreferences("nova_artwork", 0).edit()
+            .putFloat("logo_${gameId}_scale", scale.coerceIn(0.25f, 4f))
+            .putFloat("logo_${gameId}_x", x.coerceIn(0f, 1f))
+            .putFloat("logo_${gameId}_y", y.coerceIn(0f, 1f))
+            .apply()
     }
 
     private fun logPreflightOptimization(
@@ -1168,6 +1276,28 @@ data class NovaSteamLaunchModeOptionsState(
     val options: List<NovaSteamLaunchModeItem>
 )
 
+data class NovaArtworkCorrectionState(
+    val working: Boolean = false,
+    val error: String? = null,
+    val candidates: List<PolarisArtworkMatchCandidate> = emptyList(),
+    val overrideActive: Boolean = false,
+    val logoScale: Float = 1f,
+    val logoX: Float = 0.5f,
+    val logoY: Float = 0.5f,
+) {
+    companion object {
+        fun from(game: PolarisGame): NovaArtworkCorrectionState {
+            val transform = game.artwork?.override?.logoTransform
+            return NovaArtworkCorrectionState(
+                overrideActive = game.artwork?.override?.active == true,
+                logoScale = transform?.scale?.toFloat() ?: 1f,
+                logoX = transform?.x?.toFloat() ?: 0.5f,
+                logoY = transform?.y?.toFloat() ?: 0.5f,
+            )
+        }
+    }
+}
+
 @Composable
 fun NovaGameDetailSheetContent(
     uiState: NovaGameDetailUiState,
@@ -1209,6 +1339,25 @@ fun NovaGameDetailSheetContent(
     onSteamLaunchMode: () -> Unit,
     onSteamLaunchModeSelected: (NovaSteamLaunchModeItem) -> Unit = {},
     onDismissSteamLaunchModeOptions: () -> Unit = {},
+    artworkState: NovaArtworkCorrectionState,
+    onRefreshArtwork: () -> Unit,
+    onSearchArtwork: (String) -> Unit,
+    onApplyArtwork: (PolarisArtworkMatchCandidate, List<String>) -> Unit,
+    onClearArtwork: () -> Unit,
+    onLogoTransform: (Float, Float, Float) -> Unit,
+    candidatePreviewLoader: (ImageView, PolarisArtworkMatchCandidate) -> Unit,
+    heroAvailable: Boolean = false,
+    heroPresentationKey: String = "",
+    heroLoader: (ImageView) -> Unit = {},
+    heroContentDescription: String = "",
+    logoAvailable: Boolean,
+    logoPresentationKey: String,
+    logoLoader: (ImageView) -> Unit,
+    logoContentDescription: String = "",
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+    iconContentDescription: String = "",
     coverLoader: (ImageView) -> Unit
 ) {
     val colors = LocalNovaComposeColors.current
@@ -1234,7 +1383,20 @@ fun NovaGameDetailSheetContent(
                 uiState = uiState,
                 lastPlayedText = lastPlayedText,
                 coverContentDescription = coverContentDescription,
-                coverLoader = coverLoader
+                coverLoader = coverLoader,
+                artworkState = artworkState,
+                heroAvailable = heroAvailable,
+                heroPresentationKey = heroPresentationKey,
+                heroLoader = heroLoader,
+                heroContentDescription = heroContentDescription,
+                logoAvailable = logoAvailable,
+                logoPresentationKey = logoPresentationKey,
+                logoLoader = logoLoader,
+                logoContentDescription = logoContentDescription,
+                iconAvailable = iconAvailable,
+                iconPresentationKey = iconPresentationKey,
+                iconLoader = iconLoader,
+                iconContentDescription = iconContentDescription,
             )
 
             LaunchControlsPanel(
@@ -1306,6 +1468,23 @@ fun NovaGameDetailSheetContent(
             optimizationState.stability?.let {
                 InsightCard(card = it)
             }
+
+            ArtworkCorrectionPanel(
+                state = artworkState,
+                initialQuery = uiState.game.name,
+                onRefresh = onRefreshArtwork,
+                onSearch = onSearchArtwork,
+                onApply = onApplyArtwork,
+                onClear = onClearArtwork,
+                onTransform = onLogoTransform,
+                previewLoader = candidatePreviewLoader,
+                logoAvailable = logoAvailable,
+                logoPresentationKey = logoPresentationKey,
+                logoLoader = logoLoader,
+                iconAvailable = iconAvailable,
+                iconPresentationKey = iconPresentationKey,
+                iconLoader = iconLoader,
+            )
 
             NovaControllerHintBar(
                 hints = novaGameDetailControllerHints(),
@@ -1581,14 +1760,185 @@ private fun NovaDesktopSteamLaunchDecisionContent(
 }
 
 @Composable
+private fun ArtworkCorrectionPanel(
+    state: NovaArtworkCorrectionState,
+    initialQuery: String,
+    onRefresh: () -> Unit,
+    onSearch: (String) -> Unit,
+    onApply: (PolarisArtworkMatchCandidate, List<String>) -> Unit,
+    onClear: () -> Unit,
+    onTransform: (Float, Float, Float) -> Unit,
+    previewLoader: (ImageView, PolarisArtworkMatchCandidate) -> Unit,
+    logoAvailable: Boolean,
+    logoPresentationKey: String,
+    logoLoader: (ImageView) -> Unit,
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+) {
+    val colors = LocalNovaComposeColors.current
+    var expanded by remember(initialQuery) { mutableStateOf(false) }
+    var query by remember(initialQuery) { mutableStateOf(initialQuery) }
+    var pendingCandidate by remember { mutableStateOf<PolarisArtworkMatchCandidate?>(null) }
+    val artworkKinds = listOf("poster", "hero", "logo", "icon")
+    var selectedKinds by remember { mutableStateOf(artworkKinds.toSet()) }
+    val artworkTitle = stringResource(R.string.nova_artwork_title)
+    val artworkSummary = stringResource(R.string.nova_artwork_summary)
+    val toggleDescription = stringResource(if (expanded) R.string.nova_artwork_collapse else R.string.nova_artwork_expand)
+    val iconDescription = stringResource(R.string.nova_artwork_icon_content_description, initialQuery)
+    LaunchedEffect(state.candidates) { pendingCandidate = null }
+    NovaDetailPanel(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 14.dp, end = 14.dp, top = 12.dp),
+        contentDescription = toggleDescription,
+        contentPadding = PaddingValues(0.dp),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = toggleDescription }
+                    .clickable { expanded = !expanded }
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (iconAvailable) {
+                    key(iconPresentationKey) {
+                        AndroidView(
+                            factory = { context ->
+                                ImageView(context).apply {
+                                    scaleType = ImageView.ScaleType.FIT_CENTER
+                                    contentDescription = iconDescription
+                                    iconLoader(this)
+                                }
+                            },
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(colors.window)
+                                .border(1.dp, colors.divider, RoundedCornerShape(10.dp)),
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(10.dp))
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(artworkTitle, color = colors.textPrimary, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+                    Text(artworkSummary, color = colors.textMuted, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+                Text(if (expanded) "▴" else "▾", color = colors.textSecondary, fontSize = 18.sp)
+            }
+            if (expanded) {
+                Column(modifier = Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, bottom = 12.dp)) {
+                    OutlinedTextField(
+            value = query,
+            onValueChange = { candidate ->
+                if (candidate.toByteArray(Charsets.UTF_8).size <= 160 && candidate.none { it.code < 0x20 || it.code in 0x7f..0x9f }) query = candidate
+            },
+            label = { Text(stringResource(R.string.nova_artwork_search_title)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(top = 8.dp)) {
+            NovaActionButton(stringResource(R.string.nova_artwork_refresh), onRefresh, Modifier.weight(1f), enabled = !state.working)
+            NovaActionButton(stringResource(R.string.nova_artwork_fix_match), { onSearch(query.trim()) }, Modifier.weight(1f), enabled = !state.working && query.isNotBlank())
+        }
+        if (state.overrideActive) {
+            NovaActionButton(stringResource(R.string.nova_artwork_clear_match), onClear, Modifier.fillMaxWidth().padding(top = 8.dp), enabled = !state.working)
+        }
+        state.error?.let { Text(it, color = colors.textMuted, fontSize = 12.sp, modifier = Modifier.padding(top = 6.dp)) }
+        if (logoAvailable) {
+            key(logoPresentationKey) {
+                AndroidView(
+                    factory = { context -> ImageView(context).apply { scaleType = ImageView.ScaleType.FIT_CENTER; logoLoader(this) } },
+                    modifier = Modifier.fillMaxWidth().height(72.dp).graphicsLayer {
+                        scaleX = state.logoScale
+                        scaleY = state.logoScale
+                        translationX = (state.logoX - 0.5f) * 120f
+                        translationY = (state.logoY - 0.5f) * 72f
+                    }
+                )
+            }
+            LogoTransformControls(state, onTransform)
+        } else {
+            Text(
+                stringResource(R.string.nova_artwork_logo_unavailable),
+                color = colors.textMuted,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        state.candidates.forEach { candidate ->
+            key(candidate.providerGameId) {
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                AndroidView(factory = { context -> ImageView(context).apply { scaleType = ImageView.ScaleType.CENTER_CROP; previewLoader(this, candidate) } }, modifier = Modifier.size(56.dp))
+                NovaActionButton(stringResource(R.string.nova_artwork_preview_candidate, candidate.title), { pendingCandidate = candidate }, Modifier.weight(1f).padding(start = 8.dp), enabled = !state.working)
+            }
+        }
+        }
+        pendingCandidate?.let { candidate ->
+            Text(stringResource(R.string.nova_artwork_confirm_candidate, candidate.title), modifier = Modifier.padding(top = 10.dp), color = colors.textPrimary)
+            Text(stringResource(R.string.nova_artwork_select_kinds), modifier = Modifier.padding(top = 6.dp), color = colors.textMuted, fontSize = 12.sp)
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.padding(top = 4.dp)) {
+                artworkKinds.forEach { kind ->
+                    val label = stringResource(when (kind) {
+                        "poster" -> R.string.nova_artwork_kind_poster
+                        "hero" -> R.string.nova_artwork_kind_hero
+                        "logo" -> R.string.nova_artwork_kind_logo
+                        else -> R.string.nova_artwork_kind_icon
+                    })
+                    NovaActionButton(label, { selectedKinds = if (kind in selectedKinds) selectedKinds - kind else selectedKinds + kind }, Modifier.weight(1f), enabled = !state.working, primary = kind in selectedKinds)
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(top = 6.dp)) {
+                NovaActionButton(stringResource(R.string.nova_artwork_apply_match), { pendingCandidate = null; onApply(candidate, artworkKinds.filter { it in selectedKinds }) }, Modifier.weight(1f), enabled = !state.working && selectedKinds.isNotEmpty(), primary = true)
+                NovaActionButton(stringResource(R.string.cancel), { pendingCandidate = null }, Modifier.weight(1f), enabled = !state.working)
+            }
+        }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogoTransformControls(state: NovaArtworkCorrectionState, onTransform: (Float, Float, Float) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(stringResource(R.string.nova_artwork_logo_controls), fontSize = 12.sp, modifier = Modifier.padding(bottom = 4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            NovaActionButton(stringResource(R.string.nova_artwork_smaller), { onTransform((state.logoScale - 0.1f).coerceAtLeast(0.25f), state.logoX, state.logoY) }, Modifier.weight(1f))
+            NovaActionButton(stringResource(R.string.nova_artwork_reset), { onTransform(1f, 0.5f, 0.5f) }, Modifier.weight(1f))
+            NovaActionButton(stringResource(R.string.nova_artwork_larger), { onTransform((state.logoScale + 0.1f).coerceAtMost(4f), state.logoX, state.logoY) }, Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.padding(top = 6.dp)) {
+            NovaActionButton(stringResource(R.string.nova_artwork_left), { onTransform(state.logoScale, (state.logoX - 0.05f).coerceAtLeast(0f), state.logoY) }, Modifier.weight(1f))
+            NovaActionButton(stringResource(R.string.nova_artwork_up), { onTransform(state.logoScale, state.logoX, (state.logoY - 0.05f).coerceAtLeast(0f)) }, Modifier.weight(1f))
+            NovaActionButton(stringResource(R.string.nova_artwork_down), { onTransform(state.logoScale, state.logoX, (state.logoY + 0.05f).coerceAtMost(1f)) }, Modifier.weight(1f))
+            NovaActionButton(stringResource(R.string.nova_artwork_right), { onTransform(state.logoScale, (state.logoX + 0.05f).coerceAtMost(1f), state.logoY) }, Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
 private fun GameDetailsPanel(
     uiState: NovaGameDetailUiState,
     lastPlayedText: String?,
     coverContentDescription: String,
-    coverLoader: (ImageView) -> Unit
+    coverLoader: (ImageView) -> Unit,
+    artworkState: NovaArtworkCorrectionState,
+    heroAvailable: Boolean,
+    heroPresentationKey: String,
+    heroLoader: (ImageView) -> Unit,
+    heroContentDescription: String,
+    logoAvailable: Boolean,
+    logoPresentationKey: String,
+    logoLoader: (ImageView) -> Unit,
+    logoContentDescription: String,
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+    iconContentDescription: String,
 ) {
-    val colors = LocalNovaComposeColors.current
-    val surfaces = LocalNovaLibrarySurfaces.current
     val game = uiState.game
 
     NovaDetailPanel(
@@ -1600,71 +1950,251 @@ private fun GameDetailsPanel(
         accent = true,
         contentPadding = PaddingValues(12.dp)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            key(game.id, game.coverUrl) {
+        if (heroAvailable) {
+            NovaGameDetailHero(
+                game = game,
+                artworkState = artworkState,
+                heroPresentationKey = heroPresentationKey,
+                heroLoader = heroLoader,
+                heroContentDescription = heroContentDescription,
+                logoAvailable = logoAvailable,
+                logoPresentationKey = logoPresentationKey,
+                logoLoader = logoLoader,
+                logoContentDescription = logoContentDescription,
+                iconAvailable = iconAvailable,
+                iconPresentationKey = iconPresentationKey,
+                iconLoader = iconLoader,
+                iconContentDescription = iconContentDescription,
+            )
+        } else {
+            NovaGameDetailPosterFallback(
+                uiState = uiState,
+                lastPlayedText = lastPlayedText,
+                coverContentDescription = coverContentDescription,
+                coverLoader = coverLoader,
+                iconAvailable = iconAvailable,
+                iconPresentationKey = iconPresentationKey,
+                iconLoader = iconLoader,
+                iconContentDescription = iconContentDescription,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NovaGameDetailHero(
+    game: PolarisGame,
+    artworkState: NovaArtworkCorrectionState,
+    heroPresentationKey: String,
+    heroLoader: (ImageView) -> Unit,
+    heroContentDescription: String,
+    logoAvailable: Boolean,
+    logoPresentationKey: String,
+    logoLoader: (ImageView) -> Unit,
+    logoContentDescription: String,
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+    iconContentDescription: String,
+) {
+    val colors = LocalNovaComposeColors.current
+    val menuOpacityScale = LocalNovaMenuOpacityScale.current
+
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(136.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.window)
+    ) {
+        key(heroPresentationKey) {
+            AndroidView(
+                factory = { context ->
+                    ImageView(context).apply {
+                        scaleType = ImageView.ScaleType.CENTER_CROP
+                        setBackgroundColor(NovaThemeManager.getCardBackgroundColor(context))
+                        contentDescription = heroContentDescription
+                        heroLoader(this)
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(136.dp)
+                    .semantics { contentDescription = heroContentDescription }
+            )
+        }
+
+        if (logoAvailable) {
+            val logoWidth = maxWidth * 0.56f
+            val logoHeight = maxHeight * 0.46f
+            val logoOffsetX = (maxWidth - logoWidth) * artworkState.logoX
+            val logoOffsetY = (maxHeight - logoHeight) * artworkState.logoY
+            key(logoPresentationKey) {
                 AndroidView(
                     factory = { context ->
                         ImageView(context).apply {
-                            scaleType = ImageView.ScaleType.CENTER_CROP
-                            setBackgroundColor(NovaThemeManager.getCardBackgroundColor(context))
-                            contentDescription = coverContentDescription
-                            coverLoader(this)
+                            scaleType = ImageView.ScaleType.FIT_CENTER
+                            setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                            contentDescription = logoContentDescription
+                            logoLoader(this)
                         }
                     },
                     modifier = Modifier
-                        .width(108.dp)
-                        .aspectRatio(88f / 118f)
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(colors.window)
-                        .border(1.dp, colors.divider, RoundedCornerShape(14.dp))
-                        .semantics { contentDescription = coverContentDescription }
+                        .offset(x = logoOffsetX, y = logoOffsetY)
+                        .size(logoWidth, logoHeight)
+                        .graphicsLayer {
+                            scaleX = artworkState.logoScale
+                            scaleY = artworkState.logoScale
+                        }
+                        .semantics { contentDescription = logoContentDescription }
                 )
             }
+        }
 
-            Column(
+        NovaGameDetailIdentity(
+            game = game,
+            iconAvailable = iconAvailable,
+            iconPresentationKey = iconPresentationKey,
+            iconLoader = iconLoader,
+            iconContentDescription = iconContentDescription,
+            compact = true,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .background(colors.window.copy(alpha = 0.84f * menuOpacityScale))
+                .padding(horizontal = 10.dp, vertical = 7.dp)
+        )
+    }
+}
+
+@Composable
+private fun NovaGameDetailPosterFallback(
+    uiState: NovaGameDetailUiState,
+    lastPlayedText: String?,
+    coverContentDescription: String,
+    coverLoader: (ImageView) -> Unit,
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+    iconContentDescription: String,
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val game = uiState.game
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER)) {
+            AndroidView(
+                factory = { context ->
+                    ImageView(context).apply {
+                        scaleType = ImageView.ScaleType.CENTER_CROP
+                        setBackgroundColor(NovaThemeManager.getCardBackgroundColor(context))
+                        contentDescription = coverContentDescription
+                        coverLoader(this)
+                    }
+                },
                 modifier = Modifier
-                    .padding(start = 12.dp)
-                    .weight(1f),
-                verticalArrangement = Arrangement.Center
-            ) {
+                    .width(108.dp)
+                    .aspectRatio(88f / 118f)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(colors.window)
+                    .border(1.dp, colors.divider, RoundedCornerShape(14.dp))
+                    .semantics { contentDescription = coverContentDescription }
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .padding(start = 12.dp)
+                .weight(1f),
+            verticalArrangement = Arrangement.Center
+        ) {
+            NovaGameDetailIdentity(
+                game = game,
+                iconAvailable = iconAvailable,
+                iconPresentationKey = iconPresentationKey,
+                iconLoader = iconLoader,
+                iconContentDescription = iconContentDescription,
+                compact = false,
+            )
+
+            MetadataBadges(game)
+            GenresRow(game.genres)
+
+            if (lastPlayedText != null) {
+                NovaBadge(
+                    text = lastPlayedText,
+                    modifier = Modifier.padding(top = 7.dp),
+                    color = colors.textSecondary,
+                    backgroundColor = surfaces.control.copy(alpha = 0.78f * LocalNovaMenuOpacityScale.current),
+                    borderColor = surfaces.tileBorder,
+                    fontSize = 11.sp,
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 5.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NovaGameDetailIdentity(
+    game: PolarisGame,
+    iconAvailable: Boolean,
+    iconPresentationKey: String,
+    iconLoader: (ImageView) -> Unit,
+    iconContentDescription: String,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LocalNovaComposeColors.current
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (iconAvailable) {
+            key(iconPresentationKey) {
+                AndroidView(
+                    factory = { context ->
+                        ImageView(context).apply {
+                            scaleType = ImageView.ScaleType.FIT_CENTER
+                            setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                            contentDescription = iconContentDescription
+                            iconLoader(this)
+                        }
+                    },
+                    modifier = Modifier
+                        .size(if (compact) 34.dp else 38.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .semantics { contentDescription = iconContentDescription }
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .padding(start = if (iconAvailable) 9.dp else 0.dp)
+                .weight(1f)
+        ) {
+            Text(
+                text = game.name,
+                color = colors.textPrimary,
+                fontSize = if (compact) 17.sp else 20.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = if (compact) 19.sp else 22.sp,
+                maxLines = if (compact) 1 else 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (game.sourceRuntimeLabel.isNotBlank()) {
                 Text(
-                    text = game.name,
-                    color = colors.textPrimary,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    lineHeight = 22.sp,
-                    maxLines = 2,
+                    text = game.sourceRuntimeLabel,
+                    modifier = Modifier.padding(top = if (compact) 1.dp else 5.dp),
+                    color = colors.textSecondary,
+                    fontSize = 11.sp,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-
-                if (game.sourceRuntimeLabel.isNotBlank()) {
-                    Text(
-                        text = game.sourceRuntimeLabel,
-                        modifier = Modifier.padding(top = 5.dp),
-                        color = colors.textSecondary,
-                        fontSize = 11.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-
-                MetadataBadges(game)
-                GenresRow(game.genres)
-
-                if (lastPlayedText != null) {
-                    NovaBadge(
-                        text = lastPlayedText,
-                        modifier = Modifier.padding(top = 7.dp),
-                        color = colors.textSecondary,
-                        backgroundColor = surfaces.control.copy(alpha = 0.78f * LocalNovaMenuOpacityScale.current),
-                        borderColor = surfaces.tileBorder,
-                        fontSize = 11.sp,
-                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 5.dp)
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -675,7 +675,10 @@ class NovaLibraryActivity : NovaActivity() {
             game = game,
             apiClient = apiClient,
             defaultToVirtualDisplay = defaultToVirtualDisplay,
-            clientSettings = clientSettings
+            clientSettings = clientSettings,
+            onGameUpdated = { updated ->
+                allGames = allGames.map { if (it.id == updated.id) updated else it }
+            }
         ) { selectedGame, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, preflightOptimization ->
             launchGame(selectedGame, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, preflightOptimization)
         }
@@ -1364,7 +1367,7 @@ class NovaLibraryActivity : NovaActivity() {
         ) { targetGame ->
             if (targetGame != null) {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    key(targetGame.id, targetGame.coverUrl) {
+                    key(PolarisApiClient.artworkPresentationKey(targetGame, PolarisGame.ARTWORK_KIND_POSTER)) {
                         AndroidView(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -1583,7 +1586,7 @@ class NovaLibraryActivity : NovaActivity() {
                 .background(surfaces.mediaPlaceholder)
                 .border(1.dp, surfaces.tileBorder.copy(alpha = 0.74f * LocalNovaMenuOpacityScale.current), shape)
         ) {
-            key(targetGame.id, targetGame.coverUrl) {
+            key(PolarisApiClient.artworkPresentationKey(targetGame, PolarisGame.ARTWORK_KIND_POSTER)) {
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
                     factory = { context ->
@@ -2545,7 +2548,7 @@ class NovaLibraryActivity : NovaActivity() {
                             .clip(RoundedCornerShape(10.dp))
                             .background(surfaces.mediaPlaceholder)
                     ) {
-                        key(game.id, game.coverUrl) {
+                        key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER)) {
                             AndroidView(
                                 modifier = Modifier.fillMaxSize(),
                                 factory = { context ->
@@ -2602,7 +2605,7 @@ class NovaLibraryActivity : NovaActivity() {
                     }
                 }
             } else {
-                key(game.id, game.coverUrl) {
+                key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER)) {
                     AndroidView(
                         modifier = Modifier.fillMaxSize(),
                         factory = { context ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1344,4 +1344,39 @@
     <string name="nova_settings_modern">Modern</string>
     <string name="nova_server_manage">Manage</string>
     <string name="nova_server_remove_failed">Couldn\'t remove server. Try again.</string>
+
+    <!-- Polaris artwork correction -->
+    <string name="nova_artwork_title">Artwork</string>
+    <string name="nova_artwork_summary">Manage poster, hero, logo, and icon</string>
+    <string name="nova_artwork_expand">Expand artwork preferences</string>
+    <string name="nova_artwork_collapse">Collapse artwork preferences</string>
+    <string name="nova_artwork_icon_content_description">%1$s game icon</string>
+    <string name="nova_artwork_hero_content_description">%1$s hero artwork</string>
+    <string name="nova_artwork_logo_content_description">%1$s game logo</string>
+    <string name="nova_artwork_logo_unavailable">No game logo is available yet. Refresh artwork or choose a custom match.</string>
+    <string name="nova_artwork_search_title">Search title</string>
+    <string name="nova_artwork_refresh">Refresh artwork</string>
+    <string name="nova_artwork_fix_match">Fix match</string>
+    <string name="nova_artwork_clear_match">Clear custom match</string>
+    <string name="nova_artwork_preview_candidate">Preview %1$s</string>
+    <string name="nova_artwork_confirm_candidate">Use %1$s as the custom artwork match?</string>
+    <string name="nova_artwork_apply_match">Apply match</string>
+    <string name="nova_artwork_no_matches">No matches found</string>
+    <string name="nova_artwork_search_failed">Artwork search unavailable. Check SteamGridDB in Polaris and try again.</string>
+    <string name="nova_artwork_refresh_failed">Artwork refresh failed</string>
+    <string name="nova_artwork_apply_failed">Custom match failed</string>
+    <string name="nova_artwork_clear_failed">Clear custom match failed</string>
+    <string name="nova_artwork_select_kinds">Artwork types to replace</string>
+    <string name="nova_artwork_kind_poster">Poster</string>
+    <string name="nova_artwork_kind_hero">Hero</string>
+    <string name="nova_artwork_kind_logo">Logo</string>
+    <string name="nova_artwork_kind_icon">Icon</string>
+    <string name="nova_artwork_logo_controls">Logo position and size</string>
+    <string name="nova_artwork_smaller">Smaller</string>
+    <string name="nova_artwork_reset">Reset</string>
+    <string name="nova_artwork_larger">Larger</string>
+    <string name="nova_artwork_left">Left</string>
+    <string name="nova_artwork_up">Up</string>
+    <string name="nova_artwork_down">Down</string>
+    <string name="nova_artwork_right">Right</string>
 </resources>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -3,8 +3,10 @@ package com.papi.nova.api
 import com.papi.nova.shared.polaris.model.PolarisGame
 import okhttp3.OkHttpClient
 import org.json.JSONObject
+import java.io.IOException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,7 +19,7 @@ import org.robolectric.annotation.Config
 class PolarisApiClientParsingTest {
 
     @Test
-    fun artworkHttpClientDisablesAllRedirects() {
+    fun artworkHttpClientDisablesRedirectsAndAllowsBoundedProviderWorkflows() {
         val base = OkHttpClient.Builder().build()
         val artwork = PolarisApiClient.buildArtworkHttpClient(base)
 
@@ -25,6 +27,80 @@ class PolarisApiClientParsingTest {
         assertTrue(base.followSslRedirects)
         assertFalse(artwork.followRedirects)
         assertFalse(artwork.followSslRedirects)
+        assertEquals(120_000, artwork.readTimeoutMillis)
+        assertEquals(120_000, artwork.callTimeoutMillis)
+    }
+
+    @Test
+    fun artworkHttpClientRefreshesBaseTlsStateForEveryCall() {
+        var baseCalls = 0
+        val baseForCall = {
+            baseCalls += 1
+            OkHttpClient.Builder().build()
+        }
+
+        val first = PolarisApiClient.buildArtworkHttpClientForCall(baseForCall)
+        val second = PolarisApiClient.buildArtworkHttpClientForCall(baseForCall)
+
+        assertEquals(2, baseCalls)
+        assertFalse(first.followRedirects)
+        assertFalse(second.followSslRedirects)
+        assertEquals(120_000, first.callTimeoutMillis)
+        assertEquals(120_000, second.readTimeoutMillis)
+    }
+
+    @Test
+    fun malformedArtworkJsonIsRejectedWithoutRetainingResponseBody() {
+        val marker = "provider-response-must-not-reach-logs"
+        val failure = try {
+            PolarisApiClient.parseArtworkJsonBytes("{invalid:$marker".toByteArray())
+            null
+        } catch (e: IOException) {
+            e
+        }
+
+        val sanitized = requireNotNull(failure)
+        assertEquals("invalid artwork JSON", sanitized.message)
+        assertFalse(sanitized.toString().contains(marker))
+        assertNull(sanitized.cause)
+    }
+
+    @Test
+    fun artworkPresentationKeyTracksRevisionAndLegacyCoverChanges() {
+        val asset = PolarisGame.ArtworkAsset(url = "/polaris/v1/games/g/artwork/poster", cached = true)
+        fun game(revision: String) = PolarisGame(id = "g", artwork = PolarisGame.ArtworkManifest(revision = revision, assets = PolarisGame.ArtworkAssets(poster = asset)))
+        val first = PolarisApiClient.artworkPresentationKey(game("a"), PolarisGame.ARTWORK_KIND_POSTER)
+        val second = PolarisApiClient.artworkPresentationKey(game("b"), PolarisGame.ARTWORK_KIND_POSTER)
+        assertFalse(first == second)
+        val legacyA = PolarisGame(id = "g", coverUrl = "/a")
+        val legacyB = PolarisGame(id = "g", coverUrl = "/b")
+        assertFalse(PolarisApiClient.artworkPresentationKey(legacyA, "poster") == PolarisApiClient.artworkPresentationKey(legacyB, "poster"))
+    }
+
+    @Test
+    fun trustedCandidatePreviewUrlRequiresExactPairedOriginAndOpaquePath() {
+        val good = "https://polaris.lan:47984/polaris/v1/games/game-1/artwork/candidate/0123456789abcdef0123456789abcdef/poster"
+        assertTrue(PolarisApiClient.isTrustedCandidatePreviewUrl(good, "POLARIS.LAN", 47984))
+        assertFalse(PolarisApiClient.isTrustedCandidatePreviewUrl("https://user@polaris.lan:47984/x", "polaris.lan", 47984))
+        assertFalse(PolarisApiClient.isTrustedCandidatePreviewUrl("$good?token=secret", "polaris.lan", 47984))
+        assertFalse(PolarisApiClient.isTrustedCandidatePreviewUrl(good.replace("/poster", "/hero"), "polaris.lan", 47984))
+    }
+
+    @Test
+    fun artworkRequestLogLabelsNeverContainCandidatePreviewTokens() {
+        val token = "0123456789abcdef0123456789abcdef"
+        val candidateUrl = "https://polaris.lan:47984/polaris/v1/games/game-1/" +
+            "artwork/candidate/$token/poster"
+        val label = PolarisApiClient.artworkRequestLogLabel(candidateUrl)
+
+        assertEquals("candidate-preview", label)
+        assertFalse(label.contains(token))
+        assertFalse(label.contains(candidateUrl))
+        assertEquals(
+            "manifest-artwork",
+            PolarisApiClient.artworkRequestLogLabel("https://polaris.lan:47984/polaris/v1/games/game-1/artwork/poster"),
+        )
+        assertEquals("legacy-cover", PolarisApiClient.artworkRequestLogLabel("https://polaris.lan:47984/cover/game-1"))
     }
 
     @Test
@@ -700,6 +776,70 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
+    fun artworkCandidatesAreSanitizedAndMatchBodyIsBounded() {
+        val response = JSONObject("""{"status":true,"candidates":[
+          {"provider":"steamgriddb","provider_game_id":"12345","title":"Portal 2","steam_appid":"620","release_year":2011,"confidence":0.98,
+           "preview":{"poster":"/polaris/v1/games/game-1/artwork/candidate/00000000000000000000000000000001/poster"}},
+          {"provider":"evil","provider_game_id":"9","title":"Bad"},
+          {"provider":"steamgriddb","provider_game_id":"../1","title":"Bad"},
+          {"provider":"steamgriddb","provider_game_id":"7","title":"Absolute","preview":{"poster":"https://cdn.invalid/poster.png"}},
+          {"provider":"steamgriddb","provider_game_id":"12345","title":"Portal II"}
+        ]}""")
+
+        val candidates = PolarisApiClient.parseArtworkCandidates(response, "game-1", "polaris.lan", 47984)
+        assertEquals(2, candidates.size)
+        val first = candidates.first()
+        assertEquals("12345", first.providerGameId)
+        assertEquals("https://polaris.lan:47984/polaris/v1/games/game-1/artwork/candidate/00000000000000000000000000000001/poster", first.posterPreviewUrl)
+        assertNull(candidates.last().posterPreviewUrl)
+
+        val body = PolarisApiClient.buildArtworkMatchBody(first, listOf("poster", "hero", "logo", "icon"))
+        assertEquals(setOf("provider", "provider_game_id", "title", "steam_appid", "kinds"), body.keys().asSequence().toSet())
+        assertEquals(4, body.getJSONArray("kinds").length())
+        assertFalse(body.toString().contains("preview"))
+        assertFalse(body.toString().contains("api_key"))
+        var invalidKindsRejected = false
+        try { PolarisApiClient.buildArtworkMatchBody(first, listOf("poster", "poster")) }
+        catch (_: IllegalArgumentException) { invalidKindsRejected = true }
+        assertTrue(invalidKindsRejected)
+    }
+
+    @Test
+    fun artworkCandidateEnvelopeRejectsApplicationFailuresButAllowsTrueEmptyResults() {
+        val validEmpty = JSONObject("{\"status\":true,\"candidates\":[]}")
+        assertTrue(PolarisApiClient.parseArtworkCandidates(validEmpty, "game-1", "polaris.lan", 47984).isEmpty())
+
+        val invalidEnvelopes = listOf(
+            JSONObject("{\"status\":false,\"candidates\":[]}"),
+            JSONObject("{\"candidates\":[]}"),
+            JSONObject("{\"status\":true}"),
+            JSONObject("{\"status\":true,\"candidates\":{}}"),
+        )
+        for (response in invalidEnvelopes) {
+            val failure = try {
+                PolarisApiClient.parseArtworkCandidates(response, "game-1", "polaris.lan", 47984)
+                null
+            } catch (e: IOException) {
+                e
+            }
+            assertEquals("invalid artwork candidate search response", requireNotNull(failure).message)
+            assertNull(failure.cause)
+        }
+    }
+
+    @Test
+    fun artworkCandidateContractRejectsUtf8ByteOverflowAndForgedApplyBodies() {
+        val oversizedTitle = "é".repeat(81)
+        val response = JSONObject("""{"status":true,"candidates":[{"provider":"steamgriddb","provider_game_id":"1","title":"$oversizedTitle"}]}""")
+        assertTrue(PolarisApiClient.parseArtworkCandidates(response, "game-1", "polaris.lan", 47984).isEmpty())
+        val forged = PolarisArtworkMatchCandidate("evil", "../1", "Bad\nTitle")
+        var rejected = false
+        try { PolarisApiClient.buildArtworkMatchBody(forged, listOf("poster")) }
+        catch (_: IllegalArgumentException) { rejected = true }
+        assertTrue(rejected)
+    }
+
+    @Test
     fun artworkResolveResponseAcceptsDirectAndNestedEnvelopes() {
         val direct = PolarisApiClient.parseArtworkResolveResponse(
             JSONObject("{\"version\":1,\"revision\":\"direct\",\"assets\":{\"poster\":{\"url\":\"/polaris/v1/games/a/artwork/poster\"}}}")
@@ -708,8 +848,13 @@ class PolarisApiClientParsingTest {
             JSONObject("{\"data\":{\"game\":{\"artwork\":{\"version\":1,\"revision\":\"nested\",\"assets\":{\"poster\":{\"url\":\"/polaris/v1/games/b/artwork/poster\"}}}}}}")
         )
 
+        val envelope = PolarisApiClient.parseArtworkResolveResponse(
+            JSONObject("{\"status\":true,\"artwork\":{\"version\":1,\"revision\":\"envelope\",\"assets\":{}}}")
+        )
+
         assertEquals("direct", direct?.revision)
         assertEquals("nested", nested?.revision)
+        assertEquals("envelope", envelope?.revision)
         assertNull(PolarisApiClient.parseArtworkResolveResponse(JSONObject("{\"success\":true}")))
     }
 

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -1,9 +1,11 @@
 package com.papi.nova.api
 
 import com.papi.nova.shared.polaris.model.PolarisGame
+import okhttp3.OkHttpClient
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +15,17 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class PolarisApiClientParsingTest {
+
+    @Test
+    fun artworkHttpClientDisablesAllRedirects() {
+        val base = OkHttpClient.Builder().build()
+        val artwork = PolarisApiClient.buildArtworkHttpClient(base)
+
+        assertTrue(base.followRedirects)
+        assertTrue(base.followSslRedirects)
+        assertFalse(artwork.followRedirects)
+        assertFalse(artwork.followSslRedirects)
+    }
 
     @Test
     fun parseUnlockResponse_requiresSuccessFlag() {
@@ -486,6 +499,218 @@ class PolarisApiClientParsingTest {
             "Steam Big Picture compatibility mode may also receive controller input.",
             game.steamLaunch?.modeReason
         )
+    }
+
+    @Test
+    fun parseGame_includesArtworkManifestWithDefaults() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject(
+                """
+                {
+                  "id":"game-artwork",
+                  "cover_url":"/legacy-cover",
+                  "artwork":{
+                    "revision":"revision-a",
+                    "assets":{
+                      "poster":{"url":"/polaris/v1/games/game-artwork/artwork/poster","source":"local","mime_type":"image/png","cached":true},
+                      "hero":{"url":"/polaris/v1/games/game-artwork/artwork/hero"}
+                    }
+                  }
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals(1, game.artwork?.version)
+        assertEquals("revision-a", game.artwork?.revision)
+        assertEquals("/polaris/v1/games/game-artwork/artwork/poster", game.posterArtwork?.url)
+        assertEquals("local", game.posterArtwork?.source)
+        assertEquals("image/png", game.posterArtwork?.mimeType)
+        assertTrue(game.posterArtwork?.cached == true)
+        assertEquals("", game.heroArtwork?.source)
+        assertEquals("/legacy-cover", game.coverUrl)
+    }
+
+    @Test
+    fun parseGame_includesCompleteArtworkManifestV1Shape() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject(
+                """
+                {
+                  "id":"game-complete",
+                  "artwork":{
+                    "version":1,
+                    "revision":"rev-complete",
+                    "state":"partial",
+                    "match":{"source":"steamgriddb","provider_game_id":"99","title":"Corrected Match","confidence":1.5,"manual":true},
+                    "cached_at":1785641400000,
+                    "assets":{
+                      "screenshots":[
+                        {"url":"/polaris/v1/games/game-complete/artwork/screenshots/0","source":"steam","mime_type":"image/jpeg","cached":true},
+                        "malformed"
+                      ],
+                      "trailer":{"url":"/polaris/v1/games/game-complete/artwork/trailer","source":"steam","mime_type":"video/mp4","cached":true}
+                    },
+                    "override":{"active":true,"kinds":["logo"],"logo_transform":{"x":-2,"y":0.75,"scale":9}}
+                  }
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals("partial", game.artwork?.state)
+        assertEquals(1785641400000, game.artwork?.cachedAt)
+        assertEquals(1.0, game.artwork?.match?.confidence)
+        assertTrue(game.artwork?.match?.manual == true)
+        assertEquals(1, game.screenshotArtwork.size)
+        assertEquals("video/mp4", game.trailerArtwork?.mimeType)
+        assertEquals(0.0, game.artwork?.override?.logoTransform?.x)
+        assertEquals(0.75, game.artwork?.override?.logoTransform?.y)
+        assertEquals(4.0, game.artwork?.override?.logoTransform?.scale)
+    }
+
+    @Test
+    fun parseGame_ignoresMalformedArtworkKindsAndKeepsLegacyCover() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject(
+                """
+                {
+                  "id":"game-malformed-artwork",
+                  "cover_url":"/polaris/v1/games/game-malformed-artwork/cover",
+                  "artwork":{
+                    "version":"not-an-int",
+                    "assets":{
+                      "poster":"not-an-object",
+                      "hero":{"url":""},
+                      "banner":{"url":"https://provider.invalid/banner.png"}
+                    }
+                  }
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertEquals(1, game.artwork?.version)
+        assertNull(game.posterArtwork)
+        assertNull(game.heroArtwork)
+        assertNull(game.artworkAsset("banner"))
+        assertEquals("/polaris/v1/games/game-malformed-artwork/cover", game.coverUrl)
+    }
+
+    @Test
+    fun parseGame_withoutArtworkRemainsCompatibleWithOldHosts() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject("{\"id\":\"legacy\",\"cover_url\":\"https://legacy.example/cover.png\"}")
+        )
+
+        assertNull(game.artwork)
+        assertEquals("https://legacy.example/cover.png", game.coverUrl)
+    }
+
+    @Test
+    fun artworkUrlSelectionPrefersSanitizedManifestThenLegacyFallbacks() {
+        val manifestGame = PolarisGame(
+            id = "game-url",
+            coverUrl = "/polaris/v1/games/game-url/cover",
+            artwork = PolarisGame.ArtworkManifest(
+                revision = "rev-1",
+                assets = PolarisGame.ArtworkAssets(
+                    poster = PolarisGame.ArtworkAsset(
+                        url = "/polaris/v1/games/game-url/artwork/poster",
+                        cached = true
+                    )
+                )
+            )
+        )
+
+        assertEquals(
+            "https://polaris.lan:47984/polaris/v1/games/game-url/artwork/poster",
+            PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, manifestGame, "poster")
+        )
+
+        val absoluteManifest = manifestGame.copy(
+            artwork = manifestGame.artwork?.copy(
+                assets = PolarisGame.ArtworkAssets(
+                    poster = PolarisGame.ArtworkAsset("https://steam.invalid/poster.jpg")
+                )
+            )
+        )
+        assertEquals(
+            "https://polaris.lan:47984/polaris/v1/games/game-url/cover",
+            PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, absoluteManifest, "poster")
+        )
+
+        val absoluteLegacy = PolarisGame(
+            id = "legacy-hosted",
+            coverUrl = "https://provider.example/should-not-leave-the-host.jpg"
+        )
+        assertEquals(
+            "https://polaris.lan:47984/polaris/v1/games/legacy-hosted/cover",
+            PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, absoluteLegacy, "poster")
+        )
+
+        val legacyEndpoint = PolarisGame(id = "legacy-endpoint")
+        assertEquals(
+            "https://polaris.lan:47984/polaris/v1/games/legacy-endpoint/cover",
+            PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, legacyEndpoint, "poster")
+        )
+        assertNull(PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, legacyEndpoint, "hero"))
+
+        val uncachedManifest = manifestGame.copy(
+            artwork = manifestGame.artwork?.copy(
+                assets = PolarisGame.ArtworkAssets(
+                    poster = PolarisGame.ArtworkAsset(
+                        url = "/polaris/v1/games/game-url/artwork/poster",
+                        cached = false
+                    )
+                )
+            )
+        )
+        assertEquals(
+            "https://polaris.lan:47984/polaris/v1/games/game-url/cover",
+            PolarisApiClient.selectArtworkUrl("polaris.lan", 47984, uncachedManifest, "poster")
+        )
+        assertNull(
+            PolarisApiClient.selectArtworkUrl(
+                "polaris.lan",
+                47984,
+                PolarisGame(id = "../unsafe", coverUrl = "javascript:bad"),
+                "poster"
+            )
+        )
+    }
+
+    @Test
+    fun manifestUrlResolutionRejectsAbsoluteProtocolRelativeAndTraversalPaths() {
+        assertEquals(
+            "https://host.example:444/polaris/v1/games/abc/artwork/logo?revision=2",
+            PolarisApiClient.resolveManifestPath(
+                "host.example",
+                444,
+                "/polaris/v1/games/abc/artwork/logo?revision=2"
+            )
+        )
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "https://sgdb.invalid/logo.png"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "//sgdb.invalid/logo.png"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "/polaris/v1/../private/logo.png"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "/covers/logo.png"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "/polaris/v1\\evil"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "/polaris/v1/%2e%2e/private/logo.png"))
+        assertNull(PolarisApiClient.resolveManifestPath("host.example", 444, "/polaris/v1/%252e%252e/private/logo.png"))
+    }
+
+    @Test
+    fun artworkResolveResponseAcceptsDirectAndNestedEnvelopes() {
+        val direct = PolarisApiClient.parseArtworkResolveResponse(
+            JSONObject("{\"version\":1,\"revision\":\"direct\",\"assets\":{\"poster\":{\"url\":\"/polaris/v1/games/a/artwork/poster\"}}}")
+        )
+        val nested = PolarisApiClient.parseArtworkResolveResponse(
+            JSONObject("{\"data\":{\"game\":{\"artwork\":{\"version\":1,\"revision\":\"nested\",\"assets\":{\"poster\":{\"url\":\"/polaris/v1/games/b/artwork/poster\"}}}}}}")
+        )
+
+        assertEquals("direct", direct?.revision)
+        assertEquals("nested", nested?.revision)
+        assertNull(PolarisApiClient.parseArtworkResolveResponse(JSONObject("{\"success\":true}")))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -78,6 +79,219 @@ class PolarisArtworkDiskCacheTest {
         })
         assertEquals(1, cache.cacheFilesForTest("game-offline", "poster").size)
         cache.clear()
+    }
+
+    @Test
+    fun failedAtomicReplacementKeepsExistingExactRevisionReadable() {
+        var replacements = 0
+        lateinit var cache: PolarisArtworkDiskCache
+        cache = PolarisArtworkDiskCache(context, "failure-host", 47984) { from, to ->
+            replacements += 1
+            if (replacements == 1) PolarisArtworkDiskCache.atomicReplace(from, to) else {
+                assertTrue(to.isFile)
+                assertNotNull(cache.load("game", "poster", "rev", allowStale = false))
+                false
+            }
+        }
+        cache.clear()
+        assertNotNull(cache.store("game", "poster", "rev", pngBytes(2, 3), "image/png"))
+        assertNull(cache.store("game", "poster", "rev", pngBytes(5, 6), "image/png"))
+        val preserved = checkNotNull(cache.load("game", "poster", "rev", allowStale = false))
+        assertEquals(2, preserved.width)
+        assertEquals(3, preserved.height)
+        preserved.recycle()
+        assertTrue(cache.rawCacheFilesForTest().none { it.name.endsWith(".tmp") || it.name.endsWith(".bak") })
+        cache.clear()
+    }
+
+    @Test
+    fun concurrentReaderSeesOldBitmapUntilAtomicReplacementPublishesNewBitmap() {
+        val enteredReplace = CountDownLatch(1)
+        val releaseReplace = CountDownLatch(1)
+        val replacements = AtomicInteger()
+        val cache = PolarisArtworkDiskCache(context, "concurrent-replace-host", 47984) { from, to ->
+            if (replacements.incrementAndGet() == 2) {
+                enteredReplace.countDown()
+                assertTrue(releaseReplace.await(2, TimeUnit.SECONDS))
+            }
+            PolarisArtworkDiskCache.atomicReplace(from, to)
+        }
+        cache.clear()
+        assertNotNull(cache.store("game", "poster", "rev", pngBytes(2, 3), "image/png"))
+        val pool = Executors.newSingleThreadExecutor()
+        val replacement = pool.submit<File?> {
+            cache.store("game", "poster", "rev", pngBytes(5, 6), "image/png")
+        }
+        assertTrue(enteredReplace.await(2, TimeUnit.SECONDS))
+        val beforePublish = checkNotNull(cache.load("game", "poster", "rev", allowStale = false))
+        assertEquals(2, beforePublish.width)
+        beforePublish.recycle()
+        releaseReplace.countDown()
+        assertNotNull(replacement.get(2, TimeUnit.SECONDS))
+        val afterPublish = checkNotNull(cache.load("game", "poster", "rev", allowStale = false))
+        assertEquals(5, afterPublish.width)
+        afterPublish.recycle()
+        pool.shutdownNow()
+        cache.clear()
+    }
+
+    @Test
+    fun revisionlessManifestAssetsNeverEnterPersistentCache() {
+        val root = File(context.cacheDir, "revisionless-artwork-${System.nanoTime()}").apply { deleteRecursively() }
+        val cache = PolarisArtworkDiskCache(context, "revisionless-host", 47984, cacheRoot = root)
+        val png = pngBytes(3, 4)
+
+        assertNull(cache.store("game", "poster", "", png, "image/png"))
+        assertNull(cache.store("game", "poster", "   ", png, "image/png"))
+        assertNull(cache.load("game", "poster", "", allowStale = true))
+        assertTrue(cache.rawCacheFilesForTest().isEmpty())
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun globalByteBudgetEvictsOldestArtworkAcrossHosts() {
+        val root = File(context.cacheDir, "bounded-artwork-bytes-${System.nanoTime()}").apply { deleteRecursively() }
+        val png = pngBytes(24, 24)
+        val budget = png.size.toLong() * 2L
+        val firstHost = PolarisArtworkDiskCache(
+            context,
+            "budget-host-a",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = budget,
+            maxCacheEntries = 10,
+        )
+        val secondHost = PolarisArtworkDiskCache(
+            context,
+            "budget-host-b",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = budget,
+            maxCacheEntries = 10,
+        )
+        val oldest = checkNotNull(firstHost.store("game-a", "poster", "rev-a", png, "image/png"))
+        val newer = checkNotNull(firstHost.store("game-b", "poster", "rev-a", png, "image/png"))
+        oldest.setLastModified(1_000L)
+        newer.setLastModified(2_000L)
+
+        val newest = checkNotNull(secondHost.store("game-c", "poster", "rev-a", png, "image/png"))
+
+        assertFalse(oldest.exists())
+        assertTrue(newer.isFile)
+        assertTrue(newest.isFile)
+        assertNull(firstHost.load("game-a", "poster", "rev-a", allowStale = false))
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun globalEntryBudgetUsesReadRefreshedLruAcrossHosts() {
+        val root = File(context.cacheDir, "bounded-artwork-entries-${System.nanoTime()}").apply { deleteRecursively() }
+        val png = pngBytes(24, 24)
+        val firstHost = PolarisArtworkDiskCache(
+            context,
+            "entry-host-a",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = Long.MAX_VALUE,
+            maxCacheEntries = 2,
+        )
+        val secondHost = PolarisArtworkDiskCache(
+            context,
+            "entry-host-b",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = Long.MAX_VALUE,
+            maxCacheEntries = 2,
+        )
+        val first = checkNotNull(firstHost.store("game-a", "poster", "rev-a", png, "image/png"))
+        val second = checkNotNull(firstHost.store("game-b", "poster", "rev-a", png, "image/png"))
+        first.setLastModified(1_000L)
+        second.setLastModified(2_000L)
+        checkNotNull(firstHost.load("game-a", "poster", "rev-a", allowStale = false)).recycle()
+
+        val third = checkNotNull(secondHost.store("game-c", "poster", "rev-a", png, "image/png"))
+
+        assertTrue(first.isFile)
+        assertFalse(second.exists())
+        assertTrue(third.isFile)
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun concurrentRevisionWritersSerializeAndLeaveOnePublishedGeneration() {
+        val root = File(context.cacheDir, "concurrent-writers-${System.nanoTime()}").apply { deleteRecursively() }
+        val enteredStore = CountDownLatch(2)
+        val startStores = CountDownLatch(1)
+        val enteredReplace = CountDownLatch(2)
+        val activeWriters = AtomicInteger()
+        val maxActiveWriters = AtomicInteger()
+        val cache = PolarisArtworkDiskCache(
+            context,
+            "writer-host",
+            47984,
+            cacheRoot = root,
+            replaceFile = { from, to ->
+                val active = activeWriters.incrementAndGet()
+                maxActiveWriters.updateAndGet { previous -> maxOf(previous, active) }
+                enteredReplace.countDown()
+                enteredReplace.await(500, TimeUnit.MILLISECONDS)
+                try {
+                    PolarisArtworkDiskCache.atomicReplace(from, to)
+                } finally {
+                    activeWriters.decrementAndGet()
+                }
+            },
+        )
+        val pool = Executors.newFixedThreadPool(2)
+        val results = listOf("rev-a", "rev-b").map { revision ->
+            pool.submit<File?> {
+                enteredStore.countDown()
+                startStores.await(2, TimeUnit.SECONDS)
+                cache.store("game", "poster", revision, pngBytes(24, 24), "image/png")
+            }
+        }
+        assertTrue(enteredStore.await(2, TimeUnit.SECONDS))
+        startStores.countDown()
+        val published = results.map { checkNotNull(it.get(3, TimeUnit.SECONDS)) }
+
+        assertEquals(1, maxActiveWriters.get())
+        assertEquals(1, cache.rawCacheFilesForTest().count { it.name.endsWith(".image") })
+        assertEquals(1, published.count(File::isFile))
+        pool.shutdownNow()
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun globalEvictionPreservesUnrelatedRootContent() {
+        val root = File(context.cacheDir, "owned-cache-files-${System.nanoTime()}").apply { deleteRecursively() }
+        val unrelated = File(root, "not-a-cache-host").apply { mkdirs() }
+        val unrelatedImage = File(unrelated, "keep.image").apply {
+            writeBytes(byteArrayOf(1, 2, 3))
+            setLastModified(1_000L)
+        }
+        val unrelatedEmptyDirectory = File(root, "empty-unrelated").apply { mkdirs() }
+        val cache = PolarisArtworkDiskCache(
+            context,
+            "owned-host",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = Long.MAX_VALUE,
+            maxCacheEntries = 1,
+        )
+        val first = checkNotNull(cache.store("game-a", "poster", "rev-a", pngBytes(24, 24), "image/png"))
+        val unrelatedInOwnedHost = File(first.parentFile, "keep.image").apply {
+            writeBytes(byteArrayOf(4, 5, 6))
+            setLastModified(1_000L)
+        }
+
+        val second = checkNotNull(cache.store("game-b", "poster", "rev-a", pngBytes(24, 24), "image/png"))
+
+        assertFalse(first.exists())
+        assertTrue(second.isFile)
+        assertTrue(unrelatedImage.isFile)
+        assertTrue(unrelatedInOwnedHost.isFile)
+        assertTrue(unrelatedEmptyDirectory.isDirectory)
+        root.deleteRecursively()
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
@@ -1,0 +1,153 @@
+package com.papi.nova.api
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.CRC32
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class PolarisArtworkDiskCacheTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun cacheKeysAreHashedAndIsolatedByHostPortGameKindAndRevision() {
+        val base = PolarisArtworkDiskCache.cacheKey("host-a", 47984, "game-a", "poster", "rev-a")
+
+        assertTrue(base.matches(Regex("[a-f0-9]{64}")))
+        assertNotEquals(base, PolarisArtworkDiskCache.cacheKey("host-b", 47984, "game-a", "poster", "rev-a"))
+        assertNotEquals(base, PolarisArtworkDiskCache.cacheKey("host-a", 47985, "game-a", "poster", "rev-a"))
+        assertNotEquals(base, PolarisArtworkDiskCache.cacheKey("host-a", 47984, "game-b", "poster", "rev-a"))
+        assertNotEquals(base, PolarisArtworkDiskCache.cacheKey("host-a", 47984, "game-a", "hero", "rev-a"))
+        assertNotEquals(base, PolarisArtworkDiskCache.cacheKey("host-a", 47984, "game-a", "poster", "rev-b"))
+        assertFalse(base.contains("host-a"))
+    }
+
+    @Test
+    fun boundedReadAndMimeValidationRejectOversizedOrNonImageResponses() {
+        assertEquals(
+            4,
+            PolarisArtworkDiskCache.readBounded(ByteArrayInputStream(byteArrayOf(1, 2, 3, 4)), 4)?.size
+        )
+        assertNull(
+            PolarisArtworkDiskCache.readBounded(ByteArrayInputStream(byteArrayOf(1, 2, 3, 4, 5)), 4)
+        )
+        assertTrue(PolarisArtworkDiskCache.isSupportedImageMime("image/png; charset=binary"))
+        assertTrue(PolarisArtworkDiskCache.isSupportedImageMime("IMAGE/JPEG"))
+        assertFalse(PolarisArtworkDiskCache.isSupportedImageMime("application/octet-stream"))
+        assertFalse(PolarisArtworkDiskCache.isSupportedImageMime(null))
+        assertNull(PolarisArtworkDiskCache.decodeBounded(pngWithDeclaredDimensions(9_000, 1)))
+        assertNull(PolarisArtworkDiskCache.decodeBounded(pngWithDeclaredDimensions(8_000, 8_000)))
+    }
+
+    @Test
+    fun cacheValidatesDecodeSupportsOfflineFallbackAndCleansStaleRevision() {
+        val cache = PolarisArtworkDiskCache(context, "offline-host", 47984)
+        cache.clear()
+        val png = pngBytes(3, 4)
+
+        assertNull(cache.store("game-offline", "poster", "rev-bad-mime", png, "text/plain"))
+        assertNull(cache.store("game-offline", "poster", "rev-bad-image", byteArrayOf(1, 2, 3), "image/png"))
+
+        assertNotNull(cache.store("game-offline", "poster", "rev-1", png, "image/png"))
+        assertNotNull(cache.load("game-offline", "poster", "rev-1", allowStale = false))
+        assertNotNull(cache.load("game-offline", "poster", "rev-2", allowStale = true))
+        assertNull(cache.load("game-offline", "poster", "rev-2", allowStale = false))
+
+        assertNotNull(cache.store("game-offline", "poster", "rev-2", pngBytes(5, 6), "image/png"))
+        assertNotNull(cache.load("game-offline", "poster", "rev-2", allowStale = false))
+        assertNull(cache.load("game-offline", "poster", "rev-1", allowStale = false))
+        assertTrue(cache.cacheFilesForTest("game-offline", "poster").none {
+            it.name.contains(".tmp") || it.name.contains(".bak")
+        })
+        assertEquals(1, cache.cacheFilesForTest("game-offline", "poster").size)
+        cache.clear()
+    }
+
+    @Test
+    fun resolveCoordinatorRunsOneResolverForConcurrentAndRepeatedRequests() {
+        val coordinator = ArtworkResolveOnce<String>()
+        val starts = AtomicInteger()
+        val release = CountDownLatch(1)
+        val pool = Executors.newFixedThreadPool(6)
+
+        val futures = (0 until 6).map {
+            pool.submit<String?> {
+                coordinator.resolve("game-a") {
+                    starts.incrementAndGet()
+                    release.await(2, TimeUnit.SECONDS)
+                    "resolved"
+                }
+            }
+        }
+        while (starts.get() == 0) Thread.yield()
+        release.countDown()
+
+        assertEquals(List(6) { "resolved" }, futures.map { it.get(2, TimeUnit.SECONDS) })
+        assertEquals(1, starts.get())
+        assertEquals("resolved", coordinator.resolve("game-a") { "should-not-run" })
+        assertEquals(1, starts.get())
+        coordinator.invalidate("game-a")
+        assertEquals("resolved-again", coordinator.resolve("game-a") {
+            starts.incrementAndGet()
+            "resolved-again"
+        })
+        assertEquals(2, starts.get())
+        pool.shutdownNow()
+    }
+
+    @Test
+    fun resolveCoordinatorRetriesAfterNullResult() {
+        val coordinator = ArtworkResolveOnce<String>()
+        val starts = AtomicInteger()
+
+        assertNull(coordinator.resolve("game-retry") {
+            starts.incrementAndGet()
+            null
+        })
+        assertEquals("resolved", coordinator.resolve("game-retry") {
+            starts.incrementAndGet()
+            "resolved"
+        })
+        assertEquals(2, starts.get())
+    }
+
+    private fun pngWithDeclaredDimensions(width: Int, height: Int): ByteArray {
+        val bytes = pngBytes(1, 1)
+        writeInt(bytes, 16, width)
+        writeInt(bytes, 20, height)
+        val crc = CRC32().apply { update(bytes, 12, 17) }.value.toInt()
+        writeInt(bytes, 29, crc)
+        return bytes
+    }
+
+    private fun writeInt(bytes: ByteArray, offset: Int, value: Int) {
+        for (index in 0..3) {
+            bytes[offset + index] = (value ushr ((3 - index) * 8)).toByte()
+        }
+    }
+
+    private fun pngBytes(width: Int, height: Int): ByteArray {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        return ByteArrayOutputStream().use { output ->
+            assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+            output.toByteArray()
+        }.also { bitmap.recycle() }
+    }
+}

--- a/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
@@ -1,11 +1,13 @@
 package com.papi.nova.api
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -215,6 +217,51 @@ class PolarisArtworkDiskCacheTest {
         assertFalse(second.exists())
         assertTrue(third.isFile)
         root.deleteRecursively()
+    }
+
+    @Test
+    fun cacheOwnershipChecksRemainApi21Compatible() {
+        val source = File("src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt").readText()
+
+        assertFalse(source.contains("java.nio.file.Files"))
+        assertFalse(source.contains(".toPath()"))
+        assertTrue(source.contains("file.canonicalFile == file.absoluteFile"))
+    }
+
+    @SuppressLint("NewApi")
+    @Test
+    fun globalEvictionDoesNotFollowOwnedLookingSymlinkDirectory() {
+        val root = File(context.cacheDir, "symlink-cache-${System.nanoTime()}").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        val outside = File(context.cacheDir, "symlink-target-${System.nanoTime()}").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        val outsideImage = File(
+            outside,
+            "${"b".repeat(64)}.${"c".repeat(64)}.image",
+        ).apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val ownedLookingLink = File(root, "a".repeat(64))
+        Files.createSymbolicLink(ownedLookingLink.toPath(), outside.toPath())
+        val cache = PolarisArtworkDiskCache(
+            context,
+            "real-host",
+            47984,
+            cacheRoot = root,
+            maxCacheBytes = Long.MAX_VALUE,
+            maxCacheEntries = 1,
+        )
+
+        val published = cache.store("game", "poster", "revision", pngBytes(24, 24), "image/png")
+
+        assertNotNull(published)
+        assertTrue(outsideImage.isFile)
+        assertTrue(Files.isSymbolicLink(ownedLookingLink.toPath()))
+        Files.deleteIfExists(ownedLookingLink.toPath())
+        root.deleteRecursively()
+        outside.deleteRecursively()
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -402,9 +402,15 @@ class NovaComposeSourceGuardTest {
     fun libraryCoverLoadingIsKeyedOutsideAndroidViewUpdate() {
         val source = readNovaLibraryActivity()
 
+        val revisionKey = "key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER))"
+        val focusedRevisionKey = "key(PolarisApiClient.artworkPresentationKey(targetGame, PolarisGame.ARTWORK_KIND_POSTER))"
         assertTrue(
-            "cover view should be keyed by the game cover identity",
-            source.contains("key(game.id, game.coverUrl)")
+            "both library cover views should be keyed by the manifest revision or legacy cover identity",
+            source.split(revisionKey).size - 1 >= 2
+        )
+        assertTrue(
+            "focused backdrop and home Hero cover should also recreate when the Poster revision changes",
+            source.split(focusedRevisionKey).size - 1 >= 2
         )
         assertTrue(
             "cover load should happen when the keyed ImageView is created",
@@ -1090,13 +1096,14 @@ class NovaComposeSourceGuardTest {
         )
 
         assertTrue(
-            "Retroid landscape first paint should treat game identity as a compact launch header, not a second hero slab",
+            "Retroid landscape first paint should keep either Hero or Poster identity inside the compact launch header ceiling",
             detailsPanel.contains(".heightIn(min = 136.dp)") &&
                 detailsPanel.contains("contentPadding = PaddingValues(12.dp)") &&
+                detailsPanel.contains(".height(136.dp)") &&
                 detailsPanel.contains(".width(108.dp)") &&
-                detailsPanel.contains("fontSize = 20.sp") &&
-                detailsPanel.contains("lineHeight = 22.sp") &&
-                detailsPanel.contains("maxLines = 2")
+                detailsPanel.contains("fontSize = if (compact) 17.sp else 20.sp") &&
+                detailsPanel.contains("lineHeight = if (compact) 19.sp else 22.sp") &&
+                detailsPanel.contains("maxLines = if (compact) 1 else 2")
         )
         assertFalse(
             "game detail should not keep the old oversized first-paint panel that pushed launch mode choices below the fold",
@@ -1259,16 +1266,159 @@ class NovaComposeSourceGuardTest {
 
     @Test
     fun gameDetailCoverLoadingIsKeyedByGameIdentity() {
-        val detailsPanel = readNovaGameDetailSheet().section(
+        val source = readNovaGameDetailSheet()
+        val detailsPanel = source.section(
             "private fun GameDetailsPanel(",
             "@Composable\nprivate fun LaunchControlsPanel("
         )
 
         assertTrue(
-            "detail sheet cover view should be keyed by game identity so reused panels do not show stale artwork",
-            detailsPanel.contains("key(game.id, game.coverUrl)") &&
+            "detail sheet cover view should follow artwork revision changes",
+            detailsPanel.contains("key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER))") &&
                 detailsPanel.contains("coverLoader(this)")
         )
+        assertTrue("logo view should follow artwork revision changes", source.contains("key(logoPresentationKey)"))
+        assertTrue(
+            "successful artwork mutations should refresh detail state before propagation",
+            source.contains("currentGame = currentGame.copy(artwork = manifest)\n            refreshUiState()")
+        )
+    }
+
+    @Test
+    fun gameDetailUsesHeroBackdropLogoTransformIconIdentityAndPosterFallback() {
+        val source = readNovaGameDetailSheet()
+        val sheetContent = source.section(
+            "fun NovaGameDetailSheetContent(",
+            "@Composable\nprivate fun NovaGameDetailScrollableContent("
+        )
+        val detailsPanel = source.section(
+            "private fun GameDetailsPanel(",
+            "@Composable\nprivate fun LaunchControlsPanel("
+        )
+
+        assertTrue(
+            "detail content should route revision-aware Hero, Logo, and Icon presentation into the identity panel",
+            sheetContent.contains("heroAvailable = heroAvailable") &&
+                sheetContent.contains("heroPresentationKey = heroPresentationKey") &&
+                sheetContent.contains("heroLoader = heroLoader") &&
+                sheetContent.contains("logoPresentationKey = logoPresentationKey") &&
+                sheetContent.contains("iconPresentationKey = iconPresentationKey")
+        )
+        assertTrue(
+            "a real manifest Hero should become the compact detail backdrop",
+            detailsPanel.contains("if (heroAvailable)") &&
+                detailsPanel.contains("NovaGameDetailHero(") &&
+                detailsPanel.contains("key(heroPresentationKey)") &&
+                detailsPanel.contains("heroLoader(this)") &&
+                detailsPanel.contains(".height(136.dp)")
+        )
+        assertTrue(
+            "the manifest Logo should be revision-aware and use the saved normalized transform over Hero",
+            detailsPanel.contains("BoxWithConstraints(") &&
+                detailsPanel.contains("key(logoPresentationKey)") &&
+                detailsPanel.contains("logoLoader(this)") &&
+                detailsPanel.contains("offset(x = logoOffsetX, y = logoOffsetY)") &&
+                detailsPanel.contains("scaleX = artworkState.logoScale") &&
+                detailsPanel.contains("scaleY = artworkState.logoScale")
+        )
+        assertTrue(
+            "the manifest Icon should provide a compact revision-aware identity mark beside the title",
+            detailsPanel.contains("if (iconAvailable)") &&
+                detailsPanel.contains("key(iconPresentationKey)") &&
+                detailsPanel.contains("iconLoader(this)") &&
+                detailsPanel.contains("text = game.name")
+        )
+        assertTrue(
+            "Poster must remain the no-Hero fallback instead of disappearing from detail presentation",
+            detailsPanel.contains("NovaGameDetailPosterFallback(") &&
+                detailsPanel.contains("key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER))") &&
+                detailsPanel.contains("coverLoader(this)")
+        )
+    }
+
+    @Test
+    fun artworkPreferencesAreCollapsedAtBottomAndUseManifestArtwork() {
+        val source = readNovaGameDetailSheet()
+        val content = source.section(
+            "fun NovaGameDetailSheetContent(",
+            "@Composable\nprivate fun NovaGameDetailScrollableContent("
+        )
+        val artworkIndex = content.indexOf("ArtworkCorrectionPanel(")
+        val stabilityIndex = content.indexOf("optimizationState.stability?.let")
+        val hintIndex = content.indexOf("NovaControllerHintBar(")
+        assertTrue("artwork preferences should follow functional and insight content", artworkIndex > stabilityIndex)
+        assertTrue("artwork preferences should remain above the controller hint footer", artworkIndex in 1 until hintIndex)
+
+        val panel = source.section(
+            "private fun ArtworkCorrectionPanel(",
+            "@Composable\nprivate fun LogoTransformControls("
+        )
+        assertTrue("artwork preferences should start collapsed", panel.contains("var expanded by remember(initialQuery) { mutableStateOf(false) }"))
+        assertTrue("artwork header should toggle expansion", panel.contains("clickable { expanded = !expanded }") && panel.contains("if (expanded)"))
+        assertTrue("compact artwork header should load the real manifest icon only when available", panel.contains("if (iconAvailable)") && panel.contains("key(iconPresentationKey)") && panel.contains("iconLoader(this)"))
+        assertTrue("logo preview should not show a generic placeholder when no logo exists", panel.contains("if (logoAvailable)") && panel.contains("nova_artwork_logo_unavailable"))
+    }
+
+    @Test
+    fun artworkProviderFailuresAreNotReportedAsNoMatches() {
+        val sheet = readNovaGameDetailSheet()
+        val api = readSource("src/main/java/com/papi/nova/api/PolarisApiClient.kt")
+        val strings = readSource("src/main/res/values/strings.xml")
+        val searchHandler = sheet.section(
+            "onSearchArtwork = { query ->",
+            "onApplyArtwork = { candidate, kinds ->",
+        )
+
+        assertTrue(
+            "candidate search should surface HTTP, envelope, and malformed-body failures without retaining provider response content",
+            api.contains("throw IOException(\"artwork candidate search HTTP \${response.code}\")") &&
+                api.contains("throw IOException(\"invalid artwork candidate search response\")") &&
+                api.contains("catch (_: JSONException)") &&
+                api.contains("throw IOException(\"invalid artwork JSON\")") &&
+                api.contains("Nova: artwork candidate search failed")
+        )
+        assertTrue(
+            "detail UI should reserve No matches for successful empty searches, rethrow cancellation, and map ordinary failures separately",
+            searchHandler.contains("try {") &&
+                searchHandler.contains("catch (e: CancellationException)") &&
+                searchHandler.contains("throw e") &&
+                searchHandler.contains("catch (_: Exception)") &&
+                !searchHandler.contains("runCatching") &&
+                searchHandler.contains("R.string.nova_artwork_search_failed") &&
+                searchHandler.contains("R.string.nova_artwork_no_matches")
+        )
+        assertTrue(
+            "provider failure copy should direct the user to Polaris without pretending a search succeeded",
+            strings.contains("name=\"nova_artwork_search_failed\">Artwork search unavailable. Check SteamGridDB in Polaris and try again.</string>")
+        )
+    }
+
+    @Test
+    fun artworkRequestsUseFreshTlsStateWithoutCachingTheDerivedClient() {
+        val api = readSource("src/main/java/com/papi/nova/api/PolarisApiClient.kt")
+        assertTrue(
+            "production artwork calls should rebuild policy from the fresh per-call TLS client",
+            api.contains("private fun executeArtwork(request: Request) = buildArtworkHttpClientForCall(::clientForCall).newCall(") &&
+                api.contains("SSLContext.getInstance(\"TLS\").apply") &&
+                api.contains(".sslSocketFactory(sslContext.socketFactory, trustManager)")
+        )
+        assertFalse(
+            "artwork client must not be cached across mTLS calls",
+            api.contains("private val artworkHttpClient")
+        )
+    }
+
+    @Test
+    fun artworkFetchLogsUseFixedClassificationWithoutUrlsOrExceptionMessages() {
+        val api = readSource("src/main/java/com/papi/nova/api/PolarisApiClient.kt")
+        val fetch = api.section(
+            "private fun fetchArtwork(url: String)",
+            "/**\n     * Toggle MangoHud",
+        )
+        assertTrue(fetch.contains("val requestClass = artworkRequestLogLabel(url)"))
+        assertTrue(fetch.contains("e.javaClass.simpleName"))
+        assertFalse(fetch.contains("\$url"))
+        assertFalse(fetch.contains("errorMessage(e)"))
     }
 
     @Test

--- a/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
+++ b/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
@@ -25,8 +25,72 @@ data class PolarisGame(
     @SerialName("hdr_supported") val hdrSupported: Boolean = false,
     @SerialName("launch_mode") val launchMode: LaunchModeContract? = null,
     @SerialName("steam_launch") val steamLaunch: SteamLaunchContract? = null,
-    @SerialName("display_planner") val displayPlanner: DisplayPlannerContract? = null
+    @SerialName("display_planner") val displayPlanner: DisplayPlannerContract? = null,
+    @SerialName("artwork") val artwork: ArtworkManifest? = null
 ) {
+    @Serializable
+    data class ArtworkManifest(
+        @SerialName("version") val version: Int = 1,
+        @SerialName("revision") val revision: String = "",
+        @SerialName("state") val state: String = "partial",
+        @SerialName("match") val match: ArtworkMatch? = null,
+        @SerialName("cached_at") val cachedAt: Long = 0,
+        @SerialName("assets") val assets: ArtworkAssets = ArtworkAssets(),
+        @SerialName("override") val override: ArtworkOverride? = null
+    ) {
+        fun asset(kind: String): ArtworkAsset? = assets.asset(kind)
+    }
+
+    @Serializable
+    data class ArtworkMatch(
+        @SerialName("source") val source: String = "",
+        @SerialName("provider_game_id") val providerGameId: String = "",
+        @SerialName("title") val title: String = "",
+        @SerialName("confidence") val confidence: Double = 0.0,
+        @SerialName("manual") val manual: Boolean = false
+    )
+
+    @Serializable
+    data class ArtworkOverride(
+        @SerialName("active") val active: Boolean = false,
+        @SerialName("kinds") val kinds: List<String> = emptyList(),
+        @SerialName("logo_transform") val logoTransform: ArtworkLogoTransform? = null
+    )
+
+    @Serializable
+    data class ArtworkLogoTransform(
+        @SerialName("x") val x: Double = 0.5,
+        @SerialName("y") val y: Double = 0.5,
+        @SerialName("scale") val scale: Double = 1.0
+    )
+
+    @Serializable
+    data class ArtworkAssets(
+        @SerialName("poster") val poster: ArtworkAsset? = null,
+        @SerialName("hero") val hero: ArtworkAsset? = null,
+        @SerialName("logo") val logo: ArtworkAsset? = null,
+        @SerialName("icon") val icon: ArtworkAsset? = null,
+        @SerialName("screenshots") val screenshots: List<ArtworkAsset> = emptyList(),
+        @SerialName("trailer") val trailer: ArtworkAsset? = null
+    ) {
+        fun asset(kind: String): ArtworkAsset? = when (kind.trim().lowercase()) {
+            ARTWORK_KIND_POSTER -> poster
+            ARTWORK_KIND_HERO -> hero
+            ARTWORK_KIND_LOGO -> logo
+            ARTWORK_KIND_ICON -> icon
+            ARTWORK_KIND_TRAILER -> trailer
+            else -> null
+        }?.takeIf { it.url.isNotBlank() }
+    }
+
+    @Serializable
+    data class ArtworkAsset(
+        @SerialName("url") val url: String = "",
+        @SerialName("source") val source: String = "",
+        @SerialName("mime_type") val mimeType: String = "",
+        @SerialName("cached") val cached: Boolean = false
+    )
+
     @Serializable
     data class DisplayPlannerContract(
         @SerialName("available") val available: Boolean = false,
@@ -113,6 +177,13 @@ data class PolarisGame(
     val supportsSteamLaunchMode: Boolean get() = isSteamGame && steamLaunch?.available == true
     val steamLaunchMode: String get() = steamLaunch?.mode ?: "direct"
     val steamLaunchUsesBigPicture: Boolean get() = steamLaunchMode == "big-picture"
+    fun artworkAsset(kind: String): ArtworkAsset? = artwork?.asset(kind)
+    val posterArtwork: ArtworkAsset? get() = artworkAsset(ARTWORK_KIND_POSTER)
+    val heroArtwork: ArtworkAsset? get() = artworkAsset(ARTWORK_KIND_HERO)
+    val logoArtwork: ArtworkAsset? get() = artworkAsset(ARTWORK_KIND_LOGO)
+    val iconArtwork: ArtworkAsset? get() = artworkAsset(ARTWORK_KIND_ICON)
+    val screenshotArtwork: List<ArtworkAsset> get() = artwork?.assets?.screenshots.orEmpty().filter { it.url.isNotBlank() }
+    val trailerArtwork: ArtworkAsset? get() = artworkAsset(ARTWORK_KIND_TRAILER)
 
     val categoryLabel: String get() = when (category) {
         "fast_action" -> "Action"
@@ -155,6 +226,13 @@ data class PolarisGame(
     }
 
     companion object {
+        const val ARTWORK_KIND_POSTER = "poster"
+        const val ARTWORK_KIND_HERO = "hero"
+        const val ARTWORK_KIND_LOGO = "logo"
+        const val ARTWORK_KIND_ICON = "icon"
+        const val ARTWORK_KIND_SCREENSHOT = "screenshot"
+        const val ARTWORK_KIND_TRAILER = "trailer"
+
         fun normalizeLaunchMode(mode: String): String {
             return when (mode.trim().lowercase()) {
                 "headless", "headless_stream", "desktop_display", "windowed_stream", "host_display" -> "headless"

--- a/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
+++ b/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PolarisGameContractTest {
@@ -91,6 +92,116 @@ class PolarisGameContractTest {
         assertEquals(null, game.steamLaunch)
         assertEquals(null, game.displayPlanner)
         assertEquals("direct", game.steamLaunchMode)
+    }
+
+    @Test
+    fun decodesVersionedArtworkManifestAndSelectsKnownKinds() {
+        val game = json.decodeFromString<PolarisGame>(
+            """
+            {
+              "id":"game-artwork",
+              "name":"Artwork Game",
+              "artwork":{
+                "version":1,
+                "revision":"rev-42",
+                "assets":{
+                  "poster":{"url":"/polaris/v1/games/game-artwork/artwork/poster","source":"steamgriddb","mime_type":"image/png","cached":true},
+                  "hero":{"url":"/polaris/v1/games/game-artwork/artwork/hero","source":"steam","mime_type":"image/jpeg","cached":false},
+                  "logo":{"url":"/polaris/v1/games/game-artwork/artwork/logo","source":"local","mime_type":"image/png","cached":true},
+                  "icon":{"url":"/polaris/v1/games/game-artwork/artwork/icon","source":"host","mime_type":"image/webp","cached":true}
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val artwork = assertNotNull(game.artwork)
+        assertEquals(1, artwork.version)
+        assertEquals("rev-42", artwork.revision)
+        assertEquals("/polaris/v1/games/game-artwork/artwork/poster", game.artworkAsset("poster")?.url)
+        assertEquals("steamgriddb", game.posterArtwork?.source)
+        assertEquals("image/jpeg", game.heroArtwork?.mimeType)
+        assertEquals("local", game.logoArtwork?.source)
+        assertEquals("image/webp", game.iconArtwork?.mimeType)
+    }
+
+    @Test
+    fun artworkManifestDefaultsAndMalformedKindsRemainBackwardCompatible() {
+        val game = json.decodeFromString<PolarisGame>(
+            """
+            {
+              "id":"game-defaults",
+              "cover_url":"/legacy-cover",
+              "artwork":{
+                "assets":{
+                  "poster":{"url":""},
+                  "banner":{"url":"https://provider.invalid/banner.png"}
+                },
+                "future_field":"ignored"
+              }
+            }
+            """.trimIndent()
+        )
+
+        val artwork = assertNotNull(game.artwork)
+        assertEquals(1, artwork.version)
+        assertEquals("", artwork.revision)
+        assertNull(game.artworkAsset("poster"))
+        assertNull(game.artworkAsset("banner"))
+        assertNull(game.artworkAsset("../../poster"))
+        assertEquals("/legacy-cover", game.coverUrl)
+    }
+
+    @Test
+    fun legacyCoverOnlyPayloadDoesNotRequireArtworkManifest() {
+        val game = json.decodeFromString<PolarisGame>(
+            """{"id":"game-legacy-art","cover_url":"/polaris/v1/games/game-legacy-art/cover"}"""
+        )
+
+        assertNull(game.artwork)
+        assertNull(game.posterArtwork)
+        assertEquals("/polaris/v1/games/game-legacy-art/cover", game.coverUrl)
+    }
+
+    @Test
+    fun decodesCompleteArtworkManifestV1Shape() {
+        val game = json.decodeFromString<PolarisGame>(
+            """
+            {
+              "id":"game-complete-artwork",
+              "artwork":{
+                "version":1,
+                "revision":"rev-complete",
+                "state":"cached",
+                "match":{"source":"steamgriddb","provider_game_id":"12345","title":"Portal 2","confidence":0.98,"manual":true},
+                "cached_at":1785641400000,
+                "assets":{
+                  "poster":{"url":"/polaris/v1/games/game-complete-artwork/artwork/poster","source":"steamgriddb","mime_type":"image/jpeg","cached":true},
+                  "hero":{"url":"/polaris/v1/games/game-complete-artwork/artwork/hero","source":"steam","mime_type":"image/jpeg","cached":true},
+                  "screenshots":[
+                    {"url":"/polaris/v1/games/game-complete-artwork/artwork/screenshots/0","source":"steam","mime_type":"image/jpeg","cached":true},
+                    {"url":"","source":"steam","mime_type":"image/jpeg","cached":true}
+                  ],
+                  "trailer":{"url":"/polaris/v1/games/game-complete-artwork/artwork/trailer","source":"steam","mime_type":"video/mp4","cached":true}
+                },
+                "override":{"active":true,"kinds":["poster","logo"],"logo_transform":{"x":0.42,"y":0.76,"scale":1.15}}
+              }
+            }
+            """.trimIndent()
+        )
+
+        val artwork = assertNotNull(game.artwork)
+        assertEquals("cached", artwork.state)
+        assertEquals(1785641400000, artwork.cachedAt)
+        assertEquals("12345", artwork.match?.providerGameId)
+        assertEquals(0.98, artwork.match?.confidence)
+        assertTrue(artwork.match?.manual == true)
+        assertEquals(1, game.screenshotArtwork.size)
+        assertEquals("video/mp4", game.trailerArtwork?.mimeType)
+        assertEquals(listOf("poster", "logo"), artwork.override?.kinds)
+        assertEquals(0.42, artwork.override?.logoTransform?.x)
+        assertEquals(0.76, artwork.override?.logoTransform?.y)
+        assertEquals(1.15, artwork.override?.logoTransform?.scale)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- consume Polaris artwork manifests and authenticated candidate search/preview/apply/clear operations
- render Hero as the compact 136dp detail backdrop, Logo as a saved normalized transform overlay, and Icon beside the game title
- retain Poster as library artwork and the truthful no-Hero detail fallback
- recreate detail and library AndroidViews when manifest revisions change
- add compact collapsed-by-default Artwork controls

## Cache and network safety
- bypass persistent disk cache for missing or blank revisions
- bound the process-global cross-host artwork cache to 96 MiB / 128 entries with read-refreshed deterministic LRU
- serialize cache writers while preserving old-until-publish concurrent readers
- restrict eviction to owned hashed host directories and hashed cache files
- retain authenticated no-redirect requests, ordinary 10-second timeouts, artwork-only 120-second timeouts, and a fresh current mTLS client per artwork operation
- never accept arbitrary provider URLs or log candidate-preview tokens/URLs

## Verification
- app unit tests: 1,066/1,066
- shared model tests: 9/9
- focused disk-cache tests: 12/12
- Android-test Kotlin compilation, ARM64 assembly, lint task, and `git diff --check` passed
- exact-tree independent review: APPROVE
- final reviewed dirty-tree fingerprint before commit: `c3126038f08e14392eaedc1c178c1a804e60712f2d0bbf26b549baa9f40ece67`
- committed file bytes verified against the reviewed manifest: 9/9
- RP6 validated Clear and all-four Apply with immediate detail/library refresh and no game launch
- reviewed debug APK SHA-256: `4568bfa45cc5bc60382a422a064fd0d2d2fc8ca5f20c3b236bc31d63c86c7fd3`

## Dependency
Requires the Polaris contract in papi-ux/polaris#276.



## CI remediation
- replace API-26 NIO cache ownership checks with API-21-compatible canonical-path validation
- preserve no-follow behavior with an owned-looking symlink regression
- independently approved exact delta fingerprint `f2891fe24b8c8378191b2520dfb948c57e922cdbcdad106352777806196c9d45`
