### PR TITLE
fix(deps): align Netty tooling pins at 4.1.136.Final

### DIFF
--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -3,6 +3,7 @@ package com.papi.nova.ui
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -67,12 +68,25 @@ class NovaComposeBuildConfigurationTest {
             rootBuild.contains("details.requested.group == 'io.netty'") &&
                 rootBuild.contains("details.useVersion patchedNettyVersion")
         )
-        constrainedModules.forEach { module ->
-            assertTrue(
-                "$module should use the project-wide patched Netty version",
-                rootBuild.contains("classpath('io.netty:$module:$expectedVersion')")
-            )
-        }
+        val nettyConstraints = Regex(
+            """(?m)^\s*classpath\('io\.netty:([^:']+):([^']+)'\)\s*\{"""
+        ).findAll(rootBuild).map { match ->
+            match.groupValues[1] to match.groupValues[2]
+        }.toList()
+        val expectedConstraints = constrainedModules.map { module ->
+            module to expectedVersion
+        }.toSet()
+
+        assertEquals(
+            "buildscript should contain exactly the expected Netty module/version constraints",
+            expectedConstraints,
+            nettyConstraints.toSet()
+        )
+        assertEquals(
+            "buildscript should not contain duplicate Netty constraints",
+            expectedConstraints.size,
+            nettyConstraints.size
+        )
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -3,7 +3,6 @@ package com.papi.nova.ui
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -50,14 +49,6 @@ class NovaComposeBuildConfigurationTest {
     fun gradlePinsNettyForToolingDependencyAlerts() {
         val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
         val expectedVersion = "4.1.136.Final"
-        val constrainedModules = listOf(
-            "netty-codec",
-            "netty-codec-http",
-            "netty-codec-http2",
-            "netty-common",
-            "netty-handler",
-            "netty-handler-proxy"
-        )
 
         assertTrue(
             "root build should keep a single patched Netty version for Gradle and Android test tooling",
@@ -68,24 +59,10 @@ class NovaComposeBuildConfigurationTest {
             rootBuild.contains("details.requested.group == 'io.netty'") &&
                 rootBuild.contains("details.useVersion patchedNettyVersion")
         )
-        val nettyConstraints = Regex(
-            """(?m)^\s*classpath\('io\.netty:([^:']+):([^']+)'\)\s*\{"""
-        ).findAll(rootBuild).map { match ->
-            match.groupValues[1] to match.groupValues[2]
-        }.toList()
-        val expectedConstraints = constrainedModules.map { module ->
-            module to expectedVersion
-        }.toSet()
-
-        assertEquals(
-            "buildscript should contain exactly the expected Netty module/version constraints",
-            expectedConstraints,
-            nettyConstraints.toSet()
-        )
-        assertEquals(
-            "buildscript should not contain duplicate Netty constraints",
-            expectedConstraints.size,
-            nettyConstraints.size
+        assertTrue(
+            "Gradle configuration should validate active Netty constraints from its parsed model",
+            rootBuild.contains("buildscript.configurations.classpath.allDependencyConstraints") &&
+                rootBuild.contains("Netty buildscript constraints must exactly match")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -48,23 +48,31 @@ class NovaComposeBuildConfigurationTest {
     @Test
     fun gradlePinsNettyForToolingDependencyAlerts() {
         val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
+        val expectedVersion = "4.1.136.Final"
+        val constrainedModules = listOf(
+            "netty-codec",
+            "netty-codec-http",
+            "netty-codec-http2",
+            "netty-common",
+            "netty-handler",
+            "netty-handler-proxy"
+        )
 
         assertTrue(
             "root build should keep a single patched Netty version for Gradle and Android test tooling",
-            rootBuild.contains("patchedNettyVersion = '4.1.135.Final'")
+            rootBuild.contains("patchedNettyVersion = '$expectedVersion'")
         )
         assertTrue(
             "all project configurations should force Netty transitives onto the patched line",
             rootBuild.contains("details.requested.group == 'io.netty'") &&
                 rootBuild.contains("details.useVersion patchedNettyVersion")
         )
-        assertTrue(
-            "the existing buildscript classpath constraints should still cover settings/build-tool Netty transitives",
-            rootBuild.contains("classpath('io.netty:netty-codec:4.1.135.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-codec-http:4.1.135.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-codec-http2:4.1.135.Final')") &&
-                rootBuild.contains("classpath('io.netty:netty-handler-proxy:4.1.135.Final')")
-        )
+        constrainedModules.forEach { module ->
+            assertTrue(
+                "$module should use the project-wide patched Netty version",
+                rootBuild.contains("classpath('io.netty:$module:$expectedVersion')")
+            )
+        }
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -3,22 +3,22 @@ buildscript {
     dependencies {
         constraints {
             // These pins only affect the Gradle/AGP build toolchain, not the app's runtime graph.
-            classpath('io.netty:netty-codec:4.1.135.Final') {
+            classpath('io.netty:netty-codec:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-codec-http:4.1.135.Final') {
+            classpath('io.netty:netty-codec-http:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-codec-http2:4.1.135.Final') {
+            classpath('io.netty:netty-codec-http2:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-common:4.1.135.Final') {
+            classpath('io.netty:netty-common:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-handler:4.1.135.Final') {
+            classpath('io.netty:netty-handler:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
-            classpath('io.netty:netty-handler-proxy:4.1.135.Final') {
+            classpath('io.netty:netty-handler-proxy:4.1.136.Final') {
                 because 'Keep any settings/build-tool Netty transitives on a patched line'
             }
             classpath('org.apache.commons:commons-lang3:3.18.0') {
@@ -53,7 +53,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose' version '2.3.21' apply false
 }
 
-def patchedNettyVersion = '4.1.135.Final'
+def patchedNettyVersion = '4.1.136.Final'
 def patchedWireVersion = '6.3.0'
 def patchedWireModules = ['wire-runtime', 'wire-runtime-jvm'] as Set
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,29 @@ plugins {
 }
 
 def patchedNettyVersion = '4.1.136.Final'
+def expectedNettyBuildscriptModules = [
+    'netty-codec',
+    'netty-codec-http',
+    'netty-codec-http2',
+    'netty-common',
+    'netty-handler',
+    'netty-handler-proxy'
+]
+def expectedNettyBuildscriptConstraints = expectedNettyBuildscriptModules.collect { module ->
+    [module, patchedNettyVersion]
+}
+def actualNettyBuildscriptConstraints = buildscript.configurations.classpath.allDependencyConstraints
+    .findAll { constraint -> constraint.group == 'io.netty' }
+    .collect { constraint -> [constraint.name, constraint.version] }
+if (
+    actualNettyBuildscriptConstraints.size() != expectedNettyBuildscriptConstraints.size() ||
+        actualNettyBuildscriptConstraints.toSet() != expectedNettyBuildscriptConstraints.toSet()
+) {
+    throw new GradleException(
+        "Netty buildscript constraints must exactly match ${expectedNettyBuildscriptConstraints}; " +
+            "found ${actualNettyBuildscriptConstraints}"
+    )
+}
 def patchedWireVersion = '6.3.0'
 def patchedWireModules = ['wire-runtime', 'wire-runtime-jvm'] as Set
 


### PR DESCRIPTION
## Summary

- bump the six Gradle/AGP build-tool Netty constraints from `4.1.135.Final` to `4.1.136.Final`
- align Nova's project-wide `patchedNettyVersion` with those constraints so every guarded configuration stays on one Netty line
- enforce the exact six-module/version contract against Gradle's parsed buildscript constraint model, so inactive comments/strings cannot satisfy the guard and missing, extra, or mixed constraints fail configuration
- keep `NovaComposeBuildConfigurationTest` focused on the canonical version, project-wide resolution rule, and presence of the parsed-model guard
- supersede #180, whose Dependabot-only edit left the project-wide forced version stale and failed the JVM-test gate

## Testing

- [x] `./gradlew --no-daemon -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug`
- [x] `./gradlew --no-daemon -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest` (1,066 tests)
- [x] `python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight` (51 tests)
- [x] `./gradlew --no-daemon assembleNonRoot_gameRelease` (arm64-v8a, armeabi-v7a, and x86_64 APKs)
- [x] Focused RED/GREEN regression: `NovaComposeBuildConfigurationTest.gradlePinsNettyForToolingDependencyAlerts`
- [x] Parsed-model mutation probes: extra stale active constraint, block-comment fake, and triple-string fake all fail configuration with the guard error
- [x] Real-device/emulator testing is not applicable; this changes build/test dependency policy only.
- [x] Screenshots are not applicable; there is no visible UI change.
- [x] Documentation/release-note updates are not required; there is no user-facing behavior change.

## Notes

No changes to pairing, certificate handling, discovery, exported Android components, input handling, or Moonlight-core integration.

Netty is guarded here for Gradle/Android tooling transitives rather than Nova's shipped runtime graph.

Gradle canonicalizes identical duplicate constraints before exposing `allDependencyConstraints`; the guard therefore enforces the active semantic module/version set. A redundant identical textual declaration remains a Gradle no-op, while missing modules, extra modules, and mixed versions fail configuration.
