### PR TITLE
feat(nova): hold the stage rail still until focus nears an edge

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaLibraryStageComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaLibraryStageComposeTest.kt
@@ -855,6 +855,73 @@ class NovaLibraryStageComposeTest {
         assertTrue("$label bottom reflowed: $before -> $after", kotlin.math.abs(before.bottom - after.bottom) <= 0.5f)
     }
 
+    @Test
+    fun stageRailHoldsStillUntilFocusApproachesAnEdge() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val apiClient = PolarisApiClient(context, "127.0.0.1", 47984)
+        val many = (0 until 14).map { index ->
+            game("game-$index", "Game $index", "steam")
+        }
+
+        composeRule.setContent {
+            NovaComposeTheme {
+                Box(Modifier.requiredSize(width = 833.dp, height = 390.dp)) {
+                    NovaLibraryStage(
+                        games = many,
+                        focusedGame = many.first(),
+                        restoreFocusGameId = many.first().id,
+                        primaryActionLabel = "Review & Launch",
+                        apiClient = apiClient,
+                        showPosterTitles = false,
+                        onPrimaryAction = {},
+                        onGameFocused = {},
+                        onOpenDetail = {},
+                        artworkLoader = { _, _, _ -> },
+                        posterLoader = { _, _ -> },
+                    )
+                }
+            }
+        }
+
+        fun railOriginOf(id: String): Float =
+            composeRule.onNodeWithTag("nova-stage-poster-$id").fetchSemanticsNode().boundsInRoot.left
+
+        // Anchor on a poster that stays composed throughout so its screen position is a
+        // direct readout of how far the rail has scrolled.
+        composeRule.onNodeWithTag("nova-poster-${many[2].id}")
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+        composeRule.waitForIdle()
+        val anchorAfterNearFocus = railOriginOf(many[2].id)
+
+        // Moving the selection one step, well inside the rail, must not drag the library
+        // sideways: the focus travels across stationary posters.
+        composeRule.onNodeWithTag("nova-poster-${many[3].id}")
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+        composeRule.waitForIdle()
+        val anchorAfterInteriorStep = railOriginOf(many[2].id)
+        assertEquals(
+            "interior focus step must not scroll the rail",
+            anchorAfterNearFocus,
+            anchorAfterInteriorStep,
+            0.5f,
+        )
+
+        // Stepping on until the selection reaches the trailing edge must scroll, otherwise
+        // the tail of the library would be unreachable. Lazy items only exist once visible,
+        // so walk the selection the way a D-pad would rather than jumping to the end.
+        for (index in 4..7) {
+            composeRule.onNodeWithTag("nova-poster-${many[index].id}")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+            composeRule.waitForIdle()
+        }
+        val anchorAfterEdgeFocus = railOriginOf(many[2].id)
+        assertTrue(
+            "focus reaching the trailing edge must scroll the rail: " +
+                "$anchorAfterInteriorStep -> $anchorAfterEdgeFocus",
+            anchorAfterInteriorStep - anchorAfterEdgeFocus > 1f,
+        )
+    }
+
     private fun games(): List<PolarisGame> = listOf(
         game("alpha", "Alpha", "steam"),
         game("bravo", "Bravo", "epic"),

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryCinematicChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryCinematicChrome.kt
@@ -28,11 +28,13 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.papi.nova.R
@@ -173,6 +175,23 @@ internal fun NovaLibraryCinematicControllerHints(
             .testTag("nova-library-cinematic-controller-hints"),
         contentAlignment = Alignment.CenterEnd,
     ) {
+        // Sits in the empty space the right-aligned hints leave behind, so it costs no
+        // vertical budget. Dropped on compact shells where that space is not free.
+        if (!compact) {
+            Text(
+                text = stringResource(R.string.nova_stage_footer_brand),
+                color = colors.textSecondary.copy(alpha = 0.72f),
+                fontSize = 9.sp,
+                lineHeight = 11.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.18.em,
+                maxLines = 1,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 12.dp)
+                    .testTag("nova-stage-footer-brand"),
+            )
+        }
         Row(
             modifier = Modifier
                 .widthIn(max = rowMaxWidth)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
@@ -2,6 +2,8 @@ package com.papi.nova.ui
 
 import android.widget.ImageView
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.BringIntoViewSpec
+import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -35,6 +37,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -520,6 +523,38 @@ private fun NovaLibraryStageSessionHero(
  *  comes from [NovaLibraryUiStateMapper.stageRailPosterWidthDp]. */
 private val NovaStageCarouselGapDp = 12.dp
 
+/** How close (in card widths) the focused poster may come to a rail edge before the rail
+ *  scrolls. Inside that band the rail holds still and the selection travels across
+ *  stationary posters, which is what keeps a sense of place in a long library. */
+private const val NovaStageEdgeScrollMarginCards = 1.15f
+
+/**
+ * Edge-scrolling policy for the poster rail.
+ *
+ * Compose already asks the scrollable to bring a newly focused child into view; the default
+ * spec scrolls the minimum needed, which re-seats the selection against the viewport edge on
+ * every step. Supplying the spec — rather than running a second scroller next to it — keeps a
+ * single scroll authority and lets the rail stay put until the selection nears an edge.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+private object NovaStageEdgeScrollSpec : BringIntoViewSpec {
+    override fun calculateScrollDistance(
+        offset: Float,
+        size: Float,
+        containerSize: Float,
+    ): Float {
+        val margin = (size * NovaStageEdgeScrollMarginCards)
+            .coerceAtMost((containerSize - size) / 2f)
+            .coerceAtLeast(0f)
+        val trailingEdge = offset + size
+        return when {
+            offset < margin -> offset - margin
+            trailingEdge > containerSize - margin -> trailingEdge - (containerSize - margin)
+            else -> 0f
+        }
+    }
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun NovaLibraryStageHero(
@@ -850,42 +885,8 @@ internal fun NovaLibraryStageRow(
     val focusRequesters = remember(gameIds) { List(effectiveGames.size) { FocusRequester() } }
     val scope = rememberCoroutineScope()
     var focusedCardId by remember(gameIds) { mutableStateOf<String?>(null) }
-    var smoothScrollJob by remember(gameIds) { mutableStateOf<Job?>(null) }
     val largeText = LocalDensity.current.fontScale >= 1.5f
     val inputModeManager = LocalInputModeManager.current
-
-    fun requestSmoothScrollToIndex(targetIndex: Int) {
-        if (effectiveGames.isEmpty()) return
-        smoothScrollJob?.cancel()
-        smoothScrollJob = scope.launch {
-            val maxIndex = effectiveGames.lastIndex
-            val clampedIndex = targetIndex.coerceIn(0, maxIndex)
-            val layoutInfo = listState.layoutInfo
-            if (layoutInfo.totalItemsCount == 0) return@launch
-
-            val viewportStart = layoutInfo.viewportStartOffset
-            val viewportEnd = layoutInfo.viewportEndOffset
-            val viewportCenter = (viewportStart + viewportEnd) / 2f
-            val viewportWidth = (viewportEnd - viewportStart).coerceAtLeast(0)
-            val visibleItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == clampedIndex }
-
-            val needsScroll = if (visibleItem == null) {
-                true
-            } else {
-                val itemCenter = visibleItem.offset + (visibleItem.size / 2f)
-                kotlin.math.abs(itemCenter - viewportCenter) > (visibleItem.size * 0.08f)
-            }
-
-            if (!listState.isScrollInProgress && needsScroll) {
-                if (visibleItem != null) {
-                    val targetOffset = (viewportStart + (viewportWidth / 2f) - (visibleItem.size / 2f)).roundToInt()
-                    listState.animateScrollToItem(clampedIndex, targetOffset.coerceAtLeast(0))
-                } else {
-                    listState.animateScrollToItem(clampedIndex)
-                }
-            }
-        }
-    }
 
     // A FocusRequester bound to a lazy item that has not been composed yet silently does
     // nothing, so wait for the target to actually appear in the layout before asking. Without
@@ -955,6 +956,7 @@ internal fun NovaLibraryStageRow(
             cardWidthDp = cellWidthDp,
         )
 
+        CompositionLocalProvider(LocalBringIntoViewSpec provides NovaStageEdgeScrollSpec) {
         LazyRow(
             state = listState,
             modifier = Modifier
@@ -989,7 +991,6 @@ internal fun NovaLibraryStageRow(
                         showPosterTitle = showPosterTitles,
                         onOpenDetail = {
                             onGameFocused(game)
-                            requestSmoothScrollToIndex(index)
                             onOpenDetail(game)
                         },
                         modifier = Modifier.fillMaxWidth(),
@@ -1001,10 +1002,7 @@ internal fun NovaLibraryStageRow(
                                 isFocused = isFocused,
                             )
                         },
-                        onFocused = {
-                            onGameFocused(game)
-                            requestSmoothScrollToIndex(index)
-                        },
+                        onFocused = { onGameFocused(game) },
                         onNavigate = { delta ->
                             val nextIndex = NovaLibraryUiStateMapper.stageAdjacentIndex(
                                 currentIndex = index,
@@ -1012,7 +1010,6 @@ internal fun NovaLibraryStageRow(
                                 itemCount = effectiveGames.size,
                             )
                             if (nextIndex != index) {
-                                requestSmoothScrollToIndex(nextIndex)
                                 scope.launch {
                                     repeat(STAGE_FOCUS_REQUEST_ATTEMPTS) {
                                         withFrameNanos { }
@@ -1032,6 +1029,7 @@ internal fun NovaLibraryStageRow(
                     )
                 }
             }
+        }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1431,4 +1431,5 @@
     <string name="nova_artwork_library_update_retry_hint">Checks only the games that failed.</string>
     <string name="nova_artwork_library_update_retry_all">Try again</string>
     <string name="nova_artwork_library_update_retry_all_hint">Starts a new all-games artwork check.</string>
+    <string name="nova_stage_footer_brand">POLARIS CINEMATIC STAGE</string>
 </resources>


### PR DESCRIPTION
## Summary

The stage rail re-centred the selection on every focus step, so a single D-pad press slid the whole library sideways and there was no stable sense of place in a long list.

- give the poster rail an explicit scroll policy via `BringIntoViewSpec`: it holds still while the selection travels across stationary posters, and scrolls only once the focused card comes within ~1.15 card widths of an edge
- remove the hand-rolled centring helper. Compose already issues a bring-into-view request when focus moves inside a scrollable; an earlier attempt at this ran a second scroller *alongside* that request and the two fought over rail position. Supplying the spec replaces the policy rather than competing with it, leaving one scroll authority
- cover the behaviour with an instrumented test: an interior focus step must not move the rail, and walking the selection to the trailing edge must
- add the Polaris cinematic stage wordmark to the stage footer, in the space the right-aligned controller hints already leave empty, so it costs no vertical budget. Dropped on compact shells where that space is not free

## Exact candidate

- Commit: `9fa1a49efd22da04c6db3782e99b6f5db77b2a9a`
- Tree: `9552c622a94a1687b9d9351a4c543f469545ebf8`
- Parent: `8c99589a33fb456e561deef7915c95116bbbdb1e`
- Base: `e48fe1afb2bcaf768c67a41ecf276fd4cc8b03d9`

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1,170 tests, 0 failures/errors
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebugAndroidTest`
- [x] physical Retroid Pocket 6, shipping `nonRoot_gameDebug` flavor, class-filtered — 21 tests, 0 failures:

```
./gradlew :app:connectedNonRoot_gameDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=com.papi.nova.ui.NovaLibraryStageComposeTest,com.papi.nova.ui.NovaLibraryPosterCardComposeTest
```

- [x] hands-on review of the installed build on the Retroid, Stage layout, live Polaris library
- [x] `git diff --check`
- [x] modified-file scan for secrets, debug logging and capture harnesses: zero hits

### Notes for review

`BringIntoViewSpec` is `@ExperimentalFoundationApi` on Compose Foundation 1.9.5, and is scoped to the stage rail through a `CompositionLocalProvider` around that `LazyRow` only — no other scrollable changes behaviour.

The new test walks the selection one poster at a time instead of jumping to the last item, because lazy children only exist once visible — a direct `RequestFocus` on an off-screen index finds no node.

The remaining cinematic chrome (NOVA wordmark, `LIBRARY / FEATURED GAME` and `YOUR LIBRARY` eyebrow labels) is deliberately not included. Those add lines into the fixed hero and toolbar height budgets, which is what produced the regressions fixed in #184; landing them wants the hero sized from its content rather than a constant, which is a change of its own.
