### PR TITLE
feat(nova): give the library bar one treatment across layouts

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -3575,7 +3575,10 @@ class NovaLibraryActivity : NovaActivity() {
         val surfaces = LocalNovaLibrarySurfaces.current
         Surface(
             modifier = modifier,
-            shape = RoundedCornerShape(if (cinematic) 8.dp else 18.dp),
+            // One corner radius for library surfaces whichever layout is showing. Only the
+            // fill still varies: the cinematic stage lets the backdrop through, while the
+            // grid keeps a panel behind its poster wall.
+            shape = RoundedCornerShape(8.dp),
             color = if (cinematic) {
                 androidx.compose.ui.graphics.Color.Transparent
             } else if (subtle) {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -1209,7 +1209,12 @@ class NovaLibraryActivity : NovaActivity() {
         ) {
             NovaLibraryCinematicBackdrop(
                 game = focusedBackdropGame,
-                apiClient = apiClient
+                apiClient = apiClient,
+                strength = if (model.optionsState.layoutMode == NovaLibraryLayoutMode.STAGE) {
+                    1f
+                } else {
+                    NovaLibraryGridBackdropStrength
+                },
             )
             if (surfaces.particlesEnabled) {
                 AndroidView(
@@ -1562,7 +1567,9 @@ class NovaLibraryActivity : NovaActivity() {
                 compact = compact
             )
             Column(
-                modifier = Modifier.weight(1f),
+                // fill = false so the action sits with the content it belongs to instead of
+                // being pushed to the far edge across a gulf of empty row.
+                modifier = Modifier.weight(1f, fill = false),
                 verticalArrangement = Arrangement.spacedBy(if (compact) 1.dp else 5.dp)
             ) {
                 Text(
@@ -2413,6 +2420,7 @@ class NovaLibraryActivity : NovaActivity() {
                             posterLoader = stablePosterLoader
                         )
                     } else {
+                        Box(modifier = Modifier.fillMaxSize()) {
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(gridColumns),
                             modifier = Modifier.fillMaxSize(),
@@ -2444,6 +2452,23 @@ class NovaLibraryActivity : NovaActivity() {
                                     onOpenDetail = { onOpenDetail(game) },
                                 )
                             }
+                        }
+                        // The grid scrolls, so its last visible row is cut mid-artwork. A
+                        // short fade reads as there is more below instead of a severed edge.
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .height(NovaLibraryGridScrollFadeHeight)
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors = listOf(
+                                            androidx.compose.ui.graphics.Color.Transparent,
+                                            LocalNovaComposeColors.current.window.copy(alpha = 0.85f),
+                                        ),
+                                    ),
+                                ),
+                        )
                         }
                     }
                 }
@@ -3683,6 +3708,13 @@ class NovaLibraryActivity : NovaActivity() {
         /** One corner radius for library surfaces, so panels, the continue-playing row and
          *  the bar keep the same edge whichever layout is showing. */
         private val NovaLibrarySurfaceCornerRadius = 8.dp
+
+        /** The poster wall owns the screen in grid layouts, so the shared backdrop reads
+         *  as atmosphere behind it rather than competing with twenty covers. */
+        private const val NovaLibraryGridBackdropStrength = 0.45f
+
+        /** Height of the fade at the foot of the scrolling poster grid. */
+        private val NovaLibraryGridScrollFadeHeight = 44.dp
 
         private val LARGE_TEXT_HINT_INDICES = setOf(0, 1, 3)
         private val PRIMARY_HINT_INDICES = setOf(0, 1, 2)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -1528,9 +1528,9 @@ class NovaLibraryActivity : NovaActivity() {
                     focused = focused,
                     focusedScale = NovaFocusMotionSpec.CardFocusedScale,
                     haloAlpha = NovaFocusMotionSpec.CardFocusedHaloAlpha,
-                    cornerRadius = 20.dp
+                    cornerRadius = NovaLibrarySurfaceCornerRadius
                 )
-                .clip(RoundedCornerShape(20.dp))
+                .clip(RoundedCornerShape(NovaLibrarySurfaceCornerRadius))
                 .background(
                     Brush.horizontalGradient(
                         colors = listOf(
@@ -1543,7 +1543,7 @@ class NovaLibraryActivity : NovaActivity() {
                 .border(
                     width = if (focused) 3.dp else 1.dp,
                     color = if (focused) surfaces.focusRing else surfaces.tileBorder,
-                    shape = RoundedCornerShape(20.dp)
+                    shape = RoundedCornerShape(NovaLibrarySurfaceCornerRadius)
                 )
                 .onFocusChanged {
                     focused = it.isFocused || it.hasFocus
@@ -3578,7 +3578,7 @@ class NovaLibraryActivity : NovaActivity() {
             // One corner radius for library surfaces whichever layout is showing. Only the
             // fill still varies: the cinematic stage lets the backdrop through, while the
             // grid keeps a panel behind its poster wall.
-            shape = RoundedCornerShape(8.dp),
+            shape = RoundedCornerShape(NovaLibrarySurfaceCornerRadius),
             color = if (cinematic) {
                 androidx.compose.ui.graphics.Color.Transparent
             } else if (subtle) {
@@ -3680,6 +3680,10 @@ class NovaLibraryActivity : NovaActivity() {
         private const val CONTROLLER_HINT_IDLE_REVEAL_MS = 4_000L
         private const val CONTROLLER_HINT_ANIMATION_MS = 180
         private const val CONTROLLER_AXIS_INTENT_THRESHOLD = 0.35f
+        /** One corner radius for library surfaces, so panels, the continue-playing row and
+         *  the bar keep the same edge whichever layout is showing. */
+        private val NovaLibrarySurfaceCornerRadius = 8.dp
+
         private val LARGE_TEXT_HINT_INDICES = setOf(0, 1, 3)
         private val PRIMARY_HINT_INDICES = setOf(0, 1, 2)
         private val CONTROLLER_BROWSE_KEYS = setOf(

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -1781,7 +1781,10 @@ class NovaLibraryActivity : NovaActivity() {
             resultCount = model.resultCount,
             layoutLabel = layoutModeLabel(model.optionsState.layoutMode),
             polarisReady = clientSettings != null,
-            cinematic = model.optionsState.layoutMode == NovaLibraryLayoutMode.STAGE,
+            // The library bar is the same furniture whichever layout is below it, so it
+            // keeps one treatment across Grid, Compact and Stage rather than changing
+            // weight and shape as the content does.
+            cinematic = true,
             onOpenOptions = onOpenOptions,
             onOpenSystemMenu = onOpenSystemMenu,
         )

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryCinematicChrome.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryCinematicChrome.kt
@@ -56,6 +56,12 @@ internal fun NovaLibraryCinematicBackdrop(
     game: PolarisGame?,
     apiClient: PolarisApiClient,
     modifier: Modifier = Modifier,
+    /**
+     * How strongly the artwork reads. The cinematic stage pairs one hero with small
+     * posters, so the art is the subject there; the grid puts twenty covers on screen and
+     * the same artwork competes with them, so it is pulled back behind that wall.
+     */
+    strength: Float = 1f,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -116,7 +122,7 @@ internal fun NovaLibraryCinematicBackdrop(
                         modifier = Modifier
                             .fillMaxSize()
                             .graphicsLayer {
-                                alpha = 0.9f + (surfaces.focusedArtworkAlpha * 0.1f)
+                                alpha = (0.9f + (surfaces.focusedArtworkAlpha * 0.1f)) * strength
                             }
                             .testTag("nova-library-cinematic-artwork"),
                     )

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
@@ -85,10 +85,6 @@ import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-private val PolarisStageIce = androidx.compose.ui.graphics.Color(0xFFC8D6E5)
-private val PolarisStageTwilight = androidx.compose.ui.graphics.Color(0xFF4C5265)
-private val PolarisStageVoid = androidx.compose.ui.graphics.Color(0xFF2A2840)
-private val PolarisStageAccent = androidx.compose.ui.graphics.Color(0xFF7C73FF)
 
 @Composable
 internal fun NovaLibraryLandscapeStageShell(
@@ -127,12 +123,12 @@ internal fun NovaLibraryLandscapeToolbarContent(
     val largeText = LocalDensity.current.fontScale >= 1.5f
     val shape = RoundedCornerShape(if (cinematic) 8.dp else 18.dp)
     val toolbarColor = if (cinematic) {
-        PolarisStageTwilight.copy(alpha = 0.34f * LocalNovaMenuOpacityScale.current)
+        surfaces.panel.copy(alpha = 0.34f * LocalNovaMenuOpacityScale.current)
     } else {
         surfaces.panel.copy(alpha = 0.72f * LocalNovaMenuOpacityScale.current)
     }
     val toolbarBorder = if (cinematic) {
-        PolarisStageIce.copy(alpha = 0.14f)
+        surfaces.tileBorder
     } else {
         surfaces.tileBorder
     }
@@ -156,7 +152,7 @@ internal fun NovaLibraryLandscapeToolbarContent(
                 if (polarisReady) {
                     Text(
                         text = stringResource(R.string.nova_system_menu_status_polaris_ready),
-                        color = if (cinematic) PolarisStageIce.copy(alpha = 0.62f) else LocalNovaComposeColors.current.textSecondary,
+                        color = LocalNovaComposeColors.current.textSecondary,
                         fontSize = 10.sp,
                         lineHeight = 12.sp,
                         maxLines = 1,
@@ -267,7 +263,7 @@ private fun NovaLibraryToolbarIdentity(
             }
             Text(
                 text = if (cinematic) hostLabel else "· $hostLabel",
-                color = if (cinematic) PolarisStageIce.copy(alpha = 0.72f) else colors.textSecondary,
+                color = colors.textSecondary,
                 fontSize = 11.sp,
                 lineHeight = 13.sp,
                 maxLines = 1,
@@ -294,7 +290,7 @@ private fun NovaLibraryResultAndLayoutMeta(
     ) {
         Text(
             text = stringResource(R.string.nova_library_results_format, resultCount),
-            color = if (cinematic) PolarisStageIce.copy(alpha = 0.62f) else colors.textSecondary,
+            color = colors.textSecondary,
             fontSize = 10.sp,
             lineHeight = 12.sp,
             maxLines = 1,
@@ -302,7 +298,7 @@ private fun NovaLibraryResultAndLayoutMeta(
         )
         Text(
             text = layoutLabel,
-            color = if (cinematic) PolarisStageAccent else colors.textMuted,
+            color = colors.accent,
             fontSize = 10.sp,
             lineHeight = 12.sp,
             maxLines = 1,
@@ -570,6 +566,7 @@ private fun NovaLibraryStageHero(
     onSessionAction: (() -> Unit)? = null,
     onSecondaryAction: (() -> Unit)? = null,
 ) {
+    val heroColors = LocalNovaComposeColors.current
     val hasIcon = game.iconArtwork != null
     val iconKey = PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_ICON)
     // No scrim here: NovaLibraryCinematicBackdrop is the single owner of the stage
@@ -627,7 +624,7 @@ private fun NovaLibraryStageHero(
             if (heroMetadata.isNotBlank() && !largeText) {
                 Text(
                     text = heroMetadata,
-                    color = PolarisStageIce.copy(alpha = 0.72f),
+                    color = heroColors.textSecondary,
                     fontSize = if (compact) 9.sp else 10.sp,
                     lineHeight = if (compact) 11.sp else 12.sp,
                     fontWeight = FontWeight.SemiBold,

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -601,7 +601,7 @@ class NovaComposeSourceGuardTest {
         )
         assertTrue(
             "compact landscape hero should place artwork, title context, and a bounded launch CTA in that order",
-            hero.indexOf("NovaLibraryHeroArtwork(") in 0 until hero.indexOf("Column(\n                modifier = Modifier.weight(1f)") &&
+            hero.indexOf("NovaLibraryHeroArtwork(") in 0 until hero.indexOf("Column(\n                // fill = false") &&
                 hero.contains("Modifier.width(if (compact) 132.dp else 168.dp)")
         )
         assertFalse(


### PR DESCRIPTION
## Summary

The landscape library bar changed weight and shape depending on the layout below it. Grid and Compact kept the heavier treatment — an 18dp radius, a denser panel, a bold `Library` title restating the screen you are already on, and a filled primary `Options` button — while Stage used the lighter cinematic one.

- use one treatment for the landscape library bar across Grid, Compact and Stage: host-led identity, lighter panel, 8dp radius, outlined actions
- the bar is the same furniture whichever layout sits beneath it, so it no longer restyles itself as the content changes

Measured on a Retroid Pocket 6 before the change, sampling the bar region: Grid vs Compact differed by 17.8 (only the mode label and the backdrop showing through), while Grid vs Stage differed by 93.3. Afterwards the three agree.

Scope is deliberately the bar only. `NovaLibraryPanel` still takes its cinematic flag from the layout mode, because that governs content surfaces rather than chrome.

## Exact candidate

- Commit: `67a6b5d59b03450f12e9fa491ac259dbff970deb`
- Tree: `1f10a674fbaba58a02e7119beda53323ad315872`
- Parent: `aec9d68097d54f6c65631c5c8dc489710d9eaded`
- Base: `aec9d68097d54f6c65631c5c8dc489710d9eaded`

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1,170 tests, 0 failures/errors
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebugAndroidTest`
- [x] physical Retroid Pocket 6, shipping `nonRoot_gameDebug` flavor, class-filtered — 21 tests, 0 failures
- [x] on-device review of the bar in Grid, Compact and Stage
- [x] `git diff --check`
- [x] modified-file scan for secrets, debug logging and capture harnesses: zero hits
