### PR TITLE
feat(nova): make a wrong completion estimate correctable, and guard the gauge

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
@@ -193,6 +193,7 @@ internal fun NovaGameDetailOverview(
                 gameName = uiState.game.name,
                 playTime = uiState.game.playTime,
                 beatTime = uiState.game.beatTime,
+                onCorrectMatch = { onDestination(NovaGameDetailDestination.ARTWORK) },
             )
 
             NovaGameDetailStatusLine(
@@ -504,6 +505,7 @@ private fun NovaGameDetailBeatGauge(
     gameName: String,
     playTime: PolarisGame.PlayTime?,
     beatTime: PolarisGame.BeatTime?,
+    onCorrectMatch: () -> Unit,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -667,15 +669,21 @@ private fun NovaGameDetailBeatGauge(
         // name it actually found is shown whenever it is not plainly the same game.
         val matched = beatTime?.matchedName.orEmpty()
         if (matched.isNotBlank() && novaSameTitle(matched, gameName).not()) {
+            var correctionFocused by remember { mutableStateOf(false) }
             Text(
                 text = stringResource(R.string.nova_game_detail_matched_as, matched),
-                color = colors.textMuted,
+                // The estimate follows whatever identity the studio settled on, so the
+                // admission of a mismatch is also the way to the place that fixes it.
+                color = if (correctionFocused) colors.accent else colors.textMuted,
                 fontSize = 10.sp,
                 letterSpacing = 0.06.em,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .padding(top = 5.dp)
+                    .onFocusChanged { correctionFocused = it.isFocused || it.hasFocus }
+                    .clickable(role = Role.Button, onClick = onCorrectMatch)
+                    .focusable()
                     .width(NOVA_GAUGE_WIDTH),
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -272,7 +272,7 @@
     <string name="nova_game_detail_group_insight">Insight</string>
     <string name="nova_game_detail_close">Close</string>
     <string name="nova_game_detail_not_started">Not started</string>
-    <string name="nova_game_detail_matched_as">Estimate for %1$s</string>
+    <string name="nova_game_detail_matched_as">Estimate for %1$s · fix in Artwork</string>
     <string name="nova_game_detail_beat_main">Main %1$d h</string>
     <string name="nova_game_detail_beat_extras">Extras %1$d h</string>
     <string name="nova_game_detail_beat_complete">100%% %1$d h</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2780,4 +2780,119 @@ class NovaComposeSourceGuardTest {
         }
         error("Unbalanced block after: $startMarker")
     }
+
+    @Test
+    fun gameDetailGaugeMeasuresPlayedAgainstTheLongestEstimate() {
+        val gauge = readNovaGameDetail().section(
+            "private fun NovaGameDetailBeatGauge(",
+            "/**\n * Whether two titles are the same game"
+        )
+
+        assertTrue(
+            "the bar's full width is the completionist figure, falling back to whatever is actually known",
+            gauge.contains("beatTime?.longestSeconds?.takeIf { it > 0 }")
+        )
+        assertTrue(
+            "played past the end caps the bar, because a bar cannot say more than full",
+            gauge.contains("(playedSeconds.toFloat() / fullWidthSeconds.toFloat()).coerceIn(0f, 1f)")
+        )
+        assertFalse(
+            "the played figure is not clamped with the bar: the hours someone actually spent " +
+                "stay true past the end of an estimate",
+            gauge.contains("playedSeconds.coerceAtMost")
+        )
+    }
+
+    @Test
+    fun gameDetailGaugeCutsItsNotchesThroughTheBarRatherThanOntoIt() {
+        val gauge = readNovaGameDetail().section(
+            "private fun NovaGameDetailBeatGauge(",
+            "/**\n * Whether two titles are the same game"
+        )
+
+        // Overhang top and bottom is the whole difference between a notch in the bar and
+        // a mark sitting on it, and it is visible only in the drawing, never in the prose.
+        assertTrue(
+            "the canvas is taller than the bar so the notches can overhang it",
+            gauge.contains(".height(NOVA_GAUGE_BAR + NOVA_GAUGE_NOTCH_OVERHANG * 2)") &&
+                gauge.contains("val barTop = NOVA_GAUGE_NOTCH_OVERHANG.toPx()")
+        )
+        assertTrue(
+            "a notch is drawn in the ground colour over a lighter ring, which is what reads as a cut",
+            gauge.contains("val notchInk = colors.window") &&
+                gauge.contains("val notchRing = colors.textPrimary.copy(alpha = 0.34f)")
+        )
+        assertTrue(
+            "a notch at or past the full width would sit on the end cap and say nothing",
+            gauge.contains("it > 0 && it < fullWidthSeconds")
+        )
+    }
+
+    @Test
+    fun gameDetailGaugeSaysWhichEstimateIsWhich() {
+        val gauge = readNovaGameDetail().section(
+            "private fun NovaGameDetailBeatGauge(",
+            "/**\n * Whether two titles are the same game"
+        )
+
+        assertTrue(
+            "three bare numbers do not say which is the main story and which is everything",
+            gauge.contains("R.string.nova_game_detail_beat_main") &&
+                gauge.contains("R.string.nova_game_detail_beat_extras") &&
+                gauge.contains("R.string.nova_game_detail_beat_complete")
+        )
+        assertTrue(
+            "the played figure leads and the estimates follow it, so the row has a reading order",
+            gauge.indexOf("color = colors.textPrimary,") in
+                0 until gauge.indexOf("color = colors.textSecondary,")
+        )
+    }
+
+    @Test
+    fun gameDetailGaugeDrawsNothingItCannotBack() {
+        val gauge = readNovaGameDetail().section(
+            "private fun NovaGameDetailBeatGauge(",
+            "/**\n * Whether two titles are the same game"
+        )
+
+        assertTrue(
+            "with neither a duration nor an estimate the block is absent entirely",
+            gauge.contains("if (playedSeconds <= 0L && fullWidthSeconds <= 0L)")
+        )
+        assertTrue(
+            "an estimate with nothing played reads Not started rather than zero hours",
+            gauge.contains("R.string.nova_game_detail_not_started")
+        )
+        assertTrue(
+            "the bar only appears once there is something to measure against",
+            gauge.contains("if (fullWidthSeconds > 0L) {")
+        )
+    }
+
+    @Test
+    fun gameDetailGaugeSurfacesAWrongMatchAndLeadsToItsFix() {
+        val detail = readNovaGameDetail()
+        val gauge = detail.section(
+            "private fun NovaGameDetailBeatGauge(",
+            "/**\n * Whether two titles are the same game"
+        )
+
+        assertTrue(
+            "a fuzzy match that went wrong looks exactly like one that went right, so the name " +
+                "it found is shown when it is not plainly the same game",
+            gauge.contains("novaSameTitle(matched, gameName).not()") &&
+                gauge.contains("R.string.nova_game_detail_matched_as")
+        )
+        assertTrue(
+            "punctuation and case disagree constantly between a launcher and a catalogue, and " +
+                "saying so every time would bury the mismatches that matter",
+            detail.contains("private fun novaSameTitle(") &&
+                detail.contains("value.forEach { if (it.isLetterOrDigit()) append(it.lowercaseChar()) }")
+        )
+        assertTrue(
+            "seeing the mismatch is half of it: the line is the way to the studio that fixes the identity",
+            gauge.contains("onCorrectMatch") &&
+                detail.contains("onCorrectMatch = { onDestination(NovaGameDetailDestination.ARTWORK) }")
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Stacked behind papi-ux/polaris#287, which lets a curated artwork identity decide which
game a completion estimate is for. This is the client half: making a mismatch visible was
only ever half of what the concept asked for.

> `beat_time.matched_name` — so a wrong match is visible and correctable, as artwork
> matches already are

Until now the second half meant hand-editing JSON on the host. The artwork studio is where
an entry's identity is decided, and Polaris now lets that identity decide the estimate too,
so it is the one place to fix both. The line that admits the mismatch is therefore the way
there: it takes focus, it says where it goes, and it lands on the studio for that game.

It only appears when the names genuinely differ. Punctuation and case disagree constantly
between a launcher and a catalogue — `Control Ultimate Edition` against `Control: Ultimate
Edition` is the same answer, and saying so every time would bury the mismatches that matter.

### Guards for the gauge

The gauge is the newest surface in this window and had nothing pinning it, which is how it
spent a whole build cycle drawn from the concept's prose instead of its drawing. Five
guards, each pinning something already got wrong once:

| Guard | Pins |
|---|---|
| measures played against the longest estimate | the bar caps, the figure does not |
| cuts its notches through the bar | the overhang that makes a notch a cut and not a mark |
| says which estimate is which | labels, not three bare numbers |
| draws nothing it cannot back | absent is not zero; "Not started" is not "0 h" |
| surfaces a wrong match and leads to its fix | the disclosure, and where it goes |

**These were checked by breaking what they pin**, not by watching them pass. Removing the
overhang, collapsing the estimate labels into one, and deleting the early return each fail
exactly one guard — the one covering it.

That check is the difference between a guard and a tautology. A guard in this same file had
quietly stopped asserting anything once the composable it referenced was deleted, because a
missing needle returns `-1` and any real position beats it.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

`:app:testNonRoot_gameDebugUnitTest`, `:app:lintNonRoot_gameDebug -PlintFailOnError=true`,
`:app:assembleNonRoot_gameRelease`, `:app:assembleNonRoot_gameDebugAndroidTest` — all pass.

On the Retroid against a live host: Slay the Spire 2 reads
`Estimate for Slay the Spire II · fix in Artwork`, and following it opens
`Artwork Studio · Slay the Spire 2` with its current match shown. Phasmophobia, which
matched exactly, shows no line at all.

## Notes

The disclosure is focusable, so a controller reaches it — nothing in this window requires
the touchscreen.

Without papi-ux/polaris#287 the line still appears and still opens the studio; correcting
the identity there simply will not change the estimate yet.
