### PR TITLE
chore(release): prepare 1.3.4, with focus routing and dashboard feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+## 1.3.4 - 2026-08-07
+
+Nova 1.3.4 rebuilds the game detail window as a destination of its own and then holds the rest of the app to the standard it set. It replaces the launch-path modals with a single Play Setup screen, puts Nova on the Polaris brand palette and typeface, makes Portable Chrome mean what its contract always said, and fixes a set of controller defects that compiled and tested cleanly while being unusable in the hand.
+
+### Highlights
+
+- Rebuilds the **game detail window** around its artwork and opens it as its own window rather than a bottom sheet, with the launch path collapsed into a single **Play Setup** destination — the last three modals become a contextual strip, and the host's answer is shown beside the game's so a per-game override and the host default are no longer a screen apart.
+- Puts Nova on the **Polaris brand palette and typeface**, adding Space Grotesk as the chrome face with a subset that keeps tabular figures, and takes Title Case app-wide for names while leaving prose in sentence case.
+- Makes **Portable Chrome** literal. The contract has said "smoked graphite / dim moonlight grey / silver shell chrome" since it was written; what shipped was an `#A2ADBA` window with dark text, the only always-light theme in Nova. The reference is a silver PSP-1000: the shell is silver, the screen is not. Every contrast ratio is measured rather than judged by eye.
+- Reduces **thirteen corner values to three steps and a pill**, and moves sixteen uppercase chrome labels onto one typeface — they had been spelling out eleven trackings across three units, seven of them with no font family at all and so rendering in Roboto beside Space Grotesk.
+- **Separates focus from selection.** Six components drew them identically, and the damage ran the direction that is easy to miss: an unfocused *selected* item was painted with the focus fill, so two things on screen claimed to be where you are.
+- Fixes controls that **watched focus but could never receive it**. The Polaris Sync stream display selector could not be reached with a controller at all — changing it required touching the screen, on a handheld.
+- Gives surfaces that opened with **focus left behind** somewhere to land: Polaris Sync opens on the stream display modes, Settings on the category rail rather than on Back, where the first press used to leave the screen you had just opened.
+- Fixes the **settings search field trapping the d-pad**: it was a plain text field, so once focused the direction keys went into the text and there was no way off it without a touchscreen.
+- Keeps the **companion window focusable** instead of clearing focus from the companion display, which had left Android's input dispatcher with no focused window and timing out on controller input, and adds a reversible Hide Companion action driven from the notification.
+- Makes a **wrong completion estimate correctable** and guards the gauge that shows it.
+- Replaces the raw toasts drawn **over a running game** with themed, differentiated feedback, so a failure no longer looks exactly like a success.
+
+### Compatibility and behavior
+
+- Preserves every Library mode, the theme set, minSdk 21, targetSdk 36, existing database and routing authorities, Moonlight-compatible hosts, Polaris integration, and signed in-place upgrades.
+- Portable Chrome changes polarity from light to dark. Its surfaces, focus alphas, particle density and error colour all move with it; the previous error colour was a dark maroon that fails the 4.5:1 gate on dark cards, where the fallback is silent.
+- Sheets keep their own 26dp corner: a sheet reads as an edge of the screen rather than as a card on it.
+- Six sentences that had been hardcoded English became string resources. Three of them were also assigned to the library's on-screen error state, so the same untranslated sentence was appearing twice at once.
+- The dashboard theme picker now reads the shared theme array instead of keeping a second copy in Kotlin, so a theme added to the array can no longer appear in Settings and silently not on the dashboard.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.4 and versionCode 36.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus portable SHA-256 sidecars through the GitHub release workflow.
+
+### Validation notes
+
+- Verified on a Retroid Pocket 6 against a Polaris host: library, game detail, Play Setup, artwork studio, Settings, the System and Options drawers, the theme picker, the Polaris Sync sheet, and the in-stream Command Center.
+- `connectedNonRoot_gameDebugAndroidTest` passes 36/36 on that device; the JVM suite is green, as are `lintNonRoot_gameRelease` with `-PlintFailOnError=true`, both release and androidTest assembles, and the helper and onboarding tests.
+- Two changes are **not** verified on hardware and are called out rather than implied: the drawer-anchored snackbar placement inside the in-stream Command Center, and HUD theming under the graphite Portable Chrome. Both need a live stream to observe, and both fall back to previously shipped behaviour.
+- The first-focus request lands after a settle delay, so an input arriving inside that window is overwritten when the request completes. This is a race between the delay and the user rather than a wrong destination, and it wants measuring on hardware.
+- Roughly ninety raw toasts remain, all in files that host dialogs. Each needs the same question answered individually — is a window above the activity when this fires — because a naive conversion hides the message rather than restyling it. Three of them pass an application context and cannot become snackbars without moving where the message is raised.
+- Issues #177 and #178 stay open until physical AYN Thor results are captured; the companion focus lifecycle work here is not itself proof of that validation.
+
 ## 1.3.3 - 2026-07-30
 
 Nova 1.3.3 turns the Library and dual-screen experience into a controller-first command surface. It adds Spotlight Row, explicit Follow / Stream / Companion display roles, the Thor companion command deck, broader Material You semantics, and focused navigation, lifecycle, and API 33 reliability fixes.

--- a/README.md
+++ b/README.md
@@ -107,18 +107,17 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.3.3
+## Latest release: v1.3.4
 
-Nova v1.3.3 adds an optional Spotlight Row, explicit dual-display roles, and a Thor companion command deck while tightening Material You, controller focus, large-text behavior, and display/session reliability.
+Nova v1.3.4 rebuilds the game detail window as a destination of its own, then holds the rest of the app to the standard it set: one Play Setup screen instead of a stack of modals, the Polaris brand palette and typeface, a Portable Chrome that finally means what its contract said, and a set of controller fixes for things that compiled and tested cleanly while being unusable in the hand.
 
-- **Spotlight Row**: choose a centered, artwork-forward fourth Library mode with adjacent-card peeks, stable focus restoration, touch snapping, offline fallbacks, and adaptive controller hints.
-- **Display roles**: assign Follow, Stream, and Companion visually, preview Swap safely, and apply changes without creating a second routing authority.
-- **Thor command deck**: keep keyboard, Quick Menu, touchpad, and useful session controls on the non-stream display with controller/touch focus and lifecycle-aware teardown.
-- **Material You and OLED**: semantic surfaces, system bars, dialogs, settings, focus states, Library chrome, and companion controls now follow the selected theme more consistently.
-- **Controller and accessibility polish**: server focus survives polling; Spotlight uses genuine Android text scaling, meaningful two-line titles, complete semantics, and handled-input-only chrome transitions.
-- **Reliability**: fixes the API 33 codec-settings crash and strengthens display reconciliation, target-aware stream geometry, server removal/polling, manual add, and active-session cleanup.
+- **Play Setup**: one destination for how a game should run, with the host's answer shown beside the game's instead of a screen apart.
+- **Polaris brand**: Space Grotesk chrome, the brand palette, Title Case for names, and one corner scale in place of thirteen values.
+- **Portable Chrome**: smoked graphite with silver text and PlayStation-symbol glints, measured for contrast rather than judged by eye.
+- **Reachable by controller**: the Polaris Sync display selector could not be focused at all; Settings and Polaris Sync now open with focus somewhere useful, and the settings search field no longer traps the d-pad.
+- **Companion**: the companion window stays focusable, so the input dispatcher no longer times out on controller input, and hiding it is reversible from the notification.
 - **Compatibility**: preserves Grid, Compact Grid, List, existing routing and persistence authorities, minSdk 21, targetSdk 36, Polaris integration, Moonlight-compatible hosts, and signed in-place upgrades.
-- **Release packaging**: signed ARM64, ARMv7, and x86_64 APKs ship with portable SHA-256 sidecars. VersionCode 35 keeps Obtainium and manual installs on a clean upgrade path.
+- **Release packaging**: signed ARM64, ARMv7, and x86_64 APKs ship with portable SHA-256 sidecars. VersionCode 36 keeps Obtainium and manual installs on a clean upgrade path.
 - **Release validation**: final publication requires the tagged ARM64 APK to pass signer/package checks and the complete physical AYN Thor dual-display, OLED, controller, touch, reconnect, lifecycle, and teardown matrix. Issue #127 remains separate; use **Screen Launch → Top Screen**, not Auto.
 
 See the [changelog](CHANGELOG.md) for the full release history.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.3"
-        versionCode = 35
+        versionName "1.3.4"
+        versionCode = 36
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -1337,7 +1337,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
             if (computerObject != null) {
                 maybeProbeLibraryReadiness(computerObject)
             }
-            Toast.makeText(this, R.string.pcview_library_checking, Toast.LENGTH_SHORT).show()
+            NovaSnackbar.show(this, getString(R.string.pcview_library_checking))
             return
         }
 
@@ -1460,7 +1460,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
             if (::viewModel.isInitialized) viewModel.computersLiveData.value else null,
         )
         if (selected == null) {
-            Toast.makeText(this, R.string.pcview_library_no_server, Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.pcview_library_no_server))
             return
         }
         doNovaLibrary(selected.details)
@@ -1471,7 +1471,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
             if (::viewModel.isInitialized) viewModel.computersLiveData.value else null,
         )
         if (selected == null) {
-            Toast.makeText(this, R.string.pcview_polaris_start_no_server, Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.pcview_polaris_start_no_server))
             return
         }
         startPolarisFromNova(selected.details)
@@ -2123,7 +2123,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
     private fun handleQrScanResult(contents: String) {
         val uri = Uri.parse(contents)
         if (uri.scheme != "art") {
-            Toast.makeText(this, "Invalid QR code — expected Polaris pairing code", Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.nova_qr_invalid_code))
             return
         }
 
@@ -2133,13 +2133,13 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         val port = if (uri.port != -1) uri.port else NvHTTP.DEFAULT_HTTP_PORT
 
         if (pin == null || passphrase == null || host == null) {
-            Toast.makeText(this, "QR code is missing pairing data", Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.nova_qr_missing_pairing_data))
             return
         }
 
         val binder = managerBinder
         if (binder == null) {
-            Toast.makeText(this, getString(R.string.error_manager_not_running), Toast.LENGTH_LONG).show()
+            NovaSnackbar.showError(this, getString(R.string.error_manager_not_running))
             return
         }
 
@@ -2410,11 +2410,11 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
     private fun startPolarisFromNova(computer: ComputerDetails) {
         val binder = managerBinder
         if (binder == null) {
-            Toast.makeText(this, resources.getString(R.string.error_manager_not_running), Toast.LENGTH_LONG).show()
+            NovaSnackbar.showError(this, getString(R.string.error_manager_not_running))
             return
         }
         if (needsPairing(computer)) {
-            Toast.makeText(this, R.string.pcview_polaris_start_pair_first, Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.pcview_polaris_start_pair_first))
             return
         }
         val uuid = computer.uuid
@@ -2517,11 +2517,11 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
 
     private fun doAppList(computer: ComputerDetails, newlyPaired: Boolean, showHiddenGames: Boolean) {
         if (computer.state == ComputerDetails.State.OFFLINE) {
-            Toast.makeText(this, resources.getString(R.string.error_pc_offline), Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.error_pc_offline))
             return
         }
         if (managerBinder == null) {
-            Toast.makeText(this, resources.getString(R.string.error_manager_not_running), Toast.LENGTH_LONG).show()
+            NovaSnackbar.showError(this, getString(R.string.error_manager_not_running))
             return
         }
 
@@ -2537,12 +2537,12 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
     private fun doNovaLibrary(computer: ComputerDetails) {
         val activeAddress = computer.activeAddress
         if (computer.state == ComputerDetails.State.OFFLINE || activeAddress == null) {
-            Toast.makeText(this, resources.getString(R.string.error_pc_offline), Toast.LENGTH_SHORT).show()
+            NovaSnackbar.showError(this, getString(R.string.error_pc_offline))
             return
         }
         val binder = managerBinder
         if (binder == null) {
-            Toast.makeText(this, resources.getString(R.string.error_manager_not_running), Toast.LENGTH_LONG).show()
+            NovaSnackbar.showError(this, getString(R.string.error_manager_not_running))
             return
         }
 

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsScreen.kt
@@ -83,6 +83,7 @@ import com.papi.nova.ui.compose.NovaMenuBackdropBlur
 import com.papi.nova.ui.compose.NovaRadius
 import com.papi.nova.ui.compose.NovaSearchTextField
 import com.papi.nova.ui.compose.novaFocusMotion
+import com.papi.nova.ui.compose.novaHoldsFirstFocus
 import kotlin.math.roundToInt
 
 @Composable
@@ -274,10 +275,15 @@ private fun NovaSettingsContent(
                     .fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(NovaSettingsMetrics.wideColumnSpacingDp().dp)
             ) {
+                // Settings opened on whatever Android's traversal picked first, which is
+                // Back — so the first press on a controller left the screen you had just
+                // asked for. It lands on the rail instead, where the next press moves
+                // between categories.
                 NovaSettingsCategoryRail(
                     state = state,
                     onCategory = onCategory,
                     modifier = Modifier
+                        .novaHoldsFirstFocus()
                         .width(NovaSettingsMetrics.categoryRailWidthDp().dp)
                         .fillMaxHeight()
                 )

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.papi.nova.ui.compose.NovaChromeType
 import com.papi.nova.ui.compose.NovaRadius
+import com.papi.nova.ui.compose.novaHoldsFirstFocus
 import kotlinx.coroutines.delay
 import com.papi.nova.R
 import com.papi.nova.ui.compose.LocalNovaComposeColors
@@ -143,21 +144,6 @@ internal fun NovaGameDetailPanel(
             NovaGameDetailDestinationHints()
         }
     }
-}
-
-/**
- * Takes focus for its first focusable child once it has been laid out. Without this a
- * destination opens with focus left behind on the Overview, so the d-pad has nothing to
- * move. The delay is the same one the library uses: the request only lands after layout.
- */
-@Composable
-private fun Modifier.novaHoldsFirstFocus(): Modifier {
-    val requester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        delay(NOVA_DETAIL_FOCUS_SETTLE_MS)
-        runCatching { requester.requestFocus() }
-    }
-    return focusRequester(requester).focusGroup()
 }
 
 /**

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncContent.kt
@@ -42,6 +42,7 @@ import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
 import com.papi.nova.ui.compose.NovaActionButton
 import com.papi.nova.ui.compose.NovaRadius
+import com.papi.nova.ui.compose.novaHoldsFirstFocus
 
 @Composable
 fun NovaPolarisSyncContent(
@@ -113,7 +114,13 @@ fun NovaPolarisSyncContent(
                 color = colors.textMuted,
                 fontSize = 12.sp
             )
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // The sheet opened with no focus ring at all, so the first d-pad press went
+            // nowhere useful. It lands on the modes: they are what this sheet is for, and
+            // until this branch they could not be reached by controller at all.
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.novaHoldsFirstFocus()
+            ) {
                 uiState.modes.chunked(2).forEach { row ->
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         row.forEach { mode ->

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaFirstFocus.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaFirstFocus.kt
@@ -1,0 +1,34 @@
+package com.papi.nova.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.foundation.focusGroup
+import androidx.compose.ui.focus.focusRequester
+import kotlinx.coroutines.delay
+
+/** Long enough for the surface to have been laid out; the request lands on nothing before that. */
+const val NOVA_FIRST_FOCUS_SETTLE_MS = 120L
+
+/**
+ * Takes focus for the first focusable child once the surface has been laid out.
+ *
+ * Without it a surface opens with focus wherever the previous one left it, and the first d-pad
+ * press either does nothing or dismisses the screen that was just opened. The game detail
+ * window worked this out first and kept it to itself; the Polaris Sync sheet had no focus ring
+ * at all until this was shared.
+ *
+ * Attach it to the group that should own the first press, not to the outermost container —
+ * where focus lands is a decision about what the surface is for.
+ */
+@Composable
+fun Modifier.novaHoldsFirstFocus(settleMillis: Long = NOVA_FIRST_FOCUS_SETTLE_MS): Modifier {
+    val requester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        delay(settleMillis)
+        runCatching { requester.requestFocus() }
+    }
+    return focusRequester(requester).focusGroup()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1486,4 +1486,7 @@
     <string name="nova_library_launch_missing_id">This game entry is missing a launch ID</string>
     <string name="nova_library_launch_missing_session">Missing Polaris session details for launch</string>
     <string name="nova_library_resume_missing_session">Missing Polaris session details for resume</string>
+    <!-- Were English literals in PcView.handleQrScanResult. -->
+    <string name="nova_qr_invalid_code">Invalid QR code — expected a Polaris pairing code</string>
+    <string name="nova_qr_missing_pairing_data">QR code is missing pairing data</string>
 </resources>

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -19,21 +19,21 @@ class NovaReleaseMetadataTest {
         val readme = File(root, "README.md").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/35.txt"
+            "fastlane/metadata/android/en-US/changelogs/36.txt"
         )
         val storeNotesBody = storeNotes.readText().trimEnd()
 
-        assertTrue(build.contains("versionName \"1.3.3\""))
-        assertTrue(build.contains("versionCode = 35"))
-        assertTrue(changelog.contains("## 1.3.3 - 2026-07-30"))
-        assertTrue(readme.contains("## Latest release: v1.3.3"))
-        assertTrue(readme.contains("VersionCode 35"))
-        assertFalse(readme.contains("## Latest release: v1.3.2"))
+        assertTrue(build.contains("versionName \"1.3.4\""))
+        assertTrue(build.contains("versionCode = 36"))
+        assertTrue(changelog.contains("## 1.3.4 - 2026-08-07"))
+        assertTrue(readme.contains("## Latest release: v1.3.4"))
+        assertTrue(readme.contains("VersionCode 36"))
+        assertFalse(readme.contains("## Latest release: v1.3.3"))
         assertTrue(storeNotes.isFile)
         assertTrue(
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.3.3"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.3.4"))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/36.txt
+++ b/fastlane/metadata/android/en-US/changelogs/36.txt
@@ -1,0 +1,7 @@
+Nova 1.3.4
+
+- Rebuilds the game detail window as its own screen and collapses the launch path into one Play Setup destination.
+- Puts Nova on the Polaris brand palette and typeface, with Title Case for names.
+- Portable Chrome becomes the dark graphite handheld theme its contract described.
+- Fixes controls a controller could not reach, including the Polaris Sync display selector.
+- Settings and Polaris Sync now open with focus somewhere useful instead of on Back.


### PR DESCRIPTION
## Summary

Pre-release polish plus the 1.3.4 release preparation.

- **Surfaces that opened with focus left behind now take it.** `novaHoldsFirstFocus` moves out of the game detail window, which had kept it private, and is applied where focus was landing nowhere. Polaris Sync opens on the stream display modes; Settings opens on the category rail rather than on Back, where the first press of a controller used to leave the screen you had just asked for.
- **Twelve of the dashboard's messages become themed feedback.** They fire from dashboard actions with an Activity in hand and no window above them, and failures now use `showError`, which a Toast could not express. Two of them were hardcoded English — the invalid-QR-code and missing-pairing-data messages a user sees precisely when pairing has gone wrong.
- **Prepares 1.3.4.** Twelve commits had been sitting on master unreleased with an empty `## Unreleased` section; the entry covers all of them plus this branch. Version goes to `1.3.4` / `36`.

`NovaReleaseMetadataTest` is what makes the release honest here: it pins `build.gradle`, the changelog heading, the README block and a Play Store notes file named for the version code as one set, so a bump touching only `build.gradle` fails. The Play notes have a hard 500-character ceiling; this one is 468.

## Exact candidate

- `Commit: b14e0f46`
- `Base: a9c313a2` (master, after #190)

Three commits: focus routing, the dashboard messages, and the release preparation.

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — green
- [x] `:app:lintNonRoot_gameRelease` with `-PlintFailOnError=true`
- [x] `:app:assembleNonRoot_gameRelease`
- [x] Device QA on a Retroid Pocket 6: Settings now opens on **Client Stream Defaults** instead of Back, and the Polaris Sync stream display modes are reachable and traverse one press at a time.

### Not covered

- The drawer-anchored snackbar placement in the in-stream Command Center and HUD theming under the graphite Portable Chrome are both unverified on hardware; seeing either needs a live stream. Both fall back to behaviour that already shipped, and the changelog states this rather than implying coverage.
- The first-focus request lands after a settle delay, so an input arriving inside that window is overwritten when it completes. That is a race between the delay and the user rather than a wrong destination, and it wants measuring on hardware rather than a guessed-smaller number.
- Around ninety raw Toasts remain, all in files that host dialogs. Each needs to know whether a window sits above the activity when it fires, because a naive conversion hides the message instead of restyling it. Three of them pass an application context and cannot become snackbars without moving where the message is raised.
