### PR TITLE
fix(nova): the settings and stream-setup toasts, and one that has to stay a Toast

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -1,6 +1,7 @@
 package com.papi.nova
 
 
+import com.google.android.material.snackbar.Snackbar
 import com.papi.nova.utils.ServerHelper.getActiveDisplay
 import com.papi.nova.utils.ServerHelper.getAndroidCompanionDisplay
 
@@ -1115,7 +1116,7 @@ Build.VERSION.SDK_INT,
 displaySupportsHdr10
 ))
 {
-Toast.makeText(this, "Display does not support HDR10. Nova will request a 10-bit SDR stream.", Toast.LENGTH_LONG).show()
+NovaSnackbar.show(this, getString(R.string.nova_hdr_display_unsupported), Snackbar.LENGTH_LONG)
 }
 else if (shouldShowHdrRequiresAndroidNToast(
 prefConfig!!.enableHdr,
@@ -1123,7 +1124,7 @@ isOnExternalDisplay,
 Build.VERSION.SDK_INT
 ))
 {
-Toast.makeText(this, "HDR requires Android 7.0 or later", Toast.LENGTH_LONG).show()
+NovaSnackbar.show(this, getString(R.string.nova_hdr_requires_android_n), Snackbar.LENGTH_LONG)
 }
 
  // Check if the user has enabled performance stats overlay
@@ -1226,18 +1227,18 @@ catch (ignored:Throwable) {}
         if (willStreamHdr && !decoderRenderer!!.isHevcMain10Hdr10Supported && !decoderRenderer!!.isAv1Main10Supported)
 {
 willStreamHdr = false
-Toast.makeText(this, "Decoder does not support HDR10 profile", Toast.LENGTH_LONG).show()
+NovaSnackbar.showError(this, getString(R.string.nova_hdr_decoder_unsupported))
 }
  // Display a message to the user if HEVC was forced on but we still didn't find a decoder
         if (prefConfig!!.videoFormat == PreferenceConfiguration.FormatOption.FORCE_HEVC && !decoderRenderer!!.isHevcSupported)
 {
-Toast.makeText(this, "No HEVC decoder found", Toast.LENGTH_LONG).show()
+NovaSnackbar.showError(this, getString(R.string.nova_decoder_no_hevc))
 }
 
  // Display a message to the user if AV1 was forced on but we still didn't find a decoder
         if (prefConfig!!.videoFormat == PreferenceConfiguration.FormatOption.FORCE_AV1 && !decoderRenderer!!.isAv1Supported)
 {
-Toast.makeText(this, "No AV1 decoder found", Toast.LENGTH_LONG).show()
+NovaSnackbar.showError(this, getString(R.string.nova_decoder_no_av1))
 }
 
  // H.264 is always supported
@@ -4915,7 +4916,7 @@ LimeLog.severe(stage + " failed: " + errorCode)
                     var currentSurface:Surface? = streamContainer!!.getSurface()
 if (stage.contains("video") && currentSurface != null && currentSurface!!.isValid())
 {
-Toast.makeText(this@Game, getResources().getText(R.string.video_decoder_init_failed), Toast.LENGTH_LONG).show()
+NovaSnackbar.showError(this@Game, getString(R.string.video_decoder_init_failed))
 }
 
 var dialogText:String = getResources().getString(R.string.conn_error_msg) + " " + stage + " (error " + errorCode + ")"

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -57,6 +57,7 @@ import com.papi.nova.R
 import com.papi.nova.binding.input.virtual_controller.keyboard.KeyBoardControllerConfigurationLoader
 import com.papi.nova.binding.video.MediaCodecHelper
 import com.papi.nova.ui.NovaSheetChrome
+import com.papi.nova.ui.NovaSnackbar
 import com.papi.nova.ui.NovaThemeManager
 import com.papi.nova.ui.compose.NovaComposeTheme
 import com.papi.nova.utils.Dialog
@@ -204,18 +205,17 @@ class StreamSettings : NovaActivity() {
             "option_software_release" -> checkForNovaUpdate()
             "option_follow_update" -> HelpLauncher.launchUrl(this, getString(R.string.obtainium_app_url))
             else -> {
-                Toast.makeText(
+                NovaSnackbar.show(
                     this,
-                    "Opening legacy settings for ${definition.title}",
-                    Toast.LENGTH_SHORT
-                ).show()
+                    getString(R.string.nova_settings_opening_legacy, definition.title)
+                )
                 showLegacySettings()
             }
         }
     }
 
     private fun checkForNovaUpdate() {
-        Toast.makeText(this, R.string.nova_update_checking, Toast.LENGTH_SHORT).show()
+        NovaSnackbar.show(this, getString(R.string.nova_update_checking))
         lifecycleScope.launch {
             val result = runCatching {
                 withContext(Dispatchers.IO) {
@@ -378,9 +378,13 @@ class StreamSettings : NovaActivity() {
                 intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
                 startActivity(intent, null)
             } else if (newPrefs.language == PreferenceConfiguration.DEFAULT_LANGUAGE) {
+                // Deliberately still a Toast. A Toast is a system window that outlives the
+                // process; a Snackbar lives in this activity's view hierarchy, and the
+                // System.exit below kills the process before one could ever be drawn. The
+                // message would simply vanish.
                 Toast.makeText(
                     this,
-                    "Language has been reset to default, please restart the app!",
+                    getString(R.string.nova_language_reset_restart),
                     Toast.LENGTH_LONG
                 ).show()
                 System.exit(0)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1494,4 +1494,10 @@
     <!-- Were English literals in StreamSettings. -->
     <string name="nova_settings_opening_legacy">Opening legacy settings for %1$s</string>
     <string name="nova_language_reset_restart">Language has been reset to default, please restart the app!</string>
+    <!-- Were English literals in Game.kt, shown while a stream is being set up. -->
+    <string name="nova_hdr_display_unsupported">Display does not support HDR10. Nova will request a 10-bit SDR stream.</string>
+    <string name="nova_hdr_requires_android_n">HDR requires Android 7.0 or later</string>
+    <string name="nova_hdr_decoder_unsupported">Decoder does not support HDR10 profile</string>
+    <string name="nova_decoder_no_hevc">No HEVC decoder found</string>
+    <string name="nova_decoder_no_av1">No AV1 decoder found</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1491,4 +1491,7 @@
     <!-- Were English literals in PcView.handleQrScanResult. -->
     <string name="nova_qr_invalid_code">Invalid QR code — expected a Polaris pairing code</string>
     <string name="nova_qr_missing_pairing_data">QR code is missing pairing data</string>
+    <!-- Were English literals in StreamSettings. -->
+    <string name="nova_settings_opening_legacy">Opening legacy settings for %1$s</string>
+    <string name="nova_language_reset_restart">Language has been reset to default, please restart the app!</string>
 </resources>


### PR DESCRIPTION
## Summary

Eight more raw Toasts become themed feedback, and one is deliberately left as a Toast because converting it would delete the message.

- **StreamSettings — two of twenty-two.** The other nineteen live in `SettingsFragment`, the legacy preference screen, reached only by tapping Legacy, which sets the compose-settings flag to false. Converting a screen users see only after opting out of the new one is not worth touching. The two on the path everyone takes become snackbars.
- **The third does not, and it is the point of the branch.** It announces the language reset and then calls `System.exit(0)`. A Toast is a system window that outlives the process; a Snackbar lives in the activity's view hierarchy, so the exit would destroy it before it drew and the message would simply vanish — the last thing the app says before closing. It keeps its Toast with a comment saying why, so a later sweep does not quietly undo the reasoning.
- **Game.kt — six stream-setup capability warnings.** The display not supporting HDR10, HDR needing Android 7, the decoder lacking an HDR10 profile, HEVC or AV1 forced with no decoder present, and the video decoder failing to initialise. The five reporting a missing capability now read as errors rather than neutral notices, which is what they are: someone asked for HEVC and did not get it.

All five of those were hardcoded English, so a user running Nova in any other language was told **in English** that their decoder could not do what they asked. They are string resources now, along with the two from StreamSettings.

Establishing which sites were safe took more care than the edit did. `Game.kt` puts its braces on their own lines, which defeated the heuristic I was using to find each toast's enclosing function — it attributed three decoder warnings to `notifyCrash` and one to `onStop`, neither of which was true. Reading the actual surrounding lines gave a different and correct answer; the sites that really are terminal or dialog-bound are still untouched.

Left deliberately in `Game.kt`: the app-quit results, which may fire while the app-list sheet is still on screen; `displayMessage`, a generic connection callback that can arrive at any moment including under a dialog; and the HUD diagnostics confirmation, which is raised from the Command Center and needs that drawer's view as its anchor, which is not in scope here.

## Exact candidate

- `Commit: fe32ceb3`
- `Base: 9c46b275` (master)

Two commits: the settings activity, then the stream-setup warnings.

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — green
- [x] `:app:lintNonRoot_gameRelease` with `-PlintFailOnError=true`
- [x] Raw `Toast.makeText` in `app/src/main/java`: **93 on master → 85 here**. `NovaSnackbar` adoptions: **76**.

### Not covered

- Neither batch was exercised on hardware. The StreamSettings pair needs the language-reset and legacy-settings paths; the `Game.kt` six need a host whose display or decoder actually lacks the capability, which this Retroid and pc-papi do not reproduce. Every converted site keeps the same trigger condition and text, so the fallback is the message that already shipped, restyled.
- **Eighty-five remain, and the migration is past its useful point.** What is left is legacy screens, sites where a Toast is structurally correct (followed by `System.exit` or a crash, or raised from a background callback that can arrive under a dialog), and sites needing plumbing that costs more than the consistency buys — three pass an application context and have no Activity to hang a window on.
