### PR TITLE
fix(nova): Play Setup becomes four rows that fit, and a launch stops skipping its guard

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -720,7 +720,9 @@ class NovaGameDetailActivity : NovaActivity() {
                 stripTitle = getString(R.string.nova_play_setup_strip_tuning),
                 options = AutoQualityProfilePreferences.values().map { value ->
                     NovaPlaySetupOption(
-                        label = getString(AutoQualityProfilePreferences.labelRes(value)),
+                        // shortLabelRes, not labelRes: the long form is "AI Preference: X",
+                        // and four cards of it ellipsize to four identical words.
+                        label = getString(AutoQualityProfilePreferences.shortLabelRes(value)),
                         consequence = getString(novaProfilePreferenceConsequenceRes(value)),
                         current = value == profilePreference,
                         onSelect = { selectProfilePreference(value) },

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -106,6 +106,8 @@ import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaFocusableCard
 import com.papi.nova.utils.DeviceUtils
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -250,19 +252,12 @@ class NovaGameDetailActivity : NovaActivity() {
     /**
      * Unwinds one level: an expanded review collapses, a destination returns to the
      * Overview, and only then does back leave for the library.
-     */
-    /**
-     * Closes whichever row's options are showing in the comparison strip.
      *
-     * Set from the composition, because the picker states live with the content rather
-     * than the activity. Back unwinds one level at a time, so an open picker has to be
-     * the first level: without this, B on a list of tuning profiles left the destination
-     * entirely rather than returning to the rows.
+     * There used to be a level above these for closing whichever row's options were
+     * showing in the strip. The strip is a legend now rather than something that opens,
+     * so there is nothing to close and back has one fewer step to take.
      */
-    private var dismissActivePicker: (() -> Boolean)? = null
-
     private fun dismissActiveDetailDestination(): Boolean = when {
-        dismissActivePicker?.invoke() == true -> true
         reviewExpanded -> {
             reviewExpanded = false
             true
@@ -314,29 +309,33 @@ class NovaGameDetailActivity : NovaActivity() {
         var mangoHudEnabled by mutableStateOf(game.mangohud)
         var resetWorking by mutableStateOf(false)
         var optimizationState by mutableStateOf(NovaGameDetailOptimizationState())
-        var launchOptionsState by mutableStateOf<NovaLaunchOptionsState?>(null)
-        var profileOptionsState by mutableStateOf<NovaProfilePreferenceOptionsState?>(null)
-        var steamLaunchOptionsState by mutableStateOf<NovaSteamLaunchModeOptionsState?>(null)
         var artworkState by mutableStateOf(loadArtworkState(game))
+        // Which row the comparison strip is explaining. It follows focus, and a tap sets
+        // it too -- touch has no cursor for the strip to follow, and a finger that lands
+        // on a row should get the same explanation a d-pad would.
+        var explainedRow by mutableStateOf(NovaPlaySetupRow.WHERE_IT_RUNS)
+        // An explicit resolution, held until launch rather than launching on the spot.
+        // Picking one used to start the game immediately, which is why the row that owned
+        // it could not be a setting: there was nothing to set.
+        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(null)
+        // Changing a row is cheap; telling the host about it is not. Presses settle first
+        // so that cycling past three values costs one round-trip rather than three.
+        var settleJob: Job? = null
         // A launch was asked for while the preflight that arms the desktop-Steam guard was
         // still on the wire. The press is held rather than dropped: being quick should not
-        // cost you the launch, and it must not cost you the guard either. The option is
-        // carried alongside because an option card launches with its own blob and its own
-        // display mode, so replaying the press has to replay the choice, not just the intent.
+        // cost you the launch, and it must not cost you the guard either.
         var pendingLaunch by mutableStateOf(false)
-        var pendingLaunchOption by mutableStateOf<NovaLaunchOptionItem?>(null)
+
+        /**
+         * The blob this launch would go out with: the resolution chosen here if there is
+         * one, otherwise whatever the host last planned.
+         */
+        fun launchOptimization(): JSONObject? = chosenResolution
+            ?.let { NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(it, "nova_display_planner") }
+            ?: optimizationState.rawOptimization
 
         fun refreshUiState(preference: String = profilePreference) {
             uiState = buildUiState(currentGame, preference)
-        }
-
-        dismissActivePicker = {
-            when {
-                launchOptionsState != null -> { launchOptionsState = null; true }
-                profileOptionsState != null -> { profileOptionsState = null; true }
-                steamLaunchOptionsState != null -> { steamLaunchOptionsState = null; true }
-                else -> false
-            }
         }
 
         /**
@@ -421,22 +420,21 @@ class NovaGameDetailActivity : NovaActivity() {
         }
 
 
-        fun launchConfirmed(
-            mirrorDesktop: Boolean,
-            forcePrivateAfterSteamClose: Boolean = false,
-            option: NovaLaunchOptionItem? = null
-        ) {
+        // Assigned once loadOptimization exists. Held work runs early when a launch is
+        // waiting on it, so pressing Play never means waiting out a delay meant for
+        // someone still cycling.
+        var flushSettled: () -> Unit = {}
+
+        fun launchConfirmed(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
             pendingLaunch = false
-            pendingLaunchOption = null
             onLaunch?.invoke(
                 currentGame.copy(mangohud = mangoHudEnabled),
-                option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay,
+                uiState.playUsesVirtualDisplay,
                 mirrorDesktop,
                 forcePrivateAfterSteamClose,
                 profilePreference,
-                option?.launchOptimization ?: optimizationState.rawOptimization
+                launchOptimization()
             )
-            if (option != null) launchOptionsState = null
             finish()
         }
 
@@ -454,21 +452,19 @@ class NovaGameDetailActivity : NovaActivity() {
          * its own answer was still judged by whatever the last preflight said. Both paths
          * come through here now, and the blob that decides is the blob that launches.
          */
-        fun attemptLaunch(option: NovaLaunchOptionItem? = null) {
+        fun attemptLaunch() {
             if (!uiState.playEnabled) return
-            val optimization = option?.launchOptimization ?: optimizationState.rawOptimization
+            val optimization = launchOptimization()
             if (optimization == null && optimizationState.preflightInFlight) {
                 pendingLaunch = true
-                pendingLaunchOption = option
+                // Whatever is waiting to settle is what this launch is waiting on, so run
+                // it now instead of holding the press for a delay that exists to absorb
+                // presses nobody is making any more.
+                flushSettled()
                 return
             }
             pendingLaunch = false
-            pendingLaunchOption = null
-            val decision = NovaDesktopSteamLaunchDecision.from(
-                uiState,
-                optimization,
-                usesVirtualDisplay = option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay
-            )
+            val decision = NovaDesktopSteamLaunchDecision.from(uiState, optimization)
             when {
                 // A choice of where to run belongs in the destination that
                 // owns where it runs, not in a sheet raised over the artwork.
@@ -481,7 +477,7 @@ class NovaGameDetailActivity : NovaActivity() {
                 optimizationState.reviewRequired && !reviewExpanded -> {
                     reviewExpanded = true
                 }
-                else -> launchConfirmed(false, option = option)
+                else -> launchConfirmed(false)
             }
         }
 
@@ -512,7 +508,35 @@ class NovaGameDetailActivity : NovaActivity() {
                     LimeLog.warning("Nova: Preflight optimization failed: ${e.message}")
                     NovaGameDetailOptimizationState()
                 }
-                if (pendingLaunch) attemptLaunch(pendingLaunchOption)
+                if (pendingLaunch) attemptLaunch()
+            }
+        }
+
+        /**
+         * Tell the host once the presses stop.
+         *
+         * Every row here used to write to the host on each selection, which was tolerable
+         * when a selection meant opening a picker and choosing from it, and is not when a
+         * row advances on every press. What matters is that the state is marked in flight
+         * *immediately*: during the settle the last answer belongs to the previous value,
+         * so a launch in that window has to wait rather than be armed from it. That is the
+         * same rule as the preflight guard, applied to a gap this introduces.
+         */
+        fun settleThen(work: () -> Unit) {
+            optimizationState = NovaGameDetailOptimizationState(preflightInFlight = true)
+            settleJob?.cancel()
+            settleJob = lifecycleScope.launch {
+                delay(NOVA_PLAY_SETUP_SETTLE_MS)
+                work()
+            }
+        }
+
+        flushSettled = {
+            val job = settleJob
+            if (job != null && job.isActive) {
+                job.cancel()
+                settleJob = null
+                loadOptimization(profilePreference)
             }
         }
 
@@ -535,7 +559,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     LimeLog.warning("Nova: High FPS trial preflight failed: ${e.message}")
                     NovaGameDetailOptimizationState()
                 }
-                if (pendingLaunch) attemptLaunch(pendingLaunchOption)
+                if (pendingLaunch) attemptLaunch()
             }
         }
 
@@ -557,7 +581,190 @@ class NovaGameDetailActivity : NovaActivity() {
             currentGame = currentGame.copy(launchMode = updatedLaunchMode)
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
-            loadOptimization(profilePreference, usesVirtualDisplay = mode == "virtual_display")
+            // A resolution was an answer to "how should this run on that display". Changing
+            // the display changes the question, so the answer does not carry over.
+            chosenResolution = null
+            settleThen { loadOptimization(profilePreference, usesVirtualDisplay = mode == "virtual_display") }
+        }
+
+        /**
+         * Hold the resolution rather than launching with it.
+         *
+         * Choosing one used to start the stream on the spot, which is why the row that
+         * owned it could not read as a setting: there was no state, only a launch wearing
+         * a picker's clothes. It rides along as an optimization override now, and the row
+         * says so.
+         */
+        fun chooseResolution(choice: NovaDisplayResolutionChoice) {
+            chosenResolution = choice
+        }
+
+        fun selectProfilePreference(value: String) {
+            if (value == profilePreference) return
+            profilePreference = value
+            saveProfilePreference(currentGame, value)
+            refreshUiState(value)
+            settleThen { loadOptimization(value) }
+        }
+
+        fun selectSteamLaunchMode(value: String) {
+            val previousGame = currentGame
+            val requestedMode = PolarisGame.SteamLaunchContract.normalizeMode(value)
+            if (requestedMode == previousGame.steamLaunchMode) return
+
+            // Shown immediately and reconciled when the host answers. The row is a value
+            // someone is cycling through, so it cannot wait on a round-trip to redraw.
+            currentGame = previousGame.copy(
+                steamLaunch = previousGame.steamLaunch?.copy(mode = requestedMode)
+            )
+            refreshUiState()
+            settleThen {
+                lifecycleScope.launch {
+                    val confirmedMode = withContext(Dispatchers.IO) {
+                        apiClient.setSteamLaunchMode(previousGame.id, requestedMode)
+                    }
+                    if (confirmedMode != null) {
+                        currentGame = currentGame.copy(
+                            steamLaunch = currentGame.steamLaunch?.copy(mode = confirmedMode)
+                        )
+                    } else {
+                        currentGame = previousGame
+                        NovaSnackbar.showError(
+                            this@NovaGameDetailActivity,
+                            getString(R.string.nova_steam_launch_mode_failed),
+                        )
+                    }
+                    refreshUiState()
+                    loadOptimization(profilePreference)
+                }
+            }
+        }
+
+        /**
+         * The act column, resolved. Four rows at most, and fewer when a row has nothing to
+         * offer -- a host with one launch mode, or no display planner, drops the row rather
+         * than drawing a control with a single value in it.
+         */
+        fun buildPlaySetupRows(): List<NovaPlaySetupRowState> {
+            val rows = mutableListOf<NovaPlaySetupRowState>()
+
+            val modeOptions = buildList {
+                if (uiState.headlessAllowed) {
+                    add(
+                        NovaPlaySetupOption(
+                            label = modeBadgeLabel("headless"),
+                            consequence = getString(R.string.nova_play_setup_compare_private),
+                            current = uiState.playMode == "headless",
+                            onSelect = { selectLaunchMode("headless") },
+                        )
+                    )
+                }
+                if (uiState.virtualDisplayAllowed) {
+                    add(
+                        NovaPlaySetupOption(
+                            label = modeBadgeLabel("virtual_display"),
+                            consequence = getString(R.string.nova_play_setup_compare_virtual),
+                            current = uiState.playMode == "virtual_display",
+                            enabled = !uiState.virtualDisplayUnavailable,
+                            onSelect = { selectLaunchMode("virtual_display") },
+                        )
+                    )
+                }
+            }
+            rows += NovaPlaySetupRowState(
+                row = NovaPlaySetupRow.WHERE_IT_RUNS,
+                label = getString(R.string.nova_game_detail_where_it_runs),
+                caption = getString(R.string.nova_play_setup_where_caption),
+                value = modeBadgeLabel(uiState.playMode),
+                stripTitle = getString(R.string.nova_play_setup_strip_where),
+                options = modeOptions,
+                enabled = modeOptions.count { it.enabled } > 1,
+                overridden = uiState.overridesHostMode,
+            )
+
+            val planner = resolutionPlanner(currentGame)
+            if (planner.available && planner.visibleChoices.isNotEmpty()) {
+                val chosen = chosenResolution
+                val recommended = planner.visibleChoices.firstOrNull { it.recommended }
+                val effective = chosen ?: recommended
+                val overridden = chosen != null && chosen.id != recommended?.id
+                rows += NovaPlaySetupRowState(
+                    row = NovaPlaySetupRow.RESOLUTION,
+                    label = getString(R.string.nova_play_setup_resolution),
+                    caption = if (overridden) {
+                        getString(R.string.nova_play_setup_resolution_chosen)
+                    } else {
+                        getString(R.string.nova_play_setup_resolution_caption)
+                    },
+                    value = effective?.targetMode.orEmpty(),
+                    stripTitle = getString(R.string.nova_play_setup_strip_resolution),
+                    options = planner.visibleChoices.map { choice ->
+                        NovaPlaySetupOption(
+                            label = choice.title,
+                            consequence = listOf(choice.targetMode, choice.reason)
+                                .filter { it.isNotBlank() }
+                                .joinToString(" · "),
+                            current = choice.id == effective?.id,
+                            onSelect = { chooseResolution(choice) },
+                        )
+                    },
+                    overridden = overridden,
+                )
+            }
+
+            rows += NovaPlaySetupRowState(
+                row = NovaPlaySetupRow.TUNING,
+                label = getString(R.string.nova_play_setup_tuning),
+                caption = getString(R.string.nova_game_detail_profile_caption),
+                value = getString(AutoQualityProfilePreferences.shortLabelRes(profilePreference)),
+                stripTitle = getString(R.string.nova_play_setup_strip_tuning),
+                options = AutoQualityProfilePreferences.values().map { value ->
+                    NovaPlaySetupOption(
+                        label = getString(AutoQualityProfilePreferences.labelRes(value)),
+                        consequence = getString(novaProfilePreferenceConsequenceRes(value)),
+                        current = value == profilePreference,
+                        onSelect = { selectProfilePreference(value) },
+                    )
+                },
+            )
+
+            if (uiState.showSteamLaunchMode) {
+                rows += NovaPlaySetupRowState(
+                    row = NovaPlaySetupRow.STEAM_LAUNCH,
+                    label = getString(R.string.nova_steam_launch_detail_label),
+                    caption = steamLaunchCaption(uiState),
+                    value = steamLaunchModeLabel(uiState.steamLaunchMode),
+                    stripTitle = getString(R.string.nova_play_setup_strip_steam),
+                    options = listOf("direct", "big-picture").map { mode ->
+                        val normalized = PolarisGame.SteamLaunchContract.normalizeMode(mode)
+                        NovaPlaySetupOption(
+                            label = steamLaunchModeLabel(normalized),
+                            consequence = getString(novaSteamLaunchConsequenceRes(normalized)),
+                            current = normalized == uiState.steamLaunchMode,
+                            onSelect = { selectSteamLaunchMode(normalized) },
+                        )
+                    },
+                )
+            }
+
+            return rows
+        }
+
+        /**
+         * A press moves the row to its next value.
+         *
+         * Read off the same option list the strip draws, so the order someone sees is the
+         * order they get. Disabled options are stepped over rather than landed on, which is
+         * what made the blocked virtual-display case reachable-but-inert before.
+         */
+        fun advancePlaySetupRow(row: NovaPlaySetupRow) {
+            explainedRow = row
+            val options = buildPlaySetupRows().firstOrNull { it.row == row }?.options.orEmpty()
+            val selectable = options.filter { it.enabled && it.onSelect != null }
+            if (selectable.size < 2) return
+            val currentIndex = selectable.indexOfFirst { it.current }
+            val next = selectable[(currentIndex + 1).mod(selectable.size)]
+            next.onSelect?.invoke()
         }
 
         fun resetProfile() {
@@ -601,8 +808,8 @@ class NovaGameDetailActivity : NovaActivity() {
                     steamLaunchModeLabel = steamLaunchModeLabel(uiState.steamLaunchMode),
                     steamLaunchCaption = steamLaunchCaption(uiState),
                     optimizationState = optimizationState,
-                    launchOptionsState = launchOptionsState,
-                    profileOptionsState = profileOptionsState,
+                    playSetupRows = buildPlaySetupRows(),
+                    explainedPlaySetupRow = explainedRow,
                     playLabel = if (pendingLaunch) {
                         // The press landed and is being held, so say so. A button that
                         // looks untouched for the length of an HTTP round-trip reads as
@@ -616,12 +823,13 @@ class NovaGameDetailActivity : NovaActivity() {
                             ?.takeIf { it.isNotBlank() }
                             ?: primaryPlayLabel(uiState)
                     },
-                    launchOptionsLabel = getString(R.string.nova_library_launch_options_secondary),
                     launchModeTitle = getString(R.string.nova_library_launch_mode_title),
                     headlessModeLabel = modeBadgeLabel("headless"),
                     virtualDisplayModeLabel = modeBadgeLabel("virtual_display"),
                     coverContentDescription = getString(R.string.nova_a11y_game_cover),
                     onPrimaryLaunch = { attemptLaunch() },
+                    onExplainPlaySetupRow = { row -> explainedRow = row },
+                    onAdvancePlaySetupRow = { row -> advancePlaySetupRow(row) },
                     destination = destination,
                     steamDecision = steamDecision,
                     reviewExpanded = reviewExpanded,
@@ -641,47 +849,6 @@ class NovaGameDetailActivity : NovaActivity() {
                             NovaSteamLaunchChoice.CLOSE_STEAM_THEN_PRIVATE ->
                                 launchConfirmed(mirrorDesktop = false, forcePrivateAfterSteamClose = true)
                         }
-                    },
-                    onLaunchOptions = {
-                        val nextState = showLaunchOptions(currentGame, uiState)
-                        if (nextState == null) {
-                            Toast.makeText(this@NovaGameDetailActivity, R.string.nova_library_no_launch_modes, Toast.LENGTH_SHORT).show()
-                        } else {
-                            launchOptionsState = nextState
-                            profileOptionsState = null
-                        }
-                    },
-                    onLaunchModeSelected = { mode ->
-                        // Choosing sets the mode and stays here. Returning to the Overview
-                        // put the Play button under the thumb at the exact moment the mode
-                        // change had cleared the preflight the desktop-Steam guard is read
-                        // from, which made the quickest path through this screen the one
-                        // that skipped the guard. The readout it was returning to refresh
-                        // is on this surface too.
-                        selectLaunchMode(mode)
-                    },
-                    // Through the same gate as the primary action. This used to build its own
-                    // decision and its own launch, which is how it came to decide from one
-                    // blob and launch with another, and how it kept a route past the guard
-                    // after the primary action lost its.
-                    onLaunchOptionSelected = { option -> attemptLaunch(option) },
-                    onDismissLaunchOptions = {
-                        launchOptionsState = null
-                    },
-                    onProfilePreference = {
-                        profileOptionsState = showProfilePreferenceOptions(currentGame)
-                        launchOptionsState = null
-                    },
-                    onProfilePreferenceSelected = { selected ->
-                        saveProfilePreference(currentGame, selected.value)
-                        profilePreference = selected.value
-                        refreshUiState(selected.value)
-                        optimizationState = NovaGameDetailOptimizationState()
-                        profileOptionsState = null
-                        loadOptimization(selected.value)
-                    },
-                    onDismissProfileOptions = {
-                        profileOptionsState = null
                     },
                     onRetryHighFps = { retryHighFpsTrial() },
                     onOpenHostSettings = { openHostSettings() },
@@ -703,45 +870,6 @@ class NovaGameDetailActivity : NovaActivity() {
                             Toast.makeText(sheetContext, message, Toast.LENGTH_SHORT).show()
                             resetWorking = false
                         }
-                    },
-                    steamLaunchOptionsState = steamLaunchOptionsState,
-                    onSteamLaunchMode = {
-                        steamLaunchOptionsState = steamLaunchModeOptionsState(currentGame)
-                    },
-                    onSteamLaunchModeSelected = { selected ->
-                        val previousGame = currentGame
-                        val requestedMode = PolarisGame.SteamLaunchContract.normalizeMode(selected.value)
-                        if (requestedMode == previousGame.steamLaunchMode) {
-                            steamLaunchOptionsState = null
-                            return@NovaGameDetailContent
-                        }
-
-                        currentGame = previousGame.copy(
-                            steamLaunch = previousGame.steamLaunch?.copy(mode = requestedMode)
-                        )
-                        refreshUiState()
-                        lifecycleScope.launch {
-                            val confirmedMode = withContext(Dispatchers.IO) {
-                                apiClient.setSteamLaunchMode(previousGame.id, requestedMode)
-                            }
-                            val message = if (confirmedMode != null) {
-                                currentGame = currentGame.copy(
-                                    steamLaunch = currentGame.steamLaunch?.copy(mode = confirmedMode)
-                                )
-                                refreshUiState()
-                                steamLaunchOptionsState = null
-                                R.string.nova_steam_launch_mode_updated
-                            } else {
-                                currentGame = previousGame
-                                refreshUiState()
-                                steamLaunchOptionsState = steamLaunchModeOptionsState(previousGame)
-                                R.string.nova_steam_launch_mode_failed
-                            }
-                            Toast.makeText(this@NovaGameDetailActivity, message, Toast.LENGTH_SHORT).show()
-                        }
-                    },
-                    onDismissSteamLaunchModeOptions = {
-                        steamLaunchOptionsState = null
                     },
                     artworkState = artworkState,
                     onRefreshArtwork = {
@@ -971,101 +1099,25 @@ class NovaGameDetailActivity : NovaActivity() {
         )
     }
 
-    private fun showProfilePreferenceOptions(
-        game: PolarisGame
-    ): NovaProfilePreferenceOptionsState {
-        val values = AutoQualityProfilePreferences.values()
-        val current = loadProfilePreference(game)
-        val labels = values.map {
-            when (it) {
-                "quality" -> "Prefer Quality"
-                "high_fps" -> "Prefer High FPS"
-                "stability" -> "Prefer Stability"
-                else -> "Auto"
-            }
-        }
-        return NovaProfilePreferenceOptionsState(
-            title = getString(R.string.nova_library_profile_preference_title),
-            closeLabel = getString(R.string.nova_controller_hint_close),
-            options = values.mapIndexed { index, value ->
-                NovaProfilePreferenceItem(
-                    label = labels[index],
-                    value = value,
-                    selected = value == current
-                )
-            }
-        )
-    }
-
-    private fun steamLaunchModeOptionsState(game: PolarisGame): NovaSteamLaunchModeOptionsState {
-        val modes = listOf("direct", "big-picture")
-        return NovaSteamLaunchModeOptionsState(
-            title = getString(R.string.nova_steam_launch_options_title),
-            subtitle = getString(R.string.nova_steam_launch_detail_label),
-            closeLabel = getString(R.string.nova_controller_hint_close),
-            options = modes.map { mode ->
-                val normalizedMode = PolarisGame.SteamLaunchContract.normalizeMode(mode)
-                NovaSteamLaunchModeItem(
-                    label = steamLaunchModeLabel(normalizedMode),
-                    value = normalizedMode,
-                    selected = normalizedMode == game.steamLaunchMode
-                )
-            }
-        )
-    }
-
-    private fun showLaunchOptions(
-        game: PolarisGame,
-        uiState: NovaGameDetailUiState
-    ): NovaLaunchOptionsState? {
-        val options = mutableListOf<NovaLaunchOptionItem>()
+    /**
+     * The host's resolution plan for this game, or an unavailable one.
+     *
+     * This used to be showLaunchOptions, which turned the same choices into items that
+     * launched the stream the moment one was picked -- and, on a host with no planner,
+     * into a second copy of the launch-mode choice with no explanatory text on it at all.
+     * That copy is what "More Launch Settings" showed, and why pressing it looked like
+     * nothing happened. The row is a setting now, and a host without a planner has no
+     * resolution to offer, so it draws no row rather than an echo of the one above.
+     */
+    private fun resolutionPlanner(game: PolarisGame): NovaDisplayResolutionPlanner {
         val fallbackMode = clientSettings?.desired?.displayMode
             ?.takeIf { it.isNotBlank() }
             ?: clientSettings?.effective?.displayMode
             ?: ""
-        val planner = NovaDisplayResolutionPlanner.from(
+        return NovaDisplayResolutionPlanner.from(
             contract = game.displayPlanner,
             fallbackMode = fallbackMode,
             includeAdvanced = true
-        )
-        if (planner.available) {
-            planner.visibleChoices.forEach { choice ->
-                options += NovaLaunchOptionItem(
-                    label = choice.title,
-                    usesVirtualDisplay = uiState.playUsesVirtualDisplay,
-                    recommended = choice.recommended,
-                    caption = listOf(choice.targetMode, choice.reason).filter { it.isNotBlank() }.joinToString(" · "),
-                    badge = choice.badge,
-                    launchOptimization = NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(
-                        choice,
-                        source = "nova_display_planner"
-                    )
-                )
-            }
-        } else {
-            if (uiState.headlessAllowed) {
-                options += NovaLaunchOptionItem(
-                    label = optionLabel("headless", uiState.recommendedMode),
-                    usesVirtualDisplay = false,
-                    recommended = uiState.recommendedMode == "headless"
-                )
-            }
-            if (uiState.virtualDisplayAllowed) {
-                options += NovaLaunchOptionItem(
-                    label = optionLabel("virtual_display", uiState.recommendedMode),
-                    usesVirtualDisplay = true,
-                    recommended = uiState.recommendedMode == "virtual_display"
-                )
-            }
-        }
-
-        if (options.isEmpty()) return null
-
-        return NovaLaunchOptionsState(
-            title = getString(R.string.nova_library_launch_options_title),
-            closeLabel = getString(R.string.nova_controller_hint_close),
-            gameName = game.name,
-            options = options
         )
     }
 
@@ -1510,3 +1562,12 @@ class NovaGameDetailActivity : NovaActivity() {
             .putExtra(EXTRA_DEFAULT_VIRTUAL_DISPLAY, defaultToVirtualDisplay)
     }
 }
+
+/**
+ * How long a row waits before the host is told.
+ *
+ * Long enough to absorb someone cycling a row to the value they want, short enough that
+ * letting go and pressing Play does not feel like a stall -- and a launch flushes it
+ * early anyway, so this is only ever the cost of walking away mid-change.
+ */
+private const val NOVA_PLAY_SETUP_SETTLE_MS = 650L

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -318,6 +318,13 @@ class NovaGameDetailActivity : NovaActivity() {
         var profileOptionsState by mutableStateOf<NovaProfilePreferenceOptionsState?>(null)
         var steamLaunchOptionsState by mutableStateOf<NovaSteamLaunchModeOptionsState?>(null)
         var artworkState by mutableStateOf(loadArtworkState(game))
+        // A launch was asked for while the preflight that arms the desktop-Steam guard was
+        // still on the wire. The press is held rather than dropped: being quick should not
+        // cost you the launch, and it must not cost you the guard either. The option is
+        // carried alongside because an option card launches with its own blob and its own
+        // display mode, so replaying the press has to replay the choice, not just the intent.
+        var pendingLaunch by mutableStateOf(false)
+        var pendingLaunchOption by mutableStateOf<NovaLaunchOptionItem?>(null)
 
         fun refreshUiState(preference: String = profilePreference) {
             uiState = buildUiState(currentGame, preference)
@@ -414,6 +421,70 @@ class NovaGameDetailActivity : NovaActivity() {
         }
 
 
+        fun launchConfirmed(
+            mirrorDesktop: Boolean,
+            forcePrivateAfterSteamClose: Boolean = false,
+            option: NovaLaunchOptionItem? = null
+        ) {
+            pendingLaunch = false
+            pendingLaunchOption = null
+            onLaunch?.invoke(
+                currentGame.copy(mangohud = mangoHudEnabled),
+                option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay,
+                mirrorDesktop,
+                forcePrivateAfterSteamClose,
+                profilePreference,
+                option?.launchOptimization ?: optimizationState.rawOptimization
+            )
+            if (option != null) launchOptionsState = null
+            finish()
+        }
+
+        /**
+         * The single way a launch starts, so the guards in front of it cannot be walked past.
+         *
+         * The desktop-Steam decision is read out of the preflight blob. While a preflight is
+         * on the wire that blob is null, which used to fall through to an unguarded launch --
+         * and since changing a mode reloads the preflight and used to return you to the Play
+         * button, the fastest route through Play Setup was also the one that skipped the guard.
+         * A press in that window is now held and replayed when the answer lands.
+         *
+         * The option cards had the same hole and a second one of their own: they launch with
+         * the blob attached to the card but decided from the activity's, so a card carrying
+         * its own answer was still judged by whatever the last preflight said. Both paths
+         * come through here now, and the blob that decides is the blob that launches.
+         */
+        fun attemptLaunch(option: NovaLaunchOptionItem? = null) {
+            if (!uiState.playEnabled) return
+            val optimization = option?.launchOptimization ?: optimizationState.rawOptimization
+            if (optimization == null && optimizationState.preflightInFlight) {
+                pendingLaunch = true
+                pendingLaunchOption = option
+                return
+            }
+            pendingLaunch = false
+            pendingLaunchOption = null
+            val decision = NovaDesktopSteamLaunchDecision.from(
+                uiState,
+                optimization,
+                usesVirtualDisplay = option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay
+            )
+            when {
+                // A choice of where to run belongs in the destination that
+                // owns where it runs, not in a sheet raised over the artwork.
+                decision.required -> {
+                    steamDecision = decision
+                    destination = NovaGameDetailDestination.PLAY_SETUP
+                }
+                // The review is a statement about the profile, and the status
+                // line is where the profile lives, so it expands in place.
+                optimizationState.reviewRequired && !reviewExpanded -> {
+                    reviewExpanded = true
+                }
+                else -> launchConfirmed(false, option = option)
+            }
+        }
+
         fun loadOptimization(preference: String, usesVirtualDisplay: Boolean = uiState.playUsesVirtualDisplay) {
             LimeLog.info(
                 "Nova: Preflight optimization requested game=${currentGame.name} " +
@@ -423,6 +494,10 @@ class NovaGameDetailActivity : NovaActivity() {
                 "NovaPreflight",
                 "requested game=${currentGame.name} preference=$preference virtualDisplay=$usesVirtualDisplay"
             )
+            // Marked here rather than inside the coroutine. Callers used to clear the state
+            // themselves and then call this, so between those two statements it read as a
+            // settled answer of "nothing to guard" -- for as long as the round-trip took.
+            optimizationState = NovaGameDetailOptimizationState(preflightInFlight = true)
             lifecycleScope.launch {
                 optimizationState = try {
                     val opt = withContext(Dispatchers.IO) {
@@ -437,6 +512,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     LimeLog.warning("Nova: Preflight optimization failed: ${e.message}")
                     NovaGameDetailOptimizationState()
                 }
+                if (pendingLaunch) attemptLaunch(pendingLaunchOption)
             }
         }
 
@@ -444,6 +520,7 @@ class NovaGameDetailActivity : NovaActivity() {
             profilePreference = "high_fps"
             saveProfilePreference(currentGame, profilePreference)
             refreshUiState(profilePreference)
+            optimizationState = NovaGameDetailOptimizationState(preflightInFlight = true)
             lifecycleScope.launch {
                 optimizationState = try {
                     val opt = withContext(Dispatchers.IO) {
@@ -458,6 +535,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     LimeLog.warning("Nova: High FPS trial preflight failed: ${e.message}")
                     NovaGameDetailOptimizationState()
                 }
+                if (pendingLaunch) attemptLaunch(pendingLaunchOption)
             }
         }
 
@@ -479,20 +557,7 @@ class NovaGameDetailActivity : NovaActivity() {
             currentGame = currentGame.copy(launchMode = updatedLaunchMode)
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
-            optimizationState = NovaGameDetailOptimizationState()
             loadOptimization(profilePreference, usesVirtualDisplay = mode == "virtual_display")
-        }
-
-        fun launchConfirmed(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
-            onLaunch?.invoke(
-                currentGame.copy(mangohud = mangoHudEnabled),
-                uiState.playUsesVirtualDisplay,
-                mirrorDesktop,
-                forcePrivateAfterSteamClose,
-                profilePreference,
-                optimizationState.rawOptimization
-            )
-            finish()
         }
 
         fun resetProfile() {
@@ -501,7 +566,6 @@ class NovaGameDetailActivity : NovaActivity() {
                 withContext(Dispatchers.IO) {
                     apiClient.clearOptimizerProfile(deviceName, currentGame.name)
                 }
-                optimizationState = NovaGameDetailOptimizationState()
                 loadOptimization(profilePreference)
                 resetWorking = false
             }
@@ -539,7 +603,12 @@ class NovaGameDetailActivity : NovaActivity() {
                     optimizationState = optimizationState,
                     launchOptionsState = launchOptionsState,
                     profileOptionsState = profileOptionsState,
-                    playLabel = if (optimizationState.reviewRequired) {
+                    playLabel = if (pendingLaunch) {
+                        // The press landed and is being held, so say so. A button that
+                        // looks untouched for the length of an HTTP round-trip reads as
+                        // one that did not register.
+                        getString(R.string.nova_game_detail_launch_checking_host)
+                    } else if (optimizationState.reviewRequired) {
                         getString(R.string.nova_library_review_and_launch)
                     } else {
                         optimizationState.profileSummary
@@ -552,27 +621,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     headlessModeLabel = modeBadgeLabel("headless"),
                     virtualDisplayModeLabel = modeBadgeLabel("virtual_display"),
                     coverContentDescription = getString(R.string.nova_a11y_game_cover),
-                    onPrimaryLaunch = {
-                        if (!uiState.playEnabled) return@NovaGameDetailContent
-                        val decision = NovaDesktopSteamLaunchDecision.from(
-                            uiState,
-                            optimizationState.rawOptimization
-                        )
-                        when {
-                            // A choice of where to run belongs in the destination that
-                            // owns where it runs, not in a sheet raised over the artwork.
-                            decision.required -> {
-                                steamDecision = decision
-                                destination = NovaGameDetailDestination.PLAY_SETUP
-                            }
-                            // The review is a statement about the profile, and the status
-                            // line is where the profile lives, so it expands in place.
-                            optimizationState.reviewRequired && !reviewExpanded -> {
-                                reviewExpanded = true
-                            }
-                            else -> launchConfirmed(false)
-                        }
-                    },
+                    onPrimaryLaunch = { attemptLaunch() },
                     destination = destination,
                     steamDecision = steamDecision,
                     reviewExpanded = reviewExpanded,
@@ -603,40 +652,19 @@ class NovaGameDetailActivity : NovaActivity() {
                         }
                     },
                     onLaunchModeSelected = { mode ->
-                        // The concept: choosing sets the mode and returns to the Overview,
-                        // whose readout reflects it. Staying put left the pill showing the
-                        // previous mode until the window was opened again.
+                        // Choosing sets the mode and stays here. Returning to the Overview
+                        // put the Play button under the thumb at the exact moment the mode
+                        // change had cleared the preflight the desktop-Steam guard is read
+                        // from, which made the quickest path through this screen the one
+                        // that skipped the guard. The readout it was returning to refresh
+                        // is on this surface too.
                         selectLaunchMode(mode)
-                        destination = NovaGameDetailDestination.OVERVIEW
                     },
-                    onLaunchOptionSelected = { option ->
-                        fun launchSelected(mirrorDesktop: Boolean, forcePrivateAfterSteamClose: Boolean = false) {
-                            val selectedLaunchOptimization = option.launchOptimization ?: optimizationState.rawOptimization
-                            onLaunch?.invoke(
-                                currentGame.copy(mangohud = mangoHudEnabled),
-                                option.usesVirtualDisplay,
-                                mirrorDesktop,
-                                forcePrivateAfterSteamClose,
-                                profilePreference,
-                                selectedLaunchOptimization
-                            )
-                            launchOptionsState = null
-                            finish()
-                        }
-                        val desktopSteamDecision = NovaDesktopSteamLaunchDecision.from(
-                            uiState,
-                            optimizationState.rawOptimization,
-                            usesVirtualDisplay = option.usesVirtualDisplay
-                        )
-                        if (desktopSteamDecision.required) {
-                            // Same destination the primary action routes to; picking an
-                            // explicit option does not change where the choice belongs.
-                            steamDecision = desktopSteamDecision
-                            destination = NovaGameDetailDestination.PLAY_SETUP
-                        } else {
-                            launchSelected(mirrorDesktop = false)
-                        }
-                    },
+                    // Through the same gate as the primary action. This used to build its own
+                    // decision and its own launch, which is how it came to decide from one
+                    // blob and launch with another, and how it kept a route past the guard
+                    // after the primary action lost its.
+                    onLaunchOptionSelected = { option -> attemptLaunch(option) },
                     onDismissLaunchOptions = {
                         launchOptionsState = null
                     },

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -206,31 +206,23 @@ internal fun NovaGameDetailContent(
     steamLaunchModeLabel: String,
     steamLaunchCaption: String,
     optimizationState: NovaGameDetailOptimizationState,
-    launchOptionsState: NovaLaunchOptionsState?,
-    profileOptionsState: NovaProfilePreferenceOptionsState?,
+    /** The four rows of the act column, already resolved, in draw order. */
+    playSetupRows: List<NovaPlaySetupRowState>,
+    /** Which row the comparison strip is currently explaining. */
+    explainedPlaySetupRow: NovaPlaySetupRow,
     playLabel: String,
-    launchOptionsLabel: String,
     launchModeTitle: String,
     headlessModeLabel: String,
     virtualDisplayModeLabel: String,
     coverContentDescription: String,
     modifier: Modifier = Modifier,
     onPrimaryLaunch: () -> Unit,
-    onLaunchOptions: () -> Unit,
-    onLaunchModeSelected: (String) -> Unit,
-    onLaunchOptionSelected: (NovaLaunchOptionItem) -> Unit,
-    onDismissLaunchOptions: () -> Unit,
-    onProfilePreference: () -> Unit,
-    onProfilePreferenceSelected: (NovaProfilePreferenceItem) -> Unit,
-    onDismissProfileOptions: () -> Unit,
+    onExplainPlaySetupRow: (NovaPlaySetupRow) -> Unit,
+    onAdvancePlaySetupRow: (NovaPlaySetupRow) -> Unit,
     onRetryHighFps: () -> Unit,
     onResetProfile: () -> Unit,
     /** Opens the host scope. Null where no host settings surface is reachable. */
     onOpenHostSettings: (() -> Unit)? = null,
-    steamLaunchOptionsState: NovaSteamLaunchModeOptionsState? = null,
-    onSteamLaunchMode: () -> Unit,
-    onSteamLaunchModeSelected: (NovaSteamLaunchModeItem) -> Unit = {},
-    onDismissSteamLaunchModeOptions: () -> Unit = {},
     artworkState: NovaArtworkStudioState,
     onRefreshArtwork: () -> Unit,
     onSearchArtwork: (String) -> Unit,
@@ -384,111 +376,32 @@ internal fun NovaGameDetailContent(
                             },
                         ),
                         rows = {
-                            NovaSteamChoiceRow(
-                                label = launchOptionsLabel,
-                                caption = stringResource(R.string.nova_play_setup_settings_caption),
-                                enabled = true,
-                                onClick = onLaunchOptions,
-                                value = summary?.selectedLine?.let(::novaPlaySetupValue).orEmpty(),
-                            )
-                            NovaSteamChoiceRow(
-                                label = stringResource(R.string.nova_game_detail_profile_label),
-                                caption = stringResource(R.string.nova_game_detail_profile_caption),
-                                enabled = true,
-                                onClick = onProfilePreference,
-                                value = stringResource(
-                                    AutoQualityProfilePreferences.shortLabelRes(uiState.profilePreference),
-                                ),
-                            )
-                            SteamLaunchModeCard(
-                                visible = uiState.showSteamLaunchMode,
-                                label = steamLaunchLabel,
-                                modeLabel = steamLaunchModeLabel,
-                                caption = steamLaunchCaption,
-                                warning = uiState.steamLaunchWarning,
-                                onClick = onSteamLaunchMode
-                            )
-                            LaunchProfileSummaryActions(
-                                summary = summary,
-                                resetProfileLabel = resetProfileLabel,
-                                resetProfileWorking = resetProfileWorking,
-                                onRetryHighFps = onRetryHighFps,
-                                onResetProfile = onResetProfile,
-                            )
-                            // The host scope. Changing it still happens in Polaris Sync,
-                            // which owns settings loading and the handlers that write to
-                            // the host; this is a way in from where the per-game choice
-                            // is made rather than only from four items down System.
-                            if (onOpenHostSettings != null) {
+                            // Four rows, drawn in a fixed order. Each advances its own value
+                            // on A or a tap, and points the strip at itself on focus, so the
+                            // explanation follows the cursor without being a stop on it.
+                            playSetupRows.forEach { rowState ->
                                 NovaSteamChoiceRow(
-                                    label = stringResource(R.string.nova_play_setup_every_game),
-                                    caption = stringResource(R.string.nova_play_setup_every_game_caption),
-                                    enabled = true,
-                                    onClick = onOpenHostSettings,
-                                    value = uiState.hostStreamDisplayModeLabel,
+                                    label = rowState.label,
+                                    caption = rowState.caption,
+                                    enabled = rowState.enabled,
+                                    value = rowState.value,
+                                    selected = rowState.overridden,
+                                    onClick = { onAdvancePlaySetupRow(rowState.row) },
+                                    onFocused = { onExplainPlaySetupRow(rowState.row) },
                                 )
                             }
                         },
                         comparison = {
-                            // Whichever row is open fills the strip. With nothing open it
-                            // shows where the game runs, which is the decision this
-                            // destination is named for.
-                            when {
-                                launchOptionsState != null -> NovaPlaySetupComparison(
-                                    title = launchOptionsState.title,
-                                    options = launchOptionsState.options.map { option ->
-                                        NovaPlaySetupOption(
-                                            label = option.label,
-                                            consequence = listOf(option.caption, option.badge)
-                                                .filter { it.isNotBlank() }
-                                                .joinToString("  \u00b7  "),
-                                            current = option.usesVirtualDisplay ==
-                                                uiState.playUsesVirtualDisplay,
-                                            onSelect = { onLaunchOptionSelected(option) },
-                                        )
-                                    },
-                                )
-
-                                profileOptionsState != null -> NovaPlaySetupComparison(
-                                    title = profileOptionsState.title,
-                                    options = profileOptionsState.options.map { option ->
-                                        NovaPlaySetupOption(
-                                            label = option.label,
-                                            consequence = novaProfilePreferenceConsequence(option.value),
-                                            current = option.selected,
-                                            onSelect = { onProfilePreferenceSelected(option) },
-                                        )
-                                    },
-                                )
-
-                                steamLaunchOptionsState != null -> NovaPlaySetupComparison(
-                                    title = steamLaunchOptionsState.title,
-                                    options = steamLaunchOptionsState.options.map { option ->
-                                        NovaPlaySetupOption(
-                                            label = option.label,
-                                            consequence = novaSteamLaunchConsequence(option.value),
-                                            current = option.selected,
-                                            onSelect = { onSteamLaunchModeSelected(option) },
-                                        )
-                                    },
-                                )
-
-                                else -> NovaPlaySetupComparison(
-                                    title = stringResource(R.string.nova_game_detail_where_it_runs),
-                                    options = listOf(
-                                        NovaPlaySetupOption(
-                                            label = headlessModeLabel,
-                                            consequence = stringResource(R.string.nova_play_setup_compare_private),
-                                            current = uiState.playMode == "headless",
-                                            onSelect = { onLaunchModeSelected("headless") },
-                                        ),
-                                        NovaPlaySetupOption(
-                                            label = virtualDisplayModeLabel,
-                                            consequence = stringResource(R.string.nova_play_setup_compare_virtual),
-                                            current = uiState.playMode == "virtual_display",
-                                            onSelect = { onLaunchModeSelected("virtual_display") },
-                                        ),
-                                    ),
+                            // A legend for whichever row holds focus, not a picker with a
+                            // state of its own. A row that has nothing to compare -- one
+                            // launch mode, or no display planner on this host -- draws
+                            // nothing rather than a strip that repeats the row above it.
+                            val explained = playSetupRows.firstOrNull { it.row == explainedPlaySetupRow }
+                                ?: playSetupRows.firstOrNull()
+                            if (explained != null && explained.options.size > 1) {
+                                NovaPlaySetupComparison(
+                                    title = explained.stripTitle,
+                                    options = explained.options,
                                 )
                             }
                         },
@@ -549,24 +462,24 @@ private const val NOVA_DETAIL_SCENERY_CHROME_ALPHA = 0.16f
  * The picker these came from listed four names with nothing to choose between them. A
  * name is only a choice if you already know what it does.
  */
-@Composable
-private fun novaProfilePreferenceConsequence(value: String): String = stringResource(
+/**
+ * Resource ids rather than resolved strings, so the row builder in the activity can reach
+ * them. These were @Composable, which put them out of reach of the only caller left.
+ */
+internal fun novaProfilePreferenceConsequenceRes(value: String): Int =
     when (value.trim().lowercase()) {
         "quality" -> R.string.nova_play_setup_pref_quality
         "balanced" -> R.string.nova_play_setup_pref_balanced
         "high_fps" -> R.string.nova_play_setup_pref_high_fps
         else -> R.string.nova_play_setup_pref_auto
-    },
-)
+    }
 
 /** The same, for the two ways Steam can be handed the game. */
-@Composable
-private fun novaSteamLaunchConsequence(value: String): String = stringResource(
+internal fun novaSteamLaunchConsequenceRes(value: String): Int =
     when (value.trim().lowercase()) {
         "big_picture", "bigpicture" -> R.string.nova_play_setup_steam_big_picture
         else -> R.string.nova_play_setup_steam_direct
-    },
-)
+    }
 
 @Composable
 private fun NovaGameDetailScrollableContent(

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -379,8 +379,9 @@ internal fun NovaGameDetailContent(
                             // Four rows, drawn in a fixed order. Each advances its own value
                             // on A or a tap, and points the strip at itself on focus, so the
                             // explanation follows the cursor without being a stop on it.
-                            playSetupRows.forEach { rowState ->
+                            playSetupRows.forEachIndexed { index, rowState ->
                                 NovaSteamChoiceRow(
+                                    autoFocus = index == 0,
                                     label = rowState.label,
                                     caption = rowState.caption,
                                     enabled = rowState.enabled,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -403,6 +403,7 @@ internal fun NovaGameDetailContent(
                                 NovaPlaySetupComparison(
                                     title = explained.stripTitle,
                                     options = explained.options,
+                                    consequenceMaxLines = if (playSetupRows.size > 3) 1 else 2,
                                 )
                             }
                         },
@@ -477,8 +478,12 @@ internal fun novaProfilePreferenceConsequenceRes(value: String): Int =
 
 /** The same, for the two ways Steam can be handed the game. */
 internal fun novaSteamLaunchConsequenceRes(value: String): Int =
+    // "big-picture" with the hyphen is what SteamLaunchContract.normalizeMode returns, and
+    // it was the one spelling missing here -- so Big Picture described itself as Direct.
+    // Invisible while the two were never on screen together, which they now always are.
     when (value.trim().lowercase()) {
-        "big_picture", "bigpicture" -> R.string.nova_play_setup_steam_big_picture
+        "big-picture", "big_picture", "bigpicture", "gamepadui" ->
+            R.string.nova_play_setup_steam_big_picture
         else -> R.string.nova_play_setup_steam_direct
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -313,7 +314,7 @@ internal fun NovaGameDetailContent(
                 headline = uiState.game.name,
                 scrollState = verticalScroll,
                 onDismiss = onDismissDestination,
-            ) {
+            ) { bodyHeight ->
                 val decision = steamDecision
                 if (decision != null) {
                     // A blocked three-way choice is the one moment nothing else on the
@@ -324,6 +325,10 @@ internal fun NovaGameDetailContent(
                     )
                 } else {
                     val summary = optimizationState.profileSummary
+                    // Spend the room that is there rather than a number picked in advance:
+                    // a host with a display planner has a fourth row and so less of it.
+                    val consequenceLines =
+                        novaPlaySetupConsequenceLines(bodyHeight, playSetupRows.size)
                     NovaPlaySetupBody(
                         plan = novaPlaySetupPlan(
                             // The resolved mode, not the name of the control that sets
@@ -375,6 +380,10 @@ internal fun NovaGameDetailContent(
                                 }
                             },
                         ),
+                        introMaxLines = novaPlaySetupIntroLines(
+                            bodyHeight,
+                            factCount = summary?.let { 4 } ?: 2,
+                        ),
                         rows = {
                             // Four rows, drawn in a fixed order. Each advances its own value
                             // on A or a tap, and points the strip at itself on focus, so the
@@ -403,7 +412,7 @@ internal fun NovaGameDetailContent(
                                 NovaPlaySetupComparison(
                                     title = explained.stripTitle,
                                     options = explained.options,
-                                    consequenceMaxLines = if (playSetupRows.size > 3) 1 else 2,
+                                    consequenceMaxLines = consequenceLines,
                                 )
                             }
                         },

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -119,13 +119,24 @@ private fun Modifier.novaSheetHandleDrag(onDismiss: () -> Unit): Modifier = poin
     )
 }
 
+/**
+ * @property preflightInFlight A preflight is on the wire and no answer has arrived yet.
+ *
+ * A null [rawOptimization] used to carry two meanings at once: the host answered and
+ * asked for nothing, or nothing has been asked yet. The desktop-Steam guard is armed
+ * from that blob, so the two readings are not interchangeable -- changing a launch mode
+ * resets the state and reloads, and pressing Play inside that window launched with the
+ * guard silently skipped. This separates them, so a launch can wait for an answer
+ * instead of assuming one.
+ */
 data class NovaGameDetailOptimizationState(
     val ai: NovaGameDetailInsightCard? = null,
     val stability: NovaGameDetailInsightCard? = null,
     val profileSummary: NovaLaunchProfileSummary? = null,
     val rawOptimization: JSONObject? = null,
     val reviewRequired: Boolean = false,
-    val reviewReason: String = ""
+    val reviewReason: String = "",
+    val preflightInFlight: Boolean = false
 )
 
 data class NovaLaunchOptionsState(
@@ -633,131 +644,6 @@ private fun NovaDetailPanel(
     }
 }
 
-@Composable
-internal fun NovaDesktopSteamLaunchDecisionContent(
-    title: String,
-    message: String,
-    privateStreamLabel: String,
-    privateStreamUnavailableReason: String,
-    privateStreamEnabled: Boolean,
-    mirrorDesktopLabel: String,
-    mirrorDesktopEnabled: Boolean,
-    mirrorDesktopCaption: String,
-    forcePrivateLabel: String,
-    forcePrivateEnabled: Boolean,
-    forcePrivateCaption: String,
-    cancelLabel: String,
-    onPrivateStream: () -> Unit,
-    onMirrorDesktop: () -> Unit,
-    onForcePrivateAfterSteamClose: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val colors = LocalNovaComposeColors.current
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp, topEnd = NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp))
-            .background(LocalNovaLibrarySurfaces.current.panel)
-            .padding(start = 14.dp, top = 12.dp, end = 14.dp, bottom = 16.dp)
-    ) {
-        NovaSheetDragHandle(
-            onDismiss = onCancel,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
-        NovaDetailPanel(
-            modifier = Modifier.fillMaxWidth(),
-            accent = true,
-            warning = true,
-            contentPadding = PaddingValues(14.dp)
-        ) {
-            Text(
-                text = title,
-                color = colors.textPrimary,
-                fontSize = 19.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Text(
-                text = message,
-                modifier = Modifier.padding(top = 8.dp),
-                color = colors.textSecondary,
-                fontSize = 12.sp,
-                lineHeight = 15.sp
-            )
-            if (privateStreamUnavailableReason.isNotBlank()) {
-                Text(
-                    text = privateStreamUnavailableReason,
-                    modifier = Modifier.padding(top = 8.dp),
-                    color = colors.warning,
-                    fontSize = 11.sp,
-                    lineHeight = 14.sp
-                )
-            }
-            Text(
-                text = mirrorDesktopCaption,
-                modifier = Modifier.padding(top = 8.dp),
-                color = colors.textMuted,
-                fontSize = 11.sp,
-                lineHeight = 14.sp
-            )
-        }
-        NovaActionButton(
-            text = privateStreamLabel,
-            onClick = onPrivateStream,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp),
-            enabled = privateStreamEnabled,
-            contentDescription = privateStreamLabel,
-            minHeight = 46.dp,
-            cornerRadius = NovaRadius.hero,
-            fontSize = 14.sp
-        )
-        NovaActionButton(
-            text = forcePrivateLabel,
-            onClick = onForcePrivateAfterSteamClose,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            enabled = forcePrivateEnabled,
-            primary = false,
-            contentDescription = forcePrivateLabel,
-            minHeight = 46.dp,
-            cornerRadius = NovaRadius.hero,
-            fontSize = 14.sp
-        )
-        Text(
-            text = forcePrivateCaption,
-            modifier = Modifier.padding(top = 5.dp),
-            color = colors.textMuted,
-            fontSize = 11.sp,
-            lineHeight = 14.sp
-        )
-        NovaActionButton(
-            text = mirrorDesktopLabel,
-            onClick = onMirrorDesktop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            enabled = mirrorDesktopEnabled,
-            primary = true,
-            contentDescription = mirrorDesktopLabel,
-            minHeight = 48.dp,
-            cornerRadius = NovaRadius.hero,
-            fontSize = 15.sp
-        )
-        NovaActionButton(
-            text = cancelLabel,
-            onClick = onCancel,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            contentDescription = cancelLabel,
-            minHeight = 42.dp,
-            cornerRadius = NovaRadius.hero,
-            fontSize = 13.sp
-        )
-    }
-}
 
 
 @Composable

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
@@ -417,43 +417,6 @@ internal fun NovaGameDetailGroupLabel(text: String) {
     }
 }
 
-/** Retry and reset: the two things in Tune that change something rather than report it. */
-@Composable
-internal fun LaunchProfileSummaryActions(
-    summary: NovaLaunchProfileSummary?,
-    resetProfileLabel: String,
-    resetProfileWorking: Boolean,
-    onRetryHighFps: () -> Unit,
-    onResetProfile: () -> Unit,
-) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        if (summary?.showRetryHighFps == true) {
-            NovaSteamChoiceRow(
-                label = summary.retryHighFpsLabel.ifBlank {
-                    stringResource(R.string.nova_library_retry_high_fps)
-                },
-                caption = "",
-                enabled = true,
-                onClick = onRetryHighFps,
-            )
-        }
-        NovaSteamChoiceRow(
-            label = resetProfileLabel,
-            caption = "",
-            enabled = !resetProfileWorking,
-            onClick = onResetProfile,
-        )
-    }
-}
-
-/**
- * The desktop-Steam choice, as rows in Launch mode rather than a sheet over the artwork.
- * A blocked option stays visible and inert: hiding it loses the reason it is blocked,
- * which is the part worth reading.
- */
 @Composable
 internal fun NovaDesktopSteamLaunchDecisionRows(
     decision: NovaDesktopSteamLaunchDecision,
@@ -525,6 +488,9 @@ internal fun NovaDesktopSteamLaunchDecisionRows(
  * meant two shapes for one kind of control.
  *
  * @param selected this row holds the current value. Drawn as a tint.
+ * @param onFocused the row has just taken focus. Play Setup uses this to point the
+ *   comparison strip at whatever is under the cursor, so the explanation follows the
+ *   d-pad without the strip having to be a stop on it.
  *
  * Focus is drawn as a ring, and the two compose: a focused row that is not the current
  * value gets the ring alone. That state is the most common one on a d-pad and it had no
@@ -541,6 +507,7 @@ internal fun NovaSteamChoiceRow(
     onClick: (() -> Unit)? = null,
     value: String = "",
     selected: Boolean = false,
+    onFocused: (() -> Unit)? = null,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -567,7 +534,11 @@ internal fun NovaSteamChoiceRow(
             .fillMaxWidth()
             .padding(bottom = NOVA_DETAIL_ROW_GAP)
             .heightIn(min = NOVA_DETAIL_ROW_MIN_HEIGHT)
-            .onFocusChanged { focused = it.isFocused || it.hasFocus }
+            .onFocusChanged { state ->
+                val gained = state.isFocused || state.hasFocus
+                if (gained && !focused) onFocused?.invoke()
+                focused = gained
+            }
             .then(
                 if (actionable) {
                     Modifier.clickable(role = Role.Button) { onClick?.invoke() }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -196,7 +197,15 @@ internal fun NovaGameDetailWidePanel(
     headline: String,
     scrollState: ScrollState,
     onDismiss: () -> Unit,
-    content: @Composable () -> Unit,
+    /**
+     * Given the height its body actually has.
+     *
+     * Play Setup is built to fit rather than to scroll, and how much of the legend it can
+     * afford depends on how many rows the host gave it. Deriving that from constants was
+     * arithmetic that had already been wrong once -- the source said 374-393dp, the device
+     * says 444dp -- so the panel measures and says.
+     */
+    content: @Composable (bodyHeight: Dp) -> Unit,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -222,15 +231,20 @@ internal fun NovaGameDetailWidePanel(
                 compact = shortViewport,
                 onDismiss = onDismiss,
             )
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .novaFadeAtCut(scrollState.canScrollForward)
-                    .novaHoldsFirstFocus()
-                    .verticalScroll(scrollState),
-                content = { content() },
-            )
+            // The scroll stays as the fallback for a font scale or an inset that makes the
+            // content genuinely taller than the window. Measuring outside it is what lets
+            // the body lay itself out to fit in the ordinary case.
+            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                val bodyHeight = maxHeight
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .novaFadeAtCut(scrollState.canScrollForward)
+                        .novaHoldsFirstFocus()
+                        .verticalScroll(scrollState),
+                    content = { content(bodyHeight) },
+                )
+            }
             NovaGameDetailDestinationHints()
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
@@ -585,7 +585,10 @@ internal fun NovaSteamChoiceRow(
                 }
             }
             .then(if (ringing) Modifier.border(NOVA_DETAIL_FOCUS_RING, surfaces.focusRing, shape) else Modifier)
-            .padding(horizontal = 14.dp, vertical = 9.dp)
+            // 6dp, so a row with a caption lands exactly on the 48dp accessible floor
+            // rather than 6dp above it. Four rows plus a legend has to clear a 325dp
+            // landscape viewport, and four times six is most of the difference.
+            .padding(horizontal = 14.dp, vertical = 6.dp)
             .semantics { contentDescription = if (value.isBlank()) label else "$label. $value" },
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -648,7 +651,7 @@ private val NOVA_DETAIL_ROW_FOCUS_BAR = 3.dp
 private const val NOVA_DETAIL_WIDE_PANEL_ALPHA = 0.86f
 
 /** Cards need air between them where hairline rows did not. */
-private val NOVA_DETAIL_ROW_GAP = 6.dp
+private val NOVA_DETAIL_ROW_GAP = 5.dp
 
 /** The ring is focus. It sits outside whatever the selected state already drew. */
 private val NOVA_DETAIL_FOCUS_RING = 2.dp

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt
@@ -136,7 +136,7 @@ internal fun NovaGameDetailPanel(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .novaFadeAtCut()
+                    .novaFadeAtCut(scrollState.canScrollForward)
                     .novaHoldsFirstFocus()
                     .verticalScroll(scrollState),
                 content = { content() },
@@ -152,7 +152,7 @@ internal fun NovaGameDetailPanel(
  * ground: the panel is translucent, and a solid band would stripe window colour across
  * the artwork showing through it.
  */
-private fun Modifier.novaFadeAtCut(): Modifier = this
+private fun Modifier.novaFadeAtCut(active: Boolean = true): Modifier = if (!active) this else this
     .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
     .drawWithContent {
         drawContent()
@@ -226,7 +226,7 @@ internal fun NovaGameDetailWidePanel(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .novaFadeAtCut()
+                    .novaFadeAtCut(scrollState.canScrollForward)
                     .novaHoldsFirstFocus()
                     .verticalScroll(scrollState),
                 content = { content() },
@@ -277,7 +277,7 @@ internal fun NovaGameDetailFullScreen(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .novaFadeAtCut()
+                    .novaFadeAtCut(scrollState.canScrollForward)
                     .novaHoldsFirstFocus()
                     .verticalScroll(scrollState),
                 content = { content() },
@@ -508,6 +508,15 @@ internal fun NovaSteamChoiceRow(
     value: String = "",
     selected: Boolean = false,
     onFocused: (() -> Unit)? = null,
+    /**
+     * Claim focus when the panel opens.
+     *
+     * Set on the first row rather than left to traversal order. Adding one focusable below
+     * the strip was enough to make the panel open scrolled to the bottom with the cursor on
+     * a recovery button, because "whatever the group hands focus to" is not a stable answer
+     * when the group's contents change.
+     */
+    autoFocus: Boolean = false,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -528,12 +537,23 @@ internal fun NovaSteamChoiceRow(
     )
 
     val ringing = focused && actionable
+    // A tap has to move the focus ring as well as act, or the row you pressed and the row
+    // the panel says you are on are two different rows.
+    val focusRequester = remember { FocusRequester() }
+    if (autoFocus) {
+        // After the panel's own first-focus pass, so this is the answer that sticks.
+        LaunchedEffect(Unit) {
+            delay(NOVA_DETAIL_FIRST_ROW_FOCUS_DELAY_MS)
+            runCatching { focusRequester.requestFocus() }
+        }
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = NOVA_DETAIL_ROW_GAP)
             .heightIn(min = NOVA_DETAIL_ROW_MIN_HEIGHT)
+            .focusRequester(focusRequester)
             .onFocusChanged { state ->
                 val gained = state.isFocused || state.hasFocus
                 if (gained && !focused) onFocused?.invoke()
@@ -541,7 +561,10 @@ internal fun NovaSteamChoiceRow(
             }
             .then(
                 if (actionable) {
-                    Modifier.clickable(role = Role.Button) { onClick?.invoke() }
+                    Modifier.clickable(role = Role.Button) {
+                        runCatching { focusRequester.requestFocus() }
+                        onClick?.invoke()
+                    }
                 } else {
                     Modifier
                 }
@@ -650,3 +673,6 @@ private const val NOVA_DETAIL_FOCUS_SETTLE_MS = 75L
 
 /** Below this a phone in landscape has no height to spare for chrome. */
 private val NOVA_DETAIL_SHORT_VIEWPORT = 500.dp
+
+/** Long enough to land after novaHoldsFirstFocus rather than race it. */
+private const val NOVA_DETAIL_FIRST_ROW_FOCUS_DELAY_MS = 140L

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
@@ -479,22 +479,25 @@ private fun NovaGameDetailActions(
             )
         }
 
-        if (reviewExpanded) {
-            if (optimizationState.profileSummary?.showRetryHighFps == true) {
-                NovaGameDetailAction(
-                    text = stringResource(R.string.nova_library_retry_high_fps),
-                    onClick = onRetryHighFps,
-                    mark = "\u25B2",
-                    modifier = itemWidth,
-                )
-            }
+        // Reset is on the rail whatever the review is doing. It used to be drawn only
+        // while a review was expanded, which made Play Setup's copy the only one anybody
+        // could reach the rest of the time -- and the copy is what a four-row Play Setup
+        // has no room for.
+        if (reviewExpanded && optimizationState.profileSummary?.showRetryHighFps == true) {
             NovaGameDetailAction(
-                text = stringResource(R.string.nova_library_reset_game_profile),
-                onClick = onResetProfile,
-                mark = "\u21BA",
+                text = stringResource(R.string.nova_library_retry_high_fps),
+                onClick = onRetryHighFps,
+                mark = "\u25B2",
                 modifier = itemWidth,
             )
-        } else {
+        }
+        NovaGameDetailAction(
+            text = stringResource(R.string.nova_library_reset_game_profile),
+            onClick = onResetProfile,
+            mark = "\u21BA",
+            modifier = itemWidth,
+        )
+        if (!reviewExpanded) {
             // Three nodes, always. `showLaunchModeAction` used to decide whether a
             // fourth existed, so the lane changed length depending on the game; what it
             // gated is now a row inside Play Setup rather than an action beside it.

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -70,6 +71,7 @@ internal fun NovaPlaySetupBody(
     plan: NovaPlaySetupPlan,
     rows: @Composable () -> Unit,
     comparison: (@Composable () -> Unit)? = null,
+    introMaxLines: Int = 2,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         // A phone in portrait has no room for two columns, and stacking them keeps the
@@ -77,7 +79,7 @@ internal fun NovaPlaySetupBody(
         val stacked = maxWidth < NOVA_PLAY_SETUP_TWO_COLUMN_MIN
         if (stacked) {
             Column(modifier = Modifier.fillMaxWidth()) {
-                NovaPlaySetupReadColumn(plan, Modifier.fillMaxWidth())
+                NovaPlaySetupReadColumn(plan, introMaxLines, Modifier.fillMaxWidth())
                 Spacer(modifier = Modifier.height(18.dp))
                 NovaPlaySetupActColumn(rows, comparison, Modifier.fillMaxWidth())
             }
@@ -85,6 +87,7 @@ internal fun NovaPlaySetupBody(
             Row(modifier = Modifier.fillMaxWidth()) {
                 NovaPlaySetupReadColumn(
                     plan = plan,
+                    introMaxLines = introMaxLines,
                     modifier = Modifier.width(NOVA_PLAY_SETUP_READ_WIDTH).fillMaxHeight(),
                 )
                 Spacer(modifier = Modifier.width(NOVA_PLAY_SETUP_GUTTER))
@@ -96,7 +99,11 @@ internal fun NovaPlaySetupBody(
 
 /** What will happen, and where each part of it came from. Read, never operated. */
 @Composable
-private fun NovaPlaySetupReadColumn(plan: NovaPlaySetupPlan, modifier: Modifier = Modifier) {
+private fun NovaPlaySetupReadColumn(
+    plan: NovaPlaySetupPlan,
+    introMaxLines: Int,
+    modifier: Modifier = Modifier,
+) {
     val colors = LocalNovaComposeColors.current
     Column(modifier = modifier) {
         NovaPlaySetupColumnHead(stringResource(R.string.nova_play_setup_what_will_happen))
@@ -118,9 +125,7 @@ private fun NovaPlaySetupReadColumn(plan: NovaPlaySetupPlan, modifier: Modifier 
                 fontSize = 14.sp,
                 lineHeight = 19.sp,
                 modifier = Modifier.padding(top = 6.dp),
-                // Two, not three. In landscape the whole panel has to fit without
-                // scrolling, and a third line here is a line the legend loses.
-                maxLines = 2,
+                maxLines = introMaxLines,
                 overflow = TextOverflow.Ellipsis,
             )
         }
@@ -144,7 +149,7 @@ private fun NovaPlaySetupActColumn(
         NovaPlaySetupColumnHead(stringResource(R.string.nova_play_setup_what_you_can_change))
         rows()
         if (comparison != null) {
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             comparison()
         }
     }
@@ -214,7 +219,7 @@ private fun NovaPlaySetupColumnHead(text: String) {
         text = text.uppercase(),
         color = colors.textMuted,
         style = NovaChromeType.label(fontSize = 9.sp),
-        modifier = Modifier.padding(bottom = 8.dp),
+        modifier = Modifier.padding(bottom = 6.dp),
     )
 }
 
@@ -286,7 +291,7 @@ internal fun NovaPlaySetupComparison(
                             },
                             shape,
                         )
-                        .padding(horizontal = 12.dp, vertical = 9.dp)
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
                         .semantics {
                             contentDescription = "${'$'}{option.label}. ${'$'}{option.consequence}"
                             if (option.current) selected = true
@@ -381,6 +386,57 @@ internal data class NovaPlaySetupRowState(
      */
     val overridden: Boolean = false,
 )
+
+/**
+ * How much of the legend the column can afford, and how much prose the plan can.
+ *
+ * Both are a function of how many rows the host produced: a host advertising a display
+ * planner adds Resolution, and those 53dp come out of whatever is below. Rather than pick
+ * one answer for every case and truncate the rest, the panel measures its body and this
+ * spends what is actually there -- three lines of consequence where there is room for
+ * three, one where there is room for one.
+ */
+internal fun novaPlaySetupConsequenceLines(availableHeight: Dp, rowCount: Int): Int {
+    if (availableHeight <= 0.dp) return 2
+    val used = NOVA_PLAY_SETUP_COLUMN_HEAD +
+        (NOVA_PLAY_SETUP_ROW_STRIDE * rowCount) +
+        NOVA_PLAY_SETUP_LEGEND_GAP +
+        NOVA_PLAY_SETUP_COLUMN_HEAD +
+        NOVA_PLAY_SETUP_CARD_CHROME +
+        NOVA_PLAY_SETUP_SLACK
+    val room = availableHeight - used
+    if (room <= 0.dp) return 1
+    return (room / NOVA_PLAY_SETUP_CONSEQUENCE_LINE).toInt().coerceIn(1, 3)
+}
+
+/** The plan's opening sentences get the same treatment, from the same measurement. */
+internal fun novaPlaySetupIntroLines(availableHeight: Dp, factCount: Int): Int {
+    if (availableHeight <= 0.dp) return 2
+    val used = NOVA_PLAY_SETUP_COLUMN_HEAD + NOVA_PLAY_SETUP_MODE_LINE +
+        NOVA_PLAY_SETUP_RULE_BLOCK + (NOVA_PLAY_SETUP_FACT * factCount)
+    val room = availableHeight - used
+    if (room <= 0.dp) return 1
+    return (room / NOVA_PLAY_SETUP_INTRO_LINE).toInt().coerceIn(1, 4)
+}
+
+/** Drawn heights, kept beside the drawing so the two cannot drift apart unnoticed. */
+private val NOVA_PLAY_SETUP_COLUMN_HEAD = 16.dp
+private val NOVA_PLAY_SETUP_ROW_STRIDE = 53.dp
+private val NOVA_PLAY_SETUP_LEGEND_GAP = 4.dp
+private val NOVA_PLAY_SETUP_CARD_CHROME = 40.dp
+/**
+ * Slack, so the budget aims to fit rather than to just fit.
+ *
+ * Without it the four-row case landed a few dp over, which turns the bottom fade on --
+ * and the fade exists to say there is more below, so a layout that overflows by 4dp
+ * dissolves 52dp of itself saying so. Being wrong in this direction is much cheaper.
+ */
+private val NOVA_PLAY_SETUP_SLACK = 12.dp
+private val NOVA_PLAY_SETUP_CONSEQUENCE_LINE = 14.dp
+private val NOVA_PLAY_SETUP_MODE_LINE = 35.dp
+private val NOVA_PLAY_SETUP_RULE_BLOCK = 22.dp
+private val NOVA_PLAY_SETUP_FACT = 34.dp
+private val NOVA_PLAY_SETUP_INTRO_LINE = 19.dp
 
 /** Below this the two columns stack; a phone has no room to put them side by side. */
 private val NOVA_PLAY_SETUP_TWO_COLUMN_MIN = 640.dp

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -216,19 +216,23 @@ private fun NovaPlaySetupColumnHead(text: String) {
 }
 
 /**
- * The alternatives to the focused row, stated as consequences rather than as verbs, and
- * selectable in place.
+ * What the alternatives to the focused row would mean, stated as consequences rather than
+ * as verbs.
  *
- * This is what the full width is for, and it is also where the choice is made. An
- * earlier shape put the modes behind a picker raised over the destination, which cost a
- * press and re-introduced the options drawer that inline mode rows had deliberately
- * removed. Expanding the lane instead of raising a sheet is the rule this window already
- * follows for the preflight review, and it reads better here for the same reason: you
- * choose while looking at what each choice would do, rather than after dismissing the
- * thing that told you.
+ * This is a legend, not a picker. It describes whichever row currently holds focus, so it
+ * is deliberately **not** a focus target: making it one would mean stopping on a thing
+ * that exists only to explain the thing you just stopped on, and it would put a fifth and
+ * sixth stop in the path of every visit down the column. Left and right do nothing in this
+ * panel, which is the point -- four rows, no scrolling, nothing to hunt for.
  *
- * Selection is a tint, focus is a ring, and they compose -- so the card you are on and
- * the card you are using are never the same drawing.
+ * It stays tappable, because touch has no cursor for it to follow. A finger can take the
+ * card it wants directly instead of pressing a row until the right value comes round.
+ *
+ * The three pickers this replaces each wrote their own state into one shared strip, ranked
+ * by a `when` that always preferred the same one, and only one of the three ever cleared
+ * its siblings. Steam Launch was last in that chain, so it worked from a fresh panel and
+ * went dead the moment either other row had been touched. There is no picker state now, so
+ * there is no precedence to get wrong.
  */
 @Composable
 internal fun NovaPlaySetupComparison(title: String, options: List<NovaPlaySetupOption>) {
@@ -238,45 +242,33 @@ internal fun NovaPlaySetupComparison(title: String, options: List<NovaPlaySetupO
         NovaPlaySetupColumnHead(title)
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
             options.forEach { option ->
-                var focused by remember { mutableStateOf(false) }
                 val shape = RoundedCornerShape(NovaRadius.row)
                 val actionable = option.onSelect != null && option.enabled
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .onFocusChanged { focused = it.isFocused || it.hasFocus }
                         .then(
                             if (actionable) {
-                                // clickable alone leaves this reachable by touch only, which
-                                // is the same defect the sync sheet's mode buttons had.
-                                Modifier
-                                    .clickable(role = Role.Button) { option.onSelect?.invoke() }
-                                    .focusable()
+                                // Touch only, and deliberately so -- see the note above.
+                                // This used to carry two focusable modifiers as well, which
+                                // cost the d-pad two presses to cross one card and left the
+                                // inner of the two stops with no click on it at all.
+                                Modifier.clickable(role = Role.Button) { option.onSelect?.invoke() }
                             } else {
                                 Modifier
                             }
                         )
-                        // clickable alone is not a focus target; every focusable in this
-                        // app has to say so.
-                        .focusable(enabled = actionable)
                         .heightIn(min = NovaGameDetailActionHeight)
                         .clip(shape)
                         .background(if (option.current) colors.accentSurface else surfaces.tile)
                         .border(
                             1.dp,
-                            if (option.current || focused) {
+                            if (option.current) {
                                 colors.accent.copy(alpha = 0.58f)
                             } else {
                                 surfaces.tileBorder
                             },
                             shape,
-                        )
-                        .then(
-                            if (focused && actionable) {
-                                Modifier.border(2.dp, surfaces.focusRing, shape)
-                            } else {
-                                Modifier
-                            }
                         )
                         .padding(horizontal = 12.dp, vertical = 11.dp)
                         .semantics {
@@ -328,6 +320,46 @@ internal data class NovaPlaySetupOption(
     val enabled: Boolean = true,
     /** Null makes the card explanatory rather than selectable. */
     val onSelect: (() -> Unit)? = null,
+)
+
+/**
+ * The things Play Setup can change, in the order they are drawn.
+ *
+ * Four, and fixed at four. The act column has to fit a landscape viewport that is roughly
+ * 230-275dp once the panel's chrome and the bottom fade are taken out, and the strip below
+ * the rows used to start at 272dp in the lightest case and 332dp for a Steam game -- so the
+ * strip every control on this screen wrote to was off the bottom of the window at the
+ * moment it was written, with nothing scrolling to it. A fifth row would put it back there.
+ *
+ * More Launch Settings is not among them. It held resolution, and behind it codec and
+ * bitrate -- which are consequences of a resolution, not choices anyone makes separately.
+ * Resolution is a row of its own now, and the rest is stated in the read column where the
+ * other consequences already are.
+ */
+internal enum class NovaPlaySetupRow { WHERE_IT_RUNS, RESOLUTION, TUNING, STEAM_LAUNCH }
+
+/**
+ * One row: what it is called, what it currently reads, and what the alternatives mean.
+ *
+ * The options travel with the row rather than in a state the row has to open, because the
+ * strip is a legend for whatever holds focus and a legend cannot be opened or closed.
+ * [stripTitle] is a conditional sentence -- "If you changed where it runs" -- rather than a
+ * noun, so the strip reads as an explanation of a thing not yet done.
+ */
+internal data class NovaPlaySetupRowState(
+    val row: NovaPlaySetupRow,
+    val label: String,
+    val caption: String,
+    val value: String,
+    val stripTitle: String,
+    val options: List<NovaPlaySetupOption>,
+    val enabled: Boolean = true,
+    /**
+     * This row holds a choice made here rather than the answer the host would have given.
+     * Drawn as the selection tint and the accent edge, because a setting that will change
+     * the next launch should not look identical to one that is simply reporting.
+     */
+    val overridden: Boolean = false,
 )
 
 /** Below this the two columns stack; a phone has no room to put them side by side. */

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -117,10 +117,10 @@ private fun NovaPlaySetupReadColumn(plan: NovaPlaySetupPlan, modifier: Modifier 
                 color = if (index == plan.lines.lastIndex) colors.textMuted else colors.textSecondary,
                 fontSize = 14.sp,
                 lineHeight = 19.sp,
-                modifier = Modifier.padding(top = 7.dp),
-                // These are sentences when Polaris has something to explain, so they wrap
-                // rather than losing the end of the explanation mid-word.
-                maxLines = 3,
+                modifier = Modifier.padding(top = 6.dp),
+                // Two, not three. In landscape the whole panel has to fit without
+                // scrolling, and a third line here is a line the legend loses.
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
         }
@@ -144,7 +144,7 @@ private fun NovaPlaySetupActColumn(
         NovaPlaySetupColumnHead(stringResource(R.string.nova_play_setup_what_you_can_change))
         rows()
         if (comparison != null) {
-            Spacer(modifier = Modifier.height(14.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             comparison()
         }
     }
@@ -159,7 +159,7 @@ private fun NovaPlaySetupActColumn(
 @Composable
 private fun NovaPlaySetupFact(fact: NovaPlaySetupFact) {
     val colors = LocalNovaComposeColors.current
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 7.dp)) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 5.dp)) {
         Text(
             text = fact.key.uppercase(),
             color = colors.textMuted,
@@ -214,7 +214,7 @@ private fun NovaPlaySetupColumnHead(text: String) {
         text = text.uppercase(),
         color = colors.textMuted,
         style = NovaChromeType.label(fontSize = 9.sp),
-        modifier = Modifier.padding(bottom = 12.dp),
+        modifier = Modifier.padding(bottom = 8.dp),
     )
 }
 
@@ -238,7 +238,20 @@ private fun NovaPlaySetupColumnHead(text: String) {
  * there is no precedence to get wrong.
  */
 @Composable
-internal fun NovaPlaySetupComparison(title: String, options: List<NovaPlaySetupOption>) {
+internal fun NovaPlaySetupComparison(
+    title: String,
+    options: List<NovaPlaySetupOption>,
+    /**
+     * One line rather than two once the column carries a fourth row.
+     *
+     * The panel has to fit a ~325dp landscape viewport without scrolling. Four rows at the
+     * 48dp accessible floor plus their gaps is 212dp of it, and the legend has to live in
+     * what is left. A host advertising a display planner is exactly the case that adds that
+     * fourth row, so the legend gives up its second line rather than the panel giving up
+     * fitting.
+     */
+    consequenceMaxLines: Int = 2,
+) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -273,7 +286,7 @@ internal fun NovaPlaySetupComparison(title: String, options: List<NovaPlaySetupO
                             },
                             shape,
                         )
-                        .padding(horizontal = 12.dp, vertical = 11.dp)
+                        .padding(horizontal = 12.dp, vertical = 9.dp)
                         .semantics {
                             contentDescription = "${'$'}{option.label}. ${'$'}{option.consequence}"
                             if (option.current) selected = true
@@ -291,8 +304,12 @@ internal fun NovaPlaySetupComparison(title: String, options: List<NovaPlaySetupO
                         text = option.consequence,
                         color = colors.textMuted,
                         fontSize = 11.sp,
-                        lineHeight = 15.sp,
-                        modifier = Modifier.padding(top = 5.dp),
+                        lineHeight = 14.sp,
+                        // Bounded, so a long consequence cannot push the card past the cut.
+                        // The sentence is a hint at what a choice means, not the contract.
+                        maxLines = consequenceMaxLines,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp),
                     )
                 }
             }

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -165,7 +165,10 @@ private fun NovaPlaySetupFact(fact: NovaPlaySetupFact) {
             color = colors.textMuted,
             style = NovaChromeType.label(fontSize = 9.sp),
             lineHeight = 13.sp,
-            modifier = Modifier.width(NOVA_PLAY_SETUP_FACT_KEY).padding(top = 3.dp),
+            // Two lines rather than one, because a key that runs past its column prints
+            // itself over the value it is labelling.
+            maxLines = 2,
+            modifier = Modifier.width(NOVA_PLAY_SETUP_FACT_KEY).padding(top = 3.dp, end = 6.dp),
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -368,7 +371,7 @@ private val NOVA_PLAY_SETUP_TWO_COLUMN_MIN = 640.dp
 /** The read column is fixed so the choice rows keep a stable width as values change. */
 private val NOVA_PLAY_SETUP_READ_WIDTH = 246.dp
 private val NOVA_PLAY_SETUP_GUTTER = 22.dp
-private val NOVA_PLAY_SETUP_FACT_KEY = 86.dp
+private val NOVA_PLAY_SETUP_FACT_KEY = 104.dp
 
 /**
  * Turn the launch profile summary into what the left column reads.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,6 +352,9 @@
     <string name="nova_library_play_mode">Launch %1$s</string>
     <string name="nova_library_play_unavailable">Launch Unavailable</string>
     <string name="nova_library_review_and_launch">Review &amp; Launch</string>
+    <!-- Play was pressed while the preflight that decides whether desktop Steam is in the
+         way is still on the wire. The press is held, not dropped. -->
+    <string name="nova_game_detail_launch_checking_host">Checking the Host…</string>
     <string name="nova_library_preflight_review_title">Review Launch Profile</string>
     <string name="nova_library_preflight_review_message">Polaris selected a different launch profile: %1$s</string>
     <string name="nova_library_preflight_launch">Launch</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,7 +270,6 @@
     <string name="nova_play_setup_title">Play Setup</string>
     <string name="nova_play_setup_what_will_happen">What will happen</string>
     <string name="nova_play_setup_what_you_can_change">What you can change</string>
-    <string name="nova_play_setup_where_caption">Which display Polaris makes for this session</string>
     <string name="nova_play_setup_settings_caption">Resolution, frame rate, codec and bitrate</string>
     <string name="nova_play_setup_fact_last_session">Last session</string>
     <string name="nova_play_setup_fact_limited_by">Limited by</string>
@@ -290,6 +289,17 @@
     <string name="nova_play_setup_steam_direct">Launches the game itself. Nothing else opens.</string>
     <string name="nova_play_setup_steam_big_picture">Opens Big Picture first, which takes the controller until the game starts.</string>
     <string name="nova_play_setup_every_game_caption">Host defaults, profile and Auto Quality for every game</string>
+    <!-- Play Setup's four rows. The strip titles are conditional sentences rather than
+         nouns, because the strip explains a change not yet made. -->
+    <string name="nova_play_setup_where_caption">Which display Polaris makes for this session</string>
+    <string name="nova_play_setup_strip_where">If you changed where it runs</string>
+    <string name="nova_play_setup_resolution">Resolution</string>
+    <string name="nova_play_setup_resolution_caption">The display is made to match this handheld</string>
+    <string name="nova_play_setup_resolution_chosen">Chosen here \u00b7 applies at launch</string>
+    <string name="nova_play_setup_strip_resolution">If you changed the resolution</string>
+    <string name="nova_play_setup_tuning">Tuning</string>
+    <string name="nova_play_setup_strip_tuning">If you changed the tuning</string>
+    <string name="nova_play_setup_strip_steam">If you changed how Steam starts</string>
     <string name="nova_play_setup_compare_private">Its own display, made for this session. The desk keeps its own screen.</string>
     <string name="nova_play_setup_compare_virtual">Uses the host\'s virtual display driver. Advanced, and needs SudoVDA on the host.</string>
     <string name="nova_game_detail_group_state">State</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1131,23 +1131,35 @@ class NovaComposeSourceGuardTest {
         val detail = readNovaGameDetail()
 
         assertTrue(
-            "Headless/Virtual stay one press away and say what they would do while you pick. " +
-                "They moved from rows into the comparison strip, which is still inline: a picker " +
-                "raised over the destination would cost a press and re-introduce the options " +
-                "drawer that inline selection was added to remove",
-            detail.contains("NovaPlaySetupComparison(") &&
-                detail.contains("onSelect = { onLaunchModeSelected(\"headless\") }") &&
-                detail.contains("onSelect = { onLaunchModeSelected(\"virtual_display\") }") &&
-                detail.contains("consequence = stringResource(")
+            "one destination holds the whole decision, as four rows in a fixed order: where it " +
+                "runs, the resolution, the tuning and how Steam starts. Splitting these across " +
+                "two drawers is what made each of them carry half of the other's subject",
+            detail.contains("enum class NovaPlaySetupRow { WHERE_IT_RUNS, RESOLUTION, TUNING, STEAM_LAUNCH }") &&
+                detail.contains("row = NovaPlaySetupRow.WHERE_IT_RUNS,") &&
+                detail.contains("row = NovaPlaySetupRow.RESOLUTION,") &&
+                detail.contains("row = NovaPlaySetupRow.TUNING,") &&
+                detail.contains("row = NovaPlaySetupRow.STEAM_LAUNCH,")
         )
         assertTrue(
-            "one destination holds the whole decision: where it runs, the launch settings, the " +
-                "tuning profile and Steam launch. Splitting these across two drawers is what " +
-                "made each of them carry half of the other's subject",
-            detail.contains("onClick = onLaunchOptions,") &&
-                detail.contains("onClick = onProfilePreference,") &&
-                detail.contains("SteamLaunchModeCard(") &&
-                detail.contains("LaunchProfileSummaryActions(")
+            "the strip is a legend for whichever row holds focus, not a picker with a state of " +
+                "its own. Three picker states ranked by a when is what made Steam Launch work " +
+                "from a fresh panel and go dead once either other row had been touched",
+            detail.contains("onFocused = { onExplainPlaySetupRow(rowState.row) },") &&
+                detail.contains("it.row == explainedPlaySetupRow") &&
+                detail.contains("onClick = { onAdvancePlaySetupRow(rowState.row) },")
+        )
+        assertFalse(
+            "no picker state may come back: each one is a rank in a chain, and a chain needs " +
+                "every link to clear its siblings for any link to be reliable",
+            detail.contains("launchOptionsState") ||
+                detail.contains("profileOptionsState") ||
+                detail.contains("steamLaunchOptionsState")
+        )
+        assertFalse(
+            "the comparison strip must not be a focus target. It explains the row under the " +
+                "cursor, so stopping on it means stopping on the explanation of the thing you " +
+                "just stopped on, and it costs two more presses on every trip down the column",
+            playSetupComparison().contains(".focusable(")
         )
         assertFalse(
             "LaunchControls served the destination that no longer exists; leaving it behind " +
@@ -1155,6 +1167,13 @@ class NovaComposeSourceGuardTest {
             detail.contains("private fun LaunchControls(")
         )
     }
+
+    /** Just the strip, so a focusable anywhere else in Play Setup cannot satisfy the check. */
+    private fun playSetupComparison(): String =
+        readSource("src/main/java/com/papi/nova/ui/NovaPlaySetup.kt").section(
+            "internal fun NovaPlaySetupComparison(",
+            "/** The resolved plan, as one readable statement plus the facts behind it. */",
+        )
 
     @Test
     fun gameDetailKeepsMangoHudOutOfPrimaryLaunchDrawer() {
@@ -2712,6 +2731,7 @@ class NovaComposeSourceGuardTest {
         readSource("src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt")
 
     private fun readNovaGameDetail(): String =
+        readSource("src/main/java/com/papi/nova/ui/NovaPlaySetup.kt") +
         readSource("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt") +
@@ -2739,19 +2759,20 @@ class NovaComposeSourceGuardTest {
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt")
-        val launchOptions = detail.section(
-            "private fun showLaunchOptions(",
+        val planner = detail.section(
+            "private fun resolutionPlanner(",
             "private fun optionLabel("
         )
 
         assertTrue(
-            "the launch settings are chosen without a dialog and without a sheet, for the " +
-                "same reason as the tuning preference: a glass panel over the destination is " +
-                "still a modal on the launch path",
-            !launchOptions.contains("AlertDialog.Builder(") &&
-                detail.contains("data class NovaLaunchOptionsState") &&
+            "the resolution is chosen without a dialog and without a sheet, for the same " +
+                "reason as the tuning: a glass panel over the destination is still a modal on " +
+                "the launch path. It is a row with a value now rather than a list of items " +
+                "that each started the stream on the way past",
+            !planner.contains("AlertDialog.Builder(") &&
                 !detail.contains("private fun NovaLaunchOptionsSheet(") &&
-                detail.contains("launchOptionsState != null -> NovaPlaySetupComparison(")
+                detail.contains("row = NovaPlaySetupRow.RESOLUTION,") &&
+                detail.contains("onSelect = { chooseResolution(choice) },")
         )
     }
 
@@ -2761,21 +2782,15 @@ class NovaComposeSourceGuardTest {
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt")
-        val profileOptions = detail.section(
-            "private fun showProfilePreferenceOptions(",
-            "private fun steamLaunchModeOptionsState("
-        )
-
         assertTrue(
             "the tuning preference is chosen without a dialog and without a sheet. It used " +
                 "to be routed through a Nova glass panel raised over the destination, which " +
                 "was better than an AlertDialog and still a modal on the launch path; the " +
                 "options are stated as consequences in the comparison strip now",
-            !profileOptions.contains("AlertDialog.Builder(") &&
-                detail.contains("data class NovaProfilePreferenceOptionsState") &&
+            !detail.contains("AlertDialog.Builder(") &&
                 !detail.contains("private fun NovaProfilePreferenceSheet(") &&
-                detail.contains("profileOptionsState != null -> NovaPlaySetupComparison(") &&
-                detail.contains("consequence = novaProfilePreferenceConsequence(option.value)")
+                detail.contains("row = NovaPlaySetupRow.TUNING,") &&
+                detail.contains("consequence = getString(novaProfilePreferenceConsequenceRes(value)),")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1106,14 +1106,23 @@ class NovaComposeSourceGuardTest {
             detail.contains("internal val NovaGameDetailActionHeight = 48.dp") &&
                 detail.contains("heightIn(min = NovaGameDetailActionHeight)")
         )
+        // A fixed four now rather than three. Reset used to be drawn only while a review
+        // was expanded, so outside that case the only way to reach it was a copy inside
+        // Play Setup -- and a Play Setup held to four rows has no room to keep one. What
+        // the guard is really protecting is unchanged: the count must not vary by game.
         assertTrue(
-            "the rail is a fixed three, so a D-pad walk cannot find a different number of " +
-                "nodes on a different game; a review still replaces it with its own answers",
+            "the rail is a fixed four, so a D-pad walk cannot find a different number of " +
+                "nodes on a different game; only an expanded review adds to it",
             actions.contains("NovaGameDetailDestination.PLAY_SETUP") &&
                 actions.contains("NovaGameDetailDestination.ARTWORK") &&
-                actions.contains("if (reviewExpanded)") &&
+                actions.contains("if (!reviewExpanded) {") &&
                 actions.contains("onRetryHighFps") &&
                 actions.contains("onResetProfile")
+        )
+        assertFalse(
+            "reset must not be gated on a review being open: that left it unreachable in the " +
+                "ordinary case once Play Setup stopped carrying its own copy",
+            actions.contains("if (reviewExpanded) {\n            if (optimizationState.profileSummary?.showRetryHighFps == true) {")
         )
         assertFalse(
             "nothing gates a rail node any more: what showLaunchModeAction used to remove " +

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -13,8 +13,11 @@ class NovaLaunchSourceGuardTest {
         val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt")
         // launchConfirmed is shared by the primary action, the option picker and the
         // expanded review, so the MangoHUD state is asserted where they all pass through.
-        val launchConfirmed = detail.section("fun launchConfirmed(", "fun resetProfile(")
-        val launchModeSelection = detail.section("fun selectLaunchMode(", "fun launchConfirmed(")
+        // launchConfirmed and attemptLaunch moved above the preflight loader, which has to
+        // be able to replay a held launch, so these markers follow the declaration order
+        // rather than the old one.
+        val launchConfirmed = detail.section("fun launchConfirmed(", "fun attemptLaunch(")
+        val launchModeSelection = detail.section("fun selectLaunchMode(", "fun resetProfile(")
 
         assertTrue(
             "every launch path should pass the selected MangoHUD state into the launch request",
@@ -61,7 +64,7 @@ class NovaLaunchSourceGuardTest {
         assertTrue(
             "the desktop Steam choice belongs in the Launch mode destination, not a sheet or an alert raised over the artwork",
             detail.contains("destination = NovaGameDetailDestination.PLAY_SETUP") &&
-                detail.contains("steamDecision = desktopSteamDecision") &&
+                detail.contains("steamDecision = decision") &&
                 !detail.contains("BottomSheetDialog(") &&
                 !detail.contains("AlertDialog.Builder")
         )
@@ -76,10 +79,15 @@ class NovaLaunchSourceGuardTest {
             decisionRows.contains("enabled = decision.privateStreamEnabled") &&
                 decisionRows.contains("caption = decision.privateStreamUnavailableReason")
         )
+        // This asserted on the option path's own copy of the decision. It had one, which was
+        // the problem: two launch paths meant two places for the guard to be got round, and
+        // only one of them was ever watched. There is one now, and the option's display mode
+        // is what it is judged on.
         assertTrue(
             "Launch Options must not bypass desktop-Steam safety for selected private headless launches",
-            detail.contains("usesVirtualDisplay = option.usesVirtualDisplay") &&
-                detail.contains("steamDecision = desktopSteamDecision")
+            detail.contains("onLaunchOptionSelected = { option -> attemptLaunch(option) }") &&
+                detail.contains("usesVirtualDisplay = option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay") &&
+                detail.contains("steamDecision = decision")
         )
         assertTrue(
             "Mirror Desktop must be carried as an explicit launch override through the stream launch path",
@@ -110,14 +118,32 @@ class NovaLaunchSourceGuardTest {
             "private fun showNovaLaunchIssueSheet"
         )
 
+        // Pinned on the rows that actually render. This asserted onForcePrivateAfterSteamClose
+        // until it was noticed that the only declaration of that parameter lived in a
+        // composable nothing called, so the guard was green off dead code while the live
+        // path went unwatched.
         assertTrue(
-            "desktop Steam sheet should expose an explicit force-private path that closes desktop Steam before private launch",
-            detail.contains("onForcePrivateAfterSteamClose") &&
+            "desktop Steam decision should expose an explicit force-private path that closes desktop Steam before private launch",
+            detail.contains("decision.forcePrivateAfterSteamCloseEnabled") &&
+                detail.contains("onChoice(NovaSteamLaunchChoice.CLOSE_STEAM_THEN_PRIVATE)") &&
                 detail.contains("nova_desktop_steam_force_private") &&
                 serverHelper.contains("Game.EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE") &&
                 game.contains("EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE") &&
                 nvHttp.contains("closeDesktopSteamForPrivate=1") &&
                 nvHttp.contains("launchMode=force_private_stream")
+        )
+        assertTrue(
+            "a launch must wait for the preflight the desktop Steam guard is read from, rather than taking a null blob as consent",
+            detail.contains("val preflightInFlight: Boolean = false") &&
+                detail.contains("NovaGameDetailOptimizationState(preflightInFlight = true)") &&
+                detail.contains("if (optimization == null && optimizationState.preflightInFlight) {") &&
+                detail.contains("if (pendingLaunch) attemptLaunch(pendingLaunchOption)")
+        )
+        assertTrue(
+            "every launch path must come through the one gate, so a second path cannot go round the guard the first one gained",
+            detail.contains("onPrimaryLaunch = { attemptLaunch() }") &&
+                detail.contains("onLaunchOptionSelected = { option -> attemptLaunch(option) }") &&
+                !detail.contains("fun launchSelected(")
         )
         assertTrue(
             "Game connection failures should route through the Nova themed launch issue drawer instead of legacy square Dialog.displayDialog",

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -85,8 +85,8 @@ class NovaLaunchSourceGuardTest {
         // is what it is judged on.
         assertTrue(
             "Launch Options must not bypass desktop-Steam safety for selected private headless launches",
-            detail.contains("onLaunchOptionSelected = { option -> attemptLaunch(option) }") &&
-                detail.contains("usesVirtualDisplay = option?.usesVirtualDisplay ?: uiState.playUsesVirtualDisplay") &&
+            detail.contains("fun attemptLaunch() {") &&
+                detail.contains("val optimization = launchOptimization()") &&
                 detail.contains("steamDecision = decision")
         )
         assertTrue(
@@ -137,13 +137,16 @@ class NovaLaunchSourceGuardTest {
             detail.contains("val preflightInFlight: Boolean = false") &&
                 detail.contains("NovaGameDetailOptimizationState(preflightInFlight = true)") &&
                 detail.contains("if (optimization == null && optimizationState.preflightInFlight) {") &&
-                detail.contains("if (pendingLaunch) attemptLaunch(pendingLaunchOption)")
+                detail.contains("if (pendingLaunch) attemptLaunch()")
         )
         assertTrue(
             "every launch path must come through the one gate, so a second path cannot go round the guard the first one gained",
             detail.contains("onPrimaryLaunch = { attemptLaunch() }") &&
-                detail.contains("onLaunchOptionSelected = { option -> attemptLaunch(option) }") &&
-                !detail.contains("fun launchSelected(")
+                !detail.contains("fun launchSelected(") &&
+                // A settle that fires late must not let a launch through on the previous
+                // value, so it marks in flight now and the launch flushes it early.
+                detail.contains("optimizationState = NovaGameDetailOptimizationState(preflightInFlight = true)\n            settleJob?.cancel()") &&
+                detail.contains("flushSettled()")
         )
         assertTrue(
             "Game connection failures should route through the Nova themed launch issue drawer instead of legacy square Dialog.displayDialog",
@@ -389,7 +392,7 @@ class NovaLaunchSourceGuardTest {
         val planner = readSource("src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt")
         val playSetup = readSource("src/main/java/com/papi/nova/ui/NovaPlaySetup.kt")
         val optionSheet = detail.section(
-            "private fun showLaunchOptions(",
+            "private fun resolutionPlanner(",
             "private fun optionLabel("
         )
 
@@ -400,12 +403,12 @@ class NovaLaunchSourceGuardTest {
                 detail.contains("NovaDisplayResolutionPlanner.buildLaunchOptimizationOverride(")
         )
         assertTrue(
-            "Planner choices keep D-pad focus on meaningful cards rather than redundant Press A " +
-                "badges. They moved from the option sheet into the comparison strip, which is " +
-                "focusable in place and carries each option's caption as its consequence",
-            playSetup.contains(".focusable(enabled = actionable)") &&
-                detail.contains("launchOptionsState != null -> NovaPlaySetupComparison(") &&
-                detail.contains("option.caption") &&
+            "Planner choices are a row with a value rather than redundant Press A badges. The " +
+                "d-pad stops on the row, and the strip states what each choice would mean without " +
+                "being a stop of its own",
+            playSetup.contains("enum class NovaPlaySetupRow") &&
+                detail.contains("row = NovaPlaySetupRow.RESOLUTION,") &&
+                detail.contains("onSelect = { chooseResolution(choice) },") &&
                 !detail.contains("Press A") &&
                 planner.contains("takeUnless { it.equals(\"Press A\", ignoreCase = true) }")
         )
@@ -709,13 +712,16 @@ class NovaLaunchSourceGuardTest {
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt") +
             readSource("src/main/java/com/papi/nova/ui/NovaGameDetailDestinations.kt")
         val selection = detail.section(
-            "onSteamLaunchModeSelected = { selected ->",
-            "},\n                    onDismissSteamLaunchModeOptions"
+            "fun selectSteamLaunchMode(value: String) {",
+            "fun resetProfile() {"
         )
 
         assertTrue(!selection.contains("dismiss()"))
         assertTrue(!selection.contains("onLaunch?.invoke"))
         assertTrue(selection.contains("apiClient.setSteamLaunchMode"))
+        // The row advances on every press, so the host is told once the presses stop.
+        // Writing per press turned a cycle through two values into two round-trips.
+        assertTrue(selection.contains("settleThen {"))
     }
 
     @Test
@@ -728,7 +734,7 @@ class NovaLaunchSourceGuardTest {
 
         assertTrue(api.contains("fun setSteamLaunchMode(gameId: String, mode: String): String?"))
         assertTrue(api.contains("json.optString(\"mode\", normalizedMode)"))
-        assertTrue(detail.contains("steamLaunchOptionsState = steamLaunchModeOptionsState(currentGame)"))
+        assertTrue(detail.contains("row = NovaPlaySetupRow.STEAM_LAUNCH,"))
         assertTrue(detail.contains("confirmedMode != null"))
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaPlaySetupBudgetTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaPlaySetupBudgetTest.kt
@@ -1,0 +1,63 @@
+package com.papi.nova.ui
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The line budgets, against the viewport the handheld actually reports.
+ *
+ * These were arithmetic in a comment once and the arithmetic was wrong -- the source said
+ * a 374-393dp window and the device said 444dp, which is the difference between the legend
+ * fitting and the legend being off the bottom of the screen. Measured on a Retroid Pocket 6
+ * at 1920x1080, 369dpi: 444dp of app height, about 312dp of scrolling body once the panel's
+ * insets, compact header and hint bar are out.
+ */
+class NovaPlaySetupBudgetTest {
+
+    private val retroidBody = 312.dp
+
+    @Test
+    fun threeRowsAffordAFullConsequence() {
+        // An upper bound, not a target: the sentence wraps to what it needs and stops.
+        // Two is what the shipped copy actually uses at this width.
+        assertTrue(novaPlaySetupConsequenceLines(retroidBody, rowCount = 3) >= 2)
+    }
+
+    @Test
+    fun aFourthRowCostsTheLegendItsSecondLine() {
+        // A host advertising a display planner is what adds Resolution, and its 53dp come
+        // out of the legend rather than out of the panel fitting.
+        assertEquals(1, novaPlaySetupConsequenceLines(retroidBody, rowCount = 4))
+    }
+
+    @Test
+    fun theLegendNeverDisappears() {
+        // However little is left, a card keeps one line. A legend with no text is a row of
+        // labels whose whole purpose was to explain what the labels mean.
+        for (rows in 0..8) {
+            assertTrue(novaPlaySetupConsequenceLines(retroidBody, rows) >= 1)
+        }
+        assertEquals(1, novaPlaySetupConsequenceLines(40.dp, rowCount = 6))
+    }
+
+    @Test
+    fun anUnmeasuredBodyFallsBackRatherThanCollapsing() {
+        assertEquals(2, novaPlaySetupConsequenceLines(0.dp, rowCount = 3))
+        assertEquals(2, novaPlaySetupIntroLines(0.dp, factCount = 4))
+    }
+
+    @Test
+    fun thePlanGetsItsThirdLineWhenTheFactsAreFew() {
+        assertTrue(novaPlaySetupIntroLines(retroidBody, factCount = 2) >= 3)
+    }
+
+    @Test
+    fun aLongFactListTakesThePlansProseFirst() {
+        val few = novaPlaySetupIntroLines(retroidBody, factCount = 2)
+        val many = novaPlaySetupIntroLines(retroidBody, factCount = 6)
+        assertTrue("more facts must not buy more prose", many <= few)
+        assertTrue(many >= 1)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaThemeResourcesTest.kt
@@ -295,7 +295,12 @@ class NovaThemeResourcesTest {
         assertTrue("shared scrim should be light enough for NovaHUD/game context to remain visible", sheetChrome.contains("const val SCRIM_ALPHA = 0.22f"))
         assertTrue("default action row state should remain transparent glass, not an opaque mini slab", sheetChrome.contains("fillAccentBlend = 0f") && sheetChrome.contains("Color.TRANSPARENT"))
         assertTrue("Compose library surfaces should reuse shared glass alpha language", composeTheme.contains("NovaSheetChrome.SHEET_GLASS_ALPHA"))
-        assertTrue("game detail Compose drawer should reuse the shared native sheet radius token", gameDetail.contains("NovaSheetChrome.SHEET_CORNER_RADIUS_DP.dp"))
+        // There was an assertion here that the game detail window reuses the sheet radius
+        // token. It contradicted that window's own rule -- it raises no sheet, and
+        // NovaLaunchSourceGuardTest asserts as much -- and it passed only because a
+        // composable nothing ever called still mentioned the token. The window's radii come
+        // from NovaRadius; the sheet token belongs to surfaces that are actually sheets.
+        assertTrue("game detail must not reach for sheet chrome, since it raises no sheet", !gameDetail.contains("NovaSheetChrome.SHEET_CORNER_RADIUS_DP"))
     }
 
 


### PR DESCRIPTION
## Summary

Three controls in Play Setup were reported broken — **More Launch Settings** did nothing,
**Steam Launch** worked and then stopped, **Force Close Steam to Launch Game** no longer armed.
All three were traced in source rather than guessed at, and two of them turned out to be one
structural fault: five-plus rows and a single shared picker strip, stacked in a scroll region
shorter than the stack. The strip every one of those controls wrote to sat below the fold at the
moment it was written, and nothing scrolled to it.

So the act column is four fixed rows that fit the landscape viewport, and the strip stops being
a picker. It becomes a legend that describes whichever row holds focus: it is not a focus target,
left/right do nothing, and the d-pad walks four stops instead of nine. Deleting the three picker
states removes the Steam Launch bug as a class rather than as an instance — that one was a
precedence chain where two handlers cleared their siblings and the third, at the bottom of the
`when`, cleared nothing.

The Force Close fix is the correctness one and is first in the series, on its own commit. A
launch could skip the desktop-Steam guard whenever the preflight was still in flight, because
"no answer yet" and "nothing to guard" were the same null. They are now distinct states, and
Play waits for the round-trip instead of launching unguarded.

More Launch Settings is deleted rather than repaired. On a host with no display planner it
rebuilt the mode choice with empty captions, which is what "does nothing" meant; the resolution
it was hiding is now a row of its own, and its other subjects were consequences rather than
choices and already render in the read column.

Also here: a Reset Game Profile that the rebuild had left unreachable, four tuning cards that all
read "AI Preference…" because they used the long label, and both Steam Launch cards describing
themselves as Direct — `normalizeMode` returns `big-picture` with a hyphen and that was the one
spelling the consequence lookup lacked. That last one has been wrong since the function was
written and was invisible while the two cards were never on screen together.

## Exact candidate

`c6378f5a` on `nova/play-setup-four-rows`, five commits off `e71de0f6`.

- `685b2233` — a launch can no longer start while the guard that would stop it is loading
- `d0f8f1a9` — Play Setup becomes four rows and a legend that follows the cursor
- `a2ed471b` — what the Retroid found, including a Reset with nowhere to live
- `dc55ee31` — make Play Setup fit the landscape viewport instead of nearly fitting it
- `c6378f5a` — let Play Setup measure its own window and spend what is there

## Verification

```
:app:testNonRoot_gameDebugUnitTest        1216 tests, green
:app:lintNonRoot_gameRelease -PlintFailOnError=true    clean
:app:assembleNonRoot_gameDebug/Release    ok
```

On the Retroid Pocket 6 in landscape, 1920x1080 at 369dpi:

- Play Setup fits with no scrolling — three rows, the legend and both columns inside the window.
- A d-pad walk from the first row to the last, with the legend retitling at each stop, and a
  touch tap lighting the strip the same way a focus move does.
- The four-row case verified by forcing the Resolution row on device, since no game on this host
  advertises a planner: four rows, legend and both columns inside the window, nothing clipped and
  no fade. The override indication reads as intended — selection tint, accent edge, "Chosen here
  · applies at launch". The fixture was reverted; the tree is clean and the APK on the device is
  the un-stubbed build.

Every re-pointed guard was broken first to confirm it still asserts. Two were found green off
dead code: the force-private guard was reading a composable with no callers, and a sheet-radius
assertion was satisfied only by that same corpse. Both now read the live path. `NovaPlaySetup.kt`
was read by exactly one assertion in the suite and is now in `readNovaGameDetail()`.

Viewport arithmetic derived from source was wrong by about 50dp, so the budgets are measured at
runtime through `BoxWithConstraints` outside the scroll, and `NovaPlaySetupBudgetTest` pins the
constants against the height the handheld actually reports.

## Not covered

That a resolution chosen here reaches the stream. The Resolution row has been seen, but from a
forced fixture rather than from a real host — Polaris computes its display planner only in a
browser helper and never serves it on the games API, so the row does not appear in the field yet.
The plumbing, not the layout, is what remains unproven. Tracked separately.

Worth noting why it went unnoticed: `tests/integration/test_nova_contract.cpp` on the Polaris side
exists precisely to catch "the client reads a field the host never sends", and `display_planner`
appears nowhere in it — not as tracked drift, not as a known gap.
