### PR TITLE
feat(nova): log which audio outputs exist, not just the one a track landed on

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/audio/AndroidAudioRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/audio/AndroidAudioRenderer.kt
@@ -6,6 +6,7 @@ import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
+import android.media.MediaRouter
 import android.media.audiofx.AudioEffect
 import android.os.Build
 import com.papi.nova.LimeLog
@@ -173,6 +174,95 @@ class AndroidAudioRenderer(
                 LimeLog.info("Nova: Android display audio route display_id=${audioContextDisplayId()} device_id=none type=none")
             }
         }
+        logAudioOutputInventory()
+    }
+
+    /**
+     * Log every audio output the platform admits to, and every media route that names a display.
+     *
+     * The routed-device line above says where this track landed, which is not the same question as
+     * where else it could have gone. On a dual-screen host both launch paths can report the same
+     * builtin speaker while the user hears different screens, and from one line we cannot tell
+     * whether that is one device the vendor re-points below the HAL or two devices we never asked
+     * about. Only the enumeration separates those, and they have opposite fixes: a second
+     * [AudioDeviceInfo] means [AudioTrack.setPreferredDevice] (API 23) can move the audio, while a
+     * single device means nothing in the public API can and the display association at launch is
+     * the whole story.
+     *
+     * [MediaRouter.RouteInfo.getPresentationDisplay] is logged beside it because it is the only
+     * public API that maps an audio route onto a [android.view.Display], so it is the other way a
+     * pre-34 host could offer display affinity.
+     *
+     * Diagnostics only -- wrapped because a vendor audio service that throws here must not be able
+     * to take down the stream, and logged once per track for the same reason the route line is.
+     */
+    private fun logAudioOutputInventory() {
+        try {
+            val outputs = describeAudioOutputs()
+            val router = context.getSystemService(Context.MEDIA_ROUTER_SERVICE) as? MediaRouter
+            val routeCount = router?.routeCount ?: 0
+
+            LimeLog.info(
+                "Nova: Android display audio inventory display_id=${audioContextDisplayId()} " +
+                    "outputs=${outputs.size} routes=$routeCount"
+            )
+
+            outputs.forEach { LimeLog.info(it) }
+
+            val selectedLiveAudio = router?.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO)
+            for (index in 0 until routeCount) {
+                val route = router?.getRouteAt(index) ?: continue
+                val presentationDisplayId = route.presentationDisplay?.displayId
+                val liveAudio = route.supportedTypes and MediaRouter.ROUTE_TYPE_LIVE_AUDIO != 0
+                LimeLog.info(
+                    "Nova: Android display audio presentation index=$index " +
+                        "live_audio=$liveAudio " +
+                        "presentation_display_id=${presentationDisplayId ?: "none"} " +
+                        "selected=${route === selectedLiveAudio}"
+                )
+            }
+        } catch (e: Exception) {
+            LimeLog.warning("Nova: Android display audio inventory unavailable: ${e.javaClass.simpleName}")
+        }
+    }
+
+    /**
+     * Describe every output device, or nothing at all when the platform predates the enumeration.
+     *
+     * Built as strings inside a single version gate rather than returned as [android.media.AudioDeviceInfo]
+     * so that the whole API-23 surface stays behind one check. The address needs its own gate at a
+     * higher level than the rest: getId and getType arrived in 23 but getAddress only in 28, and
+     * reading the address unguarded against a minSdk of 21 is exactly the kind of thing that runs
+     * everywhere it is tested and throws on the one old device nobody has.
+     */
+    private fun describeAudioOutputs(): List<String> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return emptyList()
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+            ?: return emptyList()
+        return audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).map { device ->
+            val address = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                sanitizeDeviceAddress(device.address)
+            } else {
+                "unknown"
+            }
+            "Nova: Android display audio output device_id=${device.id} type=${device.type} " +
+                "address=$address"
+        }
+    }
+
+    /**
+     * Reduce a device address to the shape a field report can carry.
+     *
+     * Vendor addresses are the discriminator worth having -- two builtin speakers are told apart by
+     * theirs and by nothing else -- but they are vendor strings rather than a documented vocabulary,
+     * so the report keeps the characters an identifier can be made of and drops the rest rather than
+     * forwarding whatever a HAL happens to put there. Route and product names are omitted entirely:
+     * those are user-visible strings and carry people's names.
+     */
+    private fun sanitizeDeviceAddress(address: String?): String {
+        if (address.isNullOrEmpty()) return "none"
+        val cleaned = address.filter { it.isLetterOrDigit() || it == '_' || it == '-' }
+        return if (cleaned.isEmpty()) "none" else cleaned.take(MAX_DEVICE_ADDRESS_CHARS)
     }
 
     override fun start() {
@@ -208,6 +298,7 @@ class AndroidAudioRenderer(
 
     companion object {
         private const val INVALID_DISPLAY_ID = -1
+        private const val MAX_DEVICE_ADDRESS_CHARS = 32
 
         @Volatile
         @JvmField

--- a/docs/thor-audio-field-test.md
+++ b/docs/thor-audio-field-test.md
@@ -66,7 +66,7 @@ On a hot-remove-capable setup, perform one additional removal/re-add cycle. The 
 
 A healthy wiring report should show:
 
-- `schema_version: 2`
+- `schema_version: 3`
 - `source_process_scoped: true`
 - `latest_run_marker_found: true`
 - `audio_context_matches_stream: true` (selected stream ID, audio-claimed stream ID, and audio-context display ID all agree)
@@ -78,6 +78,30 @@ A healthy wiring report should show:
 - `diagnostic_evidence_complete: true`
 
 The decisive hardware result is still human-observed: playback and physical volume control follow the top/stream display while the bottom Presentation remains visible.
+
+## What the audio inventory answers
+
+`audio_route_observed` says where the track landed. It does not say where else it could have gone,
+and on a dual-screen host those are different questions: both launch lanes can report the same
+builtin speaker while the user hears different screens. From the routed device alone we cannot tell
+whether that is one device the vendor re-points below the HAL or two devices we never asked about.
+
+The inventory separates them, and the two outcomes have opposite fixes:
+
+- `audio_output_choice_exists: true` — more than one output device is enumerated, so
+  `AudioTrack.setPreferredDevice` (public since API 23, no permission) has somewhere to aim. Read
+  `audio_outputs` for the device IDs, types and addresses to aim at.
+- `presentation_route_offers_audio: true` — some media route carries live audio *and* names a
+  display. `MediaRouter.RouteInfo.getPresentationDisplay()` is the only public API that maps an
+  audio route onto a display, so this is the other pre-34 way to express display affinity.
+- both `false` — the platform offers no pre-34 lever, and the display association fixed at launch
+  is the whole story. That is a real finding, not a failed capture.
+
+`null` on either check means no inventory line was seen at all, which is what a build predating this
+diagnostic looks like. Do not read it as "this device has no choices".
+
+Neither check feeds `diagnostic_evidence_complete`: the inventory describes the platform, it does
+not grade the wiring.
 
 ## Issue reply template
 

--- a/tools/nova_thor_audio_field.py
+++ b/tools/nova_thor_audio_field.py
@@ -31,6 +31,18 @@ AUDIO_ROUTE_RE = re.compile(
     rf"^Nova: Android display audio route display_id={DISPLAY_ID} "
     r"device_id=(none|\d+) type=(none|\d+)$"
 )
+AUDIO_INVENTORY_RE = re.compile(
+    rf"^Nova: Android display audio inventory display_id={DISPLAY_ID} "
+    r"outputs=(\d+) routes=(\d+)$"
+)
+AUDIO_OUTPUT_RE = re.compile(
+    r"^Nova: Android display audio output device_id=(\d+) type=(\d+) "
+    r"address=(none|[A-Za-z0-9_-]{1,32})$"
+)
+AUDIO_PRESENTATION_RE = re.compile(
+    r"^Nova: Android display audio presentation index=(\d+) live_audio=(true|false) "
+    r"presentation_display_id=(none|\d+) selected=(true|false)$"
+)
 FOCUS_RE = re.compile(
     rf"^Nova: Android display focus role=(game|companion) display_id={DISPLAY_ID} "
     r"window=(true|false) game_top_resumed=(true|false)$"
@@ -68,6 +80,9 @@ def analyze_logcat(logcat: str, *, source_process_scoped: bool = False) -> dict:
     audio_stream_display_ids = []
     audio_context_display_ids = []
     audio_routes = []
+    audio_outputs = []
+    audio_presentation_routes = []
+    latest_audio_inventory = None
     focus_events = []
     runtime_errors = {kind: 0 for kind in ERROR_MARKERS}
     latest_stream_display_id = None
@@ -104,6 +119,33 @@ def analyze_logcat(logcat: str, *, source_process_scoped: bool = False) -> dict:
                 "type": match.group(3),
             }
             _append_unique(audio_routes, route)
+
+        match = _match(AUDIO_INVENTORY_RE, line)
+        if match:
+            latest_audio_inventory = {
+                "display_id": int(match.group(1)),
+                "outputs": int(match.group(2)),
+                "routes": int(match.group(3)),
+            }
+
+        match = _match(AUDIO_OUTPUT_RE, line)
+        if match:
+            output = {
+                "device_id": match.group(1),
+                "type": match.group(2),
+                "address": match.group(3),
+            }
+            _append_unique(audio_outputs, output)
+
+        match = _match(AUDIO_PRESENTATION_RE, line)
+        if match:
+            presentation = {
+                "index": int(match.group(1)),
+                "live_audio": match.group(2) == "true",
+                "presentation_display_id": match.group(3),
+                "selected": match.group(4) == "true",
+            }
+            _append_unique(audio_presentation_routes, presentation)
 
         match = _match(FOCUS_RE, line)
         if match:
@@ -176,8 +218,25 @@ def analyze_logcat(logcat: str, *, source_process_scoped: bool = False) -> dict:
         and runtime_errors_absent
     )
 
+    # The two questions the enumeration exists to answer, and they have opposite fixes.
+    # More than one output device means AudioTrack.setPreferredDevice (API 23) has somewhere to
+    # aim; a route that carries both live audio and a presentation display means MediaRouter can
+    # express the display affinity directly. Neither being true is itself the finding -- it says
+    # the platform offers no pre-34 lever and the launch-time display association is the whole
+    # story. None rather than False when no inventory line was seen at all, so "the build predates
+    # this diagnostic" cannot be read as "the device has no choices".
+    audio_output_choice_exists = len(audio_outputs) > 1 if latest_audio_inventory else None
+    presentation_route_offers_audio = (
+        any(
+            route["live_audio"] and route["presentation_display_id"] != "none"
+            for route in audio_presentation_routes
+        )
+        if latest_audio_inventory
+        else None
+    )
+
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "claim_status": (
             "diagnostic wiring only; physical speaker and AYN volume-slider routing require human confirmation"
         ),
@@ -196,6 +255,9 @@ def analyze_logcat(logcat: str, *, source_process_scoped: bool = False) -> dict:
         "latest_audio_context_display_id": latest_audio_context_display_id,
         "audio_routes": audio_routes,
         "latest_audio_route": latest_audio_route,
+        "latest_audio_inventory": latest_audio_inventory,
+        "audio_outputs": audio_outputs,
+        "audio_presentation_routes": audio_presentation_routes,
         "focus_events": focus_events,
         "latest_game_focus_event": latest_game_focus_event,
         "latest_companion_focus_event": latest_companion_focus_event,
@@ -206,6 +268,9 @@ def analyze_logcat(logcat: str, *, source_process_scoped: bool = False) -> dict:
             "companion_stream_matches_stream": companion_stream_matches,
             "audio_route_observed": bool(audio_routes),
             "audio_route_matches_stream": audio_route_matches,
+            "audio_inventory_observed": latest_audio_inventory is not None,
+            "audio_output_choice_exists": audio_output_choice_exists,
+            "presentation_route_offers_audio": presentation_route_offers_audio,
             "game_window_observed": game_window_observed,
             "game_top_resumed_observed": game_top_resumed_observed,
             "companion_window_observed": companion_window_observed,

--- a/tools/test_nova_thor_audio_field.py
+++ b/tools/test_nova_thor_audio_field.py
@@ -32,7 +32,7 @@ class NovaThorAudioFieldTest(unittest.TestCase):
             source_process_scoped=True,
         )
 
-        self.assertEqual(report["schema_version"], 2)
+        self.assertEqual(report["schema_version"], 3)
         self.assertEqual(report["stream_display_ids"], [0])
         self.assertEqual(report["companion_display_ids"], [1])
         self.assertEqual(report["audio_context_display_ids"], [0])
@@ -47,6 +47,105 @@ class NovaThorAudioFieldTest(unittest.TestCase):
         self.assertTrue(report["checks"]["source_process_scoped"])
         self.assertTrue(report["checks"]["diagnostic_evidence_complete"])
         self.assertFalse(report["physical_audio_verified"])
+
+    def test_inventory_reports_a_second_output_device_as_a_choice(self):
+        module = load_module(self)
+        report = module.analyze_logcat(
+            """
+            Nova: Android display role stream id=0 target=largest
+            Nova: Android display audio route display_id=0 device_id=2 type=2
+            Nova: Android display audio inventory display_id=0 outputs=2 routes=0
+            Nova: Android display audio output device_id=2 type=2 address=none
+            Nova: Android display audio output device_id=9 type=9 address=hdmi-top
+            """
+        )
+
+        self.assertEqual(report["latest_audio_inventory"]["outputs"], 2)
+        self.assertEqual(
+            report["audio_outputs"],
+            [
+                {"device_id": "2", "type": "2", "address": "none"},
+                {"device_id": "9", "type": "9", "address": "hdmi-top"},
+            ],
+        )
+        self.assertTrue(report["checks"]["audio_inventory_observed"])
+        self.assertTrue(report["checks"]["audio_output_choice_exists"])
+
+    def test_single_output_device_is_reported_as_no_choice(self):
+        module = load_module(self)
+        report = module.analyze_logcat(
+            """
+            Nova: Android display role stream id=0 target=largest
+            Nova: Android display audio inventory display_id=0 outputs=1 routes=0
+            Nova: Android display audio output device_id=2 type=2 address=none
+            """
+        )
+
+        # The whole point of the capture: one output means setPreferredDevice has nowhere to aim,
+        # so this reads False rather than None. Only a missing inventory line is unknown.
+        self.assertTrue(report["checks"]["audio_inventory_observed"])
+        self.assertFalse(report["checks"]["audio_output_choice_exists"])
+
+    def test_presentation_route_carrying_live_audio_is_flagged(self):
+        module = load_module(self)
+        report = module.analyze_logcat(
+            """
+            Nova: Android display role stream id=0 target=largest
+            Nova: Android display audio inventory display_id=0 outputs=1 routes=2
+            Nova: Android display audio output device_id=2 type=2 address=none
+            Nova: Android display audio presentation index=0 live_audio=true presentation_display_id=none selected=true
+            Nova: Android display audio presentation index=1 live_audio=true presentation_display_id=1 selected=false
+            """
+        )
+
+        self.assertEqual(
+            report["audio_presentation_routes"],
+            [
+                {
+                    "index": 0,
+                    "live_audio": True,
+                    "presentation_display_id": "none",
+                    "selected": True,
+                },
+                {
+                    "index": 1,
+                    "live_audio": True,
+                    "presentation_display_id": "1",
+                    "selected": False,
+                },
+            ],
+        )
+        # A route that names a display and carries live audio is the second pre-34 lever, and it
+        # is independent of the device count -- here there is only one output device.
+        self.assertFalse(report["checks"]["audio_output_choice_exists"])
+        self.assertTrue(report["checks"]["presentation_route_offers_audio"])
+
+    def test_route_without_a_presentation_display_offers_no_affinity(self):
+        module = load_module(self)
+        report = module.analyze_logcat(
+            """
+            Nova: Android display role stream id=0 target=largest
+            Nova: Android display audio inventory display_id=0 outputs=1 routes=1
+            Nova: Android display audio presentation index=0 live_audio=true presentation_display_id=none selected=true
+            """
+        )
+
+        self.assertFalse(report["checks"]["presentation_route_offers_audio"])
+
+    def test_absent_inventory_is_unknown_rather_than_no_choices(self):
+        module = load_module(self)
+        report = module.analyze_logcat(
+            """
+            Nova: Android display role stream id=0 target=largest
+            Nova: Android display audio route display_id=0 device_id=2 type=2
+            """
+        )
+
+        # A capture from a build that predates the inventory must not be readable as "this device
+        # has one output and no routes" -- that is the exact wrong conclusion to draw from silence.
+        self.assertFalse(report["checks"]["audio_inventory_observed"])
+        self.assertIsNone(report["checks"]["audio_output_choice_exists"])
+        self.assertIsNone(report["checks"]["presentation_route_offers_audio"])
 
     def test_analyze_logcat_flags_mismatch_and_window_failures(self):
         module = load_module(self)


### PR DESCRIPTION
## Summary

Reopens the question behind #127 rather than the issue itself. That was closed on the finding that
`AudioTrack.Builder#setContext` arrived in API 34, so on the Thor's Android 13 there is no supported
way to give a track display affinity, and pinning launches to the top screen is the right answer
rather than a workaround. The API claim holds. The conclusion drawn from it was wider than the
evidence: it rules out *display* affinity and then quietly rules out *device* affinity too.

`AudioTrack.setPreferredDevice` has been public since **API 23** and needs no permission. It cannot
name a display, but it can name a device — and on a host whose two screens have their own speakers,
that may reach the same place by another road.
`MediaRouter.RouteInfo.getPresentationDisplay` is the other one, public since **API 17**, and it is
the only API in the platform that maps an audio route onto a `Display` — precisely the link the
closing comment said did not exist.

Whether either helps turns on a fact nobody has collected. Both field reports attached to the issue
show `device_id=2 type=2` — a builtin speaker — in both launch lanes. But the diagnostic only ever
logged the device the track *landed on*, never the devices it *could have* landed on. One line
cannot tell a single output the vendor re-points below the HAL from two outputs we never asked
about, and those have opposite fixes.

So this logs the enumeration, once per track, in the single-line shape the field tool already
parses. It is diagnostics only — nothing about what any user hears changes.

**Placement is explicitly not the suspect.** `shouldUseDisplayLaunchTrampoline` already fires when
the selected display differs from the current one, `ActivityOptions#setLaunchDisplayId` is already
called, and the reporter confirms video lands on the top screen while audio stays on the bottom.
The activity goes to the right place; something below it does not follow.

## Exact candidate

`e3c89669` on `fix/issue-127-audio-device-inventory`, one commit off `e71de0f6`.

- `AndroidAudioRenderer` logs an inventory line plus one line per output device and per media route
- `tools/nova_thor_audio_field.py` grows `audio_output_choice_exists` and
  `presentation_route_offers_audio`, reported as `null` — not `false` — when no inventory line was
  seen, so a capture from a build predating this cannot be misread as a device with no choices
- neither check feeds `diagnostic_evidence_complete`: the inventory describes the platform, it does
  not grade the wiring

Route names and product names are deliberately not logged — those are user-visible strings and carry
people's names. Addresses are reduced to the characters an identifier is made of, since they are
vendor strings rather than a documented vocabulary and are worth having only to tell two otherwise
identical speakers apart.

## Verification

```
:app:testNonRoot_gameDebugUnitTest      1210 tests, 0 failures
:app:lintNonRoot_gameRelease -PlintFailOnError=true    0 errors
tools/test_nova_thor_audio_field.py     20 tests, OK
```

Lint earned its keep here: it caught `getAddress` being **API 28**, not the 23 the rest of
`AudioDeviceInfo` arrived in, against a minSdk of 21. It now has its own gate inside the one the
enumeration already sits behind.

The five new parser tests were break-tested by inverting `len(audio_outputs) > 1`, which failed two
of them as intended. Worth knowing for anyone repeating that: restoring the file can leave a stale
`__pycache__` that keeps executing the broken bytecode, because the edit is byte-identical in length
and lands in the same second, so Python's mtime+size check considers the cache valid. Clear
`tools/__pycache__` or you will debug a file that is already correct.

## Not covered

Anything actually being fixed. This replaces an assumption with a question, and the question needs
one capture on a real Thor to answer. All three outcomes are useful:

- **two or more outputs** → `setPreferredDevice` has somewhere to aim
- **a route carrying live audio that names a display** → `MediaRouter` can express the affinity
- **neither** → the platform offers no pre-34 lever, the top-screen pin is confirmed as correct
  rather than assumed, and #127 stays closed on evidence
