### PR TITLE
feat(api): read the display planner Polaris now serves

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt
@@ -64,8 +64,72 @@ object PolarisGameJsonAdapter {
             hdrSupported = json.optBoolean("hdr_supported", false),
             launchMode = launchMode,
             steamLaunch = steamLaunch,
+            displayPlanner = parseDisplayPlanner(json.optJSONObject("display_planner")),
             artwork = parseArtworkManifest(json.optJSONObject("artwork"))
         )
+    }
+
+    /**
+     * Polaris computes this once per request from the host display and attaches the same
+     * object to every game, so absence means an older host rather than a game without a
+     * plan — and the Resolution row draws nothing rather than guessing.
+     *
+     * The function and receiver names here are recorded by name in Polaris'
+     * docs/nova-contract.json (`nova_reader` for the display_planner objects); renaming
+     * them means updating that manifest in the same change.
+     */
+    @JvmStatic
+    internal fun parseDisplayPlanner(plannerJson: JSONObject?): PolarisGame.DisplayPlannerContract? {
+        if (plannerJson == null) return null
+        return PolarisGame.DisplayPlannerContract(
+            available = plannerJson.optBoolean("available", false),
+            sourceMode = plannerJson.optString("source_mode", ""),
+            sourceAspectRatio = plannerJson.optString("source_aspect_ratio", ""),
+            sourceFps = finiteDouble(plannerJson, "source_fps", 0.0).coerceAtLeast(0.0),
+            recommendedId = plannerJson.optString("recommended_id", ""),
+            recommendedTitle = plannerJson.optString("recommended_title", ""),
+            recommendedMode = plannerJson.optString("recommended_mode", ""),
+            choices = parseDisplayPlannerChoices(plannerJson.optJSONArray("choices")),
+            advancedScaleFactors = parseDisplayPlannerScaleChoices(plannerJson.optJSONArray("advanced_scale_factors"))
+        )
+    }
+
+    private fun parseDisplayPlannerChoices(array: JSONArray?): List<PolarisGame.DisplayPlannerChoice> {
+        if (array == null) return emptyList()
+        return (0 until array.length()).mapNotNull { index ->
+            array.optJSONObject(index)?.let { choiceJson ->
+                PolarisGame.DisplayPlannerChoice(
+                    id = choiceJson.optString("id", ""),
+                    title = choiceJson.optString("title", ""),
+                    intent = choiceJson.optString("intent", ""),
+                    targetMode = choiceJson.optString("target_mode", ""),
+                    badge = choiceJson.optString("badge", ""),
+                    reason = choiceJson.optString("reason", ""),
+                    advanced = choiceJson.optBoolean("advanced", false),
+                    custom = choiceJson.optBoolean("custom", false),
+                    // The contract's own defaults: an entry that says nothing is safe and
+                    // visible, matching what an older serialisation would have decoded.
+                    safe = choiceJson.optBoolean("safe", true),
+                    hidden = choiceJson.optBoolean("hidden", false),
+                    scaleFactor = finiteDouble(choiceJson, "scale_factor", 1.0),
+                    aspectRatio = choiceJson.optString("aspect_ratio", "")
+                )
+            }
+        }
+    }
+
+    private fun parseDisplayPlannerScaleChoices(array: JSONArray?): List<PolarisGame.DisplayPlannerScaleChoice> {
+        if (array == null) return emptyList()
+        return (0 until array.length()).mapNotNull { index ->
+            array.optJSONObject(index)?.let { scaleJson ->
+                PolarisGame.DisplayPlannerScaleChoice(
+                    scaleFactor = finiteDouble(scaleJson, "scale_factor", 1.0),
+                    label = scaleJson.optString("label", ""),
+                    targetMode = scaleJson.optString("target_mode", ""),
+                    safe = scaleJson.optBoolean("safe", true)
+                )
+            }
+        }
     }
 
     @JvmStatic

--- a/app/src/test/java/com/papi/nova/api/PolarisGameJsonAdapterTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisGameJsonAdapterTest.kt
@@ -1,0 +1,146 @@
+package com.papi.nova.api
+
+import com.papi.nova.shared.polaris.model.PolarisGame
+import com.papi.nova.ui.NovaDisplayResolutionPlanner
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The display_planner payload below is the exact plan Polaris serves for a
+ * 2560x1600x90 host — the same values tests/unit/test_display_planner.cpp pins
+ * on the Polaris side. If either side moves, the other moves in the same
+ * change, or the Resolution row quietly renders something the host never said.
+ */
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class PolarisGameJsonAdapterTest {
+
+    private fun plannerGameJson(): JSONObject = JSONObject(
+        """
+        {
+          "id": "game-planner",
+          "app_id": 42,
+          "name": "Planner Game",
+          "display_planner": {
+            "available": true,
+            "source_mode": "2560x1600x90",
+            "source_aspect_ratio": "8:5",
+            "source_fps": 90,
+            "recommended_id": "balanced",
+            "recommended_title": "Best for this device",
+            "recommended_mode": "1920x1200x90",
+            "choices": [
+              {"id":"native","title":"Native","intent":"Match the client panel exactly.","target_mode":"2560x1600x90","badge":"2560×1600","reason":"Match the client panel exactly.","advanced":false,"custom":false,"safe":true,"hidden":false,"scale_factor":1,"aspect_ratio":"8:5"},
+              {"id":"balanced","title":"Balanced","intent":"Best for this device: preserve aspect ratio while easing encoder and network load.","target_mode":"1920x1200x90","badge":"Best for this device","reason":"Best for this device: preserve aspect ratio while easing encoder and network load.","advanced":false,"custom":false,"safe":true,"hidden":false,"scale_factor":0.75,"aspect_ratio":"8:5"},
+              {"id":"sharp","title":"Sharp / Supersampled","intent":"Render above the client panel and downscale for extra clarity when the host has headroom.","target_mode":"3840x2400x90","badge":"1.5x supersample","reason":"Render above the client panel and downscale for extra clarity when the host has headroom.","advanced":true,"custom":false,"safe":true,"hidden":false,"scale_factor":1.5,"aspect_ratio":"8:5"},
+              {"id":"performance","title":"Performance","intent":"Favor frame pacing and bandwidth over raw pixel count.","target_mode":"1280x800x90","badge":"0.5x downscale","reason":"Favor frame pacing and bandwidth over raw pixel count.","advanced":false,"custom":false,"safe":true,"hidden":false,"scale_factor":0.5,"aspect_ratio":"8:5"},
+              {"id":"custom","title":"Custom","intent":"Advanced manual scale factor using the existing fallback display mode field.","target_mode":"2560x1600x90","badge":"Advanced","reason":"Advanced manual scale factor using the existing fallback display mode field.","advanced":true,"custom":true,"safe":true,"hidden":false,"scale_factor":1,"aspect_ratio":"8:5"}
+            ],
+            "advanced_scale_factors": [
+              {"scale_factor":0.5,"label":"0.5x","target_mode":"1280x800x90","safe":true},
+              {"scale_factor":0.75,"label":"0.75x","target_mode":"1920x1200x90","safe":true},
+              {"scale_factor":1,"label":"1x","target_mode":"2560x1600x90","safe":true},
+              {"scale_factor":1.25,"label":"1.25x","target_mode":"3200x2000x90","safe":true},
+              {"scale_factor":1.5,"label":"1.5x","target_mode":"3840x2400x90","safe":true},
+              {"scale_factor":2,"label":"2x","target_mode":"5120x3200x90","safe":true}
+            ]
+          }
+        }
+        """.trimIndent()
+    )
+
+    @Test
+    fun decodesTheDisplayPlannerContractPolarisServes() {
+        val game = PolarisGameJsonAdapter.fromJson(plannerGameJson())
+
+        val planner = requireNotNull(game.displayPlanner)
+        assertTrue(planner.available)
+        assertEquals("2560x1600x90", planner.sourceMode)
+        assertEquals("8:5", planner.sourceAspectRatio)
+        assertEquals(90.0, planner.sourceFps, 0.0)
+        assertEquals("balanced", planner.recommendedId)
+        assertEquals("Best for this device", planner.recommendedTitle)
+        assertEquals("1920x1200x90", planner.recommendedMode)
+
+        assertEquals(listOf("native", "balanced", "sharp", "performance", "custom"), planner.choices.map { it.id })
+        val native = planner.choices[0]
+        assertEquals("2560×1600", native.badge)
+        assertEquals(1.0, native.scaleFactor, 0.0)
+        val sharp = planner.choices[2]
+        assertTrue(sharp.advanced)
+        assertFalse(sharp.custom)
+        assertEquals("3840x2400x90", sharp.targetMode)
+        val custom = planner.choices[4]
+        assertTrue(custom.advanced)
+        assertTrue(custom.custom)
+        planner.choices.forEach { choice ->
+            assertTrue(choice.id, choice.safe)
+            assertFalse(choice.id, choice.hidden)
+            assertEquals(choice.id, "8:5", choice.aspectRatio)
+        }
+
+        assertEquals(listOf(0.5, 0.75, 1.0, 1.25, 1.5, 2.0), planner.advancedScaleFactors.map { it.scaleFactor })
+        assertEquals("2x", planner.advancedScaleFactors.last().label)
+        assertEquals("5120x3200x90", planner.advancedScaleFactors.last().targetMode)
+    }
+
+    @Test
+    fun parsedPlannerLightsUpTheResolutionRow() {
+        // The exact precondition NovaGameDetailActivity gates the RESOLUTION row on.
+        val game = PolarisGameJsonAdapter.fromJson(plannerGameJson())
+        val planner = NovaDisplayResolutionPlanner.from(
+            contract = game.displayPlanner,
+            fallbackMode = "",
+            includeAdvanced = true
+        )
+
+        assertTrue(planner.available)
+        assertEquals(5, planner.visibleChoices.size)
+        assertTrue(planner.hasAdvancedChoices)
+        assertEquals("balanced", planner.visibleChoices.single { it.recommended }.id)
+    }
+
+    @Test
+    fun missingDisplayPlannerStaysNullForOlderHosts() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject("""{"id":"game-legacy","app_id":7,"name":"Legacy Game"}""")
+        )
+        assertNull(game.displayPlanner)
+    }
+
+    @Test
+    fun sparsePlannerEntriesFallBackToTheContractDefaults() {
+        val game = PolarisGameJsonAdapter.fromJson(
+            JSONObject(
+                """
+                {
+                  "id": "game-sparse",
+                  "display_planner": {
+                    "available": true,
+                    "choices": ["not-an-object", {"id":"balanced","target_mode":"1920x1200x60"}],
+                    "advanced_scale_factors": [42, {"label":"1x"}]
+                  }
+                }
+                """.trimIndent()
+            )
+        )
+
+        val planner = requireNotNull(game.displayPlanner)
+        val choice = planner.choices.single()
+        assertEquals("balanced", choice.id)
+        assertTrue(choice.safe)
+        assertFalse(choice.hidden)
+        assertEquals(1.0, choice.scaleFactor, 0.0)
+        val scale = planner.advancedScaleFactors.single()
+        assertEquals("1x", scale.label)
+        assertEquals(1.0, scale.scaleFactor, 0.0)
+        assertTrue(scale.safe)
+    }
+}


### PR DESCRIPTION
## Summary

papi-ux/polaris#316 makes Polaris serve `display_planner` on every game object. On the Nova side everything that consumes it already shipped: the shared kotlinx model decodes it, `NovaDisplayResolutionPlanner` filters it (`safe && !hidden`, advanced kept behind `includeAdvanced`), and Play Setup's act column draws the fourth — Resolution — row when a plan is available, inside the dp budgets #195 established. The one missing link was `PolarisGameJsonAdapter`: it never parsed the field, so `game.displayPlanner` stayed null and the row could not render against any host.

This parses the planner, its `choices[]` and its `advanced_scale_factors[]` in the adapter's idiom — `opt*` with the contract's own defaults, `finiteDouble` for the numbers, junk array entries skipped. An entry that says nothing decodes as safe and visible, which is what the shared model's own defaults already answer.

Parsing lives in named functions with distinct receivers (`parseDisplayPlanner(plannerJson)`, choices via `choiceJson`, scale entries via `scaleJson`) because Polaris' `docs/nova-contract.json` records readers by function and receiver name. The Polaris follow-up prunes the `known_drift` entries this resolves and repoints those records at these functions.

The new test pins the exact 2560x1600x90 plan Polaris' `tests/unit/test_display_planner.cpp` pins on its side of the repository boundary — badges, flags, scale ladder — and closes the loop on the row's own precondition: the parsed plan reports available, five visible choices, `balanced` recommended.

## Exact candidate

- `Commit: afabd33a4eae8503f7dc1bb591a48f2c93c71532`
- `Tree:   caf896a4a47bec9b9cc4e0d8cd8e22e6067010c2`
- `Base:   55b7c8dc`

## Verification

On pc-papi (Fedora), in a clean worktree of master:

- [x] `:app:testDebugUnitTest --tests com.papi.nova.api.PolarisGameJsonAdapterTest` — BUILD SUCCESSFUL, and verified against the report XML (`testRootDebugUnitTest`): `tests="4" failures="0" errors="0" skipped="0"` — checked because a non-matching `--tests` filter passes silently
- [x] Resolution row on the Retroid Pocket 6 against pc-papi running `polaris-1.3.7.d866d46d` (#316 deployed): the act column shows the fourth row — Resolution `1440x810x60` from host profile `1920x1080x60` — and focusing it flips the legend to all five planner choices (Native 1920x1080 / Best for this device 1440x810 / Sharp 2880x1620 / Performance 960x540 / Custom), matching the planner math both repos pin. Screenshots archived under `~/.hermes/artifacts/nova/display-planner-resolution-row-20260807/` on pc-papi.
