### PR TITLE
fix(stream): a HUD tap reaches the game, and the drawer drag stops spawning coroutines

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -32,10 +32,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -140,6 +142,21 @@ fun NovaQuickMenuDrawer(
     }
     val drawerWidthPx = with(density) { drawerWidth.toPx().coerceAtLeast(1f) }
 
+    // One collector follows the finger, conflated to a frame's pace. The drag used to
+    // launch a coroutine per pointer-move event — sixty to a hundred and twenty a
+    // second, each stopping whatever the one before it had started — to do what a
+    // single snapTo per frame does.
+    val dragInProgress = remember { mutableStateOf(false) }
+    val dragProgress = remember { mutableFloatStateOf(1f) }
+    LaunchedEffect(Unit) {
+        snapshotFlow { if (dragInProgress.value) dragProgress.floatValue else Float.NaN }
+            .collect { target ->
+                if (!target.isNaN()) {
+                    drawerProgress.snapTo(target)
+                }
+            }
+    }
+
     suspend fun animateDrawerTo(target: Float) {
         drawerProgress.animateTo(
             targetValue = target.coerceIn(0f, 1f),
@@ -207,22 +224,22 @@ fun NovaQuickMenuDrawer(
                 .pointerInput(drawerWidthPx) {
                     detectHorizontalDragGestures(
                         onDragStart = {
+                            dragProgress.floatValue = drawerProgress.value
+                            dragInProgress.value = true
                             scope.launch { drawerProgress.stop() }
                         },
                         onDragCancel = {
+                            dragInProgress.value = false
                             scope.launch { animateDrawerTo(1f) }
                         },
                         onDragEnd = {
+                            dragInProgress.value = false
                             settleDrawerAfterDrag()
                         },
                         onHorizontalDrag = { change, dragAmount ->
                             change.consume()
-                            val nextProgress = (drawerProgress.value + dragAmount / drawerWidthPx)
-                                .coerceIn(0f, 1f)
-                            scope.launch {
-                                drawerProgress.stop()
-                                drawerProgress.snapTo(nextProgress)
-                            }
+                            dragProgress.floatValue =
+                                (dragProgress.floatValue + dragAmount / drawerWidthPx).coerceIn(0f, 1f)
                         }
                     )
                 }

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
@@ -69,6 +70,7 @@ class NovaStreamHud(
     private var viewStartY = 0f
     private var isDragging = false
     private var longPressTriggered = false
+    private var forwardingTap = false
     private var pendingLongPress: Runnable? = null
 
     fun show() {
@@ -127,6 +129,11 @@ class NovaStreamHud(
 
     private fun setupTouchHandler(view: View) {
         view.setOnTouchListener { touchedView, event ->
+            // Standing down while a tap is being replayed, so the dispatch in
+            // forwardTapToStream() falls through this view to the stream surface.
+            if (forwardingTap) {
+                return@setOnTouchListener false
+            }
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
                     dragStartX = event.rawX
@@ -156,7 +163,12 @@ class NovaStreamHud(
                     when {
                         longPressTriggered -> Unit
                         isDragging -> clampAndSaveHudPosition(touchedView)
-                        else -> cycleMode()
+                        // A tap was never the HUD's to keep: the readout sits over the
+                        // game, and a press that neither dragged it nor held it was
+                        // aimed at what is underneath. Only a drag or a long-press
+                        // claims the gesture; mode cycling stays on the Command
+                        // Center action that already does it.
+                        else -> forwardTapToStream(event)
                     }
                     true
                 }
@@ -166,6 +178,35 @@ class NovaStreamHud(
                 }
                 else -> false
             }
+        }
+    }
+
+    /**
+     * Replay a plain tap beneath the HUD.
+     *
+     * Android hands every later event of a gesture to whoever consumed its DOWN, so a
+     * listener that wants to recognise drags and long-presses has no choice but to
+     * claim the DOWN — by the time the gesture turns out to have been a tap, the game
+     * never saw it. The repair is to replay it: with the listener standing down, decor
+     * dispatch walks past this view and delivers the same coordinates to the stream
+     * surface underneath.
+     */
+    private fun forwardTapToStream(event: MotionEvent) {
+        val root = activity.window.decorView
+        forwardingTap = true
+        try {
+            val now = SystemClock.uptimeMillis()
+            val down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, event.rawX, event.rawY, 0)
+            val up = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, event.rawX, event.rawY, 0)
+            try {
+                root.dispatchTouchEvent(down)
+                root.dispatchTouchEvent(up)
+            } finally {
+                down.recycle()
+                up.recycle()
+            }
+        } finally {
+            forwardingTap = false
         }
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1870,6 +1870,51 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
+    fun streamHudForwardsPlainTapsToTheStreamInsteadOfKeepingThem() {
+        val source = readSource("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")
+        val touchHandler = source.section(
+            "private fun setupTouchHandler(view: View)",
+            "private fun forwardTapToStream("
+        )
+        assertTrue(
+            "a press that neither dragged the HUD nor held it was aimed at the game " +
+                "underneath. The gesture's DOWN has to be claimed to recognise a drag or " +
+                "long-press at all, so the tap is replayed beneath the HUD instead of " +
+                "consumed by it — and cycling modes stays on the Command Center action " +
+                "that already does it",
+            touchHandler.contains("else -> forwardTapToStream(event)") &&
+                !touchHandler.contains("cycleMode()") &&
+                touchHandler.contains("if (forwardingTap)")
+        )
+        assertTrue(
+            "the replay dispatches through the decor with the listener standing down, " +
+                "and recycles what it obtains",
+            source.contains("root.dispatchTouchEvent(down)") &&
+                source.contains("root.dispatchTouchEvent(up)") &&
+                source.contains("down.recycle()") &&
+                source.contains("up.recycle()")
+        )
+    }
+
+    @Test
+    fun commandCenterDragSnapsThroughOneCollectorNotACoroutinePerMove() {
+        val content = readNovaQuickMenuContent()
+        val dragHandler = content.section(
+            "onHorizontalDrag = { change, dragAmount ->",
+            "NovaQuickMenuContent("
+        )
+        assertTrue(
+            "dragging the drawer used to launch a coroutine per pointer-move event — " +
+                "sixty to a hundred and twenty a second, each stopping whatever the one " +
+                "before it started. The handler writes one float; a single snapshotFlow " +
+                "collector snaps the drawer at a frame's pace",
+            !dragHandler.contains("scope.launch") &&
+                dragHandler.contains("dragProgress.floatValue =") &&
+                content.contains("snapshotFlow { if (dragInProgress.value) dragProgress.floatValue else Float.NaN }")
+        )
+    }
+
+    @Test
     fun commandCenterUsesAnchoredLeftDrawerInsteadOfBottomSheet() {
         val quickMenu = readNovaQuickMenu()
         val content = readNovaQuickMenuContent()


### PR DESCRIPTION
## Summary

Two input defects in the stream session, one per surface — the two perf/input items of the ride-along list.

**A tap on the HUD reaches the game now.** `NovaStreamHud` claimed every gesture at `ACTION_DOWN`, which it must to recognise a drag or long-press at all — Android hands every later event of a gesture to whoever consumed its DOWN. But the claim meant a plain tap on the readout vanished: aimed at the game underneath, kept by the HUD, spent on cycling HUD modes nobody asked to cycle mid-session. The fix replays the tap beneath the HUD: the listener stands down (`forwardingTap`) while the same coordinates are dispatched through the decor, so dispatch walks past the HUD and delivers to the stream surface. Mode cycling stays on the Command Center action that already does it (`Game.kt` calls `hud.cycleMode()`).

**The drawer drag stops spawning coroutines.** Dragging the Command Center drawer launched a coroutine per pointer-move event — 60–120 a second, each calling `stop()` on whatever the one before it started, to move a float. The handler now writes one float; a single `snapshotFlow` collector (conflated, so at most one `snapTo` per frame) follows the finger, and `stop()` runs once per gesture in `onDragStart` where it belonged.

Both are pinned in `NovaComposeSourceGuardTest`: the tap replay with the listener's stand-down and recycled events, and the drag handler's launch-free body with its single collector.

## Exact candidate

- `Commit: 4ea8818d3f6fe53dda541323f040d89148c3db8b`
- `Tree:   0fa998c434dcc7760a516e390ba42e9804fc0e4e`
- `Base:   14ae8281`

## Verification

On pc-papi (Fedora), clean worktree of master:

- [x] `NovaComposeSourceGuardTest` — 80/80 (XML-verified): the two new guards plus every existing one, including the HUD drag-mechanics and cycleMode position-restore guards this change had to keep satisfied
- [x] `:app:compileNonRoot_gameDebugKotlin` — clean
