### PR TITLE
fix(sync): the sheet gets an exit, and its English moves out of Kotlin

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -870,6 +870,10 @@ class NovaGameDetailActivity : NovaActivity() {
                 loadingLabel = getString(R.string.nova_polaris_sync_loading),
                 unavailableLabel = getString(R.string.nova_polaris_sync_unavailable),
                 unsetLabel = getString(R.string.nova_polaris_sync_unset),
+                savedAfterRelaunchLabel = getString(R.string.nova_polaris_sync_status_saved_relaunch),
+                selectedLabel = getString(R.string.nova_polaris_sync_status_selected),
+                activeNowLabel = getString(R.string.nova_polaris_sync_status_active_now),
+                availableLabel = getString(R.string.nova_polaris_sync_status_available),
             )
         }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncContent.kt
@@ -57,6 +57,7 @@ fun NovaPolarisSyncContent(
     onClearProfile: () -> Unit,
     onAutoSyncChange: (Boolean) -> Unit,
     onAiChange: (Boolean) -> Unit,
+    onClose: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val colors = LocalNovaComposeColors.current
@@ -68,15 +69,9 @@ fun NovaPolarisSyncContent(
             .padding(horizontal = 16.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(bottom = 4.dp)
-                .height(4.dp)
-                .fillMaxWidth(0.12f)
-                .clip(RoundedCornerShape(NovaRadius.pill))
-                .background(colors.divider.copy(alpha = 0.75f))
-        )
+        // No drag pill. The sheet pins itself expanded and not draggable, and the 4dp
+        // handle it drew promised a gesture that did nothing. The way out is stated
+        // instead: the Close control here, and B.
 
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -101,6 +96,15 @@ fun NovaPolarisSyncContent(
                 )
             }
             NovaSyncStatusChip(uiState.status)
+            if (onClose != null) {
+                NovaActionButton(
+                    text = stringResource(R.string.nova_polaris_sync_close),
+                    onClick = onClose,
+                    contentDescription = stringResource(R.string.nova_polaris_sync_close_cd),
+                    minHeight = 36.dp,
+                    fontSize = 11.sp
+                )
+            }
         }
 
         NovaSyncSection(title = stringResource(R.string.nova_polaris_sync_mode_title)) {

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncSheet.kt
@@ -3,6 +3,7 @@ package com.papi.nova.ui
 import android.app.Dialog
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -118,7 +119,11 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
                         novaBitrateKbps = prefs.bitrate,
                         loadingLabel = getString(R.string.nova_polaris_sync_loading),
                         unavailableLabel = getString(R.string.nova_polaris_sync_unavailable),
-                        unsetLabel = getString(R.string.nova_polaris_sync_unset)
+                        unsetLabel = getString(R.string.nova_polaris_sync_unset),
+                        savedAfterRelaunchLabel = getString(R.string.nova_polaris_sync_status_saved_relaunch),
+                        selectedLabel = getString(R.string.nova_polaris_sync_status_selected),
+                        activeNowLabel = getString(R.string.nova_polaris_sync_status_active_now),
+                        availableLabel = getString(R.string.nova_polaris_sync_status_available)
                     )
                     key(profileVersion) {
                         NovaPolarisSyncContent(
@@ -132,7 +137,8 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
                             onUsePolaris = { engine.usePolarisProfile() },
                             onClearProfile = { engine.clearProfile() },
                             onAutoSyncChange = { engine.setAutoSync(it) },
-                            onAiChange = { engine.setAiAutoQuality(it) }
+                            onAiChange = { engine.setAiAutoQuality(it) },
+                            onClose = { dismiss() }
                         )
                     }
                 }
@@ -144,6 +150,17 @@ class NovaPolarisSyncSheet : BottomSheetDialogFragment() {
         return BottomSheetDialog(requireContext(), theme).apply {
             setOnShowListener {
                 expandBottomSheet(this)
+            }
+            // Dialogs map BACK out of the box but not a pad's B, so a controller had
+            // no way out of this sheet at all: not draggable, no close control, and B
+            // swallowed. B now leaves, the same direction it means everywhere else.
+            setOnKeyListener { _, keyCode, event ->
+                if (keyCode == KeyEvent.KEYCODE_BUTTON_B && event.action == KeyEvent.ACTION_UP) {
+                    dismiss()
+                    true
+                } else {
+                    false
+                }
             }
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
@@ -44,6 +44,9 @@ data class NovaPolarisSyncUiState(
 )
 
 object NovaPolarisSyncUiStateMapper {
+    // Every label arrives from the caller, none defaults to English here: a default
+    // is a string that ships in every locale unnoticed, which is exactly how the
+    // status labels below lived in Kotlin for a year.
     fun build(
         settings: PolarisClientSettings?,
         busy: Boolean,
@@ -52,9 +55,13 @@ object NovaPolarisSyncUiStateMapper {
         hasServerUuid: Boolean,
         novaDisplayMode: String,
         novaBitrateKbps: Int,
-        loadingLabel: String = "Loading",
-        unavailableLabel: String = "Unavailable",
-        unsetLabel: String = "Unset"
+        loadingLabel: String,
+        unavailableLabel: String,
+        unsetLabel: String,
+        savedAfterRelaunchLabel: String,
+        selectedLabel: String,
+        activeNowLabel: String,
+        availableLabel: String
     ): NovaPolarisSyncUiState {
         val fallback = if (settingsUnavailable) unavailableLabel else loadingLabel
         val desiredMode = PolarisStreamDisplayMode.normalize(settings?.desired?.streamDisplayMode)
@@ -116,11 +123,11 @@ object NovaPolarisSyncUiStateMapper {
                     reason = option?.reason.orEmpty(),
                     restartRequired = option?.restartRequired ?: true,
                     statusLabel = when {
-                        desiredSelected && relaunchRequired && !effectiveSelected -> "Saved — applies after relaunch"
-                        desiredSelected -> "Selected"
-                        effectiveSelected -> "Active now"
-                        available -> "Available"
-                        else -> "Unavailable"
+                        desiredSelected && relaunchRequired && !effectiveSelected -> savedAfterRelaunchLabel
+                        desiredSelected -> selectedLabel
+                        effectiveSelected -> activeNowLabel
+                        available -> availableLabel
+                        else -> unavailableLabel
                     }
                 )
             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,6 +474,12 @@
     <string name="nova_polaris_sync_nova_profile">Nova</string>
     <string name="nova_polaris_sync_polaris_profile">Polaris</string>
     <string name="nova_polaris_sync_unset">Unset</string>
+    <string name="nova_polaris_sync_close">Close</string>
+    <string name="nova_polaris_sync_close_cd">Close Polaris Sync</string>
+    <string name="nova_polaris_sync_status_saved_relaunch">Saved — applies after relaunch</string>
+    <string name="nova_polaris_sync_status_selected">Selected</string>
+    <string name="nova_polaris_sync_status_active_now">Active now</string>
+    <string name="nova_polaris_sync_status_available">Available</string>
     <string name="nova_polaris_sync_profile_format">%1$s · %2$d Mbps</string>
     <string name="nova_polaris_sync_profile_no_bitrate">%1$s · no bitrate override</string>
     <string name="nova_polaris_sync_desired_format">Desired: %1$s</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaPolarisSyncUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaPolarisSyncUiStateTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class NovaPolarisSyncUiStateTest {
     @Test
     fun loadingStateDisablesHostControls() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = null,
             busy = false,
             settingsUnavailable = false,
@@ -32,7 +32,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun availableSettingsSelectDesiredModeAndEnableActions() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = settings(),
             busy = false,
             settingsUnavailable = false,
@@ -58,7 +58,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun normalizedVirtualDisplayModeSelectsAndDisablesCanonicalRow() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = PolarisClientSettings(
                 desired = PolarisClientSettings.Desired(streamDisplayMode = "virtual_display"),
                 capabilities = PolarisClientSettings.Capabilities(
@@ -86,7 +86,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun busyStateDisablesAllMutatingActions() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = settings(),
             busy = true,
             settingsUnavailable = false,
@@ -107,7 +107,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun profileActionsReflectProfileComparison() {
-        val matched = NovaPolarisSyncUiStateMapper.build(
+        val matched = build(
             settings = settings(displayMode = "1920x1080@60", bitrateKbps = 30000),
             busy = false,
             settingsUnavailable = false,
@@ -116,7 +116,7 @@ class NovaPolarisSyncUiStateTest {
             novaDisplayMode = "1920x1080@60",
             novaBitrateKbps = 30000
         )
-        val different = NovaPolarisSyncUiStateMapper.build(
+        val different = build(
             settings = settings(displayMode = "2560x1440@60", bitrateKbps = 45000),
             busy = false,
             settingsUnavailable = false,
@@ -135,7 +135,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun modeMapperNormalizesCapabilitiesAndMarksPendingRelaunch() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = PolarisClientSettings(
                 desired = PolarisClientSettings.Desired(
                     streamDisplayMode = PolarisClientSettings.MODE_GPU_NATIVE_TEST
@@ -168,7 +168,7 @@ class NovaPolarisSyncUiStateTest {
 
     @Test
     fun unavailableHostVirtualDisplayCarriesReason() {
-        val state = NovaPolarisSyncUiStateMapper.build(
+        val state = build(
             settings = PolarisClientSettings(
                 desired = PolarisClientSettings.Desired(
                     streamDisplayMode = PolarisClientSettings.MODE_HEADLESS_STREAM
@@ -198,6 +198,36 @@ class NovaPolarisSyncUiStateTest {
         assertFalse(virtual.enabled)
         assertEquals("No virtual display backend", virtual.reason)
     }
+
+    /**
+     * The mapper takes every label from its caller now — the production text lives in
+     * strings.xml — so the routing assertions below keep pinning the exact words,
+     * em-dash included, by supplying the same ones the resources carry.
+     */
+    private fun build(
+        settings: PolarisClientSettings?,
+        busy: Boolean = false,
+        settingsUnavailable: Boolean = false,
+        autoSyncEnabled: Boolean = false,
+        hasServerUuid: Boolean = true,
+        novaDisplayMode: String = "1920x1080@60",
+        novaBitrateKbps: Int = 30000
+    ) = NovaPolarisSyncUiStateMapper.build(
+        settings = settings,
+        busy = busy,
+        settingsUnavailable = settingsUnavailable,
+        autoSyncEnabled = autoSyncEnabled,
+        hasServerUuid = hasServerUuid,
+        novaDisplayMode = novaDisplayMode,
+        novaBitrateKbps = novaBitrateKbps,
+        loadingLabel = "Loading",
+        unavailableLabel = "Unavailable",
+        unsetLabel = "Unset",
+        savedAfterRelaunchLabel = "Saved — applies after relaunch",
+        selectedLabel = "Selected",
+        activeNowLabel = "Active now",
+        availableLabel = "Available"
+    )
 
     private fun settings(
         displayMode: String = "2560x1440@60",


### PR DESCRIPTION
## Summary

Two of the ride-along items, both about the Polaris Sync sheet.

**An exit exists now.** The sheet pinned itself expanded with `isDraggable = false`, drew no close control, and a controller's B was swallowed — BACK worked only because dialogs map it themselves. B now dismisses (mapped on the dialog, `ACTION_UP`), and a Close control sits in the header beside the status chip. The 4dp drag pill is gone rather than wired: it promised a gesture the sheet deliberately refuses, and an exit that exists beats a handle that lies.

**Its English moves out of Kotlin.** The mode grid's status labels — "Saved — applies after relaunch", "Selected", "Active now", "Available", "Unavailable" — were literals in `NovaPolarisSyncUiStateMapper`, shipping in English in every locale. They live in `strings.xml` now, and the mapper takes **every** label from its caller with no defaults — a default is a string that ships untranslated unnoticed, which is how these lived in Kotlin for a year (the old `loadingLabel = "Loading"` defaults lose their English too). Both callers — the sheet and Play Setup's Every Game scope from #198 — feed it from resources. `NovaPolarisSyncUiStateTest` supplies the same words the resources carry through one wrapper, so its routing assertions keep pinning the exact text, em-dash included.

## Exact candidate

- `Commit: 9c745fa71c4469ae43c8298224b4564ee97e9aff`
- `Tree:   0754fa0741b4dddf43fc51b498dee154735bfc8e`
- `Base:   14ae8281`

## Verification

On pc-papi (Fedora), clean worktree of master:

- [x] `NovaPolarisSyncUiStateTest` — 7/7 (XML-verified), including the em-dash relaunch pin at its new routing
- [x] `NovaPlaySetupHostScopeTest` — 7/7 (XML-verified): the Every Game consumer of the same mapper is unaffected
- [x] `NovaComposeSourceGuardTest` — 78/78 (XML-verified)
- [x] `:app:testNonRoot_gameDebugUnitTest` compilation of both mapper call sites against the defaults-free signature
