### PR TITLE
fix(video): the latency-profile selector stops overwriting frame pacing

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -1209,16 +1209,14 @@ if (prefConfig != null && prefConfig!!.preferLowerDelays)
  // Intermediate: more responsive than Balanced but not 0 µs
                 decoderRenderer!!.setPreferLowerDelays(true)
 decoderRenderer!!.setPreferLowerDelaysTimeoutUs(500)  // 0.5 ms
-prefConfig!!.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED
-LimeLog.info("PreferLowerDelays: preferLowerDelays=true, timeout=500us, pacing=BALANCED")
+LimeLog.info("PreferLowerDelays: preferLowerDelays=true, timeout=500us")
 }
 else
 {
  // Balanced default
                 decoderRenderer!!.setPreferLowerDelays(false)
 decoderRenderer!!.setPreferLowerDelaysTimeoutUs(2000) // 2 ms
-prefConfig!!.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED
-LimeLog.info("Balanced: preferLowerDelays=false, timeout=2000us, pacing=BALANCED")
+LimeLog.info("Balanced: preferLowerDelays=false, timeout=2000us")
 }
 }
 catch (ignored:Throwable) {}


### PR DESCRIPTION
## Summary

- Roadmap: Nordstern arc, Phase 1 · P1-1 PR1 ("un-dead Nova frame pacing").
- `Game.kt`'s latency-profile selector unconditionally overwrote `prefConfig.framePacing` with `FRAME_PACING_BALANCED` in both branches of the `preferLowerDelays` check, immediately after `PreferenceConfiguration` had already loaded the user's real saved `frame_pacing` preference.
- That made every `FRAME_PACING_CAP_FPS` / `FRAME_PACING_MAX_SMOOTHNESS`-gated branch in `MediaCodecDecoderRenderer` (4 guard sites) permanently unreachable, so the unit-tested `FramePacingPolicy` math (`renderPeriodNs`, `smoothnessDropDecision`, `latencyDropDecision`) never executed in production — only the Choreographer/vsync-gated path ever ran.
- Removed the two overwrites (and the now-inaccurate `pacing=BALANCED` fragment from the two adjacent log lines) so the loaded preference reaches the renderer unmodified.
- `BALANCED` stays the shipped default — nothing in Settings currently writes another value, so default-configured users see no behavior change. Anyone with `CAP_FPS` or `MAX_SMOOTHNESS` set gets the tested pacing logic for the first time.
- Side effect: `StreamSyncManager`'s telemetry payload and `PerformanceDataTracker`'s local history, both of which just record whatever `framePacing` value they're handed, now report the real setting instead of a hardcoded `BALANCED`.

## Exact candidate

- `Commit:` `c653b85a9b28e318389cdce34627794f58f157fc`
- `Tree:` `c44bfb6d6f26bd079d06b39ae6e5c96fed74477c`
- `Parent:` `be8d9f241d4918839063be2d9b3098c5c5c31ea5`
- `Base:` `be8d9f241d4918839063be2d9b3098c5c5c31ea5` (`origin/master`)

## Verification

- [x] `:app:compileRootDebugKotlin` — clean, exit 0
- [x] `:app:testRootDebugUnitTest --tests "com.papi.nova.binding.video.FramePacingPolicyTest"` — 6/6 passed, confirmed against the JUnit XML report (`tests="6" skipped="0" failures="0" errors="0"`), not just console exit code
- [x] `:app:testRootDebugUnitTest --tests "com.papi.nova.binding.video.KotlinVideoRuntimeMigrationTest"` — 2/2 passed (adjacent test touching `framePacing` fixtures in the same package)
- [x] Manually traced every remaining `framePacing` consumer in `app/src/main` (`MediaCodecDecoderRenderer`, `StreamSyncManager`, `PerformanceDataTracker`, `PreferenceConfiguration`) — none assume the value is always `BALANCED`

**Not covered:** no on-device RP6 QA in this PR — this is a source-level un-dead fix with no default-path behavior change (default stays BALANCED); device latency measurement rides the roadmap's P0-5 bench harness once it lands, not this PR.
