### PR TITLE
perf(artwork): decode to size buckets, cancel stale loads, keep the warm cover cache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -288,7 +288,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
-    implementation 'io.coil-kt:coil:2.7.0'
     implementation 'androidx.profileinstaller:profileinstaller:1.4.1'
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.foundation:foundation'

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -11,7 +11,9 @@ import com.papi.nova.nvstream.http.LimelightCryptoProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
@@ -104,7 +106,7 @@ class PolarisApiClient @JvmOverloads constructor(
     private val webBaseUrl = "https://$serverAddress:$WEB_UI_HTTPS_PORT"
     private val artworkDiskCache = PolarisArtworkDiskCache(context.applicationContext, serverAddress, resolvedHttpsPort)
     private val artworkResolveOnce = ArtworkResolveOnce<PolarisGame.ArtworkManifest>()
-    private val imageScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(1))
+    private val imageScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(3))
     private val coverCache = object : LruCache<String, Bitmap>(32 * 1024 * 1024) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
     }
@@ -112,6 +114,9 @@ class PolarisApiClient @JvmOverloads constructor(
     companion object {
         const val WEB_UI_HTTPS_PORT = 47990
         private const val CLIENT_CERT_ALIAS = "Limelight-RSA"
+        // Poster-shaped bucket; also the fallback for studio preview cells.
+        private const val PREVIEW_TARGET_WIDTH = 512
+        private const val PREVIEW_TARGET_HEIGHT = 768
 
         @JvmStatic
         fun decodeCertificate(serverCertDer: ByteArray?): X509Certificate? {
@@ -1585,11 +1590,16 @@ class PolarisApiClient @JvmOverloads constructor(
         val requestMarker = Any()
         view.setTag(R.id.nova_artwork_request_key, requestMarker)
         view.setImageResource(R.drawable.nova_cover_placeholder)
-        imageScope.launch {
-            val fetched = fetchArtwork(url) ?: return@launch
+        (view.getTag(R.id.nova_artwork_job) as? Job)?.cancel()
+        val job = imageScope.launch {
+            val fetched = fetchArtwork(url, PREVIEW_TARGET_WIDTH, PREVIEW_TARGET_HEIGHT) ?: return@launch
             withContext(Dispatchers.Main) {
                 if (view.getTag(R.id.nova_artwork_request_key) === requestMarker) view.setImageBitmap(fetched.bitmap)
             }
+        }
+        view.setTag(R.id.nova_artwork_job, job)
+        job.invokeOnCompletion {
+            view.post { if (view.getTag(R.id.nova_artwork_job) === job) view.setTag(R.id.nova_artwork_job, null) }
         }
     }
 
@@ -1608,14 +1618,19 @@ class PolarisApiClient @JvmOverloads constructor(
         val imageUrl = manifestUrl
             ?: selectArtworkUrl(serverAddress, resolvedHttpsPort, game, normalizedKind)
         val revision = if (usesManifest) game.artwork?.revision.orEmpty() else ""
+        // The decode bucket is part of the cache key: a poster-res bitmap must never be
+        // served where the full-screen hero bucket is expected, and vice versa.
+        val (targetWidth, targetHeight) = artworkTargetSize(normalizedKind)
+        val sizeBucket = "w${targetWidth}h$targetHeight"
         val cacheKey = if (usesManifest) {
-            "polaris-artwork:${game.id}:$normalizedKind:$revision:$manifestUrl"
+            "polaris-artwork:${game.id}:$normalizedKind:$revision:$sizeBucket:$manifestUrl"
         } else {
-            "polaris-cover:${game.id}:${game.coverUrl}"
+            "polaris-cover:${game.id}:$normalizedKind:$sizeBucket:${game.coverUrl}"
         }
 
         view.setTag(R.id.nova_artwork_request_key, cacheKey)
         view.setImageResource(R.drawable.nova_cover_placeholder)
+        (view.getTag(R.id.nova_artwork_job) as? Job)?.cancel()
         if (imageUrl == null) return
 
         coverCache.get(cacheKey)?.let { cached ->
@@ -1623,12 +1638,12 @@ class PolarisApiClient @JvmOverloads constructor(
             return
         }
 
-        imageScope.launch {
+        val job = imageScope.launch {
             val exactDisk = if (usesManifest) {
-                artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = false)
+                artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = false, targetWidth, targetHeight)
             } else null
             val bitmap = exactDisk ?: run {
-                val fetched = fetchArtwork(imageUrl)
+                val fetched = fetchArtwork(imageUrl, targetWidth, targetHeight)
                 if (fetched != null) {
                     if (usesManifest) {
                         artworkDiskCache.store(
@@ -1641,7 +1656,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     }
                     fetched.bitmap
                 } else if (usesManifest) {
-                    artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = true)
+                    artworkDiskCache.load(game.id, normalizedKind, revision, allowStale = true, targetWidth, targetHeight)
                 } else null
             }
             withContext(Dispatchers.Main) {
@@ -1655,11 +1670,15 @@ class PolarisApiClient @JvmOverloads constructor(
                 }
             }
         }
+        view.setTag(R.id.nova_artwork_job, job)
+        job.invokeOnCompletion {
+            view.post { if (view.getTag(R.id.nova_artwork_job) === job) view.setTag(R.id.nova_artwork_job, null) }
+        }
     }
 
     private data class FetchedArtwork(val bytes: ByteArray, val mimeType: String, val bitmap: Bitmap)
 
-    private fun fetchArtwork(url: String): FetchedArtwork? {
+    private suspend fun fetchArtwork(url: String, targetWidth: Int = 0, targetHeight: Int = 0): FetchedArtwork? {
         val requestClass = artworkRequestLogLabel(url)
         repeat(3) { attempt ->
             try {
@@ -1681,19 +1700,30 @@ class PolarisApiClient @JvmOverloads constructor(
                         PolarisArtworkDiskCache.readBounded(it, PolarisArtworkDiskCache.MAX_IMAGE_BYTES)
                     } ?: return null
                     if (!PolarisArtworkDiskCache.hasSupportedImageSignature(bytes, mimeType)) return null
-                    val bitmap = PolarisArtworkDiskCache.decodeBounded(bytes)
+                    val bitmap = PolarisArtworkDiskCache.decodeBounded(bytes, targetWidth, targetHeight)
                     if (bitmap != null) return FetchedArtwork(bytes, mimeType.orEmpty(), bitmap)
                     LimeLog.warning("Nova: artwork decode failed [$requestClass] bytes=${bytes.size}")
                     return null
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 if (attempt == 2) {
                     LimeLog.warning("Nova: artwork fetch failed [$requestClass]: ${e.javaClass.simpleName}")
                 }
-                if (attempt < 2) Thread.sleep((attempt + 1) * 150L)
+                if (attempt < 2) delay((attempt + 1) * 150L)
             }
         }
         return null
+    }
+
+    // Decode buckets are fixed per artwork kind rather than measured from the view:
+    // AndroidView cells call this before layout, and stable buckets keep cache keys stable.
+    private fun artworkTargetSize(kind: String): Pair<Int, Int> = when (kind) {
+        PolarisGame.ARTWORK_KIND_HERO -> 1920 to 1080
+        PolarisGame.ARTWORK_KIND_LOGO -> 640 to 360
+        PolarisGame.ARTWORK_KIND_ICON -> 256 to 256
+        else -> PREVIEW_TARGET_WIDTH to PREVIEW_TARGET_HEIGHT
     }
 
     /**

--- a/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisArtworkDiskCache.kt
@@ -32,7 +32,14 @@ internal class PolarisArtworkDiskCache(
         sha256(listOf(host.trim().lowercase(), port.toString())),
     )
 
-    fun load(gameId: String, kind: String, revision: String, allowStale: Boolean): Bitmap? {
+    fun load(
+        gameId: String,
+        kind: String,
+        revision: String,
+        allowStale: Boolean,
+        targetWidth: Int = 0,
+        targetHeight: Int = 0,
+    ): Bitmap? {
         if (revision.isBlank()) return null
         val exact = cacheFile(gameId, kind, revision)
         val candidates = buildList {
@@ -49,7 +56,7 @@ internal class PolarisArtworkDiskCache(
             val bytes = runCatching {
                 file.inputStream().buffered().use { readBounded(it, MAX_IMAGE_BYTES) }
             }.getOrNull()
-            val bitmap = bytes?.let(::decodeBounded)
+            val bitmap = bytes?.let { decodeBounded(it, targetWidth, targetHeight) }
             if (bitmap != null) {
                 synchronized(CACHE_LOCK) {
                     if (file.isFile) file.setLastModified(System.currentTimeMillis())
@@ -69,8 +76,7 @@ internal class PolarisArtworkDiskCache(
             !isSupportedImageMime(mimeType) ||
             !hasSupportedImageSignature(bytes, mimeType)
         ) return null
-        val decoded = decodeBounded(bytes) ?: return null
-        decoded.recycle()
+        if (!validateImageBounds(bytes)) return null
 
         if (!cacheDir.isDirectory && !cacheDir.mkdirs() && !cacheDir.isDirectory) return null
         val target = cacheFile(gameId, kind, revision)
@@ -213,14 +219,9 @@ internal class PolarisArtworkDiskCache(
         }
 
         @JvmStatic
-        fun decodeBounded(bytes: ByteArray): Bitmap? {
-            if (bytes.isEmpty() || bytes.size > MAX_IMAGE_BYTES) return null
-            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            if (runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds) }.isFailure) return null
-            val width = bounds.outWidth
-            val height = bounds.outHeight
-            if (width !in 1..MAX_IMAGE_DIMENSION || height !in 1..MAX_IMAGE_DIMENSION) return null
-            if (width.toLong() * height.toLong() > MAX_IMAGE_PIXELS) return null
+        @JvmOverloads
+        fun decodeBounded(bytes: ByteArray, targetWidth: Int = 0, targetHeight: Int = 0): Bitmap? {
+            val bounds = readImageBounds(bytes) ?: return null
             return runCatching {
                 BitmapFactory.decodeByteArray(
                     bytes,
@@ -229,9 +230,36 @@ internal class PolarisArtworkDiskCache(
                     BitmapFactory.Options().apply {
                         inPreferredConfig = Bitmap.Config.ARGB_8888
                         inScaled = false
+                        inSampleSize = sampleSizeFor(bounds.outWidth, bounds.outHeight, targetWidth, targetHeight)
                     },
                 )
             }.getOrNull()
+        }
+
+        @JvmStatic
+        internal fun validateImageBounds(bytes: ByteArray): Boolean = readImageBounds(bytes) != null
+
+        // Never samples below the target: halving stops as soon as either dimension would
+        // undershoot, so mismatched aspect ratios err toward too much resolution, not too little.
+        @JvmStatic
+        internal fun sampleSizeFor(sourceWidth: Int, sourceHeight: Int, targetWidth: Int, targetHeight: Int): Int {
+            if (targetWidth <= 0 || targetHeight <= 0) return 1
+            var sampleSize = 1
+            while (sourceWidth / (sampleSize * 2) >= targetWidth && sourceHeight / (sampleSize * 2) >= targetHeight) {
+                sampleSize *= 2
+            }
+            return sampleSize
+        }
+
+        private fun readImageBounds(bytes: ByteArray): BitmapFactory.Options? {
+            if (bytes.isEmpty() || bytes.size > MAX_IMAGE_BYTES) return null
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            if (runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds) }.isFailure) return null
+            val width = bounds.outWidth
+            val height = bounds.outHeight
+            if (width !in 1..MAX_IMAGE_DIMENSION || height !in 1..MAX_IMAGE_DIMENSION) return null
+            if (width.toLong() * height.toLong() > MAX_IMAGE_PIXELS) return null
+            return bounds
         }
 
         @JvmStatic

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -570,7 +570,7 @@ class NovaLibraryActivity : NovaActivity() {
                         settings = settings,
                     )
                 }
-                apiClient.clearCoverCache()
+                if (forceRefresh) apiClient.clearCoverCache()
                 val published = artworkLibraryUpdateViewModel.publishRefresh(
                     token = artworkRefreshToken,
                     games = result.games,

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -2,4 +2,5 @@
 <resources>
     <item name="nova_artwork_presentation_key" type="id" />
     <item name="nova_artwork_request_key" type="id" />
+    <item name="nova_artwork_job" type="id" />
 </resources>

--- a/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisArtworkDiskCacheTest.kt
@@ -389,6 +389,51 @@ class PolarisArtworkDiskCacheTest {
         assertEquals(2, starts.get())
     }
 
+    @Test
+    fun sampleSizeNeverUndershootsTheTargetAndDefaultsToFullResolution() {
+        assertEquals(1, PolarisArtworkDiskCache.sampleSizeFor(2048, 3072, 0, 0))
+        assertEquals(1, PolarisArtworkDiskCache.sampleSizeFor(600, 900, 512, 768))
+        assertEquals(4, PolarisArtworkDiskCache.sampleSizeFor(2048, 3072, 512, 768))
+        assertEquals(16, PolarisArtworkDiskCache.sampleSizeFor(4096, 4096, 256, 256))
+        // Mismatched aspect ratios err toward too much resolution, never too little.
+        assertEquals(1, PolarisArtworkDiskCache.sampleSizeFor(1920, 620, 512, 768))
+    }
+
+    @Test
+    fun decodeAndLoadHonorTargetBucketWithoutDroppingBelowIt() {
+        val sampled = checkNotNull(PolarisArtworkDiskCache.decodeBounded(pngBytes(64, 96), 16, 24))
+        assertEquals(16, sampled.width)
+        assertEquals(24, sampled.height)
+        sampled.recycle()
+
+        val fullRes = checkNotNull(PolarisArtworkDiskCache.decodeBounded(pngBytes(64, 96)))
+        assertEquals(64, fullRes.width)
+        assertEquals(96, fullRes.height)
+        fullRes.recycle()
+
+        val cache = PolarisArtworkDiskCache(context, "sampled-host", 47984)
+        cache.clear()
+        assertNotNull(cache.store("game-sampled", "poster", "rev-1", pngBytes(64, 96), "image/png"))
+        val loaded = checkNotNull(
+            cache.load("game-sampled", "poster", "rev-1", allowStale = false, targetWidth = 16, targetHeight = 24)
+        )
+        assertEquals(16, loaded.width)
+        assertEquals(24, loaded.height)
+        loaded.recycle()
+        cache.clear()
+    }
+
+    @Test
+    fun boundsValidationAcceptsRealImagesAndRejectsEmptyOrOversizedHeaders() {
+        // Garbage non-image bytes are not asserted here: Robolectric's BitmapFactory
+        // fabricates bounds for them, and production rejects garbage earlier via the
+        // image-signature check before bounds validation runs.
+        assertTrue(PolarisArtworkDiskCache.validateImageBounds(pngBytes(3, 4)))
+        assertFalse(PolarisArtworkDiskCache.validateImageBounds(ByteArray(0)))
+        assertFalse(PolarisArtworkDiskCache.validateImageBounds(pngWithDeclaredDimensions(9_000, 1)))
+        assertFalse(PolarisArtworkDiskCache.validateImageBounds(pngWithDeclaredDimensions(8_000, 8_000)))
+    }
+
     private fun pngWithDeclaredDimensions(width: Int, height: Int): ByteArray {
         val bytes = pngBytes(1, 1)
         writeInt(bytes, 16, width)

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1363,7 +1363,7 @@ class NovaComposeSourceGuardTest {
     fun artworkFetchLogsUseFixedClassificationWithoutUrlsOrExceptionMessages() {
         val api = readSource("src/main/java/com/papi/nova/api/PolarisApiClient.kt")
         val fetch = api.section(
-            "private fun fetchArtwork(url: String)",
+            "private suspend fun fetchArtwork(url: String",
             "/**\n     * Toggle MangoHud",
         )
         assertTrue(fetch.contains("val requestClass = artworkRequestLogLabel(url)"))


### PR DESCRIPTION
## Summary
- The library's in-memory cover cache is no longer wiped on every `loadGames()` — only on a forced refresh. Targeted invalidation on artwork-revision changes already covers staleness, so returning to the library now reuses warm posters instead of re-fetching everything.
- Artwork decodes now sample down to per-kind size buckets (hero 1920×1080, poster 512×768, logo 640×360, icon 256×256) via a power-of-two `inSampleSize` that never drops below the target in either dimension. The bucket is part of the cover-cache key, so a poster-res bitmap can never serve the hero slot on manifest-less games (the legacy key previously lacked the kind entirely).
- `PolarisArtworkDiskCache.store()` validates candidate bytes by reading image bounds instead of performing a full decode it immediately recycled; `load()` forwards the caller's bucket to the decode.
- The image pipeline runs at parallelism 3 instead of 1, its retry backoff suspends (`delay`) instead of blocking the worker (`Thread.sleep`), and each ImageView tracks its in-flight `Job` so superseded requests are cancelled at the next suspension point. The request-key tag check remains the backstop for responses already inside a blocking `execute()`, which cancellation cannot abort.
- Removes the unused `io.coil-kt:coil` dependency.

## Exact candidate
- `Commit:` 16b8dd8349de06dda51fdf6a33e8a94686d3f685
- `Tree:` 4a6de2dbf23749444c9213d4d4397591fd769f45
- `Parent:` 69d7366f25983a9acd7d6ba08642c8356be4b0aa
- `Base:` origin/master @ 69d7366f25983a9acd7d6ba08642c8356be4b0aa

## Verification
- [x] `:app:testNonRoot_gameDebugUnitTest` — 1232 tests, 0 failures, 0 errors, 0 skipped (counts read from the XML reports)
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [ ] `:app:assembleNonRoot_gameDebugAndroidTest` — not covered: pre-existing compile breakage on master (`NovaGameDetailComposeTest`, `NovaPolarisSyncSheetComposeTest` are stale against the #195–#200 signature changes; none of the errors reference this PR's surfaces). Repair is queued as its own test-only change for the 1.3.5 arc.
- [ ] Device QA on the Retroid Pocket 6 — rides the combined artwork-path pass together with the connection-reuse PR before the 1.3.5 tag: warm library re-entry with no placeholder flash, forced refresh still repaints, held-dpad rail scrub, hero sharpness at full screen (a blurry hero would indicate a bucket-key leak).

New unit coverage: `sampleSizeFor` never undershooting its target, sampled `decodeBounded`/`load` honoring the bucket, and bounds-only store validation (`PolarisArtworkDiskCacheTest`). The `NovaComposeSourceGuardTest` fetch-log section marker moves to the new `suspend` signature; its assertions are unchanged.
