### PR TITLE
perf(network): reuse TLS state and pool artwork connections

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -135,10 +135,6 @@ class PolarisApiClient @JvmOverloads constructor(
                 .build()
 
         @JvmStatic
-        internal fun buildArtworkHttpClientForCall(baseForCall: () -> OkHttpClient): OkHttpClient =
-            buildArtworkHttpClient(baseForCall())
-
-        @JvmStatic
         internal fun parseArtworkJsonBytes(bytes: ByteArray): JSONObject? {
             val text = bytes.toString(Charsets.UTF_8)
             if (text.isBlank()) return null
@@ -1195,16 +1191,33 @@ class PolarisApiClient @JvmOverloads constructor(
             .build()
     }
 
-    private fun clientForCall(): OkHttpClient {
-        val keyManager = apiKeyManager ?: return client
-        val trustManager = apiTrustManager ?: return client
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
+    // Instance-scoped: the key and trust managers are assigned once in init, and re-pairing
+    // constructs a new PolarisApiClient, so cached TLS state never outlives the certificate
+    // material it was built from. Never cache these at companion/static scope.
+    private val perCallClient: OkHttpClient by lazy {
+        val keyManager = apiKeyManager
+        val trustManager = apiTrustManager
+        if (keyManager == null || trustManager == null) {
+            client
+        } else {
+            val sslContext = SSLContext.getInstance("TLS").apply {
+                init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
+            }
+            client.newBuilder()
+                .sslSocketFactory(sslContext.socketFactory, trustManager)
+                .build()
         }
-        return client.newBuilder()
-            .sslSocketFactory(sslContext.socketFactory, trustManager)
+    }
+
+    // The pool must be set explicitly: newBuilder() copies the API path's no-keep-alive pool.
+    private val artworkClient: OkHttpClient by lazy {
+        buildArtworkHttpClient(clientForCall())
+            .newBuilder()
+            .connectionPool(ConnectionPool(5, 30, TimeUnit.SECONDS))
             .build()
     }
+
+    private fun clientForCall(): OkHttpClient = perCallClient
 
 	private fun execute(request: Request) = clientForCall().newCall(
 		request.newBuilder()
@@ -1212,11 +1225,7 @@ class PolarisApiClient @JvmOverloads constructor(
 			.build()
 	).execute()
 
-    private fun executeArtwork(request: Request) = buildArtworkHttpClientForCall(::clientForCall).newCall(
-        request.newBuilder()
-            .header("Connection", "close")
-            .build()
-    ).execute()
+    private fun executeArtwork(request: Request) = artworkClient.newCall(request).execute()
 
     private fun executeGetWithRetry(request: Request, attempts: Int = 3): okhttp3.Response {
         var lastError: Exception? = null
@@ -1682,7 +1691,7 @@ class PolarisApiClient @JvmOverloads constructor(
         val requestClass = artworkRequestLogLabel(url)
         repeat(3) { attempt ->
             try {
-                val request = Request.Builder().url(url).header("Connection", "close").build()
+                val request = Request.Builder().url(url).build()
                 executeArtwork(request).use { response ->
                     if (!response.isSuccessful) {
                         LimeLog.warning("Nova: artwork request failed [$requestClass] code=${response.code}")

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -1,6 +1,8 @@
 package com.papi.nova.api
 
 import com.papi.nova.shared.polaris.model.PolarisGame
+import java.util.concurrent.TimeUnit
+import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import org.json.JSONObject
 import java.io.IOException
@@ -32,21 +34,19 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
-    fun artworkHttpClientRefreshesBaseTlsStateForEveryCall() {
-        var baseCalls = 0
-        val baseForCall = {
-            baseCalls += 1
-            OkHttpClient.Builder().build()
-        }
+    fun artworkHttpClientKeepsPolicyWhenPooled() {
+        // Mirrors the production construction chain: newBuilder() copies the base's
+        // no-keep-alive pool, so the pooled override must be applied explicitly.
+        val base = OkHttpClient.Builder().connectionPool(ConnectionPool(0, 1, TimeUnit.MILLISECONDS)).build()
+        val pooled = PolarisApiClient.buildArtworkHttpClient(base)
+            .newBuilder()
+            .connectionPool(ConnectionPool(5, 30, TimeUnit.SECONDS))
+            .build()
 
-        val first = PolarisApiClient.buildArtworkHttpClientForCall(baseForCall)
-        val second = PolarisApiClient.buildArtworkHttpClientForCall(baseForCall)
-
-        assertEquals(2, baseCalls)
-        assertFalse(first.followRedirects)
-        assertFalse(second.followSslRedirects)
-        assertEquals(120_000, first.callTimeoutMillis)
-        assertEquals(120_000, second.readTimeoutMillis)
+        assertFalse(pooled.followRedirects)
+        assertFalse(pooled.followSslRedirects)
+        assertEquals(120_000, pooled.callTimeoutMillis)
+        assertEquals(120_000, pooled.readTimeoutMillis)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaArtworkStudioSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaArtworkStudioSourceGuardTest.kt
@@ -71,11 +71,11 @@ class NovaArtworkStudioSourceGuardTest {
         assertFalse(api.contains("view.tag = cacheKey"))
         assertFalse(preview.contains("candidate.posterPreviewUrl"))
 
-        assertTrue(api.contains("private fun executeArtwork(request: Request) = buildArtworkHttpClientForCall(::clientForCall).newCall("))
+        assertTrue(api.contains("private fun executeArtwork(request: Request) = artworkClient.newCall(request).execute()"))
         assertTrue(api.contains(".followRedirects(false)"))
         assertTrue(api.contains(".followSslRedirects(false)"))
         assertTrue(api.contains("private const val ARTWORK_REQUEST_TIMEOUT_SECONDS = 120L"))
-        assertFalse(api.contains("private val artworkHttpClient"))
+        assertTrue(api.contains("private val artworkClient: OkHttpClient by lazy"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1345,17 +1345,27 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
-    fun artworkRequestsUseFreshTlsStateWithoutCachingTheDerivedClient() {
+    fun artworkRequestsPoolConnectionsOnAnInstanceScopedTlsClient() {
         val api = readSource("src/main/java/com/papi/nova/api/PolarisApiClient.kt")
         assertTrue(
-            "production artwork calls should rebuild policy from the fresh per-call TLS client",
-            api.contains("private fun executeArtwork(request: Request) = buildArtworkHttpClientForCall(::clientForCall).newCall(") &&
+            "production artwork calls should reuse the instance-scoped pooled client",
+            api.contains("private fun executeArtwork(request: Request) = artworkClient.newCall(request).execute()") &&
                 api.contains("SSLContext.getInstance(\"TLS\").apply") &&
                 api.contains(".sslSocketFactory(sslContext.socketFactory, trustManager)")
         )
+        assertTrue(
+            "the artwork pool must be set explicitly because newBuilder() copies the API path's no-keep-alive pool",
+            api.contains(".connectionPool(ConnectionPool(5, 30, TimeUnit.SECONDS))")
+        )
+        assertTrue(
+            "TLS-bearing clients must stay instance-scoped so re-pairing (a new PolarisApiClient) rebuilds TLS state; never cache them at companion/static scope",
+            api.contains("private val artworkClient: OkHttpClient by lazy") &&
+                api.contains("private val perCallClient: OkHttpClient by lazy")
+        )
         assertFalse(
-            "artwork client must not be cached across mTLS calls",
-            api.contains("private val artworkHttpClient")
+            "artwork fetches must not force per-request sockets",
+            api.section("private suspend fun fetchArtwork(url: String", "/**\n     * Toggle MangoHud")
+                .contains("header(\"Connection\", \"close\")")
         )
     }
 


### PR DESCRIPTION
## Summary
- The per-call mTLS client is built once per `PolarisApiClient` instance instead of rebuilding an `SSLContext` on every request. The key/trust managers are assigned exactly once in `init`, and re-pairing constructs a new instance, so cached TLS state never outlives its certificate material — the invariant the old fresh-per-call guard protected, now pinned directly by the rewritten guard (instance-scoped, never companion/static).
- The artwork client gets a real `ConnectionPool(5, 30s)` — set explicitly, because `newBuilder()` copies the API path's no-keep-alive pool — and artwork requests stop sending `Connection: close`. Library first paint stops paying TCP + TLS + RSA client-cert per poster.
- The API path (`execute()`) keeps `Connection: close` unchanged; `NvHTTP` is untouched.
- The now-dead `buildArtworkHttpClientForCall` helper is removed with its per-call-refresh test; the replacement test exercises the same redirect/timeout policy through the pooled construction chain.

Rollback story: this PR is isolated on purpose. If the server closes keep-alives, behavior degrades to today's (`retryOnConnectionFailure` is inherited); if artwork misbehaves on device, revert this PR alone.

## Exact candidate
- `Commit:` fd8dade9ff843da7237101a2c5fddea35223c67e
- `Tree:` cb4a00d6b6a698b55054f4a5a993e82d68eb21ae
- `Parent:` 3d4356ffd98fe5985a24196cc240b1729bc55a06
- `Base:` origin/master @ 3d4356ffd98fe5985a24196cc240b1729bc55a06

## Verification
- [x] `:app:testNonRoot_gameDebugUnitTest` — 1232 tests, 0 failures, 0 errors, 0 skipped (counts read from the XML reports)
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [ ] `:app:assembleNonRoot_gameDebugAndroidTest` — not covered: pre-existing breakage on master (stale #195–#200 test signatures, unrelated; repair queued for the 1.3.5 arc)
- [ ] Device QA on the Retroid Pocket 6 — combined artwork-path pass with #202 before the 1.3.5 tag: first-load art timing against the live host, `logcat | grep -i "artwork request failed"` stays clean, warm re-entry, forced refresh.
