### PR TITLE
perf(stream): build overlay text only when shown, and take two lookups off the frame path

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -1171,6 +1171,7 @@ willStreamHdr,
 shouldInvertDecoderResolution,
 glPrefs!!.glRenderer,
 this)
+syncPerfTextWanted()
 
  // --- Force tight thresholds (prefConfig.forceTightThresholds) ---
         try
@@ -1746,7 +1747,9 @@ LimeLog.info("Nova: Android companion display added id=$displayId stream_id=$str
 showCompanionControls()
 }
 }
-override fun onDisplayChanged(displayId:Int) = Unit
+override fun onDisplayChanged(displayId:Int) {
+decoderRenderer?.refreshDisplayParameters()
+}
 override fun onDisplayRemoved(displayId:Int) {
 handleDisplayRemoved(displayId)
 }
@@ -4831,11 +4834,13 @@ com.papi.nova.LimeLog.warning("Nova: Session report failed: " + e!!.message)
  }
 novaHud!!.dismiss()
 novaHud = null
+syncPerfTextWanted()
 }
 else if (novaHud != null)
 {
 novaHud!!.dismiss()
 novaHud = null
+syncPerfTextWanted()
 }
  // Stop audio haptics and gyro aiming
             if (audioHapticEngine != null)
@@ -6215,6 +6220,13 @@ PreferenceManager.getDefaultSharedPreferences(this)
 fun dismissNovaHud() {
 novaHud?.dismiss()
 novaHud = null
+syncPerfTextWanted()
+}
+
+private fun syncPerfTextWanted() {
+decoderRenderer?.setPerfTextWanted(
+(::prefConfig.isInitialized && prefConfig!!.enablePerfOverlay) || novaHud?.isShowing == true
+)
 }
 
 fun copyNovaHudDiagnostics() {
@@ -6243,6 +6255,7 @@ showGameMenu(null)
 }
 novaHud = hud
 hud!!.show()
+syncPerfTextWanted()
 configureNovaHud(hud!!)
 return hud!!
 }

--- a/app/src/main/java/com/papi/nova/NovaApplication.kt
+++ b/app/src/main/java/com/papi/nova/NovaApplication.kt
@@ -1,12 +1,28 @@
 package com.papi.nova
 
 import android.app.Application
+import android.os.StrictMode
 import android.widget.Toast
 import com.papi.nova.profiles.ProfilesManager
 
 class NovaApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        // Debug-only: surface main-thread IO and leaked resources in logcat. Installed before
+        // the ProfilesManager load below so its synchronous disk read is observed too.
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().build()
+            )
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .detectLeakedClosableObjects()
+                    .detectLeakedRegistrationObjects()
+                    .detectActivityLeaks()
+                    .penaltyLog()
+                    .build()
+            )
+        }
         val profilesManager = ProfilesManager.getInstance()
         if (!profilesManager.load(this)) {
             Toast.makeText(this, R.string.profile_manager_failed_to_load, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -195,6 +195,16 @@ class MediaCodecDecoderRenderer(
     private var minDecodeTime = Float.MAX_VALUE
     private var minDecodeTimeFullLog = ""
 
+    // Set from the UI thread when the perf overlay or NovaHUD becomes visible; read on the
+    // decode thread to skip building overlay text nobody is going to display.
+    @Volatile
+    private var perfTextWanted = false
+
+    // appVsyncOffsetNanos goes through a locked WindowManager display lookup; cache it off
+    // the frame path and refresh on display changes.
+    @Volatile
+    private var cachedAppVsyncOffsetNanos: Long = 0
+
     private var lastNetDataNum: Long = 0
     private val outputBufferQueue = ArrayBlockingQueue<Int>(OUTPUT_BUFFER_QUEUE_LIMIT)
     private var lastRenderedFrameTimeNanos: Long = 0
@@ -510,6 +520,97 @@ class MediaCodecDecoderRenderer(
 
     fun notifyVideoForeground() {
         foreground = true
+        refreshDisplayParameters()
+    }
+
+    fun setPerfTextWanted(wanted: Boolean) {
+        perfTextWanted = wanted
+    }
+
+    fun refreshDisplayParameters() {
+        cachedAppVsyncOffsetNanos = runCatching {
+            activity.windowManager.defaultDisplay.appVsyncOffsetNanos
+        }.getOrDefault(0L)
+    }
+
+    private fun buildPerfText(
+        lastTwo: VideoStats,
+        fps: VideoStatsFps,
+        decoder: String,
+        decodeTimeMs: Float,
+        rttInfo: Long,
+    ): String {
+        val sb = StringBuilder()
+        if (prefs.enablePerfOverlayLite) {
+            if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
+                val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
+                    TrafficStatsHelper.getPackageTxBytes(Process.myUid())
+                if (lastNetDataNum != 0L) {
+                    sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
+                    val realtimeNetData = (netData - lastNetDataNum) / 1024f
+                    if (realtimeNetData >= 1000) {
+                        sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\t ")
+                    } else {
+                        sb.append(String.format("%.2f", realtimeNetData) + "K/s\t ")
+                    }
+                }
+                lastNetDataNum = netData
+            }
+            sb.append(context.getString(R.string.perf_overlay_lite_network_decoding_delay) + ": ")
+            sb.append(context.getString(R.string.perf_overlay_lite_net, (rttInfo shr 32).toInt()))
+            sb.append(" / ")
+            sb.append(context.getString(R.string.perf_overlay_lite_dectime, decodeTimeMs))
+            sb.append("\t")
+            sb.append(context.getString(R.string.perf_overlay_lite_packet_loss) + ": ")
+            sb.append(
+                context.getString(
+                    R.string.perf_overlay_lite_netdrops,
+                    lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
+                ),
+            )
+            sb.append("\t FPS：")
+            sb.append(context.getString(R.string.perf_overlay_lite_fps, fps.totalFps))
+        } else {
+            sb.append(context.getString(R.string.perf_overlay_streamdetails, "${initialWidth}x$initialHeight", fps.totalFps))
+            sb.append('\n')
+            sb.append(context.getString(R.string.perf_overlay_decoder, decoder)).append('\n')
+            sb.append(context.getString(R.string.perf_overlay_incomingfps, fps.receivedFps)).append('\n')
+            sb.append(context.getString(R.string.perf_overlay_renderingfps, fps.renderedFps)).append('\n')
+            sb.append(
+                context.getString(
+                    R.string.perf_overlay_netdrops,
+                    lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
+                ),
+            ).append('\n')
+            if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
+                val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
+                    TrafficStatsHelper.getPackageTxBytes(Process.myUid())
+                if (lastNetDataNum != 0L) {
+                    sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
+                    val realtimeNetData = (netData - lastNetDataNum) / 1024f
+                    if (realtimeNetData >= 1000) {
+                        sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\n")
+                    } else {
+                        sb.append(String.format("%.2f", realtimeNetData) + "K/s\n")
+                    }
+                }
+                lastNetDataNum = netData
+            }
+            sb.append(context.getString(R.string.perf_overlay_netlatency, (rttInfo shr 32).toInt(), rttInfo.toInt()))
+                .append('\n')
+            if (lastTwo.framesWithHostProcessingLatency > 0) {
+                sb.append(
+                    context.getString(
+                        R.string.perf_overlay_hostprocessinglatency,
+                        lastTwo.minHostProcessingLatency.code.toFloat() / 10,
+                        lastTwo.maxHostProcessingLatency.code.toFloat() / 10,
+                        lastTwo.totalHostProcessingLatency.toFloat() / 10 / lastTwo.framesWithHostProcessingLatency,
+                    ),
+                ).append('\n')
+            }
+            sb.append(context.getString(R.string.perf_overlay_dectime, decodeTimeMs))
+        }
+        return sb.toString()
     }
 
     fun notifyVideoBackground() {
@@ -763,6 +864,8 @@ class MediaCodecDecoderRenderer(
         initialHeight = if (invertResolution) width else height
         videoFormat = format
         refreshRate = redrawRate
+        refreshDisplayParameters()
+        LimeLog.info("Nova: frame pacing mode=" + prefs.framePacing + " preferLowerDelays=" + preferLowerDelays)
 
         return initializeDecoder(false)
     }
@@ -962,7 +1065,7 @@ class MediaCodecDecoderRenderer(
             return
         }
 
-        frameTime -= activity.windowManager.defaultDisplay.appVsyncOffsetNanos
+        frameTime -= cachedAppVsyncOffsetNanos
 
         val actualFrameTimeDeltaNs = frameTime - lastRenderedFrameTimeNanos
         val expectedFrameTimeDeltaNs = 800000000L / refreshRate
@@ -1036,11 +1139,11 @@ class MediaCodecDecoderRenderer(
             val ewmaJitterNs = periodNs * 0.1
 
             val info = BufferInfo()
+            val tmpInfo = BufferInfo()
             var lastOutputNs = System.nanoTime()
             while (!stopping) {
                 if (preferLowerDelays && prefs.framePacing != PreferenceConfiguration.FRAME_PACING_BALANCED) {
                     try {
-                        val tmpInfo = BufferInfo()
                         var idx = videoDecoder!!.dequeueOutputBuffer(tmpInfo, 0)
                         var last = -1
                         var lastPtsUs = -1L
@@ -1477,75 +1580,17 @@ class MediaCodecDecoderRenderer(
 
             val decodeTimeMs = lastTwo.decoderTimeMs.toFloat() / lastTwo.totalFramesReceived
             val rttInfo = MoonBridge.getEstimatedRttInfo()
-            val sb = StringBuilder()
-            if (prefs.enablePerfOverlayLite) {
-                if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
-                    val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
-                        TrafficStatsHelper.getPackageTxBytes(Process.myUid())
-                    if (lastNetDataNum != 0L) {
-                        sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
-                        val realtimeNetData = (netData - lastNetDataNum) / 1024f
-                        if (realtimeNetData >= 1000) {
-                            sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\t ")
-                        } else {
-                            sb.append(String.format("%.2f", realtimeNetData) + "K/s\t ")
-                        }
-                    }
-                    lastNetDataNum = netData
+            // Overlay text costs resource lookups and TrafficStats kernel round trips on the
+            // decode thread; skip all of it unless something is actually going to display or
+            // log it. The numeric sample below stays unconditional: it feeds adaptive quality.
+            if (perfTextWanted || prefs.enablePerfLogging) {
+                val fullLog = buildPerfText(lastTwo, fps, decoder, decodeTimeMs, rttInfo)
+                perfListener.onPerfUpdate(fullLog)
+                val targetFpsMatched = fps.totalFps.toInt() == prefs.fps.toInt()
+                if (minDecodeTime > decodeTimeMs && targetFpsMatched) {
+                    minDecodeTime = decodeTimeMs
+                    minDecodeTimeFullLog = fullLog
                 }
-                sb.append(context.getString(R.string.perf_overlay_lite_network_decoding_delay) + ": ")
-                sb.append(context.getString(R.string.perf_overlay_lite_net, (rttInfo shr 32).toInt()))
-                sb.append(" / ")
-                sb.append(context.getString(R.string.perf_overlay_lite_dectime, decodeTimeMs))
-                sb.append("\t")
-                sb.append(context.getString(R.string.perf_overlay_lite_packet_loss) + ": ")
-                sb.append(
-                    context.getString(
-                        R.string.perf_overlay_lite_netdrops,
-                        lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
-                    ),
-                )
-                sb.append("\t FPS：")
-                sb.append(context.getString(R.string.perf_overlay_lite_fps, fps.totalFps))
-            } else {
-                sb.append(context.getString(R.string.perf_overlay_streamdetails, "${initialWidth}x$initialHeight", fps.totalFps))
-                sb.append('\n')
-                sb.append(context.getString(R.string.perf_overlay_decoder, decoder)).append('\n')
-                sb.append(context.getString(R.string.perf_overlay_incomingfps, fps.receivedFps)).append('\n')
-                sb.append(context.getString(R.string.perf_overlay_renderingfps, fps.renderedFps)).append('\n')
-                sb.append(
-                    context.getString(
-                        R.string.perf_overlay_netdrops,
-                        lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
-                    ),
-                ).append('\n')
-                if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
-                    val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
-                        TrafficStatsHelper.getPackageTxBytes(Process.myUid())
-                    if (lastNetDataNum != 0L) {
-                        sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
-                        val realtimeNetData = (netData - lastNetDataNum) / 1024f
-                        if (realtimeNetData >= 1000) {
-                            sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\n")
-                        } else {
-                            sb.append(String.format("%.2f", realtimeNetData) + "K/s\n")
-                        }
-                    }
-                    lastNetDataNum = netData
-                }
-                sb.append(context.getString(R.string.perf_overlay_netlatency, (rttInfo shr 32).toInt(), rttInfo.toInt()))
-                    .append('\n')
-                if (lastTwo.framesWithHostProcessingLatency > 0) {
-                    sb.append(
-                        context.getString(
-                            R.string.perf_overlay_hostprocessinglatency,
-                            lastTwo.minHostProcessingLatency.code.toFloat() / 10,
-                            lastTwo.maxHostProcessingLatency.code.toFloat() / 10,
-                            lastTwo.totalHostProcessingLatency.toFloat() / 10 / lastTwo.framesWithHostProcessingLatency,
-                        ),
-                    ).append('\n')
-                }
-                sb.append(context.getString(R.string.perf_overlay_dectime, decodeTimeMs))
             }
             val packetLossPct = if (lastTwo.totalFrames > 0) {
                 lastTwo.framesLost.toDouble() / lastTwo.totalFrames.toDouble() * 100.0
@@ -1565,13 +1610,6 @@ class MediaCodecDecoderRenderer(
                 packetLossPct = packetLossPct
             )
             perfListener.onPerfSample(perfSample)
-            val fullLog = sb.toString()
-            perfListener.onPerfUpdate(fullLog)
-            val targetFpsMatched = fps.totalFps.toInt() == prefs.fps.toInt()
-            if (minDecodeTime > decodeTimeMs && targetFpsMatched) {
-                minDecodeTime = decodeTimeMs
-                minDecodeTimeFullLog = fullLog
-            }
 
             globalVideoStats.add(activeWindowVideoStats)
             lastWindowVideoStats.copy(activeWindowVideoStats)


### PR DESCRIPTION
## Summary
- The per-second perf-overlay string (StringBuilder + ~10 resource lookups + 4 TrafficStats kernel round trips, built on the decode thread) is now gated: it builds only when the overlay/HUD actually wants it or `enablePerfLogging` needs it for the stream-end summary (`minDecodeTimeFullLog` is harvested from that string, so the gate honors it). The numeric `PerfOverlaySample` stays unconditional — it feeds adaptive quality. Game keeps the renderer's volatile flag in sync at creation and at every HUD show/dismiss.
- The `BufferInfo` allocated per loop iteration in the low-latency drain branch (live since #201 made that branch reachable) is hoisted next to the already-hoisted one.
- `doFrame` stops calling `activity.windowManager.defaultDisplay.appVsyncOffsetNanos` at up to 120 Hz; the offset is cached at stream setup and refreshed from the display-changed listener and on video-foreground transitions.
- Stream setup logs the effective frame-pacing mode once — the logcat hook that makes the post-#201 pacing options verifiable on hardware.
- Debug builds install StrictMode thread/VM policies in `NovaApplication` before the ProfilesManager load, so its known synchronous disk read is the first thing reported. Release builds untouched.

## Exact candidate
- `Commit:` 56117f2de0d2e409b4d33714fbd2624d774dc2d7
- `Tree:` 83c0db643475173227790aa91c0750a53e8c72c8
- `Parent:` e247951e70143311d390fd4f7b792c0cb8a7e1f5
- `Base:` origin/master @ e247951e70143311d390fd4f7b792c0cb8a7e1f5

## Verification
- [x] `:app:testNonRoot_gameDebugUnitTest` — 1232 tests, 0 failures, 0 errors, 0 skipped (counts read from the XML reports; includes `MediaCodecDecoderRendererPerfStatsSourceGuardTest`, whose setup and restart-ordering pins survive because the edits stay inside the 1s block)
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [ ] `:app:assembleNonRoot_gameDebugAndroidTest` — not covered: pre-existing breakage on master (stale #195–#200 test signatures; repair is queued as its own test-only change in this arc)
- [ ] Device QA on the Retroid Pocket 6 — rides the live-stream pass before the 1.3.5 tag: each pacing option visible in `logcat | grep "frame pacing mode"`, overlay on/off with HUD adaptive quality still updating, StrictMode logging the known startup read and nothing pathological mid-stream.
