### PR TITLE
fix(ux): a dropped stream offers Reconnect, and first focus lands somewhere useful

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5096,7 +5096,9 @@ MoonBridge.stringifyPortFlags(portFlags, "\n"))
 }
 
 Dialog.displayDialog(this@Game, getResources().getString(R.string.conn_terminated_title),
-message, true)
+message, true,
+getResources().getString(R.string.nova_conn_reconnect),
+Runnable { relaunchStream() })
 }
 else
 {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -74,6 +74,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -88,6 +89,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -98,6 +100,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -2411,6 +2414,8 @@ class NovaLibraryActivity : NovaActivity() {
                             ) { game ->
                                 val focusRequester = rememberLibraryPosterFocusRequester(
                                     restoreFocus = game.id == restoreFocusGameId,
+                                    coldStartFocus = restoreFocusGameId == null &&
+                                        game.id == model.filteredGames.firstOrNull()?.id,
                                 )
                                 NovaLibraryPosterCard(
                                     game = game,
@@ -2518,13 +2523,22 @@ class NovaLibraryActivity : NovaActivity() {
     @Composable
     private fun rememberLibraryPosterFocusRequester(
         restoreFocus: Boolean,
+        coldStartFocus: Boolean = false,
     ): FocusRequester {
         val focusRequester = remember { FocusRequester() }
+        val inputModeManager = LocalInputModeManager.current
         var restoreAttempted by remember { mutableStateOf(false) }
-        LaunchedEffect(restoreFocus) {
+        LaunchedEffect(restoreFocus, coldStartFocus) {
             if (restoreFocus && !restoreAttempted) {
                 restoreAttempted = focusRequester.requestFocus()
-            } else if (!restoreFocus) {
+            } else if (coldStartFocus && !restoreAttempted) {
+                // A cold start composes with nothing focused, so the first dpad press was
+                // being consumed just establishing focus. Declare keyboard intent and land
+                // it on the first card so the ring is visible immediately.
+                withFrameNanos { }
+                inputModeManager.requestInputMode(InputMode.Keyboard)
+                restoreAttempted = focusRequester.requestFocus()
+            } else if (!restoreFocus && !coldStartFocus) {
                 restoreAttempted = false
             }
         }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -269,7 +269,11 @@ fun NovaQuickMenuContent(
     val initialFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
-        // Wait one Compose frame so the drawer content and Close button focus target are attached.
+        // Wait one Compose frame so the drawer content and the diagnosis-card focus target are
+        // attached. First focus lands on the diagnosis card, not Close: the first A-press on a
+        // menu the user deliberately opened should do something, not dismiss it. If the card is
+        // disabled the request fails silently and the first dpad press establishes focus as
+        // before.
         withFrameNanos { }
         runCatching { initialFocusRequester.requestFocus() }
     }
@@ -297,11 +301,11 @@ fun NovaQuickMenuContent(
                 .align(Alignment.Start)
         )
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuHeader(state, callbacks, initialFocusRequester)
+        NovaQuickMenuHeader(state, callbacks)
         Spacer(Modifier.height(8.dp))
         NovaQuickMenuSessionStrip(state)
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
+        NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks, initialFocusRequester)
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuStabilityCard(state.stability, callbacks)
         if (state.postSessionReport.visible) {
@@ -362,8 +366,7 @@ fun NovaQuickMenuContent(
 @Composable
 private fun NovaQuickMenuHeader(
     state: NovaQuickMenuUiState,
-    callbacks: NovaQuickMenuCallbacks,
-    initialFocusRequester: FocusRequester
+    callbacks: NovaQuickMenuCallbacks
 ) {
     val configuration = LocalConfiguration.current
     val compact = configuration.screenWidthDp < 430
@@ -376,7 +379,7 @@ private fun NovaQuickMenuHeader(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     NovaQuickMenuTitleBlock(state, Modifier.weight(1f))
-                    NovaQuickMenuCloseButton(callbacks, initialFocusRequester)
+                    NovaQuickMenuCloseButton(callbacks)
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     NovaQuickMenuHeaderButton(state.disconnectAction, callbacks, Modifier.weight(1f))
@@ -389,7 +392,7 @@ private fun NovaQuickMenuHeader(
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 NovaQuickMenuTitleBlock(state, Modifier.weight(1f))
-                NovaQuickMenuCloseButton(callbacks, initialFocusRequester)
+                NovaQuickMenuCloseButton(callbacks)
                 NovaQuickMenuHeaderButton(state.disconnectAction, callbacks)
                 NovaQuickMenuHeaderButton(state.endAction, callbacks)
             }
@@ -442,7 +445,6 @@ private fun NovaQuickMenuHeaderButton(
 @Composable
 private fun NovaQuickMenuCloseButton(
     callbacks: NovaQuickMenuCallbacks,
-    initialFocusRequester: FocusRequester,
     modifier: Modifier = Modifier
 ) {
     NovaActionButton(
@@ -450,7 +452,6 @@ private fun NovaQuickMenuCloseButton(
         onClick = callbacks.onDismiss,
         modifier = modifier
             .widthIn(min = 72.dp)
-            .focusRequester(initialFocusRequester)
             .semantics { contentDescription = "Close Command Center" },
         primary = false,
         cornerRadius = NovaRadius.hero,
@@ -464,6 +465,7 @@ private fun NovaQuickMenuCloseButton(
 private fun NovaQuickMenuDiagnosisCard(
     diagnosis: NovaQuickMenuDiagnosisState,
     callbacks: NovaQuickMenuCallbacks,
+    initialFocusRequester: FocusRequester? = null,
 ) {
     val detail = buildList {
         diagnosis.tryFirst.takeIf { it.isNotBlank() }?.let { add("Try first: $it") }
@@ -471,6 +473,11 @@ private fun NovaQuickMenuDiagnosisCard(
         diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
     }.joinToString(" · ")
     NovaQuickMenuInfoCard(
+        modifier = if (initialFocusRequester != null) {
+            Modifier.focusRequester(initialFocusRequester)
+        } else {
+            Modifier
+        },
         action = NovaQuickMenuAction(
             id = NovaQuickMenuActionId.DIAGNOSE_STREAM,
             label = "${diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") } ?: "DIAG"}: ${diagnosis.likelyCause}",

--- a/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaWelcomeActivity.kt
@@ -31,6 +31,10 @@ class NovaWelcomeActivity : NovaActivity() {
                     .putExtra(EXTRA_WELCOME_ACTION, ACTION_SCAN_QR),
             )
         }
+
+        // Controller-first devices land here on first launch; without an initial focus the
+        // declared nextFocusDown chain is unreachable until a press is wasted establishing it.
+        findViewById<View>(R.id.welcome_discover_btn).requestFocus()
     }
 
     private fun finishWelcome(next: Intent) {

--- a/app/src/main/java/com/papi/nova/utils/Dialog.kt
+++ b/app/src/main/java/com/papi/nova/utils/Dialog.kt
@@ -9,7 +9,9 @@ class Dialog private constructor(
     private val activity: Activity,
     private val title: String,
     private val message: String,
-    private val runOnDismiss: Runnable
+    private val runOnDismiss: Runnable,
+    private val actionText: CharSequence? = null,
+    private val action: Runnable? = null,
 ) : Runnable {
     private var alert: AlertDialog? = null
 
@@ -35,6 +37,20 @@ class Dialog private constructor(
                 createdAlert.dismiss()
             }
             runOnDismiss.run()
+        }
+        if (actionText != null && action != null) {
+            // Deliberately skips runOnDismiss: with endAfterDismiss the dismiss path calls
+            // finish(), which would race whatever the action is about to start.
+            createdAlert.setButton(
+                AlertDialog.BUTTON_NEGATIVE,
+                actionText
+            ) { _, _ ->
+                synchronized(rundownDialogs) {
+                    rundownDialogs.remove(this)
+                    createdAlert.dismiss()
+                }
+                action.run()
+            }
         }
         createdAlert.setButton(
             AlertDialog.BUTTON_NEUTRAL,
@@ -78,6 +94,18 @@ class Dialog private constructor(
 
         @JvmStatic
         fun displayDialog(activity: Activity, title: String, message: String, endAfterDismiss: Boolean) {
+            displayDialog(activity, title, message, endAfterDismiss, null, null)
+        }
+
+        @JvmStatic
+        fun displayDialog(
+            activity: Activity,
+            title: String,
+            message: String,
+            endAfterDismiss: Boolean,
+            actionText: CharSequence?,
+            action: Runnable?,
+        ) {
             activity.runOnUiThread(
                 Dialog(
                     activity,
@@ -87,7 +115,9 @@ class Dialog private constructor(
                         if (endAfterDismiss) {
                             activity.finish()
                         }
-                    }
+                    },
+                    actionText,
+                    action,
                 )
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -959,6 +959,7 @@
     <string name="nova_quick_menu_copy_hud_diagnostics">Copy HUD Diagnostics</string>
     <string name="nova_quick_menu_copy_hud_diagnostics_caption">Privacy-safe stream summary for bug reports.</string>
     <string name="nova_quick_menu_hud_diagnostics_copied">Nova HUD diagnostics copied</string>
+    <string name="nova_conn_reconnect">Reconnect</string>
     <string name="nova_quick_menu_safe">Safe</string>
     <string name="nova_quick_menu_mouse">Mouse</string>
     <string name="nova_quick_menu_controller">Touch Controls</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -16,13 +16,13 @@ class NovaComposeSourceGuardTest {
             "fun NovaQuickMenuContent(",
             "@Composable\nprivate fun NovaQuickMenuHeader("
         )
-        val header = quickMenuContent.section(
-            "private fun NovaQuickMenuHeader(",
-            "@Composable\nprivate fun NovaQuickMenuTitleBlock("
+        val diagnosisCard = quickMenuContent.section(
+            "private fun NovaQuickMenuDiagnosisCard(",
+            "@Composable\nprivate fun NovaQuickMenuSessionStrip("
         )
         val closeButton = quickMenuContent.section(
             "private fun NovaQuickMenuCloseButton(",
-            "@Composable\nprivate fun NovaQuickMenuSessionStrip("
+            "@Composable\nprivate fun NovaQuickMenuDiagnosisCard("
         )
 
         assertTrue(
@@ -36,18 +36,20 @@ class NovaComposeSourceGuardTest {
                 content.contains("runCatching { initialFocusRequester.requestFocus() }")
         )
         assertTrue(
-            "Command Center should attach that initial focus requester to the visible Close button in both compact and wide header layouts",
-            content.contains("NovaQuickMenuHeader(state, callbacks, initialFocusRequester)") &&
-                header.contains("initialFocusRequester: FocusRequester") &&
-                header.contains("NovaQuickMenuCloseButton(callbacks, initialFocusRequester)") &&
-                closeButton.contains("initialFocusRequester: FocusRequester") &&
-                closeButton.contains(".focusRequester(initialFocusRequester)")
+            "Command Center should land initial focus on the diagnosis card, not Close: the first A-press on a menu the user deliberately opened must not dismiss it",
+            content.contains("NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks, initialFocusRequester)") &&
+                diagnosisCard.contains("initialFocusRequester: FocusRequester? = null") &&
+                diagnosisCard.contains("Modifier.focusRequester(initialFocusRequester)")
         )
-        val focusRequesterIndex = closeButton.indexOf(".focusRequester(initialFocusRequester)")
-        val semanticsIndex = closeButton.indexOf(".semantics")
+        assertFalse(
+            "the Close button must not carry the initial focus requester",
+            closeButton.contains("focusRequester")
+        )
+        val requesterIndex = diagnosisCard.indexOf("Modifier.focusRequester(initialFocusRequester)")
+        val actionIndex = diagnosisCard.indexOf("action = NovaQuickMenuAction(")
         assertTrue(
-            "Close button should attach focusRequester before later modifiers so it targets the NovaActionButton focusable node",
-            focusRequesterIndex >= 0 && semanticsIndex > focusRequesterIndex
+            "the diagnosis card should pass the requester through the surface's leading modifier so it precedes the semantics/clickable chain",
+            requesterIndex >= 0 && actionIndex > requesterIndex
         )
     }
 
@@ -2907,7 +2909,7 @@ class NovaComposeSourceGuardTest {
         )
         assertTrue(
             "the diagnosis card takes callbacks and passes them to the card it draws",
-            quickMenu.contains("NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)") &&
+            quickMenu.contains("NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks, initialFocusRequester)") &&
                 quickMenu.contains("callbacks: NovaQuickMenuCallbacks,")
         )
     }


### PR DESCRIPTION
## Summary
- An unexpected stream drop now offers **Reconnect** on the terminal dialog via the existing `relaunchStream()` trampoline. Unexpected-termination branch only; user-initiated quits still end quietly; the automatic resilience retries are untouched. OK keeps initial focus (no A-mash reconnect loops), and the dialog's new action deliberately skips the dismiss runnable so `endAfterDismiss`'s `finish()` cannot race the relaunch.
- Command Center initial controller focus moves from **Close** to the **diagnosis card** (through the surface's leading modifier, ahead of its semantics/clickable chain). A disabled card degrades silently to today's behavior. Guard tests re-pin the diagnosis-card attachment and the callbacks-wiring invariant in their new form.
- Grid/Compact cold starts now declare keyboard input intent and land focus on the first card with the ring visible immediately — verified on the RP6 beforehand: the first dpad press was being consumed establishing focus. Restore-from-detail is unchanged (its pins survive untouched). The welcome screen pre-focuses Discover, making its declared `nextFocusDown` chain reachable.

## Exact candidate
- `Commit:` 222500e121511536d1a9fe6cad7fcef43f8608b4
- `Tree:` 961544c6fd30ababa7712b551fa0ee6e0867f35b
- `Parent:` 002d1345151b4c321b3c63addf2fbf7e629705aa
- `Base:` origin/master @ 002d1345151b4c321b3c63addf2fbf7e629705aa

## Verification
- [x] `:app:testNonRoot_gameDebugUnitTest` — 1232 tests, 0 failures, 0 errors, 0 skipped (XML counts). Two deliberate guard re-pins: `commandCenterRequestsInitialFocusForDpadNavigationOnOpen` (requester → diagnosis card) and `commandCenterCardsAreWiredToTheRealCallbacks` (same invariant, new call shape).
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameDebug`
- [x] `:app:assembleNonRoot_gameRelease`
- [ ] `:app:assembleNonRoot_gameDebugAndroidTest` — repair for the pre-existing master breakage is in flight as #205; this branch does not contain it.
- [ ] Device QA on the Retroid Pocket 6 — pre-tag pass: reconnect drill (wifi toggle mid-stream → dialog with Reconnect → same game relaunches; against a still-down network the dialog returns), quick-menu first A-press hits Diagnosis and B closes, GRID cold start focuses the first poster with visible ring, welcome screen pre-focuses Discover.
