### PR TITLE
chore(release): prepare 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+## 1.3.5 - 2026-08-08
+
+Performance and polish. The library keeps its poster cache warm across visits, decodes
+artwork to per-surface size buckets (a poster-res bitmap can never serve the full-screen
+hero slot), runs image loads three-wide with cancellation of superseded requests, and
+reuses TLS state over pooled artwork connections instead of paying a handshake and an RSA
+client-cert exchange per image (#202, #203). The frame-pacing preference now actually
+reaches the renderer — the latency-profile selector had been overwriting it to Balanced
+since the setting shipped (#201) — and stream setup logs the effective mode so it is
+verifiable from logcat. The decode path stops building perf-overlay text nobody is
+displaying (including four TrafficStats kernel calls per second), hoists a per-frame
+BufferInfo allocation, and caches the per-frame vsync-offset lookup (#204). Debug builds
+now run under StrictMode.
+
+The connection-failure dialog now offers Reconnect instead of dead-ending with only OK
+(#206); it relaunches the same stream in place. First controller focus lands somewhere useful: the
+Command Center opens on the diagnosis card instead of Close, Grid/Compact cold starts
+focus the first card with the ring visible immediately, and the welcome screen pre-focuses
+its primary button (#206). The pad gets a shared haptic vocabulary — focus ticks and
+action confirms — across posters, buttons, and Command Center rows; the in-stream lock
+overlay is themed, controller-worded ("Unlock host"), and pre-focused; an unrecognized
+session-progress state can no longer print its raw protocol token as the headline; pairing
+snackbars stop saying "TOFU"; and the Material You theme-preview tile reads the real
+dynamic palette on Android 12+ (#207). The androidTest suite compiles again
+after the #195–#200 signature churn (#205).
+
+Known issue: gyro/motion sensors are not detected on some devices (#181) — under
+investigation. The audio output-device inventory added in #196 remains a diagnostic
+awaiting an AYN Thor capture, not an audio fix. Deliberately deferred: moving the library
+mapper's recovery/hero copy and the full session-stage table into resources continues the
+#200 i18n lineage as its own follow-up.
+
 ## 1.3.4 - 2026-08-07
 
 Nova 1.3.4 rebuilds the game detail window as a destination of its own and then holds the rest of the app to the standard it set. It replaces the launch-path modals with a single Play Setup screen, puts Nova on the Polaris brand palette and typeface, makes Portable Chrome mean what its contract always said, and fixes a set of controller defects that compiled and tested cleanly while being unusable in the hand.

--- a/README.md
+++ b/README.md
@@ -107,18 +107,19 @@ Use Nova with any compatible host for normal streaming. Pair it with Polaris whe
 
 If a sleeping host does not report a MAC address, open the host menu and choose **Edit Wake-on-LAN MAC**. Nova stores that address and reuses it for future wake requests, which helps VPN and routed setups where discovery metadata is incomplete.
 
-## Latest release: v1.3.4
+## Latest release: v1.3.5
 
-Nova v1.3.4 rebuilds the game detail window as a destination of its own, then holds the rest of the app to the standard it set: one Play Setup screen instead of a stack of modals, the Polaris brand palette and typeface, a Portable Chrome that finally means what its contract said, and a set of controller fixes for things that compiled and tested cleanly while being unusable in the hand.
+Nova v1.3.5 is a performance and polish release: the library stops redoing work it already did, the stream path stops paying for text nobody is reading, and the controller gets treated as the first-class input it is on the devices Nova actually runs on.
 
-- **Play Setup**: one destination for how a game should run, with the host's answer shown beside the game's instead of a screen apart.
-- **Polaris brand**: Space Grotesk chrome, the brand palette, Title Case for names, and one corner scale in place of thirteen values.
-- **Portable Chrome**: smoked graphite with silver text and PlayStation-symbol glints, measured for contrast rather than judged by eye.
-- **Reachable by controller**: the Polaris Sync display selector could not be focused at all; Settings and Polaris Sync now open with focus somewhere useful, and the settings search field no longer traps the d-pad.
-- **Companion**: the companion window stays focusable, so the input dispatcher no longer times out on controller input, and hiding it is reversible from the notification.
+- **Warm library**: the poster cache survives re-entry instead of being wiped on every load, artwork decodes to per-surface size buckets, image loads run three-wide with cancellation of superseded requests, and artwork connections reuse TLS state over a pooled client instead of a full handshake and RSA client-cert exchange per image.
+- **Frame pacing, for real**: the latency-profile selector had been silently overwriting the frame-pacing preference to Balanced since the setting shipped; the preference now reaches the renderer, and stream setup logs the effective mode.
+- **Leaner decode path**: perf-overlay text (including four TrafficStats kernel calls a second) builds only when the overlay or HUD is actually showing, a per-frame allocation is hoisted, and the per-frame vsync-offset lookup is cached.
+- **Reconnect**: the connection-failure dialog now offers Reconnect on the spot instead of dead-ending with only OK.
+- **First focus lands somewhere useful**: Grid and Compact cold starts focus the first card with the ring visible immediately, the Command Center opens on the diagnosis card instead of its own Close button, and the welcome screen pre-focuses its primary action.
+- **Feel and finish**: focus ticks and action confirms across posters, buttons, and Command Center rows; the in-stream lock overlay is themed, controller-worded, and pre-focused; pairing snackbars speak human instead of protocol jargon; the Material You preview tile reads the real dynamic palette on Android 12+.
 - **Compatibility**: preserves Grid, Compact Grid, List, existing routing and persistence authorities, minSdk 21, targetSdk 36, Polaris integration, Moonlight-compatible hosts, and signed in-place upgrades.
-- **Release packaging**: signed ARM64, ARMv7, and x86_64 APKs ship with portable SHA-256 sidecars. VersionCode 36 keeps Obtainium and manual installs on a clean upgrade path.
-- **Release validation**: final publication requires the tagged ARM64 APK to pass signer/package checks and the complete physical AYN Thor dual-display, OLED, controller, touch, reconnect, lifecycle, and teardown matrix. Issue #127 remains separate; use **Screen Launch → Top Screen**, not Auto.
+- **Release packaging**: signed ARM64, ARMv7, and x86_64 APKs ship with portable SHA-256 sidecars. VersionCode 37 keeps Obtainium and manual installs on a clean upgrade path.
+- **Known issue**: gyro/motion sensors are not detected on some devices (#181). The audio output-device inventory added in v1.3.4's follow-up remains a diagnostic awaiting an AYN Thor capture, not an audio fix.
 
 See the [changelog](CHANGELOG.md) for the full release history.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.4"
-        versionCode = 36
+        versionName "1.3.5"
+        versionCode = 37
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -19,21 +19,21 @@ class NovaReleaseMetadataTest {
         val readme = File(root, "README.md").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/36.txt"
+            "fastlane/metadata/android/en-US/changelogs/37.txt"
         )
         val storeNotesBody = storeNotes.readText().trimEnd()
 
-        assertTrue(build.contains("versionName \"1.3.4\""))
-        assertTrue(build.contains("versionCode = 36"))
-        assertTrue(changelog.contains("## 1.3.4 - 2026-08-07"))
-        assertTrue(readme.contains("## Latest release: v1.3.4"))
-        assertTrue(readme.contains("VersionCode 36"))
-        assertFalse(readme.contains("## Latest release: v1.3.3"))
+        assertTrue(build.contains("versionName \"1.3.5\""))
+        assertTrue(build.contains("versionCode = 37"))
+        assertTrue(changelog.contains("## 1.3.5 - 2026-08-08"))
+        assertTrue(readme.contains("## Latest release: v1.3.5"))
+        assertTrue(readme.contains("VersionCode 37"))
+        assertFalse(readme.contains("## Latest release: v1.3.4"))
         assertTrue(storeNotes.isFile)
         assertTrue(
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.3.4"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.3.5"))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/37.txt
+++ b/fastlane/metadata/android/en-US/changelogs/37.txt
@@ -1,0 +1,2 @@
+Nova 1.3.5
+Faster library: posters stay warm across visits, artwork decodes to fit, and images load in parallel over pooled connections. Smoother streaming: frame pacing settings now reach the renderer, and overlay stats no longer build unless shown. The connection-failure dialog offers Reconnect. Controller polish: focus lands on content at launch, the Command Center opens on diagnostics, and buttons and posters get haptic feedback. The lock overlay matches your theme.


### PR DESCRIPTION
## Summary
- Bumps `versionName` to **1.3.5** and `versionCode` to **37**.
- Moves the five release-metadata artifacts `NovaReleaseMetadataTest` guards in lockstep: CHANGELOG `## 1.3.5 - 2026-08-08` section, README latest-release block rewritten (old `## Latest release: v1.3.4` heading removed, VersionCode 37), new `fastlane/metadata/android/en-US/changelogs/37.txt` store notes (474/500 code points, starts "Nova 1.3.5"), and the metadata test's own expectations bumped to 37 so the JVM suite proves the set is consistent before anything assembles.
- Packages the 1.3.5 arc: #201 frame-pacing, #202 artwork, #203 network, #204 stream, #205 androidTest repair, #206 reconnect/focus, #207 haptics/lock-overlay/strings. Gyro (#181) ships as a known issue.

## Exact candidate
- `Commit:` 019fba13b521e9df59b2bffb153c6fad4cb46a99
- `Tree:` 65bc866d637f0e6f4b3f78abb2a93a632a348852
- `Parent:` 179949f68ece17469fe940066544932e197d43e7
- `Base:` origin/master @ 179949f68ece17469fe940066544932e197d43e7

## Verification
- [x] `:app:testNonRoot_gameDebugUnitTest` — 1233 tests, 0 failures, 0 errors; `NovaReleaseMetadataTest` green with the 1.3.5/37 expectations (proves build.gradle, CHANGELOG, README, and 37.txt are mutually consistent)
- [x] `:app:lintNonRoot_gameRelease`
- [x] `:app:assembleNonRoot_gameRelease`
- [ ] Tag publish: pushing annotated `v1.3.5` on the merge commit triggers the release workflow (assemble + sign 3 ABI APKs + `--generate-notes`); post-publish check verifies 6 assets and a sha256 match.
