### PR TITLE
fix(api): recover idempotent POSTs from transient TLS failures

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.KeyManager
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLException
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 import javax.net.ssl.TrustManager
@@ -133,6 +134,28 @@ class PolarisApiClient @JvmOverloads constructor(
                 .callTimeout(ARTWORK_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .readTimeout(ARTWORK_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .build()
+
+        // TLS session resumption against a server that intermittently rejects it (e.g. a
+        // missing server-side session id context) surfaces as an SSLException on an
+        // otherwise-healthy link; one fresh-handshake retry is the correct recovery. Only
+        // idempotent requests may ride this helper.
+        @JvmStatic
+        internal fun <T> runWithTransientTlsRetry(
+            onTransient: () -> Unit,
+            retryDelayMs: Long = 150L,
+            attempt: () -> T
+        ): T {
+            return try {
+                attempt()
+            } catch (e: SSLException) {
+                LimeLog.warning("Nova: retrying once after transient TLS failure: ${e.javaClass.simpleName}: ${e.message}")
+                onTransient()
+                if (retryDelayMs > 0) {
+                    Thread.sleep(retryDelayMs)
+                }
+                attempt()
+            }
+        }
 
         @JvmStatic
         internal fun parseArtworkJsonBytes(bytes: ByteArray): JSONObject? {
@@ -1194,10 +1217,13 @@ class PolarisApiClient @JvmOverloads constructor(
     // Instance-scoped: the key and trust managers are assigned once in init, and re-pairing
     // constructs a new PolarisApiClient, so cached TLS state never outlives the certificate
     // material it was built from. Never cache these at companion/static scope.
-    private val perCallClient: OkHttpClient by lazy {
+    @Volatile
+    private var perCallClientCache: OkHttpClient? = null
+
+    private fun buildPerCallClient(): OkHttpClient {
         val keyManager = apiKeyManager
         val trustManager = apiTrustManager
-        if (keyManager == null || trustManager == null) {
+        return if (keyManager == null || trustManager == null) {
             client
         } else {
             val sslContext = SSLContext.getInstance("TLS").apply {
@@ -1217,7 +1243,20 @@ class PolarisApiClient @JvmOverloads constructor(
             .build()
     }
 
-    private fun clientForCall(): OkHttpClient = perCallClient
+    private fun clientForCall(): OkHttpClient =
+        perCallClientCache ?: synchronized(this) {
+            perCallClientCache ?: buildPerCallClient().also { perCallClientCache = it }
+        }
+
+    // Dropping the cached client discards its SSLContext and with it any cached TLS
+    // sessions, so the next call performs a full handshake instead of offering a
+    // resumption the server may refuse.
+    private fun resetCallClient() {
+        synchronized(this) { perCallClientCache = null }
+    }
+
+    private fun executeWithTransientRetry(request: Request): okhttp3.Response =
+        runWithTransientTlsRetry(onTransient = { resetCallClient() }) { execute(request) }
 
 	private fun execute(request: Request) = clientForCall().newCall(
 		request.newBuilder()
@@ -1234,6 +1273,9 @@ class PolarisApiClient @JvmOverloads constructor(
                 return execute(request)
             } catch (e: Exception) {
                 lastError = e
+                if (e is SSLException) {
+                    resetCallClient()
+                }
                 if (attempt == attempts - 1) {
                     throw e
                 }
@@ -1333,7 +1375,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 val responseBody = response.body?.string().orEmpty()
                 if (response.code != 200) {
                     LimeLog.warning("Nova: Client settings update rejected code=${response.code}")
@@ -1748,7 +1790,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 response.code == 200
             }
         } catch (e: Exception) {
@@ -1768,7 +1810,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 val responseBody = response.body?.string().orEmpty()
                 if (response.code != 200) {
                     LimeLog.warning("Nova: Steam launch mode update rejected code=${response.code}")
@@ -1796,7 +1838,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 response.code == 200
             }
         } catch (e: Exception) {
@@ -1818,7 +1860,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 response.code == 200
             }
         } catch (e: Exception) {
@@ -1849,7 +1891,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 response.code == 200
             }
         } catch (e: Exception) {
@@ -1871,7 +1913,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 response.code == 200
             }
         } catch (e: Exception) {
@@ -2068,7 +2110,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     body.toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 if (response.code != 200) return null
                 val responseJson = JSONObject(response.body?.string() ?: "{}")
                 responseJson.optBoolean("cleared", false)
@@ -2111,7 +2153,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     JSONObject().toString()
                 ))
                 .build()
-            execute(request).use { response ->
+            executeWithTransientRetry(request).use { response ->
                 if (response.code != 200) return null
                 val responseJson = JSONObject(response.body?.string() ?: "{}")
                 responseJson.optBoolean("cleared", false)

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientTransientRetryTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientTransientRetryTest.kt
@@ -1,0 +1,79 @@
+package com.papi.nova.api
+
+import java.io.IOException
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class PolarisApiClientTransientRetryTest {
+
+    @Test
+    fun succeedsFirstAttemptWithoutReset() {
+        var resets = 0
+        var attempts = 0
+        val result = PolarisApiClient.runWithTransientTlsRetry(onTransient = { resets++ }, retryDelayMs = 0L) {
+            attempts++
+            "ok"
+        }
+        assertEquals("ok", result)
+        assertEquals(1, attempts)
+        assertEquals(0, resets)
+    }
+
+    @Test
+    fun retriesOnceAfterSslExceptionAndResets() {
+        var resets = 0
+        var attempts = 0
+        val result = PolarisApiClient.runWithTransientTlsRetry(onTransient = { resets++ }, retryDelayMs = 0L) {
+            attempts++
+            if (attempts == 1) {
+                throw SSLHandshakeException("resumption refused")
+            }
+            "recovered"
+        }
+        assertEquals("recovered", result)
+        assertEquals(2, attempts)
+        assertEquals(1, resets)
+    }
+
+    @Test
+    fun secondSslFailurePropagates() {
+        var resets = 0
+        var attempts = 0
+        try {
+            PolarisApiClient.runWithTransientTlsRetry<Unit>(onTransient = { resets++ }, retryDelayMs = 0L) {
+                attempts++
+                throw SSLException("still broken")
+            }
+            fail("expected SSLException to propagate")
+        } catch (expected: SSLException) {
+            // second failure must surface to the caller
+        }
+        assertEquals(2, attempts)
+        assertEquals(1, resets)
+    }
+
+    @Test
+    fun nonTlsFailuresDoNotRetry() {
+        var resets = 0
+        var attempts = 0
+        try {
+            PolarisApiClient.runWithTransientTlsRetry<Unit>(onTransient = { resets++ }, retryDelayMs = 0L) {
+                attempts++
+                throw IOException("plain network error")
+            }
+            fail("expected IOException to propagate")
+        } catch (expected: IOException) {
+            // non-TLS failures take the normal error path, no retry
+        }
+        assertEquals(1, attempts)
+        assertEquals(0, resets)
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1362,7 +1362,15 @@ class NovaComposeSourceGuardTest {
         assertTrue(
             "TLS-bearing clients must stay instance-scoped so re-pairing (a new PolarisApiClient) rebuilds TLS state; never cache them at companion/static scope",
             api.contains("private val artworkClient: OkHttpClient by lazy") &&
-                api.contains("private val perCallClient: OkHttpClient by lazy")
+                api.contains("private var perCallClientCache: OkHttpClient? = null") &&
+                api.contains("private fun buildPerCallClient(): OkHttpClient")
+        )
+        assertTrue(
+            "transient-TLS recovery must rebuild the per-call client (dropping cached TLS sessions), and only idempotent requests may ride the retry helper",
+            api.contains("private fun resetCallClient()") &&
+                api.contains("runWithTransientTlsRetry(onTransient = { resetCallClient() })") &&
+                !api.section("fun launchGame(", "fun unlockScreen(")
+                    .contains("executeWithTransientRetry")
         )
         assertFalse(
             "artwork fetches must not force per-request sockets",


### PR DESCRIPTION
## Summary

Since #203 made the TLS client instance-scoped, Nova offers TLS session resumption on new connections. Against a host that rejects resumption (Polaris does today — it never sets a server-side session id context, fixed separately in polaris#330), every resumed handshake dies with `TLSV1_ALERT_INTERNAL_ERROR`. POSTs ride the no-retry `execute()` path, so **Reset Game Profile visibly fails every time** and client-settings sync fails intermittently, while GET-driven screens quietly recover through their 3-attempt retry. This PR makes the client self-healing for that failure class regardless of host version.

## Exact candidate

- `PolarisApiClient.kt`: the per-call client becomes a resettable cache (`@Volatile` + double-checked build). `resetCallClient()` drops it so the next call handshakes with a fresh `SSLContext`, discarding cached TLS sessions the server refuses.
- New companion helper `runWithTransientTlsRetry` (retry exactly once, only on `SSLException`, resetting the client first). Wired as `executeWithTransientRetry` and applied to the idempotent POST family only: `updateClientSettings`, `setMangoHud`, `setSteamLaunchMode`, `setBitrate`, `setAdaptiveBitrateEnabled`, `setAiOptimizerEnabled`, `setCursorVisibility`, `clearOptimizerProfile`, `clearOptimizerProfiles` (and `setAiAutoQualityEnabled` via its two delegates). `launchGame` (non-idempotent) and the report POSTs deliberately keep the single-attempt path.
- `executeGetWithRetry` now also resets the cached client on `SSLException` between attempts.
- `NovaComposeSourceGuardTest`: the pin on the old `perCallClient by lazy` literal is re-pinned to the new shape — same invariant, same assertion message (instance-scoped, never companion/static) — plus a new pin asserting the reset wiring and that `launchGame` stays off the retry helper.

## Verification

- New `PolarisApiClientTransientRetryTest` (4 cases): success passes through untouched; one `SSLHandshakeException` → reset + one retry + success; two SSL failures → second propagates after exactly one reset; plain `IOException` → propagates with no retry and no reset.
- Full unit suite `:app:testNonRoot_gameDebugUnitTest`: **1244/1244** (was 1240, +4 new).
- `:app:lintNonRoot_gameDebug`: clean against baseline.
- No androidTest signature changes.
- On-device (after polaris#330 deploys): Reset Game Profile recovers even mid-TLS-flap; against the fixed host it just works.
