### PR TITLE
fix(hud): flag network and decoder risk only when the host says elevated

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -299,6 +299,10 @@ data class NovaHudUiState(
             else -> NovaHudTone.DANGER
         }
 
+        // Polaris serves risk fields unconditionally as "normal" | "elevated", so presence
+        // alone means nothing — only the elevated value is a warning.
+        private fun riskElevated(risk: String?): Boolean = risk.equals("elevated", ignoreCase = true)
+
         private fun buildHealthReason(
             status: PolarisSessionStatus?,
             fps: Double,
@@ -311,9 +315,9 @@ data class NovaHudUiState(
                 status?.isHdrDowngraded == true -> "HDR downgraded" to NovaHudTone.WARNING
                 status?.isHostRenderLimited == true || primaryIssue == "host_render_limited" || issues.contains("host_render_limited") ->
                     "Host capped" to NovaHudTone.WARNING
-                primaryIssue.contains("network") || status?.health?.networkRisk?.isNotBlank() == true ->
+                primaryIssue.contains("network") || riskElevated(status?.health?.networkRisk) ->
                     "Network jitter" to NovaHudTone.WARNING
-                primaryIssue.contains("decoder") || status?.health?.decoderRisk?.isNotBlank() == true ->
+                primaryIssue.contains("decoder") || riskElevated(status?.health?.decoderRisk) ->
                     "Decoder late" to NovaHudTone.WARNING
                 latencyMs > 50 -> "High latency" to NovaHudTone.DANGER
                 targetFps > 0.0 && fps > 0.0 && fps < targetFps * 0.75 ->
@@ -361,14 +365,14 @@ data class NovaHudUiState(
             }
             val networkTone = when {
                 primaryIssue.contains("network") || issues.any { it.contains("network") } ||
-                    status?.health?.networkRisk?.isNotBlank() == true -> NovaHudTone.WARNING
+                    riskElevated(status?.health?.networkRisk) -> NovaHudTone.WARNING
                 latencyMs > 50 -> NovaHudTone.DANGER
                 latencyMs > 20 -> NovaHudTone.WARNING
                 else -> NovaHudTone.STABLE
             }
             val clientTone = when {
                 primaryIssue.contains("decoder") || issues.any { it.contains("decoder") } ||
-                    status?.health?.decoderRisk?.isNotBlank() == true -> NovaHudTone.WARNING
+                    riskElevated(status?.health?.decoderRisk) -> NovaHudTone.WARNING
                 status?.encoder?.targetResidency.equals("cpu", ignoreCase = true) -> NovaHudTone.WARNING
                 else -> NovaHudTone.STABLE
             }

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -360,6 +360,99 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun normalRiskValuesDoNotRaiseNetworkOrDecoderWarnings() {
+        // Polaris serves network_risk/decoder_risk unconditionally as "normal" | "elevated";
+        // the healthy value must not read as a warning just because it is non-blank.
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = 60.0,
+            latencyMs = 18,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "good",
+                    networkRisk = "normal",
+                    decoderRisk = "normal"
+                )
+            ),
+            sparklineSamples = listOf(60f)
+        )
+
+        assertEquals("Stable", state.healthReasonLabel)
+        assertEquals(NovaHudTone.STABLE, state.healthReasonTone)
+        assertEquals(
+            listOf(
+                NovaHudLayerHealth("HOST", NovaHudTone.STABLE),
+                NovaHudLayerHealth("NET", NovaHudTone.STABLE),
+                NovaHudLayerHealth("CLIENT", NovaHudTone.STABLE)
+            ),
+            state.layerHealth
+        )
+    }
+
+    @Test
+    fun elevatedNetworkRiskRaisesTheJitterWarning() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = 60.0,
+            latencyMs = 18,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "watch",
+                    networkRisk = "elevated",
+                    decoderRisk = "normal"
+                )
+            ),
+            sparklineSamples = listOf(60f)
+        )
+
+        assertEquals("Network jitter", state.healthReasonLabel)
+        assertEquals(NovaHudTone.WARNING, state.healthReasonTone)
+        assertEquals(
+            NovaHudLayerHealth("NET", NovaHudTone.WARNING),
+            state.layerHealth[1]
+        )
+    }
+
+    @Test
+    fun elevatedDecoderRiskRaisesDecoderLate() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = 60.0,
+            latencyMs = 18,
+            codec = "hevc",
+            bitrateKbps = 22000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "watch",
+                    networkRisk = "normal",
+                    decoderRisk = "elevated"
+                )
+            ),
+            sparklineSamples = listOf(60f)
+        )
+
+        assertEquals("Decoder late", state.healthReasonLabel)
+        assertEquals(NovaHudTone.WARNING, state.healthReasonTone)
+        assertEquals(
+            NovaHudLayerHealth("CLIENT", NovaHudTone.WARNING),
+            state.layerHealth[2]
+        )
+    }
+
+    @Test
     fun hdrDowngradeUsesExplicitWarningCopyAndTenBitSdrTruth() {
         val state = NovaHudUiState.from(
             mode = NovaHudMode.PERFORMANCE,


### PR DESCRIPTION
## Summary

The in-stream HUD shows "Network jitter" (and an amber NET chip) on essentially every healthy session. Polaris serves `health.network_risk`/`health.decoder_risk` unconditionally as `"normal" | "elevated"`; the HUD gated on `isNotBlank()`, which the literal string `"normal"` always satisfies. Verified live: the RP6's link during the reports was excellent (−43 dBm, 5 GHz, 600 Mbps link, Wi-Fi score 60/60) — the warning was pure false positive. The decoder-risk check had the identical bug.

## Exact candidate

`NovaHudUiState.kt`: one `riskElevated()` helper (`equals("elevated", ignoreCase = true)`), applied at the four gating sites — `buildHealthReason` network + decoder branches, and `buildLayerHealth` NET + CLIENT tones. `primaryIssue`/`issues` handling is unchanged, so a host that names a network issue still warns regardless of the risk field.

## Verification

- Three new `NovaHudUiStateTest` cases: `networkRisk="normal"`+`decoderRisk="normal"` → "Stable" with all three layer chips STABLE; `networkRisk="elevated"` → "Network jitter" + NET WARNING; `decoderRisk="elevated"` → "Decoder late" + CLIENT WARNING.
- Full unit suite `:app:testNonRoot_gameDebugUnitTest` + `:app:lintNonRoot_gameDebug`: green.
- On-device follow-up (batched with the Wave-0 deploy pass): healthy LAN stream on the RP6 shows the Stable chip; after the Polaris periodic-ping stats fix lands, an induced-latency run must flip it to a legitimate warning.
