### PR TITLE
feat(play-setup): server-authoritative launch-mode pickers with grouped bands

### DIFF
--- a/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailComposeTest.kt
@@ -128,6 +128,9 @@ class NovaGameDetailComposeTest {
                         onResumeSession = {},
                         onEndSession = {},
                         onDismissDestination = {},
+                        modePicker = null,
+                        onPickMode = {},
+                        onPickHostDefault = {},
                     )
                 }
             }

--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -737,14 +737,14 @@ class ShortcutTrampoline : NovaActivity() {
         clientSettings: PolarisClientSettings?,
     ) {
         val preferences = PreferenceConfiguration.readPreferences(this)
-        val syncedSettings = apiClient.updateClientSettings(
-            streamDisplayMode = PolarisStreamDisplayMode.preflightModeForLaunch(withVirtualDisplay, clientSettings),
-            displayMode = PreferenceConfiguration.formatStreamingDisplayMode(
-                preferences.width,
-                preferences.height,
-                preferences.fps,
-            ),
-            targetBitrateKbps = preferences.bitrate.takeIf { it > 0 },
+        val syncedSettings = com.papi.nova.ui.NovaLaunchPreflight.push(
+            apiClient = apiClient,
+            clientSettings = clientSettings,
+            usesVirtualDisplay = withVirtualDisplay,
+            width = preferences.width,
+            height = preferences.height,
+            fps = preferences.fps,
+            bitrateKbps = preferences.bitrate,
         )
         if (syncedSettings == null) {
             LimeLog.warning("Nova: Shortcut launch preflight client settings sync failed; continuing launch")

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -499,7 +499,9 @@ class PolarisApiClient @JvmOverloads constructor(
                         label = mode.optString("label", ""),
                         available = mode.optBoolean("available", true),
                         restartRequired = mode.optBoolean("restart_required", true),
-                        reason = mode.optString("reason", "")
+                        reason = mode.optString("reason", ""),
+                        group = mode.optString("group", ""),
+                        unavailableReason = mode.optString("unavailable_reason", "")
                     )
                 }
             }

--- a/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
@@ -50,7 +50,11 @@ data class PolarisClientSettings(
         val label: String = "",
         val available: Boolean = true,
         val restartRequired: Boolean = true,
-        val reason: String = ""
+        val reason: String = "",
+        /** Registry grouping: "private" (desktop untouched) or "host" (uses/swaps the host screen). */
+        val group: String = "",
+        /** Host-supplied explanation served when available is false. */
+        val unavailableReason: String = ""
     )
 
     val desiredModeLabel: String
@@ -64,6 +68,8 @@ data class PolarisClientSettings(
         const val MODE_DESKTOP_DISPLAY = "desktop_display"
         const val MODE_HOST_VIRTUAL_DISPLAY = "host_virtual_display"
         const val MODE_GPU_NATIVE_TEST = "windowed_stream"
+        const val MODE_GAMESCOPE_STREAM = "gamescope_stream"
+        const val MODE_HEADLESS_DONGLE = "headless_dongle"
 
         @JvmStatic
         fun labelForMode(mode: String): String = when (mode) {
@@ -71,6 +77,8 @@ data class PolarisClientSettings(
             MODE_HOST_VIRTUAL_DISPLAY -> "Host Virtual Display"
             MODE_GPU_NATIVE_TEST -> "Private Stream (GPU-native)"
             MODE_DESKTOP_DISPLAY -> "Mirror Desktop"
+            MODE_GAMESCOPE_STREAM -> "Gamescope Stream"
+            MODE_HEADLESS_DONGLE -> "Headless Dongle"
             "headless" -> "Private Stream"
             "virtual_display" -> "Host Virtual Display"
             "desktop_display", "host_display" -> "Mirror Desktop"

--- a/app/src/main/java/com/papi/nova/api/PolarisGameLaunchModeAdapter.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisGameLaunchModeAdapter.kt
@@ -4,36 +4,38 @@ import com.papi.nova.shared.polaris.model.PolarisGame
 
 fun PolarisGame.resolveLaunchModeChoice(defaultToVirtualDisplay: Boolean, clientSettings: PolarisClientSettings? = null): PolarisGame.LaunchModeChoice {
     val contract = launchMode
-    val headlessAvailable = modeAvailability(clientSettings, "headless")
-    val virtualAvailable = modeAvailability(clientSettings, "virtual_display")
-    val headlessAllowed = (contract?.allows("headless") ?: true) && headlessAvailable != false
-    val virtualDisplayAllowed = (contract?.allows("virtual_display") ?: true) && virtualAvailable != false
+    val headlessAvailable = modeAvailability(clientSettings, PolarisGame.MODE_HEADLESS_STREAM)
+    val virtualAvailable = modeAvailability(clientSettings, PolarisGame.MODE_HOST_VIRTUAL_DISPLAY)
+    val headlessAllowed = (contract?.allows(PolarisGame.MODE_HEADLESS_STREAM) ?: true) && headlessAvailable != false
+    val virtualDisplayAllowed = (contract?.allows(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) ?: true) && virtualAvailable != false
     val hostRequestedMode = clientSettings?.desired?.streamDisplayMode?.takeIf { it.isNotBlank() }
         ?: clientSettings?.effective?.streamDisplayMode?.takeIf { it.isNotBlank() }
         ?: ""
     val hostDefaultMode = hostRequestedMode.takeIf { it.isNotBlank() }?.let {
         PolarisGame.resolveLaunchMode(it, headlessAllowed, virtualDisplayAllowed)
     } ?: ""
-    val fallbackMode = if (defaultToVirtualDisplay && virtualDisplayAllowed) "virtual_display" else "headless"
+    val fallbackMode = if (defaultToVirtualDisplay && virtualDisplayAllowed) PolarisGame.MODE_HOST_VIRTUAL_DISPLAY else PolarisGame.MODE_HEADLESS_STREAM
     val preferredMode = PolarisGame.resolveLaunchMode(contract?.preferredMode?.takeIf { it.isNotBlank() } ?: fallbackMode, headlessAllowed, virtualDisplayAllowed)
     val recommendedMode = PolarisGame.resolveLaunchMode(hostDefaultMode.takeIf { it.isNotBlank() } ?: contract?.recommendedMode?.takeIf { it.isNotBlank() } ?: preferredMode, headlessAllowed, virtualDisplayAllowed)
-    val virtualUnavailableReason = modeUnavailableReason(clientSettings, "virtual_display")
+    val virtualUnavailableReason = modeUnavailableReason(clientSettings, PolarisGame.MODE_HOST_VIRTUAL_DISPLAY)
 
     return PolarisGame.LaunchModeChoice(
         preferredMode = preferredMode,
         recommendedMode = recommendedMode,
         headlessAllowed = headlessAllowed,
         virtualDisplayAllowed = virtualDisplayAllowed,
-        virtualDisplayUnavailable = (contract?.allows("virtual_display") ?: defaultToVirtualDisplay) && virtualAvailable == false,
+        virtualDisplayUnavailable = (contract?.allows(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) ?: defaultToVirtualDisplay) && virtualAvailable == false,
         virtualDisplayUnavailableReason = virtualUnavailableReason,
         hostDefaultMode = hostDefaultMode,
         hostModeReason = clientSettings?.desired?.streamDisplayModeReason?.takeIf { it.isNotBlank() } ?: clientSettings?.effective?.streamDisplayModeReason ?: ""
     )
 }
 
-private val HEADLESS_MODE_ALIASES = setOf("headless", PolarisClientSettings.MODE_HEADLESS_STREAM, PolarisClientSettings.MODE_DESKTOP_DISPLAY, PolarisClientSettings.MODE_GPU_NATIVE_TEST, "host_display")
-private val VIRTUAL_DISPLAY_MODE_ALIASES = setOf("virtual_display", PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY)
-
+// Canonical ids make alias sets unnecessary: normalizeLaunchMode maps every
+// legacy spelling onto one registry id, so catalog matching is plain
+// id-equality after normalization. The old alias sets deliberately lumped
+// desktop_display and windowed_stream in with "headless", which is how a host
+// reporting "GPU-native available" used to read as "headless available".
 private fun modeAvailability(clientSettings: PolarisClientSettings?, mode: String): Boolean? {
     val modes = clientSettings?.capabilities?.modes ?: return null
     val matches = matchingModes(modes, mode)
@@ -47,16 +49,6 @@ private fun modeUnavailableReason(clientSettings: PolarisClientSettings?, mode: 
 }
 
 private fun matchingModes(modes: List<PolarisClientSettings.ModeOption>, mode: String): List<PolarisClientSettings.ModeOption> {
-    val aliases = aliasesForMode(mode)
     val normalizedMode = PolarisGame.normalizeLaunchMode(mode)
-    return modes.filter { option ->
-        option.value in aliases || PolarisGame.normalizeLaunchMode(option.value) == normalizedMode
-    }
-}
-
-private fun aliasesForMode(mode: String): Set<String> {
-    return when (PolarisGame.normalizeLaunchMode(mode)) {
-        "virtual_display" -> VIRTUAL_DISPLAY_MODE_ALIASES
-        else -> HEADLESS_MODE_ALIASES
-    }
+    return modes.filter { option -> PolarisGame.normalizeLaunchMode(option.value) == normalizedMode }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -201,6 +201,7 @@ class NovaGameDetailActivity : NovaActivity() {
      * and the header pill does the same by touch.
      */
     private var playSetupScope by mutableStateOf(NovaPlaySetupScope.THIS_GAME)
+    private var modePickerOpen by mutableStateOf(false)
 
     /** The strip explains this row; rows point it at themselves as focus moves. */
     private var explainedRow by mutableStateOf(NovaPlaySetupRow.WHERE_IT_RUNS)
@@ -281,9 +282,14 @@ class NovaGameDetailActivity : NovaActivity() {
             reviewExpanded = false
             true
         }
+        modePickerOpen -> {
+            modePickerOpen = false
+            true
+        }
         destination != NovaGameDetailDestination.OVERVIEW -> {
             destination = NovaGameDetailDestination.OVERVIEW
             steamDecision = null
+            modePickerOpen = false
             // The panel reopens on the game it was opened for; host scope is a place
             // someone flips to, not a place the panel should quietly resume in.
             playSetupScope = NovaPlaySetupScope.THIS_GAME
@@ -316,6 +322,7 @@ class NovaGameDetailActivity : NovaActivity() {
             return
         }
         playSetupScope = scope
+        modePickerOpen = false
         explainedRow = if (scope == NovaPlaySetupScope.EVERY_GAME) {
             NovaPlaySetupRow.HOST_DEFAULT_DISPLAY
         } else {
@@ -669,6 +676,68 @@ class NovaGameDetailActivity : NovaActivity() {
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
+        /** The sheet's mapper, fed from the engine, so panel and sheet read alike. */
+        fun hostScopeUiState(): NovaPolarisSyncUiState {
+            val engine = hostSyncEngine
+            val prefs = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
+            return NovaPolarisSyncUiStateMapper.build(
+                settings = engine?.currentSettings ?: clientSettings,
+                busy = engine?.busy == true,
+                settingsUnavailable = engine?.settingsUnavailable == true,
+                autoSyncEnabled = engine?.autoSyncEnabled == true,
+                hasServerUuid = !serverUuid.isNullOrBlank(),
+                novaDisplayMode = PreferenceConfiguration.formatStreamingDisplayMode(
+                    prefs.width,
+                    prefs.height,
+                    prefs.fps
+                ),
+                novaBitrateKbps = prefs.bitrate,
+                loadingLabel = getString(R.string.nova_polaris_sync_loading),
+                unavailableLabel = getString(R.string.nova_polaris_sync_unavailable),
+                unsetLabel = getString(R.string.nova_polaris_sync_unset),
+                savedAfterRelaunchLabel = getString(R.string.nova_polaris_sync_status_saved_relaunch),
+                selectedLabel = getString(R.string.nova_polaris_sync_status_selected),
+                activeNowLabel = getString(R.string.nova_polaris_sync_status_active_now),
+                availableLabel = getString(R.string.nova_polaris_sync_status_available),
+            )
+        }
+
+        /**
+         * How many modes the full-panel picker would offer this game: the host
+         * catalog cut to the contract's allowed list. Decides row enablement and
+         * whether a press opens the picker or cycles the classic pair in place.
+         */
+        fun gameModeCatalogSize(): Int = buildGameModePickerState(
+            modes = hostScopeUiState().modes,
+            allowedModes = currentGame.launchMode?.allowedModes.orEmpty(),
+            playMode = uiState.playMode,
+            hasExplicitOverride = uiState.hasExplicitOverride,
+            title = "",
+            hostDefaultLabel = "",
+        ).choices.size
+
+        /**
+         * A pick from the full-panel picker. The picker only offers what the host
+         * catalog allows for this game, so unlike [selectLaunchMode] there is no
+         * pair gate to re-check: the override becomes the chosen canonical id.
+         */
+        fun pickPlayMode(mode: String) {
+            modePickerOpen = false
+            NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
+            refreshUiState()
+            chosenResolution = null
+            settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
+        }
+
+        /** The pinned entry: drop the override so this game follows the host again. */
+        fun pickHostDefault() {
+            modePickerOpen = false
+            NovaLaunchModeOverrides.clear(this@NovaGameDetailActivity, currentGame)
+            refreshUiState()
+            chosenResolution = null
+            settleThen { loadOptimization(profilePreference, usesVirtualDisplay = uiState.playUsesVirtualDisplay) }
+        }
+
         /**
          * Hold the resolution rather than launching with it.
          *
@@ -760,7 +829,8 @@ class NovaGameDetailActivity : NovaActivity() {
                 value = modeBadgeLabel(uiState.playMode),
                 stripTitle = getString(R.string.nova_play_setup_strip_where),
                 options = modeOptions,
-                enabled = modeOptions.count { it.enabled } > 1,
+                enabled = modeOptions.count { it.enabled } > 1 ||
+                    novaModePickerEligible(gameModeCatalogSize()),
                 overridden = uiState.overridesHostMode,
             )
 
@@ -849,32 +919,6 @@ class NovaGameDetailActivity : NovaActivity() {
             val currentIndex = selectable.indexOfFirst { it.current }
             val next = selectable[(currentIndex + 1).mod(selectable.size)]
             next.onSelect?.invoke()
-        }
-
-        /** The sheet's mapper, fed from the engine, so panel and sheet read alike. */
-        fun hostScopeUiState(): NovaPolarisSyncUiState {
-            val engine = hostSyncEngine
-            val prefs = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
-            return NovaPolarisSyncUiStateMapper.build(
-                settings = engine?.currentSettings ?: clientSettings,
-                busy = engine?.busy == true,
-                settingsUnavailable = engine?.settingsUnavailable == true,
-                autoSyncEnabled = engine?.autoSyncEnabled == true,
-                hasServerUuid = !serverUuid.isNullOrBlank(),
-                novaDisplayMode = PreferenceConfiguration.formatStreamingDisplayMode(
-                    prefs.width,
-                    prefs.height,
-                    prefs.fps
-                ),
-                novaBitrateKbps = prefs.bitrate,
-                loadingLabel = getString(R.string.nova_polaris_sync_loading),
-                unavailableLabel = getString(R.string.nova_polaris_sync_unavailable),
-                unsetLabel = getString(R.string.nova_polaris_sync_unset),
-                savedAfterRelaunchLabel = getString(R.string.nova_polaris_sync_status_saved_relaunch),
-                selectedLabel = getString(R.string.nova_polaris_sync_status_selected),
-                activeNowLabel = getString(R.string.nova_polaris_sync_status_active_now),
-                availableLabel = getString(R.string.nova_polaris_sync_status_available),
-            )
         }
 
         fun hostPolarisProfileValue(sync: NovaPolarisSyncUiState): String {
@@ -989,6 +1033,39 @@ class NovaGameDetailActivity : NovaActivity() {
                     } else {
                         null
                     },
+                    modePicker = if (modePickerOpen && steamDecision == null) {
+                        if (playSetupScope == NovaPlaySetupScope.EVERY_GAME) {
+                            buildHostModePickerState(
+                                modes = hostScopeUiState().modes,
+                                title = getString(R.string.nova_play_setup_host_default_display),
+                            )
+                        } else {
+                            buildGameModePickerState(
+                                modes = hostScopeUiState().modes,
+                                allowedModes = currentGame.launchMode?.allowedModes.orEmpty(),
+                                playMode = uiState.playMode,
+                                hasExplicitOverride = uiState.hasExplicitOverride,
+                                title = getString(R.string.nova_game_detail_where_it_runs),
+                                hostDefaultLabel = getString(
+                                    R.string.nova_play_setup_host_default_entry_detail,
+                                    uiState.hostStreamDisplayModeLabel.ifBlank {
+                                        getString(R.string.nova_polaris_sync_unset)
+                                    },
+                                ),
+                            )
+                        }
+                    } else {
+                        null
+                    },
+                    onPickMode = { mode ->
+                        if (playSetupScope == NovaPlaySetupScope.EVERY_GAME) {
+                            modePickerOpen = false
+                            hostSyncEngine?.setStreamDisplayMode(mode)
+                        } else {
+                            pickPlayMode(mode)
+                        }
+                    },
+                    onPickHostDefault = { pickHostDefault() },
                     playLabel = if (pendingLaunch) {
                         // The press landed and is being held, so say so. A button that
                         // looks untouched for the length of an HTTP round-trip reads as
@@ -1010,9 +1087,23 @@ class NovaGameDetailActivity : NovaActivity() {
                     onExplainPlaySetupRow = { row -> explainedRow = row },
                     onAdvancePlaySetupRow = { row ->
                         if (playSetupScope == NovaPlaySetupScope.EVERY_GAME) {
-                            advanceHostPlaySetupRow(row)
+                            if (row == NovaPlaySetupRow.HOST_DEFAULT_DISPLAY &&
+                                novaModePickerEligible(hostScopeUiState().modes.size)
+                            ) {
+                                explainedRow = row
+                                modePickerOpen = true
+                            } else {
+                                advanceHostPlaySetupRow(row)
+                            }
                         } else {
-                            advancePlaySetupRow(row)
+                            if (row == NovaPlaySetupRow.WHERE_IT_RUNS &&
+                                novaModePickerEligible(gameModeCatalogSize())
+                            ) {
+                                explainedRow = row
+                                modePickerOpen = true
+                            } else {
+                                advancePlaySetupRow(row)
+                            }
                         }
                     },
                     destination = destination,
@@ -1393,6 +1484,8 @@ class NovaGameDetailActivity : NovaActivity() {
             PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_virtual_display)
             PolarisGame.MODE_DESKTOP_DISPLAY -> getString(R.string.nova_library_launch_desktop_display)
             PolarisGame.MODE_WINDOWED_STREAM -> getString(R.string.nova_library_launch_gpu_native_test)
+            PolarisGame.MODE_GAMESCOPE_STREAM -> getString(R.string.nova_library_launch_gamescope)
+            PolarisGame.MODE_HEADLESS_DONGLE -> getString(R.string.nova_library_launch_dongle)
             else -> getString(R.string.nova_library_launch_headless)
         }
     }
@@ -1402,6 +1495,8 @@ class NovaGameDetailActivity : NovaActivity() {
             PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_virtual_short)
             PolarisGame.MODE_DESKTOP_DISPLAY -> getString(R.string.nova_library_launch_desktop_display)
             PolarisGame.MODE_WINDOWED_STREAM -> getString(R.string.nova_library_launch_gpu_native_test)
+            PolarisGame.MODE_GAMESCOPE_STREAM -> getString(R.string.nova_library_launch_gamescope)
+            PolarisGame.MODE_HEADLESS_DONGLE -> getString(R.string.nova_library_launch_dongle)
             else -> getString(R.string.nova_library_launch_headless)
         }
     }

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -646,8 +646,8 @@ class NovaGameDetailActivity : NovaActivity() {
         }
 
         fun selectLaunchMode(mode: String) {
-            val allowed = when (mode) {
-                "virtual_display" -> uiState.virtualDisplayAllowed && !uiState.virtualDisplayUnavailable
+            val allowed = when (PolarisGame.normalizeLaunchMode(mode)) {
+                PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> uiState.virtualDisplayAllowed && !uiState.virtualDisplayUnavailable
                 else -> uiState.headlessAllowed
             }
             if (!allowed || mode == uiState.playMode) return
@@ -655,7 +655,7 @@ class NovaGameDetailActivity : NovaActivity() {
             val previousLaunchMode = currentGame.launchMode
             val allowedModes = previousLaunchMode?.allowedModes
                 ?.takeIf { it.isNotEmpty() }
-                ?: listOf("headless", "virtual_display")
+                ?: listOf(PolarisGame.MODE_HEADLESS_STREAM, PolarisGame.MODE_HOST_VIRTUAL_DISPLAY)
             val updatedLaunchMode = (previousLaunchMode ?: PolarisGame.LaunchModeContract()).copy(
                 preferredMode = mode,
                 allowedModes = allowedModes
@@ -666,7 +666,7 @@ class NovaGameDetailActivity : NovaActivity() {
             // A resolution was an answer to "how should this run on that display". Changing
             // the display changes the question, so the answer does not carry over.
             chosenResolution = null
-            settleThen { loadOptimization(profilePreference, usesVirtualDisplay = mode == "virtual_display") }
+            settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
         /**
@@ -734,21 +734,21 @@ class NovaGameDetailActivity : NovaActivity() {
                 if (uiState.headlessAllowed) {
                     add(
                         NovaPlaySetupOption(
-                            label = modeBadgeLabel("headless"),
+                            label = modeBadgeLabel(PolarisGame.MODE_HEADLESS_STREAM),
                             consequence = getString(R.string.nova_play_setup_compare_private),
-                            current = uiState.playMode == "headless",
-                            onSelect = { selectLaunchMode("headless") },
+                            current = uiState.playMode == PolarisGame.MODE_HEADLESS_STREAM,
+                            onSelect = { selectLaunchMode(PolarisGame.MODE_HEADLESS_STREAM) },
                         )
                     )
                 }
                 if (uiState.virtualDisplayAllowed) {
                     add(
                         NovaPlaySetupOption(
-                            label = modeBadgeLabel("virtual_display"),
+                            label = modeBadgeLabel(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY),
                             consequence = getString(R.string.nova_play_setup_compare_virtual),
-                            current = uiState.playMode == "virtual_display",
+                            current = uiState.playMode == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY,
                             enabled = !uiState.virtualDisplayUnavailable,
-                            onSelect = { selectLaunchMode("virtual_display") },
+                            onSelect = { selectLaunchMode(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) },
                         )
                     )
                 }
@@ -1003,8 +1003,8 @@ class NovaGameDetailActivity : NovaActivity() {
                             ?: primaryPlayLabel(uiState)
                     },
                     launchModeTitle = getString(R.string.nova_library_launch_mode_title),
-                    headlessModeLabel = modeBadgeLabel("headless"),
-                    virtualDisplayModeLabel = modeBadgeLabel("virtual_display"),
+                    headlessModeLabel = modeBadgeLabel(PolarisGame.MODE_HEADLESS_STREAM),
+                    virtualDisplayModeLabel = modeBadgeLabel(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY),
                     coverContentDescription = getString(R.string.nova_a11y_game_cover),
                     onPrimaryLaunch = { attemptLaunch() },
                     onExplainPlaySetupRow = { row -> explainedRow = row },
@@ -1389,15 +1389,19 @@ class NovaGameDetailActivity : NovaActivity() {
     }
 
     private fun modeLabel(mode: String): String {
-        return when (mode) {
-            "virtual_display" -> getString(R.string.nova_library_launch_virtual_display)
+        return when (PolarisGame.normalizeLaunchMode(mode)) {
+            PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_virtual_display)
+            PolarisGame.MODE_DESKTOP_DISPLAY -> getString(R.string.nova_library_launch_desktop_display)
+            PolarisGame.MODE_WINDOWED_STREAM -> getString(R.string.nova_library_launch_gpu_native_test)
             else -> getString(R.string.nova_library_launch_headless)
         }
     }
 
     private fun modeBadgeLabel(mode: String): String {
-        return when (mode) {
-            "virtual_display" -> getString(R.string.nova_library_launch_virtual_short)
+        return when (PolarisGame.normalizeLaunchMode(mode)) {
+            PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_virtual_short)
+            PolarisGame.MODE_DESKTOP_DISPLAY -> getString(R.string.nova_library_launch_desktop_display)
+            PolarisGame.MODE_WINDOWED_STREAM -> getString(R.string.nova_library_launch_gpu_native_test)
             else -> getString(R.string.nova_library_launch_headless)
         }
     }
@@ -1454,7 +1458,7 @@ class NovaGameDetailActivity : NovaActivity() {
             }
             uiState.launchChoice.hostModeReason.isNotBlank() -> uiState.launchChoice.hostModeReason
             uiState.game.launchMode?.modeReason?.isNotBlank() == true -> uiState.game.launchMode?.modeReason.orEmpty()
-            uiState.recommendedMode == "virtual_display" -> getString(R.string.nova_library_launch_intro_virtual_default)
+            uiState.recommendedMode == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_intro_virtual_default)
             else -> getString(R.string.nova_library_launch_intro_headless_default)
         }
         return parts.joinToString(" ")

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -1322,14 +1322,14 @@ class NovaGameDetailActivity : NovaActivity() {
         clientSettings: PolarisClientSettings?
     ): PolarisClientSettings? {
         val preferences = PreferenceConfiguration.readPreferences(context)
-        return apiClient.updateClientSettings(
-            streamDisplayMode = PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings),
-            displayMode = PreferenceConfiguration.formatStreamingDisplayMode(
-                preferences.width,
-                preferences.height,
-                preferences.fps
-            ),
-            targetBitrateKbps = preferences.bitrate.takeIf { it > 0 }
+        return NovaLaunchPreflight.push(
+            apiClient = apiClient,
+            clientSettings = clientSettings,
+            usesVirtualDisplay = usesVirtualDisplay,
+            width = preferences.width,
+            height = preferences.height,
+            fps = preferences.fps,
+            bitrateKbps = preferences.bitrate
         )
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -397,8 +397,11 @@ internal fun NovaGameDetailContent(
                             // The resolved mode, not the name of the control that sets
                             // it: this is the one line the column exists to state.
                             modeLabel = when (uiState.playMode) {
-                                "virtual_display" -> virtualDisplayModeLabel
-                                else -> headlessModeLabel
+                                PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> virtualDisplayModeLabel
+                                PolarisGame.MODE_HEADLESS_STREAM -> headlessModeLabel
+                                // Following a host default outside the pair: say what it
+                                // actually is instead of mislabeling it Private Stream.
+                                else -> uiState.hostStreamDisplayModeLabel.ifBlank { headlessModeLabel }
                             },
                             lines = listOfNotNull(
                                 summary?.selectedLine

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -217,6 +217,10 @@ internal fun NovaGameDetailContent(
     /** Host-scope rows and plan; empty and null while This Game is showing. */
     hostPlaySetupRows: List<NovaPlaySetupRowState>,
     hostPlaySetupPlan: NovaPlaySetupPlan?,
+    /** Full-panel mode picker; non-null while it owns the Play Setup body. */
+    modePicker: NovaPlaySetupModePickerState?,
+    onPickMode: (String) -> Unit,
+    onPickHostDefault: () -> Unit,
     playLabel: String,
     launchModeTitle: String,
     headlessModeLabel: String,
@@ -320,7 +324,7 @@ internal fun NovaGameDetailContent(
                 headline = uiState.game.name,
                 scrollState = verticalScroll,
                 onDismiss = onDismissDestination,
-                headerAccessory = if (steamDecision == null) {
+                headerAccessory = if (steamDecision == null && modePicker == null) {
                     {
                         NovaPlaySetupScopePill(
                             scope = playSetupScope,
@@ -340,6 +344,18 @@ internal fun NovaGameDetailContent(
                     NovaDesktopSteamLaunchDecisionRows(
                         decision = decision,
                         onChoice = onSteamChoice,
+                    )
+                } else if (modePicker != null) {
+                    // Choosing where a game runs owns the body the way the Steam
+                    // decision does; the rows return when a choice lands or B backs out.
+                    NovaPlaySetupModePicker(
+                        state = modePicker,
+                        onPick = onPickMode,
+                        onPickHostDefault = if (playSetupScope == NovaPlaySetupScope.THIS_GAME) {
+                            onPickHostDefault
+                        } else {
+                            null
+                        },
                     )
                 } else if (playSetupScope == NovaPlaySetupScope.EVERY_GAME && hostPlaySetupPlan != null) {
                     // The same four-row shape, absorbing the Polaris Sync sheet's three
@@ -377,8 +393,10 @@ internal fun NovaGameDetailContent(
                                     consequenceMaxLines = consequenceLines,
                                     // The 2x2 the sync sheet taught: four mode names in
                                     // one row leave no room for their status lines.
+                                    // 2x2 for the classic four; three per row once a
+                                    // six-mode catalog would otherwise stack three rows.
                                     perRow = if (explained.row == NovaPlaySetupRow.HOST_DEFAULT_DISPLAY) {
-                                        2
+                                        if (explained.options.size > 4) 3 else 2
                                     } else {
                                         Int.MAX_VALUE
                                     },

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailUiState.kt
@@ -51,6 +51,8 @@ data class NovaGameDetailUiState(
     val steamLaunchWarning: Boolean,
     val hostStreamDisplayMode: String,
     val hostStreamDisplayModeLabel: String,
+    /** True only when this client stored a per-game launch-mode override. */
+    val hasExplicitOverride: Boolean,
     /**
      * The profile the host would use for anything that does not ask for its own, as
      * "1920x1080@60 · 20 Mbps". Blank when the host has no profile set.
@@ -64,12 +66,12 @@ data class NovaGameDetailUiState(
      * on screen and the disagreement is named.
      */
     val overridesHostMode: Boolean
-        get() = hostStreamDisplayMode.isNotBlank() &&
+        get() = hasExplicitOverride &&
+            hostStreamDisplayMode.isNotBlank() &&
             playMode.isNotBlank() &&
-            // Both sides, because these are two vocabularies for the same thing: playMode
-            // speaks the contract's "headless" while the host mode has already been
-            // normalised to MODE_HEADLESS_STREAM. Comparing them raw reports an override
-            // on every game, including the ones that agree with the host.
+            // Normalized on both sides so legacy spellings and canonical ids compare
+            // as the same mode. Without hasExplicitOverride this reported an override
+            // on every game whenever the host default sat outside the per-game pair.
             PolarisStreamDisplayMode.normalize(playMode) !=
             PolarisStreamDisplayMode.normalize(hostStreamDisplayMode)
 
@@ -96,14 +98,24 @@ data class NovaGameDetailUiState(
                 ?.takeIf { it.isNotBlank() }
                 ?.let { PolarisGame.resolveLaunchMode(it, choice.headlessAllowed, choice.virtualDisplayAllowed) }
             val playMode = when {
-                chosen == "virtual_display" && choice.virtualDisplayAllowed &&
-                    !choice.virtualDisplayUnavailable -> "virtual_display"
-                chosen == "headless" && choice.headlessAllowed -> "headless"
+                chosen == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY && choice.virtualDisplayAllowed &&
+                    !choice.virtualDisplayUnavailable -> PolarisGame.MODE_HOST_VIRTUAL_DISPLAY
+                chosen == PolarisGame.MODE_HEADLESS_STREAM && choice.headlessAllowed -> PolarisGame.MODE_HEADLESS_STREAM
+                // A deliberate override outside the legacy pair resolves to itself;
+                // the picker only offers modes the host catalog advertised.
+                !chosen.isNullOrBlank() && chosen != PolarisGame.MODE_HOST_VIRTUAL_DISPLAY &&
+                    chosen != PolarisGame.MODE_HEADLESS_STREAM -> chosen
 
-                choice.recommendedMode == "virtual_display" && choice.virtualDisplayAllowed -> "virtual_display"
-                choice.recommendedMode == "headless" && choice.headlessAllowed -> "headless"
-                choice.headlessAllowed -> "headless"
-                choice.virtualDisplayAllowed -> "virtual_display"
+                choice.recommendedMode == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY && choice.virtualDisplayAllowed -> PolarisGame.MODE_HOST_VIRTUAL_DISPLAY
+                choice.recommendedMode == PolarisGame.MODE_HEADLESS_STREAM && choice.headlessAllowed -> PolarisGame.MODE_HEADLESS_STREAM
+                // No override and the host default sits outside the pair: follow the
+                // host instead of quietly coercing to headless — this is what used to
+                // fire the false "This game overrides it" warning.
+                choice.recommendedMode.isNotBlank() &&
+                    choice.recommendedMode != PolarisGame.MODE_HOST_VIRTUAL_DISPLAY &&
+                    choice.recommendedMode != PolarisGame.MODE_HEADLESS_STREAM -> choice.recommendedMode
+                choice.headlessAllowed -> PolarisGame.MODE_HEADLESS_STREAM
+                choice.virtualDisplayAllowed -> PolarisGame.MODE_HOST_VIRTUAL_DISPLAY
                 else -> ""
             }
             val actionableLaunchModeCount = listOf(
@@ -147,7 +159,7 @@ data class NovaGameDetailUiState(
                 virtualDisplayUnavailableReason = choice.virtualDisplayUnavailableReason,
                 playMode = playMode,
                 playEnabled = playMode.isNotBlank(),
-                playUsesVirtualDisplay = playMode == "virtual_display",
+                playUsesVirtualDisplay = playMode == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY,
                 launchOptionsEnabled = launchOptionsEnabled,
                 actionableLaunchModeCount = actionableLaunchModeCount,
                 showLaunchOptionsButton = showLaunchOptionsButton,
@@ -161,6 +173,7 @@ data class NovaGameDetailUiState(
                 steamLaunchWarning = steamLaunchWarning,
                 hostStreamDisplayMode = hostStreamDisplayMode,
                 hostStreamDisplayModeLabel = hostStreamDisplayModeLabel,
+                hasExplicitOverride = !launchModeOverride.isNullOrBlank(),
                 hostProfileLabel = hostProfileLabel(clientSettings),
             )
         }

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchModeOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchModeOverrides.kt
@@ -20,15 +20,27 @@ object NovaLaunchModeOverrides {
     private fun key(game: PolarisGame): String =
         KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
 
+    // Values written before the canonical-id vocabulary ("headless",
+    // "virtual_display") map forward at read time, forever — no bulk migration,
+    // no stranded prefs.
     fun load(context: Context, game: PolarisGame): String? =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(key(game), null)
             ?.takeIf { it.isNotBlank() }
+            ?.let { PolarisGame.normalizeLaunchMode(it) }
 
     fun save(context: Context, game: PolarisGame, mode: String) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit()
-            .putString(key(game), mode)
+            .putString(key(game), PolarisGame.normalizeLaunchMode(mode))
+            .apply()
+    }
+
+    /** Remove the per-game choice so the game follows the host default again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
             .apply()
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
@@ -1,0 +1,38 @@
+package com.papi.nova.ui
+
+import com.papi.nova.api.PolarisApiClient
+import com.papi.nova.api.PolarisClientSettings
+import com.papi.nova.api.PolarisStreamDisplayMode
+import com.papi.nova.preferences.PreferenceConfiguration
+
+/**
+ * The one place a launch pushes its display intent to the host before starting.
+ *
+ * Three surfaces launch games (game detail, the library result path, and shortcut
+ * trampolines) and each used to carry its own copy of this POST; a change to how
+ * the mode travels had to find all three. Mirror wins outright because it is a
+ * session-scoped request, not a persistent host mode; everything else resolves
+ * through preflightModeForLaunch so a private-family host default survives the
+ * launch untouched.
+ */
+object NovaLaunchPreflight {
+
+    fun push(
+        apiClient: PolarisApiClient,
+        clientSettings: PolarisClientSettings?,
+        usesVirtualDisplay: Boolean,
+        mirrorDesktop: Boolean = false,
+        width: Int,
+        height: Int,
+        fps: Float,
+        bitrateKbps: Int?,
+    ): PolarisClientSettings? = apiClient.updateClientSettings(
+        streamDisplayMode = if (mirrorDesktop) {
+            PolarisClientSettings.MODE_DESKTOP_DISPLAY
+        } else {
+            PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings)
+        },
+        displayMode = PreferenceConfiguration.formatStreamingDisplayMode(width, height, fps),
+        targetBitrateKbps = bitrateKbps?.takeIf { it > 0 },
+    )
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -905,18 +905,15 @@ class NovaLibraryActivity : NovaActivity() {
                         "displayMode=" + (preflightOptimization?.optString("display_mode", "") ?: "")
                 )
                 val syncedSettings = withContext(Dispatchers.IO) {
-                    apiClient.updateClientSettings(
-                        streamDisplayMode = if (mirrorDesktop) {
-                            PolarisClientSettings.MODE_DESKTOP_DISPLAY
-                        } else {
-                            PolarisStreamDisplayMode.preflightModeForLaunch(withVirtualDisplay, clientSettings)
-                        },
-                        displayMode = com.papi.nova.preferences.PreferenceConfiguration.formatStreamingDisplayMode(
-                            launchResolution.width,
-                            launchResolution.height,
-                            launchFps
-                        ),
-                        targetBitrateKbps = preferences.bitrate.takeIf { it > 0 }
+                    NovaLaunchPreflight.push(
+                        apiClient = apiClient,
+                        clientSettings = clientSettings,
+                        usesVirtualDisplay = withVirtualDisplay,
+                        mirrorDesktop = mirrorDesktop,
+                        width = launchResolution.width,
+                        height = launchResolution.height,
+                        fps = launchFps,
+                        bitrateKbps = preferences.bitrate
                     )
                 }
                 if (syncedSettings == null) {

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -217,7 +217,7 @@ private fun NovaPlaySetupRule() {
 }
 
 @Composable
-private fun NovaPlaySetupColumnHead(text: String) {
+internal fun NovaPlaySetupColumnHead(text: String) {
     val colors = LocalNovaComposeColors.current
     Text(
         text = text.uppercase(),

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
@@ -1,0 +1,361 @@
+package com.papi.nova.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.papi.nova.R
+import com.papi.nova.api.PolarisStreamDisplayMode
+import com.papi.nova.shared.polaris.model.PolarisGame
+import com.papi.nova.ui.compose.LocalNovaComposeColors
+import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.NovaRadius
+
+/** One selectable mode in the picker: the host catalog entry plus its standing here. */
+internal data class NovaPlaySetupModeChoice(
+    val id: String,
+    val label: String,
+    /** What choosing it means — or, when unavailable, the host's reason it cannot be. */
+    val detail: String,
+    /** Registry grouping: "private" or "host"; anything else bands together at the end. */
+    val group: String,
+    val current: Boolean,
+    /** In effect this session without being the saved choice (fallback or pending relaunch). */
+    val active: Boolean,
+    val enabled: Boolean,
+)
+
+internal data class NovaPlaySetupModeBand(
+    val group: String,
+    val choices: List<NovaPlaySetupModeChoice>,
+)
+
+/**
+ * The full-panel mode picker's state. Per-game scope carries the pinned follow-the-host
+ * entry; host scope has no host to follow, so [hostDefaultLabel] is null there.
+ */
+internal data class NovaPlaySetupModePickerState(
+    val title: String,
+    val hostDefaultLabel: String?,
+    val hostDefaultCurrent: Boolean,
+    val choices: List<NovaPlaySetupModeChoice>,
+)
+
+/**
+ * Whether a row's press should open the picker rather than cycle in place.
+ *
+ * Two options cycle in one press and need no panel; the moment a host offers a third,
+ * cycling means walking a ring blind and the picker takes over. Hosts that predate the
+ * mode catalog can never exceed the classic pair per game, so they keep the old press.
+ */
+internal fun novaModePickerEligible(choiceCount: Int): Boolean = choiceCount > 2
+
+/**
+ * Band order is the mental model of the choice: private modes (the desktop stays
+ * untouched) first, host-display modes (uses or swaps the host screen) second, and any
+ * grouping a future host invents appended in the order it arrived rather than dropped.
+ */
+internal fun novaModePickerBands(choices: List<NovaPlaySetupModeChoice>): List<NovaPlaySetupModeBand> {
+    val known = listOf("private", "host")
+    val byGroup = choices.groupBy { it.group }
+    val bands = mutableListOf<NovaPlaySetupModeBand>()
+    known.forEach { group ->
+        byGroup[group]?.let { bands += NovaPlaySetupModeBand(group, it) }
+    }
+    byGroup.keys.filterNot { it in known }.forEach { group ->
+        bands += NovaPlaySetupModeBand(group, byGroup.getValue(group))
+    }
+    return bands
+}
+
+/** Every Game: the host catalog verbatim — pick sets the host's Default Display. */
+internal fun buildHostModePickerState(
+    modes: List<NovaPolarisModeUiState>,
+    title: String,
+): NovaPlaySetupModePickerState = NovaPlaySetupModePickerState(
+    title = title,
+    hostDefaultLabel = null,
+    hostDefaultCurrent = false,
+    choices = modes.map { mode ->
+        NovaPlaySetupModeChoice(
+            id = mode.mode,
+            label = mode.label,
+            detail = if (!mode.available && mode.unavailableReason.isNotBlank()) {
+                mode.unavailableReason
+            } else {
+                mode.reason
+            },
+            group = mode.group,
+            current = mode.selectedDesired,
+            active = mode.selectedEffective && !mode.selectedDesired,
+            enabled = mode.enabled,
+        )
+    },
+)
+
+/**
+ * This Game: the host catalog cut down to what this game's contract allows, with the
+ * saved per-game override (not the resolved playMode) as the current card — because the
+ * picker edits the override, and the pinned Host default entry is "no override".
+ */
+internal fun buildGameModePickerState(
+    modes: List<NovaPolarisModeUiState>,
+    allowedModes: List<String>,
+    playMode: String,
+    hasExplicitOverride: Boolean,
+    title: String,
+    hostDefaultLabel: String,
+): NovaPlaySetupModePickerState {
+    val allowed = allowedModes.map { PolarisGame.normalizeLaunchMode(it) }.toSet()
+    return NovaPlaySetupModePickerState(
+        title = title,
+        hostDefaultLabel = hostDefaultLabel,
+        hostDefaultCurrent = !hasExplicitOverride,
+        choices = modes
+            .filter { allowed.isEmpty() || PolarisStreamDisplayMode.normalize(it.mode) in allowed }
+            .map { mode ->
+                NovaPlaySetupModeChoice(
+                    id = mode.mode,
+                    label = mode.label,
+                    detail = if (!mode.available && mode.unavailableReason.isNotBlank()) {
+                        mode.unavailableReason
+                    } else {
+                        mode.reason
+                    },
+                    group = mode.group,
+                    current = hasExplicitOverride && mode.mode == playMode,
+                    active = mode.mode == playMode && !hasExplicitOverride,
+                    enabled = mode.available,
+                )
+            },
+    )
+}
+
+/**
+ * The picker owns the panel body the way the desktop-Steam decision does: choosing where
+ * a game runs is the one moment nothing else on the screen matters. Unlike the
+ * comparison strip below the rows — a legend, deliberately not a focus target — these
+ * cards ARE the surface, so they take d-pad focus; a disabled card still takes it so a
+ * controller can read the host's reason in the footer, it just does nothing on press.
+ */
+@Composable
+internal fun NovaPlaySetupModePicker(
+    state: NovaPlaySetupModePickerState,
+    onPick: (String) -> Unit,
+    onPickHostDefault: (() -> Unit)?,
+) {
+    val colors = LocalNovaComposeColors.current
+    var footer by remember(state) {
+        mutableStateOf(state.choices.firstOrNull { it.current }?.detail.orEmpty())
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        NovaPlaySetupColumnHead(state.title)
+
+        if (state.hostDefaultLabel != null && onPickHostDefault != null) {
+            NovaPlaySetupModeHostDefaultCard(
+                label = stringResource(R.string.nova_play_setup_fact_host_default),
+                detail = state.hostDefaultLabel,
+                current = state.hostDefaultCurrent,
+                onPick = onPickHostDefault,
+                onFocusedDetail = { footer = it },
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        novaModePickerBands(state.choices).forEach { band ->
+            when (band.group) {
+                "private" -> NovaPlaySetupColumnHead(stringResource(R.string.nova_play_setup_band_private))
+                "host" -> NovaPlaySetupColumnHead(stringResource(R.string.nova_play_setup_band_host))
+                // A blank or future group carries no header rather than a made-up one.
+                else -> Unit
+            }
+            band.choices.chunked(3).forEachIndexed { chunkIndex, chunk ->
+                if (chunkIndex > 0) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    chunk.forEach { choice ->
+                        NovaPlaySetupModeCard(
+                            choice = choice,
+                            onPick = { onPick(choice.id) },
+                            onFocusedDetail = { footer = it },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        // The focused card's full story — this line is why the cards themselves can stay
+        // one status line tall, and where an unavailable mode's host reason is quoted.
+        Text(
+            text = footer,
+            color = colors.textMuted,
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 28.dp)
+                .padding(top = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun NovaPlaySetupModeCard(
+    choice: NovaPlaySetupModeChoice,
+    onPick: () -> Unit,
+    onFocusedDetail: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val shape = RoundedCornerShape(NovaRadius.row)
+    var focused by remember { mutableStateOf(false) }
+    Column(
+        modifier = modifier
+            .onFocusChanged {
+                focused = it.isFocused
+                if (it.isFocused) {
+                    onFocusedDetail(choice.detail)
+                }
+            }
+            .focusable()
+            .then(
+                if (choice.enabled) {
+                    Modifier.clickable(role = Role.Button) { onPick() }
+                } else {
+                    Modifier
+                }
+            )
+            .heightIn(min = NovaGameDetailActionHeight)
+            .clip(shape)
+            .background(if (choice.current) colors.accentSurface else surfaces.tile)
+            .border(
+                1.dp,
+                when {
+                    focused -> colors.accent
+                    choice.current -> colors.accent.copy(alpha = 0.58f)
+                    choice.active -> colors.accent.copy(alpha = 0.34f)
+                    else -> surfaces.tileBorder
+                },
+                shape,
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .semantics {
+                contentDescription = "${choice.label}. ${choice.detail}"
+                if (choice.current) selected = true
+            },
+    ) {
+        Text(
+            text = choice.label,
+            color = if (choice.enabled) colors.textPrimary else colors.textMuted,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = choice.detail,
+            color = if (choice.active && !choice.current) colors.accent else colors.textMuted,
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun NovaPlaySetupModeHostDefaultCard(
+    label: String,
+    detail: String,
+    current: Boolean,
+    onPick: () -> Unit,
+    onFocusedDetail: (String) -> Unit,
+) {
+    val colors = LocalNovaComposeColors.current
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val shape = RoundedCornerShape(NovaRadius.row)
+    var focused by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged {
+                focused = it.isFocused
+                if (it.isFocused) {
+                    onFocusedDetail(detail)
+                }
+            }
+            .focusable()
+            .clickable(role = Role.Button) { onPick() }
+            .clip(shape)
+            .background(if (current) colors.accentSurface else surfaces.tile)
+            .border(
+                1.dp,
+                when {
+                    focused -> colors.accent
+                    current -> colors.accent.copy(alpha = 0.58f)
+                    else -> surfaces.tileBorder
+                },
+                shape,
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .semantics {
+                contentDescription = "$label. $detail"
+                if (current) selected = true
+            },
+    ) {
+        Text(
+            text = label,
+            color = colors.textPrimary,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = detail,
+            color = colors.textMuted,
+            fontSize = 11.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
@@ -21,7 +21,11 @@ data class NovaPolarisModeUiState(
     val available: Boolean,
     val reason: String,
     val restartRequired: Boolean,
-    val statusLabel: String
+    val statusLabel: String,
+    /** Registry grouping from the host catalog: "private" or "host"; blank on legacy hosts. */
+    val group: String = "",
+    /** Host-supplied explanation for an unavailable mode; blank when available. */
+    val unavailableReason: String = ""
 )
 
 data class NovaPolarisSyncUiState(
@@ -107,20 +111,30 @@ object NovaPolarisSyncUiStateMapper {
             },
             desiredModeLabel = desiredModeLabel,
             effectiveModeLabel = effectiveModeLabel,
-            modes = PolarisStreamDisplayMode.ORDER.map { mode ->
-                val option = availableModes?.get(mode)
+            // Server-authoritative catalog: when the host serves capabilities.modes,
+            // render exactly that list in the host order — every entry, including
+            // unavailable ones, which stay visible but disabled with the host reason.
+            // The hardcoded ORDER synthesis remains only for hosts that predate the
+            // catalog and can never offer more than the classic four.
+            modes = (settings?.capabilities?.modes?.takeIf { it.isNotEmpty() }
+                ?.map { option -> PolarisStreamDisplayMode.normalize(option.value) to option }
+                ?: PolarisStreamDisplayMode.ORDER.map { mode -> mode to availableModes?.get(mode) }
+            ).map { (mode, option) ->
                 val available = option?.available ?: true
                 val desiredSelected = selectedMode == mode
                 val effectiveSelected = effectiveMode == mode
                 NovaPolarisModeUiState(
                     mode = mode,
-                    label = PolarisStreamDisplayMode.labelForMode(mode),
+                    label = option?.label?.takeIf { it.isNotBlank() }
+                        ?: PolarisStreamDisplayMode.labelForMode(mode),
                     selected = desiredSelected,
                     selectedDesired = desiredSelected,
                     selectedEffective = effectiveSelected,
                     enabled = settings != null && available && !busy,
                     available = available,
                     reason = option?.reason.orEmpty(),
+                    group = option?.group.orEmpty(),
+                    unavailableReason = option?.unavailableReason.orEmpty(),
                     restartRequired = option?.restartRequired ?: true,
                     statusLabel = when {
                         desiredSelected && relaunchRequired && !effectiveSelected -> savedAfterRelaunchLabel

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,9 @@
     <string name="nova_play_setup_granted_format">Granted: %1$s</string>
     <string name="nova_play_setup_compare_where">If you changed where it runs</string>
     <string name="nova_play_setup_fact_host_default">Host default</string>
+    <string name="nova_play_setup_band_private">Private — your desktop stays untouched</string>
+    <string name="nova_play_setup_band_host">Host display — uses or swaps the host screen</string>
+    <string name="nova_play_setup_host_default_entry_detail">Follow the host\'s Default Display — currently %1$s</string>
     <string name="nova_play_setup_fact_host_profile">Host profile</string>
     <string name="nova_play_setup_host_overridden">This game overrides it. Every other game follows the host.</string>
     <string name="nova_play_setup_host_followed">This game follows it.</string>
@@ -388,6 +391,8 @@
     <string name="nova_library_launch_headless">Private Stream</string>
     <string name="nova_library_launch_virtual_display">Host Virtual Display</string>
     <string name="nova_library_launch_virtual_short">Host Virtual</string>
+    <string name="nova_library_launch_gamescope">Gamescope Stream</string>
+    <string name="nova_library_launch_dongle">Headless Dongle</string>
     <string name="nova_library_launch_desktop_display">Mirror Desktop</string>
     <string name="nova_library_launch_gpu_native_test">Private Stream (GPU-native)</string>
     <string name="nova_library_play">Launch Recommended</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -466,10 +466,10 @@ class PolarisApiClientParsingTest {
         val launchMode = game.launchMode!!
 
         assertEquals("game-uuid", game.id)
-        assertEquals("virtual_display", launchMode.preferredMode)
-        assertEquals("headless", launchMode.recommendedMode)
-        assertTrue(launchMode.allowedModes.contains("headless"))
-        assertTrue(launchMode.allowedModes.contains("virtual_display"))
+        assertEquals("host_virtual_display", launchMode.preferredMode)
+        assertEquals("headless_stream", launchMode.recommendedMode)
+        assertTrue(launchMode.allowedModes.contains("headless_stream"))
+        assertTrue(launchMode.allowedModes.contains("host_virtual_display"))
     }
 
     @Test
@@ -483,9 +483,9 @@ class PolarisApiClientParsingTest {
         val game = PolarisGameJsonAdapter.fromJson(json)
         val launchMode = game.launchMode!!
 
-        assertEquals("headless", launchMode.preferredMode)
-        assertTrue(launchMode.allowedModes.contains("headless"))
-        assertTrue(launchMode.allowedModes.contains("virtual_display"))
+        assertEquals("headless_stream", launchMode.preferredMode)
+        assertTrue(launchMode.allowedModes.contains("headless_stream"))
+        assertTrue(launchMode.allowedModes.contains("host_virtual_display"))
     }
 
     @Test
@@ -507,8 +507,8 @@ class PolarisApiClientParsingTest {
         val game = PolarisGameJsonAdapter.fromJson(gameJson)
         val choice = game.resolveLaunchModeChoice(true, settings)
 
-        assertEquals("headless", choice.preferredMode)
-        assertEquals("headless", choice.recommendedMode)
+        assertEquals("headless_stream", choice.preferredMode)
+        assertEquals("headless_stream", choice.recommendedMode)
         assertTrue(choice.headlessAllowed)
         assertFalse(choice.virtualDisplayAllowed)
         assertTrue(choice.virtualDisplayUnavailable)
@@ -536,9 +536,9 @@ class PolarisApiClientParsingTest {
         val game = PolarisGameJsonAdapter.fromJson(gameJson)
         val choice = game.resolveLaunchModeChoice(true, settings)
 
-        assertEquals("virtual_display", choice.preferredMode)
-        assertEquals("headless", choice.recommendedMode)
-        assertEquals("headless", choice.hostDefaultMode)
+        assertEquals("host_virtual_display", choice.preferredMode)
+        assertEquals("headless_stream", choice.recommendedMode)
+        assertEquals("headless_stream", choice.hostDefaultMode)
         assertTrue(choice.virtualDisplayAllowed)
         assertFalse(choice.virtualDisplayUnavailable)
         assertEquals(

--- a/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaGameDetailUiStateTest.kt
@@ -33,7 +33,7 @@ class NovaGameDetailUiStateTest {
             profilePreference = "quality"
         )
 
-        assertEquals("headless", state.playMode)
+        assertEquals("headless_stream", state.playMode)
         assertFalse("agreeing with the host is not overriding it", state.overridesHostMode)
     }
 
@@ -54,7 +54,7 @@ class NovaGameDetailUiStateTest {
             launchModeOverride = "virtual_display",
         )
 
-        assertEquals("virtual_display", state.playMode)
+        assertEquals("host_virtual_display", state.playMode)
         assertTrue(state.overridesHostMode)
     }
 
@@ -75,7 +75,7 @@ class NovaGameDetailUiStateTest {
             profilePreference = "quality"
         )
 
-        assertEquals("virtual_display", state.playMode)
+        assertEquals("host_virtual_display", state.playMode)
         assertTrue(state.playUsesVirtualDisplay)
         assertTrue(state.playEnabled)
         assertTrue(state.launchOptionsEnabled)
@@ -99,7 +99,7 @@ class NovaGameDetailUiStateTest {
             profilePreference = "auto"
         )
 
-        assertEquals("virtual_display", state.playMode)
+        assertEquals("host_virtual_display", state.playMode)
         assertTrue(state.playUsesVirtualDisplay)
         assertTrue(state.playEnabled)
     }
@@ -130,7 +130,7 @@ class NovaGameDetailUiStateTest {
             profilePreference = "invalid"
         )
 
-        assertEquals("headless", state.playMode)
+        assertEquals("headless_stream", state.playMode)
         assertFalse(state.playUsesVirtualDisplay)
         assertTrue(state.virtualDisplayUnavailable)
         assertTrue(state.showVirtualUnavailableHint)
@@ -329,7 +329,7 @@ class NovaGameDetailUiStateTest {
     }
 
     @Test
-    fun nonVirtualPolarisModesRemainPrivateLaunchFamilyButExposeHostMode() {
+    fun hostModesOutsideThePairFlowThroughAsPlayModeWithoutAnOverride() {
         val state = NovaGameDetailUiState.from(
             game = game(
                 launchMode = PolarisGame.LaunchModeContract(
@@ -347,8 +347,12 @@ class NovaGameDetailUiStateTest {
             profilePreference = "auto"
         )
 
-        assertEquals("headless", state.playMode)
+        // No override: the game follows the host's real mode instead of coercing it
+        // into the legacy pair -- the coercion is what made every game claim
+        // "This game overrides it" whenever the host ran GPU-native or Mirror.
+        assertEquals(PolarisClientSettings.MODE_GPU_NATIVE_TEST, state.playMode)
         assertFalse(state.playUsesVirtualDisplay)
+        assertFalse("following the host is not overriding it", state.overridesHostMode)
         assertEquals(PolarisClientSettings.MODE_GPU_NATIVE_TEST, state.hostStreamDisplayMode)
         assertEquals("Private Stream (GPU-native)", state.hostStreamDisplayModeLabel)
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -227,11 +227,17 @@ class NovaLaunchSourceGuardTest {
         val trampoline = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
         val displayMode = readSource("src/main/java/com/papi/nova/api/PolarisStreamDisplayMode.kt")
 
+        val preflightHelper = readSource("src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt")
+
         assertTrue(displayMode.contains("fun preflightModeForLaunch("))
         assertTrue(displayMode.contains("PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY"))
         assertTrue(displayMode.contains("PolarisClientSettings.MODE_HEADLESS_STREAM"))
-        assertTrue(detail.contains("PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings)"))
-        assertTrue(trampoline.contains("PolarisStreamDisplayMode.preflightModeForLaunch(withVirtualDisplay, clientSettings)"))
+        // All launch surfaces ride the one preflight helper, which itself resolves
+        // through preflightModeForLaunch and uses the contract constant for mirror.
+        assertTrue(preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings)"))
+        assertTrue(preflightHelper.contains("PolarisClientSettings.MODE_DESKTOP_DISPLAY"))
+        assertTrue(detail.contains("NovaLaunchPreflight.push("))
+        assertTrue(trampoline.contains("NovaLaunchPreflight.push("))
     }
 
     @Test
@@ -646,7 +652,7 @@ class NovaLaunchSourceGuardTest {
             "drawer launch should derive effective stream mode from preflight optimization before syncing settings",
             launchGame.contains("val launchResolution = StreamSyncManager.resolveAutoSafeResolution(") &&
                 launchGame.contains("val launchFps = StreamSyncManager.resolveAutoSafeTargetFps(") &&
-                launchGame.indexOf("val launchResolution") < launchGame.indexOf("apiClient.updateClientSettings(")
+                launchGame.indexOf("val launchResolution") < launchGame.indexOf("NovaLaunchPreflight.push(")
         )
         assertTrue(
             "client settings and Game intent should use launchResolution and launchFps instead of saved fps only",
@@ -681,10 +687,13 @@ class NovaLaunchSourceGuardTest {
             "private fun modeLabel("
         )
 
+        val preflightHelper = readSource("src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt")
+
         assertTrue(
             "Game detail preflight must use the full Polaris stream display mode helper, not collapse every non-virtual launch to headless_stream",
-            preflight.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
-                !preflight.contains("if (usesVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
+            preflight.contains("NovaLaunchPreflight.push") &&
+                preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
+                !preflightHelper.contains("if (usesVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )
     }
 
@@ -693,14 +702,17 @@ class NovaLaunchSourceGuardTest {
         val library = readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
         val shortcut = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
 
+        val preflightHelper = readSource("src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt")
+
         assertTrue(
             "Library launch should preserve the selected full Polaris stream display mode",
-            library.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
+            library.contains("NovaLaunchPreflight.push") &&
+                preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
                 !library.contains("if (withVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )
         assertTrue(
             "Shortcut launch should preserve the selected full Polaris stream display mode",
-            shortcut.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
+            shortcut.contains("NovaLaunchPreflight.push") &&
                 !shortcut.contains("if (withVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -25,7 +25,7 @@ class NovaLaunchSourceGuardTest {
         )
         assertTrue(
             "inline mode selection should keep the selected MangoHUD state in preview/preflight state",
-            launchModeSelection.contains("loadOptimization(profilePreference, usesVirtualDisplay = mode == \"virtual_display\")") &&
+            launchModeSelection.contains("loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY)") &&
                 launchModeSelection.contains("currentGame = currentGame.copy(launchMode = updatedLaunchMode)")
         )
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
@@ -1,0 +1,169 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaPlaySetupModePickerTest {
+
+    private fun mode(
+        id: String,
+        group: String = "",
+        available: Boolean = true,
+        desired: Boolean = false,
+        effective: Boolean = false,
+        label: String = id,
+        reason: String = "",
+        unavailableReason: String = "",
+    ) = NovaPolarisModeUiState(
+        mode = id,
+        label = label,
+        selected = desired,
+        selectedDesired = desired,
+        selectedEffective = effective,
+        enabled = available,
+        available = available,
+        reason = reason,
+        restartRequired = true,
+        statusLabel = "",
+        group = group,
+        unavailableReason = unavailableReason,
+    )
+
+    @Test
+    fun pickerOpensOnlyBeyondTheClassicPair() {
+        assertFalse(novaModePickerEligible(0))
+        assertFalse(novaModePickerEligible(2))
+        assertTrue(novaModePickerEligible(3))
+        assertTrue(novaModePickerEligible(6))
+    }
+
+    @Test
+    fun bandsOrderPrivateThenHostThenAnythingAFutureHostInvents() {
+        val choices = buildHostModePickerState(
+            modes = listOf(
+                mode("headless_dongle", group = "host"),
+                mode("containerized", group = "sandbox"),
+                mode("headless_stream", group = "private"),
+                mode("desktop_display", group = "host"),
+                mode("windowed_stream", group = "private"),
+            ),
+            title = "Default Display",
+        ).choices
+
+        val bands = novaModePickerBands(choices)
+        assertEquals(listOf("private", "host", "sandbox"), bands.map { it.group })
+        assertEquals(listOf("headless_stream", "windowed_stream"), bands[0].choices.map { it.id })
+        assertEquals(listOf("headless_dongle", "desktop_display"), bands[1].choices.map { it.id })
+    }
+
+    @Test
+    fun legacyCatalogWithoutGroupsIsOneUnlabeledBand() {
+        val bands = novaModePickerBands(
+            buildHostModePickerState(
+                modes = listOf(mode("headless_stream"), mode("host_virtual_display")),
+                title = "Default Display",
+            ).choices
+        )
+        assertEquals(1, bands.size)
+        assertEquals("", bands.single().group)
+    }
+
+    @Test
+    fun hostChoicesCarryDesiredEffectiveAndTheHostsUnavailableReason() {
+        val state = buildHostModePickerState(
+            modes = listOf(
+                mode("headless_stream", group = "private", desired = true, reason = "Recommended for handhelds"),
+                mode("desktop_display", group = "host", effective = true, reason = "Streams the visible desktop"),
+                mode(
+                    "host_virtual_display",
+                    group = "host",
+                    available = false,
+                    reason = "Creates a host-visible output",
+                    unavailableReason = "EVDI module is loaded but no device can be created",
+                ),
+            ),
+            title = "Default Display",
+        )
+
+        assertEquals("Default Display", state.title)
+        assertEquals(null, state.hostDefaultLabel)
+        val byId = state.choices.associateBy { it.id }
+        assertTrue(byId.getValue("headless_stream").current)
+        assertFalse(byId.getValue("headless_stream").active)
+        // Effective-but-not-desired is the fallback edge, never the selection tint.
+        assertTrue(byId.getValue("desktop_display").active)
+        assertFalse(byId.getValue("desktop_display").current)
+        // The rejection a client would get is the story the card tells.
+        assertEquals(
+            "EVDI module is loaded but no device can be created",
+            byId.getValue("host_virtual_display").detail,
+        )
+        assertFalse(byId.getValue("host_virtual_display").enabled)
+        assertEquals("Recommended for handhelds", byId.getValue("headless_stream").detail)
+    }
+
+    @Test
+    fun gameChoicesAreTheCatalogCutToTheContractIncludingLegacySpellings() {
+        val state = buildGameModePickerState(
+            modes = listOf(
+                mode("headless_stream", group = "private"),
+                mode("windowed_stream", group = "private"),
+                mode("host_virtual_display", group = "host"),
+                mode("headless_dongle", group = "host"),
+            ),
+            // The contract speaks the old vocabulary; the cut still has to land.
+            allowedModes = listOf("headless", "virtual_display", "windowed_stream"),
+            playMode = "headless_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Follow the host — currently Private Stream",
+        )
+
+        assertEquals(
+            listOf("headless_stream", "windowed_stream", "host_virtual_display"),
+            state.choices.map { it.id },
+        )
+        assertEquals("Follow the host — currently Private Stream", state.hostDefaultLabel)
+    }
+
+    @Test
+    fun withoutAnOverrideTheHostDefaultEntryIsCurrentAndThePlayModeOnlyActive() {
+        val state = buildGameModePickerState(
+            modes = listOf(mode("headless_stream", group = "private"), mode("windowed_stream", group = "private"), mode("desktop_display", group = "host")),
+            allowedModes = emptyList(),
+            playMode = "windowed_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Follow the host",
+        )
+
+        assertTrue(state.hostDefaultCurrent)
+        val byId = state.choices.associateBy { it.id }
+        assertFalse(byId.getValue("windowed_stream").current)
+        assertTrue(byId.getValue("windowed_stream").active)
+    }
+
+    @Test
+    fun anExplicitOverrideOwnsTheSelectionTint() {
+        val state = buildGameModePickerState(
+            modes = listOf(mode("headless_stream", group = "private"), mode("host_virtual_display", group = "host")),
+            allowedModes = emptyList(),
+            playMode = "host_virtual_display",
+            hasExplicitOverride = true,
+            title = "Where It Runs",
+            hostDefaultLabel = "Follow the host",
+        )
+
+        assertFalse(state.hostDefaultCurrent)
+        val byId = state.choices.associateBy { it.id }
+        assertTrue(byId.getValue("host_virtual_display").current)
+        assertFalse(byId.getValue("host_virtual_display").active)
+    }
+}

--- a/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
+++ b/shared/polaris/model/src/commonMain/kotlin/com/papi/nova/shared/polaris/model/PolarisGame.kt
@@ -274,11 +274,23 @@ data class PolarisGame(
         const val ARTWORK_KIND_SCREENSHOT = "screenshot"
         const val ARTWORK_KIND_TRAILER = "trailer"
 
+        // Canonical stream-path ids, matching Polaris' stream_path registry. The
+        // legacy 2-value vocabulary ("headless"/"virtual_display") collapsed every
+        // server mode into a pair at parse time; canonical ids preserve what the
+        // host actually said while still mapping the old aliases forward.
+        const val MODE_HEADLESS_STREAM = "headless_stream"
+        const val MODE_HOST_VIRTUAL_DISPLAY = "host_virtual_display"
+        const val MODE_DESKTOP_DISPLAY = "desktop_display"
+        const val MODE_WINDOWED_STREAM = "windowed_stream"
+        const val MODE_GAMESCOPE_STREAM = "gamescope_stream"
+        const val MODE_HEADLESS_DONGLE = "headless_dongle"
+
         fun normalizeLaunchMode(mode: String): String {
-            return when (mode.trim().lowercase()) {
-                "headless", "headless_stream", "desktop_display", "windowed_stream", "host_display" -> "headless"
-                "virtual_display", "host_virtual_display" -> "virtual_display"
-                else -> mode.trim()
+            return when (val key = mode.trim().lowercase()) {
+                "headless", MODE_HEADLESS_STREAM -> MODE_HEADLESS_STREAM
+                "virtual_display", MODE_HOST_VIRTUAL_DISPLAY -> MODE_HOST_VIRTUAL_DISPLAY
+                "host_display", MODE_DESKTOP_DISPLAY -> MODE_DESKTOP_DISPLAY
+                else -> key
             }
         }
 
@@ -286,27 +298,25 @@ data class PolarisGame(
             val normalizedModes = linkedSetOf<String>()
             modes.map { normalizeLaunchMode(it) }.filter { it.isNotBlank() }.forEach { normalizedModes.add(it) }
             if (defaultWhenEmpty && normalizedModes.isEmpty()) {
-                normalizedModes.add("headless")
-                normalizedModes.add("virtual_display")
+                normalizedModes.add(MODE_HEADLESS_STREAM)
+                normalizedModes.add(MODE_HOST_VIRTUAL_DISPLAY)
             }
             return normalizedModes.toList()
         }
 
         fun resolveLaunchMode(mode: String, headlessAllowed: Boolean, virtualDisplayAllowed: Boolean): String {
-            return when (normalizeLaunchMode(mode)) {
-                "virtual_display" -> when {
-                    virtualDisplayAllowed -> "virtual_display"
-                    headlessAllowed -> "headless"
+            return when (val key = normalizeLaunchMode(mode)) {
+                MODE_HOST_VIRTUAL_DISPLAY -> when {
+                    virtualDisplayAllowed -> MODE_HOST_VIRTUAL_DISPLAY
+                    headlessAllowed -> MODE_HEADLESS_STREAM
                     else -> ""
                 }
-                "headless" -> when {
-                    headlessAllowed -> "headless"
-                    virtualDisplayAllowed -> "virtual_display"
-                    else -> ""
-                }
+                // Canonical non-pair ids stay themselves: their availability is
+                // gated by the host catalog, not by the legacy boolean pair.
+                MODE_DESKTOP_DISPLAY, MODE_WINDOWED_STREAM, MODE_GAMESCOPE_STREAM, MODE_HEADLESS_DONGLE -> key
                 else -> when {
-                    headlessAllowed -> "headless"
-                    virtualDisplayAllowed -> "virtual_display"
+                    headlessAllowed -> MODE_HEADLESS_STREAM
+                    virtualDisplayAllowed -> MODE_HOST_VIRTUAL_DISPLAY
                     else -> ""
                 }
             }

--- a/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
+++ b/shared/polaris/model/src/commonTest/kotlin/com/papi/nova/shared/polaris/model/PolarisGameContractTest.kt
@@ -259,10 +259,21 @@ class PolarisGameContractTest {
 
     @Test
     fun normalizesBackwardCompatibleLaunchModeAliases() {
-        assertEquals("virtual_display", PolarisGame.normalizeLaunchMode("host_virtual_display"))
-        assertEquals("headless", PolarisGame.normalizeLaunchMode("headless_stream"))
-        assertEquals("headless", PolarisGame.normalizeLaunchMode("windowed_stream"))
-        assertEquals(listOf("headless", "virtual_display"), PolarisGame.normalizeLaunchModes(emptyList(), defaultWhenEmpty = true))
+        // The canonical vocabulary is the stream-path registry's: legacy spellings
+        // map forward onto registry ids, and registry ids no longer collapse into
+        // the old two-value pair (windowed_stream used to become "headless", which
+        // is how the per-game picker lost every mode beyond two).
+        assertEquals(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY, PolarisGame.normalizeLaunchMode("virtual_display"))
+        assertEquals(PolarisGame.MODE_HEADLESS_STREAM, PolarisGame.normalizeLaunchMode("headless"))
+        assertEquals(PolarisGame.MODE_DESKTOP_DISPLAY, PolarisGame.normalizeLaunchMode("host_display"))
+        assertEquals(PolarisGame.MODE_HOST_VIRTUAL_DISPLAY, PolarisGame.normalizeLaunchMode("host_virtual_display"))
+        assertEquals(PolarisGame.MODE_HEADLESS_STREAM, PolarisGame.normalizeLaunchMode("headless_stream"))
+        assertEquals(PolarisGame.MODE_WINDOWED_STREAM, PolarisGame.normalizeLaunchMode("windowed_stream"))
+        assertEquals(PolarisGame.MODE_GAMESCOPE_STREAM, PolarisGame.normalizeLaunchMode("Gamescope_Stream"))
+        assertEquals(
+            listOf(PolarisGame.MODE_HEADLESS_STREAM, PolarisGame.MODE_HOST_VIRTUAL_DISPLAY),
+            PolarisGame.normalizeLaunchModes(emptyList(), defaultWhenEmpty = true)
+        )
         assertEquals("big-picture", PolarisGame.SteamLaunchContract.normalizeMode("gamepadui"))
     }
 }


### PR DESCRIPTION
## Summary

Nova's launch-mode surfaces spoke three different vocabularies: the per-game "Where It Runs" collapsed every server mode into a two-value pair at JSON-parse time, the Every Game "Default Display" iterated a hardcoded four-entry list, and Polaris' six-mode registry never reached either — while the host's rich per-mode catalog (`capabilities.modes`: labels, availability, disable reasons, private/host grouping) was only used to enable/disable. Consequences papi hit directly: a 2-vs-4-vs-6 mismatch between surfaces, and every game falsely claiming "This game overrides it" whenever the host default sat outside the pair.

This PR makes both pickers server-authoritative end to end, per the approved plan's locked decisions: full per-game parity, grouped-bands one-screen picker, canonical vocabulary everywhere.

## Exact candidate

Seven slices, each suite-green when committed:

- **Vocabulary** (`1411b7ef`): `normalizeLaunchMode` canonicalizes onto stream-path registry ids instead of collapsing (legacy spellings map forward forever); the adapter's alias sets — which read "GPU-native available" as "headless available" — dissolve into normalized id-equality; `NovaGameDetailUiState` follows the host's real mode when no override exists, and `overridesHostMode` requires an actual stored override (`hasExplicitOverride`), killing the false warning by truth rather than special-case. Override prefs migrate at read; `clear()` added.
- **Contract re-pin** (`e13aa9d1`) and **activity canonicalization** (`45382c86`): behavior-preserving renames, plus label arms for `desktop_display`/`windowed_stream` reviving previously-dead strings.
- **Truthful labels** (`bc847bce`): a play mode following a non-pair host default shows the host's label instead of "Private Stream".
- **Server-authoritative catalog** (`a2f4749f`): Every Game rows render the host list in host order — all entries, unavailable ones visible-but-disabled with the host's reason; server labels preferred; legacy hosts keep the ORDER synthesis. `ModeOption` gains `group`/`unavailable_reason` (the two `known_drift` fields promised to this consumer).
- **One preflight** (`fc881b41`): the three copies of the pre-launch client-settings POST collapse into `NovaLaunchPreflight`; the four launch source-guards move their anchors with invariants intact.
- **The picker** (this commit): rows with >2 catalog modes open a full-panel grouped-bands picker (private / host display / future groups appended), three cards per row, focusable-but-inert unavailable cards with the host's verbatim reason in the footer, a pinned per-game "Host default" entry that clears the override, B-backs-out-before-panel-close, scope-flip dismissal. Legacy ≤2 hosts keep press-cycling untouched.

**Degradation matrix:** old host + new Nova → legacy 4/2 synthesis, press-cycling, gamescope/dongle never offered. New host + old Nova → unchanged bytes. New host + new Nova → full six-mode parity (host now accepts all six since polaris#335).

## Verification

- Unit suite: **1250/1250** (1243 carried + 7 new `NovaPlaySetupModePickerTest` cases); shared-module tests green; `:app:lintNonRoot_gameDebug` clean against baseline; `assembleNonRoot_gameDebugAndroidTest` compiles (the CI-blind gate).
- Guard tests re-pinned with intent, never deleted: the old "non-virtual modes remain private launch family" policy pin is now "host modes outside the pair flow through without an override"; the launch guards assert the single preflight helper and that non-virtual host modes are never collapsed.
- On-device (RP6 against the live host running `polaris-1.3.7.3cd428e7`), verified end to end: the per-game picker renders the pinned "Host default — currently Private Stream" entry above PRIVATE (Private Stream · GPU-native · Gamescope Stream) and HOST DISPLAY (Host Virtual Display · Mirror Desktop · Headless Dongle) bands with host-served labels and the active-mode accent edge; the Every Game picker shows the same six with the current tint on the desired mode and the host's reason in the footer; picking **Gamescope Stream** — a guaranteed 400 before polaris#335 — was accepted and echoed back as both desired and effective, then restored to Host Virtual Display the same way. B backs out of the picker without closing the panel; the ≤2-option legacy path keeps press-cycling. (Screenshots captured during the session; ask and I'll drop them in the thread.)
