### PR TITLE
feat(session): show the host display-mode fallback warning once

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -5977,6 +5977,26 @@ catch (ignored:Exception) {}
 
 }
 
+private var shownDisplayModeWarning = ""
+
+/**
+ * The host says when a session is not on the display the client asked for (the
+ * virtual display fell back, or the private runtime superseded the request) -
+ * the silent half of a fallback the journal alone used to know about. Shown
+ * once per distinct warning per session: a heads-up, not a nag.
+ */
+private fun maybeShowDisplayModeWarning(status:com.papi.nova.api.PolarisSessionStatus) {
+val warning = status.displayMode.warning
+if (warning.isBlank() || warning == shownDisplayModeWarning)
+{
+return
+}
+shownDisplayModeWarning = warning
+runOnUiThread {
+Toast.makeText(this, warning, Toast.LENGTH_LONG).show()
+}
+}
+
 private fun reportClientPresentationIfNeeded(status:com.papi.nova.api.PolarisSessionStatus?) {
 if (status == null || !status!!.isStreaming || novaApiClient == null)
 {
@@ -6126,6 +6146,7 @@ if (isFinishing || isDestroyed)
 return@runOnMainIfActive
 }
 novaHud?.applySessionStatus(status)
+maybeShowDisplayModeWarning(status)
 updateCompanionCommandDeck()
 }
 reportClientPresentationIfNeeded(status)

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -1000,7 +1000,8 @@ class PolarisApiClient @JvmOverloads constructor(
                     virtualDisplay = displayMode?.optBoolean("virtual_display", false) ?: false,
                     requestedHeadless = displayMode?.optBoolean("requested_headless", false) ?: false,
                     effectiveHeadless = displayMode?.optBoolean("effective_headless", false) ?: false,
-                    gpuNativeOverrideActive = displayMode?.optBoolean("gpu_native_override_active", false) ?: false
+                    gpuNativeOverrideActive = displayMode?.optBoolean("gpu_native_override_active", false) ?: false,
+                    warning = displayMode?.optString("warning", "") ?: ""
                 ),
                 presentationPolicy = PolarisSessionStatus.PresentationPolicy(
                     version = presentationPolicy?.optInt("version", 0) ?: 0,

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -65,7 +65,9 @@ data class PolarisSessionStatus(
         val virtualDisplay: Boolean = false,
         val requestedHeadless: Boolean = false,
         val effectiveHeadless: Boolean = false,
-        val gpuNativeOverrideActive: Boolean = false
+        val gpuNativeOverrideActive: Boolean = false,
+        /** Why this session is not on the display the client asked for; blank when it is. */
+        val warning: String = ""
     )
 
     data class PresentationPolicy(


### PR DESCRIPTION
## Summary

Companion to the Polaris PR that ends silent display-mode fallbacks: the host now serves `display_mode.warning` on session status when a session is not on the display the client asked for. Nova parses it and shows it **once per distinct warning per session** as a toast on the existing 15-second status refresh — a heads-up about where this session actually runs, not a nag.

## Exact candidate

- `PolarisSessionStatus.DisplayModeStatus` gains `warning` (default blank — old hosts parse unchanged).
- `PolarisApiClient` reads `display_mode.warning` beside the eight sibling fields.
- `Game`: `maybeShowDisplayModeWarning` on the status-refresh main-thread hop, guarded by a per-session `shownDisplayModeWarning` so each distinct warning shows exactly once.

## Verification

- Unit suite + lint + androidTest compile gate: green (the parse is the same `optString` pattern as its eight siblings; the data-class default keeps every existing fixture compiling).
- Live scenario (after the Polaris half deploys): re-block EVDI and launch with a virtual-display default → the toast quotes the host's reason; a healthy launch shows nothing.
