### PR TITLE
feat(ai): send the launch mode with optimization requests, show the AI pick

### DIFF
--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -683,6 +683,7 @@ class ShortcutTrampoline : NovaActivity() {
                 DeviceUtils.getModel(),
                 polarisGame.name,
                 SHORTCUT_PROFILE_PREFERENCE,
+                mode = PolarisStreamDisplayMode.preflightModeForLaunch(withVirtualDisplay, clientSettings),
             )
 
             launchPlan.copy(

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -467,7 +467,8 @@ class PolarisApiClient @JvmOverloads constructor(
             device: String,
             game: String,
             preference: String = "",
-            trial: String = ""
+            trial: String = "",
+            mode: String = ""
         ): String {
             val preferenceParam = preference
                 .takeIf { it.isNotBlank() }
@@ -477,10 +478,16 @@ class PolarisApiClient @JvmOverloads constructor(
                 .takeIf { it.isNotBlank() }
                 ?.let { "&trial=${java.net.URLEncoder.encode(it, "UTF-8")}" }
                 ?: ""
+            // Omitted when blank: an absent mode is the host's legacy cache bucket.
+            val modeParam = mode
+                .takeIf { it.isNotBlank() }
+                ?.let { "&mode=${java.net.URLEncoder.encode(it, "UTF-8")}" }
+                ?: ""
             return "/optimize?device=${java.net.URLEncoder.encode(device, "UTF-8")}" +
                 "&game=${java.net.URLEncoder.encode(game, "UTF-8")}" +
                 preferenceParam +
-                trialParam
+                trialParam +
+                modeParam
         }
 
         private fun parseStringArray(array: org.json.JSONArray?): List<String> {
@@ -2077,10 +2084,11 @@ class PolarisApiClient @JvmOverloads constructor(
         device: String,
         game: String,
         preference: String = "",
-        trial: String = ""
+        trial: String = "",
+        mode: String = ""
     ): org.json.JSONObject? {
         return try {
-            val url = "$baseUrl${buildOptimizationPath(device, game, preference, trial)}"
+            val url = "$baseUrl${buildOptimizationPath(device, game, preference, trial, mode)}"
             val request = Request.Builder().url(url).get().build()
             LimeLog.info("Nova: Optimization query start for $url")
             executeGetWithRetry(request).use { response ->

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -577,7 +577,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, usesVirtualDisplay, clientSettings)?.let {
                             clientSettings = it
                         }
-                        apiClient.getOptimization(deviceName, currentGame.name, preference)
+                        apiClient.getOptimization(deviceName, currentGame.name, preference, mode = uiState.playMode)
                     }
                     logPreflightOptimization("Preflight optimization", opt, preference)
                     buildOptimizationState(opt, preference)
@@ -628,7 +628,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, uiState.playUsesVirtualDisplay, clientSettings)?.let {
                             clientSettings = it
                         }
-                        apiClient.getOptimization(deviceName, currentGame.name, profilePreference, "high_fps")
+                        apiClient.getOptimization(deviceName, currentGame.name, profilePreference, "high_fps", mode = uiState.playMode)
                     }
                     logPreflightOptimization("High FPS trial preflight", opt, profilePreference)
                     buildOptimizationState(opt, profilePreference)
@@ -1026,6 +1026,7 @@ class NovaGameDetailActivity : NovaActivity() {
                                 allowedModes = currentGame.launchMode?.allowedModes.orEmpty(),
                                 playMode = uiState.playMode,
                                 hasExplicitOverride = uiState.hasExplicitOverride,
+                                aiRecommendedMode = optimizationState.aiRecommendedMode,
                                 title = getString(R.string.nova_game_detail_where_it_runs),
                                 hostDefaultLabel = getString(
                                     R.string.nova_play_setup_host_default_entry_detail,
@@ -1735,7 +1736,8 @@ class NovaGameDetailActivity : NovaActivity() {
             profileSummary = buildNovaLaunchProfileSummary(opt),
             rawOptimization = opt,
             reviewRequired = StreamSyncManager.requiresLaunchPreflightReview(opt),
-            reviewReason = StreamSyncManager.launchPreflightReviewReason(opt)
+            reviewReason = StreamSyncManager.launchPreflightReviewReason(opt),
+            aiRecommendedMode = opt.optString("ai_recommended_mode", "")
         )
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -137,7 +137,8 @@ data class NovaGameDetailOptimizationState(
     val rawOptimization: JSONObject? = null,
     val reviewRequired: Boolean = false,
     val reviewReason: String = "",
-    val preflightInFlight: Boolean = false
+    val preflightInFlight: Boolean = false,
+    val aiRecommendedMode: String = ""
 )
 
 data class NovaLaunchOptionsState(

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
@@ -51,6 +52,8 @@ internal data class NovaPlaySetupModeChoice(
     /** In effect this session without being the saved choice (fallback or pending relaunch). */
     val active: Boolean,
     val enabled: Boolean,
+    /** The provider's advisory pick from the current optimization payload; never auto-applied. */
+    val aiRecommended: Boolean = false,
 )
 
 internal data class NovaPlaySetupModeBand(
@@ -133,6 +136,7 @@ internal fun buildGameModePickerState(
     hasExplicitOverride: Boolean,
     title: String,
     hostDefaultLabel: String,
+    aiRecommendedMode: String = "",
 ): NovaPlaySetupModePickerState {
     val allowed = allowedModes.map { PolarisGame.normalizeLaunchMode(it) }.toSet()
     return NovaPlaySetupModePickerState(
@@ -154,6 +158,8 @@ internal fun buildGameModePickerState(
                     current = hasExplicitOverride && mode.mode == playMode,
                     active = mode.mode == playMode && !hasExplicitOverride,
                     enabled = mode.available,
+                    aiRecommended = mode.available && aiRecommendedMode.isNotBlank() &&
+                        mode.mode == aiRecommendedMode,
                 )
             },
     )
@@ -278,18 +284,35 @@ private fun NovaPlaySetupModeCard(
             )
             .padding(horizontal = 12.dp, vertical = 8.dp)
             .semantics {
-                contentDescription = "${choice.label}. ${choice.detail}"
+                contentDescription = if (choice.aiRecommended) {
+                    "${choice.label}. AI pick. ${choice.detail}"
+                } else {
+                    "${choice.label}. ${choice.detail}"
+                }
                 if (choice.current) selected = true
             },
     ) {
-        Text(
-            text = choice.label,
-            color = if (choice.enabled) colors.textPrimary else colors.textMuted,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = choice.label,
+                color = if (choice.enabled) colors.textPrimary else colors.textMuted,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            if (choice.aiRecommended) {
+                Text(
+                    text = stringResource(R.string.nova_play_setup_ai_pick),
+                    color = colors.accent,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(start = 6.dp),
+                )
+            }
+        }
         Text(
             text = choice.detail,
             color = if (choice.active && !choice.current) colors.accent else colors.textMuted,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="nova_play_setup_band_private">Private — your desktop stays untouched</string>
     <string name="nova_play_setup_band_host">Host display — uses or swaps the host screen</string>
     <string name="nova_play_setup_host_default_entry_detail">Follow the host\'s Default Display — currently %1$s</string>
+    <string name="nova_play_setup_ai_pick">AI pick</string>
     <string name="nova_play_setup_fact_host_profile">Host profile</string>
     <string name="nova_play_setup_host_overridden">This game overrides it. Every other game follows the host.</string>
     <string name="nova_play_setup_host_followed">This game follows it.</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -983,6 +983,32 @@ class PolarisApiClientParsingTest {
             path
         )
     }
+
+    @Test
+    fun buildOptimizationPath_carriesTheModeBucketAndOmitsItWhenBlank() {
+        val withMode = PolarisApiClient.buildOptimizationPath(
+            device = "RetroidPocket6",
+            game = "Control Ultimate Edition",
+            preference = "auto",
+            mode = "gamescope_stream"
+        )
+
+        assertEquals(
+            "/optimize?device=RetroidPocket6&game=Control+Ultimate+Edition&preference=auto&mode=gamescope_stream",
+            withMode
+        )
+
+        val legacy = PolarisApiClient.buildOptimizationPath(
+            device = "RetroidPocket6",
+            game = "Control Ultimate Edition",
+            preference = "auto"
+        )
+
+        assertEquals(
+            "/optimize?device=RetroidPocket6&game=Control+Ultimate+Edition&preference=auto",
+            legacy
+        )
+    }
     @Test
     fun buildSteamLaunchModeUpdateBodyNormalizesAliases() {
         val body = PolarisApiClient.buildSteamLaunchModeUpdateBody("game-1", "gamepadui")

--- a/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
@@ -166,4 +166,38 @@ class NovaPlaySetupModePickerTest {
         assertTrue(byId.getValue("host_virtual_display").current)
         assertFalse(byId.getValue("host_virtual_display").active)
     }
+
+    @Test
+    fun theAdvisoryAiPickLandsOnItsAvailableCardOnly() {
+        val state = buildGameModePickerState(
+            modes = listOf(
+                mode("headless_stream", group = "private"),
+                mode("gamescope_stream", group = "private"),
+                mode("headless_dongle", group = "private", available = false, unavailableReason = "No dongle."),
+            ),
+            allowedModes = emptyList(),
+            playMode = "headless_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Follow the host",
+            aiRecommendedMode = "gamescope_stream",
+        )
+
+        assertEquals(listOf(false, true, false), state.choices.map { it.aiRecommended })
+
+        val unavailablePick = buildGameModePickerState(
+            modes = listOf(
+                mode("headless_stream", group = "private"),
+                mode("headless_dongle", group = "private", available = false, unavailableReason = "No dongle."),
+            ),
+            allowedModes = emptyList(),
+            playMode = "headless_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Follow the host",
+            aiRecommendedMode = "headless_dongle",
+        )
+
+        assertTrue(unavailablePick.choices.none { it.aiRecommended })
+    }
 }


### PR DESCRIPTION
## Summary

Wave 3's client half: optimization requests now tell the host which launch mode the profile is for, and the mode picker shows the provider's advisory pick as an "AI pick" tag on the matching card. Advisory only — the badge never selects anything, and a blank or legacy response renders exactly today's picker.

## Exact candidate

- `buildOptimizationPath`/`getOptimization` gain an optional `mode`, omitted from the URL when blank — an absent mode is the host's legacy cache bucket, so requests against old hosts are byte-identical.
- The two fetches that know a resolved canonical mode send it: the game-detail preflight and high-fps trial pass `uiState.playMode`; the shortcut trampoline passes the same `preflightModeForLaunch` resolution its client-settings push uses.
- Deliberate deviation from the plan: `Game.loadLaunchOptimization` stays mode-less. It is the fallback for launches that skipped preflight optimization (AppView/PcView and bare library starts), surfaces that only ever speak the `virtualDisplay` boolean — threading a launch extra through ServerHelper's five `doStart` overloads would tag those fetches with a mode they never actually resolved.
- `NovaGameDetailOptimizationState` carries `ai_recommended_mode`; `buildGameModePickerState` marks the matching choice, available cards only, and the card renders a small accent "AI pick" tag beside the label (also spoken in the card's contentDescription). Host-scope picker unchanged — the recommendation is per-game context.
- `StreamSyncManager`'s `display_mode` ("WxH@fps") is untouched.

## Verification

- Unit suite, lint, and the androidTest compile gate (`assembleNonRoot_gameDebugAndroidTest`) all green; new tests pin the URL shape (mode present/omitted, encoded) and the badge rules (lands on its available card only, never on an unavailable one).
- On-device pass with Control Ultimate Edition rides the joint deploy with the Polaris half (papi-ux/polaris#340): logcat shows `&mode=…` on the preflight fetch, badge screenshot from the RP6 picker, legacy host shows no param and no badge.
