### PR TITLE
feat(build): add a Nova benchmark build type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,11 @@ android {
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 
+        // Nordstern P0-4A (measurement-spec-v1.md 7.1). Overridden to true
+        // only by the benchmark build type below - every other build type
+        // gets this false default, same pattern FDROID_BUILD uses.
+        buildConfigField "boolean", "BENCHMARK_BUILD", "false"
+
         // Generate native debug symbols to allow Google Play to symbolicate our native crashes
         ndk.debugSymbolLevel = 'FULL'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -243,6 +248,26 @@ android {
             resValue "string", "app_label", "Nova Dirty"
             resValue "string", "app_label_root", "Nova Dirty (Root)"
             resValue "string", "app_label_game", "Nova Dirty (Game)"
+        }
+
+        // Nordstern P0-4A (measurement-spec-v1.md 7.1): "based on release
+        // optimization and runtime behavior... differ from release only
+        // where required to enable bounded measurement capture, accept
+        // non-persisted harness run identity, freeze and export an
+        // app-private evidence file, permit adb run-as evidence
+        // extraction." Same initWith-release + distinct applicationIdSuffix
+        // shape as preRelease/dirty above - a separate, clearly-labeled
+        // install, never colliding with a real release install on the same
+        // device. No behavior changes live here yet; BENCHMARK_BUILD is the
+        // gate later pieces build the actual capture path behind.
+        benchmark {
+            initWith release
+            applicationIdSuffix ".benchmark"
+            versionNameSuffix "-benchmark"
+            resValue "string", "app_label", "Nova Benchmark"
+            resValue "string", "app_label_root", "Nova Benchmark (Root)"
+            resValue "string", "app_label_game", "Nova Benchmark (Game)"
+            buildConfigField "boolean", "BENCHMARK_BUILD", "true"
         }
     }
 


### PR DESCRIPTION
## Summary

First of five pieces (same "one piece per PR, in order" pacing as the Polaris Nordstern arc) for P0-4A, Nova's side of the benchmark-run measurement system (`measurement-spec-v1.md` §7.1). Gradle-only - no runtime behavior change yet.

Follows the exact `preRelease`/`dirty` precedent already established in this file: `initWith release` (inherits release's optimization and minification, satisfying "based on release optimization and runtime behavior") plus a distinct `applicationIdSuffix` (`.benchmark`) and `versionNameSuffix`, so a benchmark install is always a separate, clearly-labeled app - never colliding with a real release install on the same device.

`BENCHMARK_BUILD` is a new `BuildConfig` boolean, false by default (set in `defaultConfig`, same pattern the existing `FDROID_BUILD` flag uses) and overridden to true only in the new `benchmark` block - the gate later pieces build the actual bounded-capture path behind, keeping every other build type's behavior completely unchanged.

## Exact candidate

```
Commit: 27da3d34fbf787a1fc73ebf072010e445a4f86db
Tree:   42d49bf4dbbce800435aef8ecb3199ee61c58791
Parent: 9e2f751e56aa8dad61b2fbf0070eb7bbd224c4ea
Base:   9e2f751e56aa8dad61b2fbf0070eb7bbd224c4ea
```

## Verification

- [x] `./gradlew :app:assembleNonRoot_gameBenchmark` - `BUILD SUCCESSFUL`, clean.
- [x] `aapt dump badging` on the built APK confirms `package: name='com.papi.nova.benchmark'` and `versionName='1.3.5-benchmark'` - the applicationId/versionName suffixes took effect exactly as configured, not just inferred from reading the gradle file.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): the bounded in-memory capture buffer (piece 2), wiring it into the decoder (piece 3), the adb-driven control path (piece 4), and the frozen JSON export (piece 5). This piece only adds the build type that later pieces' benchmark-only code will compile behind.
