### PR TITLE
feat(video): add the bounded benchmark stage-capture buffer

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/video/BenchmarkStageCapture.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/BenchmarkStageCapture.kt
@@ -1,0 +1,119 @@
+package com.papi.nova.binding.video
+
+/**
+ * Which half-open-window bucket one boundary observation falls into
+ * (measurement-spec-v1.md 6.5's inclusion rule: [S, E), accepted only when
+ * S <= a <= b < E). Ported line-for-line from Polaris's own
+ * classify_boundary() in stream_stats.cpp - same five-step order, same
+ * disjoint outcomes, so a host-side and client-side sample landing on the
+ * same logical boundary classify identically.
+ */
+enum class BoundaryClassification {
+    ACCEPTED,
+    EXCLUDED_BEFORE_WINDOW,
+    EXCLUDED_AFTER_WINDOW,
+    IGNORED_POST_WINDOW,
+    INVALID_NON_MONOTONIC,
+}
+
+fun classifyBoundary(aOffsetUs: Long, bOffsetUs: Long, windowEndUs: Long): BoundaryClassification {
+    if (aOffsetUs < 0) {
+        return BoundaryClassification.EXCLUDED_BEFORE_WINDOW
+    }
+    if (aOffsetUs >= windowEndUs) {
+        return BoundaryClassification.IGNORED_POST_WINDOW
+    }
+    if (bOffsetUs >= windowEndUs) {
+        return BoundaryClassification.EXCLUDED_AFTER_WINDOW
+    }
+    if (aOffsetUs <= bOffsetUs) {
+        return BoundaryClassification.ACCEPTED
+    }
+    return BoundaryClassification.INVALID_NON_MONOTONIC
+}
+
+/**
+ * Bounded, benchmark-only capture of the T3->T4 ("reassembly_to_decoder_output",
+ * measurement-spec-v1.md 7.2) stage. Not used by the existing sampled
+ * diagnostic log (MediaCodecDecoderRenderer.logSampledStageTiming) - this is
+ * the gate-authoritative capture path, active only when a benchmark run is
+ * armed via the adb-driven control path (piece 4). Deliberately
+ * stage-agnostic in its own right, though this arc only ever has one stage
+ * to capture, unlike Polaris's three.
+ *
+ * The three parallel arrays are preallocated at construction and never grow
+ * - "no allocation after run start" (7.2). Offsets/durations are stored as
+ * Int microseconds: comfortably in range even for a worst-case multi-minute
+ * run, and matching the wire format's own start_offset_us/end_offset_us/
+ * duration_us arrays directly.
+ */
+class BenchmarkStageCapture(private val capacity: Int = MAX_SAMPLES) {
+    private val startOffsetUsArray = IntArray(capacity)
+    private val endOffsetUsArray = IntArray(capacity)
+    private val durationUsArray = IntArray(capacity)
+
+    var acceptedCount = 0
+        private set
+    var excludedStartedBeforeWindow = 0
+        private set
+    var excludedCompletedAfterWindow = 0
+        private set
+    var overflowCount = 0
+        private set
+    var invalidDurationCount = 0
+        private set
+
+    // T3 or T4 was unavailable at all for this frame - decided by the
+    // caller before it ever has a pair of offsets to classify, so this
+    // isn't something record() itself can detect. Separate from
+    // invalidDurationCount, which is for a T3/T4 pair that IS available but
+    // classifies as non-monotonic.
+    var missingTimestampCount = 0
+        private set
+
+    fun recordMissing() {
+        missingTimestampCount++
+    }
+
+    /**
+     * Classify and, if accepted, record one observation. An accepted
+     * observation that would exceed capacity is counted in overflowCount
+     * instead of being stored - ported from Polaris's own
+     * benchmark_stage_capture_t::record().
+     */
+    fun record(aOffsetUs: Long, bOffsetUs: Long, windowEndUs: Long): BoundaryClassification {
+        val classification = classifyBoundary(aOffsetUs, bOffsetUs, windowEndUs)
+        when (classification) {
+            BoundaryClassification.EXCLUDED_BEFORE_WINDOW -> excludedStartedBeforeWindow++
+            BoundaryClassification.EXCLUDED_AFTER_WINDOW -> excludedCompletedAfterWindow++
+            BoundaryClassification.IGNORED_POST_WINDOW -> {
+                // No state created - matches 6.5's "do not create run-owned
+                // in-flight state" for this case.
+            }
+            BoundaryClassification.INVALID_NON_MONOTONIC -> invalidDurationCount++
+            BoundaryClassification.ACCEPTED -> {
+                if (acceptedCount >= capacity) {
+                    overflowCount++
+                } else {
+                    startOffsetUsArray[acceptedCount] = aOffsetUs.toInt()
+                    endOffsetUsArray[acceptedCount] = bOffsetUs.toInt()
+                    durationUsArray[acceptedCount] = (bOffsetUs - aOffsetUs).toInt()
+                    acceptedCount++
+                }
+            }
+        }
+        return classification
+    }
+
+    // Copying accessors, not live views - called only at export time
+    // (piece 5), well after a run has frozen and stopped recording, so this
+    // doesn't touch the "no allocation after run start" hot-path guarantee
+    // above, which is specifically about record().
+    fun startOffsetUs(): IntArray = startOffsetUsArray.copyOf(acceptedCount)
+    fun endOffsetUs(): IntArray = endOffsetUsArray.copyOf(acceptedCount)
+    fun durationUs(): IntArray = durationUsArray.copyOf(acceptedCount)
+
+    companion object {
+        const val MAX_SAMPLES = 65536
+    }
+}

--- a/app/src/test/java/com/papi/nova/binding/video/BenchmarkStageCaptureTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/BenchmarkStageCaptureTest.kt
@@ -1,0 +1,135 @@
+package com.papi.nova.binding.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClassifyBoundaryTest {
+
+    @Test
+    fun acceptsAnObservationEntirelyWithinTheWindow() {
+        assertEquals(BoundaryClassification.ACCEPTED, classifyBoundary(10, 20, 100))
+    }
+
+    @Test
+    fun acceptsAZeroDurationObservation() {
+        assertEquals(BoundaryClassification.ACCEPTED, classifyBoundary(10, 10, 100))
+    }
+
+    @Test
+    fun acceptsAnObservationStartingExactlyAtS() {
+        assertEquals(BoundaryClassification.ACCEPTED, classifyBoundary(0, 5, 100))
+    }
+
+    @Test
+    fun excludesAnObservationThatStartedBeforeTheWindow() {
+        assertEquals(BoundaryClassification.EXCLUDED_BEFORE_WINDOW, classifyBoundary(-1, 5, 100))
+    }
+
+    @Test
+    fun ignoresAnObservationStartingAtOrAfterTheWindowEnd() {
+        assertEquals(BoundaryClassification.IGNORED_POST_WINDOW, classifyBoundary(100, 105, 100))
+    }
+
+    @Test
+    fun excludesAnObservationThatCompletesExactlyAtOrAfterTheWindowEnd() {
+        assertEquals(BoundaryClassification.EXCLUDED_AFTER_WINDOW, classifyBoundary(90, 100, 100))
+    }
+
+    @Test
+    fun rejectsANonMonotonicObservationAsInvalid() {
+        assertEquals(BoundaryClassification.INVALID_NON_MONOTONIC, classifyBoundary(20, 10, 100))
+    }
+
+    @Test
+    fun classificationOrderPrefersBeforeWindowOverNonMonotonic() {
+        // a < 0 AND b < a - before-window must win, matching Polaris's own
+        // five-step order (checked first, unconditionally).
+        assertEquals(BoundaryClassification.EXCLUDED_BEFORE_WINDOW, classifyBoundary(-5, -10, 100))
+    }
+}
+
+class BenchmarkStageCaptureTest {
+
+    @Test
+    fun recordAcceptsAndStoresWithinCapacity() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.record(10, 20, 100)
+        capture.record(30, 45, 100)
+
+        assertEquals(2, capture.acceptedCount)
+        assertEquals(listOf(10, 30), capture.startOffsetUs().toList())
+        assertEquals(listOf(20, 45), capture.endOffsetUs().toList())
+        assertEquals(listOf(10, 15), capture.durationUs().toList())
+    }
+
+    @Test
+    fun overflowsPastCapacityWithoutGrowingStorage() {
+        val capture = BenchmarkStageCapture(capacity = 1)
+        capture.record(10, 20, 100)
+        capture.record(30, 45, 100)
+
+        assertEquals(1, capture.acceptedCount)
+        assertEquals(1, capture.overflowCount)
+        assertEquals(listOf(10), capture.startOffsetUs().toList())
+    }
+
+    @Test
+    fun countsExcludedBeforeWindowWithoutStoring() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.record(-5, 10, 100)
+
+        assertEquals(0, capture.acceptedCount)
+        assertEquals(1, capture.excludedStartedBeforeWindow)
+    }
+
+    @Test
+    fun countsExcludedAfterWindowWithoutStoring() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.record(90, 105, 100)
+
+        assertEquals(0, capture.acceptedCount)
+        assertEquals(1, capture.excludedCompletedAfterWindow)
+    }
+
+    @Test
+    fun countsInvalidNonMonotonicWithoutStoring() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.record(20, 10, 100)
+
+        assertEquals(0, capture.acceptedCount)
+        assertEquals(1, capture.invalidDurationCount)
+    }
+
+    @Test
+    fun ignoredPostWindowObservationIncrementsNoCounterAtAll() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.record(100, 110, 100)
+
+        assertEquals(0, capture.acceptedCount)
+        assertEquals(0, capture.excludedStartedBeforeWindow)
+        assertEquals(0, capture.excludedCompletedAfterWindow)
+        assertEquals(0, capture.overflowCount)
+        assertEquals(0, capture.invalidDurationCount)
+    }
+
+    @Test
+    fun multipleAcceptedObservationsStayInInsertionOrder() {
+        val capture = BenchmarkStageCapture(capacity = 8)
+        capture.record(5, 8, 100)
+        capture.record(1, 2, 100)
+        capture.record(50, 60, 100)
+
+        assertEquals(listOf(5, 1, 50), capture.startOffsetUs().toList())
+    }
+
+    @Test
+    fun recordMissingIncrementsItsOwnCounterOnly() {
+        val capture = BenchmarkStageCapture(capacity = 4)
+        capture.recordMissing()
+        capture.recordMissing()
+
+        assertEquals(2, capture.missingTimestampCount)
+        assertEquals(0, capture.acceptedCount)
+        assertEquals(0, capture.invalidDurationCount)
+    }
+}


### PR DESCRIPTION
## Summary

Second of five pieces for P0-4A, Nova's side of the benchmark-run measurement system. Pure Kotlin, no Android framework dependency, not yet wired to the decoder (piece 3) or gated behind `BENCHMARK_BUILD` (that gate matters once this is actually called from production code).

`classifyBoundary()` is ported line-for-line from Polaris's own `classify_boundary()` in `stream_stats.cpp` - read directly from the current merged Polaris source before writing this, not reconstructed from memory, specifically because getting the five-step order wrong here would silently produce a host-side and client-side sample that classify the same logical boundary differently. Same order: excluded before window, ignored post window, excluded after window, accepted, non-monotonic invalid (the implicit else).

`BenchmarkStageCapture` wraps three preallocated `IntArray`s (no allocation after construction - `measurement-spec-v1.md` §7.2's "no allocation after run start") plus the same five boundary-inclusion counters Polaris's `benchmark_stage_capture_t` tracks, plus one Nova-only addition: `recordMissing()`, for when T3 or T4 is unavailable at all before there's even a pair of offsets to classify - separate from `invalidDurationCount`, which is for a pair that exists but classifies as non-monotonic. Export accessors (`startOffsetUs`/`endOffsetUs`/`durationUs`) copy rather than expose live views, but only matter at freeze time (piece 5), long after the hot path's own no-allocation guarantee has already been honored.

## Exact candidate

```
Commit: b9837513a6337927ec6c0c6047392a8bb62dfa54
Tree:   39f57f4dd0d55d9cf8fc1bbd0e57c723c7dc7414
Parent: 775a15c3e1784aea331fa9015d27d76911574da7
Base:   775a15c3e1784aea331fa9015d27d76911574da7
```

## Verification

- [x] `./gradlew :app:testNonRoot_gameDebugUnitTest` - 16/16 passing (8 `ClassifyBoundaryTest` + 8 `BenchmarkStageCaptureTest`, ported from Polaris's own equivalent piece-1 test suite), confirmed via the JUnit XML result files' own `tests`/`skipped`/`failures`/`errors` attributes, not just a build-succeeded exit code - this repo's own gradle `--tests` filter is known to pass silently when nothing actually ran.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): wiring this into `MediaCodecDecoderRenderer` (piece 3), the adb-driven control path (piece 4), and the frozen JSON export (piece 5).
