### PR TITLE
feat(video): wire the benchmark capture buffer into the decoder

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -132,6 +132,7 @@ class MediaCodecDecoderRenderer(
         }
 
         logSampledStageTiming(presentationTimeUs)
+        recordBenchmarkSample(presentationTimeUs)
     }
 
     private var t3t4LogCounter = 0
@@ -273,6 +274,101 @@ class MediaCodecDecoderRenderer(
         minDecodeTime = Float.MAX_VALUE
         minDecodeTimeFullLog = ""
         enqueueNsByPtsUs.clear()
+    }
+
+    // Nordstern P0-4A (measurement-spec-v1.md 7.2). A single incrementing
+    // counter, bumped only at the "frame sequence restart" call site below
+    // (not at ordinary "stream setup"). stopBenchmarkCapture snapshots it
+    // as terminalStreamGeneration alongside the initialStreamGeneration
+    // captured at arm time, giving the exporter (piece 5) both
+    // initial_stream_generation/terminal_stream_generation and a
+    // generation_change_count derived from their difference, without this
+    // class tracking a third separate field.
+    private var benchmarkStreamGeneration = 0
+
+    /**
+     * One armed/active Nordstern P0-4A benchmark run. Nova's whole run
+     * lifecycle is far simpler than Polaris's own armed/active/draining/
+     * frozen/aborted/expired state machine: a run here is either being
+     * recorded into or it isn't - piece 4's adb-driven control path
+     * decides when to arm one and when to stop it.
+     *
+     * startedMonotonicNs uses System.nanoTime(), the same CLOCK_MONOTONIC
+     * domain presentationTimeUs (T3) and System.nanoTime() (T4) already
+     * share in logSampledStageTiming below - not
+     * SystemClock.elapsedRealtimeNanos(), a different Android clock
+     * (CLOCK_BOOTTIME, which includes sleep time) despite the superficially
+     * similar name.
+     */
+    private class BenchmarkRunState(
+        val runId: String,
+        val expectedDurationNs: Long,
+        val initialStreamGeneration: Int,
+    ) {
+        val capture = BenchmarkStageCapture()
+        val startedMonotonicNs: Long = System.nanoTime()
+    }
+
+    /**
+     * Frozen result of one stopped Nordstern P0-4A run: the capture buffer
+     * plus the immutable run_id and the initial/terminal stream-generation
+     * pair (measurement-spec-v1.md 7.2) the exporter (piece 5) needs to
+     * derive generation_change_count and decide whether the run aborts on
+     * a generation mismatch.
+     */
+    class BenchmarkRunResult(
+        val runId: String,
+        val capture: BenchmarkStageCapture,
+        val initialStreamGeneration: Int,
+        val terminalStreamGeneration: Int,
+    )
+
+    @Volatile
+    private var benchmarkRun: BenchmarkRunState? = null
+
+    /**
+     * Arm a new Nordstern P0-4A benchmark run (measurement-spec-v1.md 7.2).
+     * No-op outside BENCHMARK_BUILD - never reachable in a real release
+     * build. Replaces any already-armed run without freezing/exporting it
+     * first; the caller (piece 4's control path) owns sequencing arm/stop
+     * calls correctly.
+     */
+    fun armBenchmarkCapture(runId: String, expectedDurationNs: Long) {
+        if (!BuildConfig.BENCHMARK_BUILD) {
+            return
+        }
+        benchmarkRun = BenchmarkRunState(runId, expectedDurationNs, benchmarkStreamGeneration)
+    }
+
+    /**
+     * Stop the current benchmark run, if any, snapshotting
+     * terminalStreamGeneration at this moment - the spec's
+     * "terminal_stream_generation from the live stream owner after drain";
+     * Nova's simpler two-state model (see BenchmarkRunState's doc comment)
+     * has no separate drain step, so stop IS the drain point. Returns null
+     * if none was armed.
+     */
+    fun stopBenchmarkCapture(): BenchmarkRunResult? {
+        val run = benchmarkRun ?: return null
+        benchmarkRun = null
+        return BenchmarkRunResult(run.runId, run.capture, run.initialStreamGeneration, benchmarkStreamGeneration)
+    }
+
+    // Nordstern P0-4A gate-authoritative capture (measurement-spec-v1.md
+    // 7.2) - independent of logSampledStageTiming's own sampled diagnostic
+    // log below; records every accepted frame while a run is armed, not
+    // just every T3_T4_LOG_SAMPLE_INTERVAL-th one. A no-op whenever no run
+    // is armed (the overwhelmingly common case until piece 4's control path
+    // arms one), so this costs one null-check on every real frame until
+    // then.
+    private fun recordBenchmarkSample(presentationTimeUs: Long) {
+        val run = benchmarkRun ?: return
+        val t3Ns = presentationTimeUs * 1000L
+        val t4Ns = System.nanoTime()
+        val startOffsetUs = (t3Ns - run.startedMonotonicNs) / 1000L
+        val endOffsetUs = (t4Ns - run.startedMonotonicNs) / 1000L
+        val windowEndUs = run.expectedDurationNs / 1000L
+        run.capture.record(startOffsetUs, endOffsetUs, windowEndUs)
     }
 
     init {
@@ -1587,6 +1683,7 @@ class MediaCodecDecoderRenderer(
         val decodeData = decodeUnitData!!
         if (frameNumber < lastFrameNumber) {
             resetRollingPerfStatsForNewStream("frame sequence restart")
+            benchmarkStreamGeneration++
         }
 
         if (lastFrameNumber == 0) {


### PR DESCRIPTION
## Summary

Third of five pieces for P0-4A, Nova's side of the benchmark-run measurement system. Calls piece 2's `BenchmarkStageCapture` from the existing T3/T4 call site in `updateDecodeLatencyStats`, gated behind an armed run so it costs one null-check per frame until piece 4's adb-driven control path actually arms one.

`recordBenchmarkSample` reuses `presentationTimeUs` (T3) and `System.nanoTime()` (T4) - the same `CLOCK_MONOTONIC` domain `logSampledStageTiming` already uses just above it - rather than `SystemClock.elapsedRealtimeNanos()`, a different Android clock (`CLOCK_BOOTTIME`, which includes sleep time) despite the superficially similar name.

`benchmarkStreamGeneration` is a single incrementing counter, bumped only at the "frame sequence restart" branch (not at ordinary "stream setup" a few lines above it) and snapshotted at both arm time (`initialStreamGeneration`) and stop time (`terminalStreamGeneration`), giving the piece-5 exporter `initial_stream_generation`, `terminal_stream_generation`, and a `generation_change_count` derived from their difference (`measurement-spec-v1.md` §7.2) without tracking a third field.

`stopBenchmarkCapture` returns a `BenchmarkRunResult` bundling the capture buffer with `runId` and both generation snapshots, rather than just the buffer alone - the run's metadata would otherwise be silently and irrecoverably dropped the moment the function returns, since nothing else holds a reference to it. Nova's arm/stop model has no separate drain step the way Polaris's host-side state machine does, so stop is the spec's "after drain" moment for this client.

## Exact candidate

```
Commit: eeecbc05b7846f5d90f747790ffa8f156c0c866d
Tree:   6b41f293590fee1a5fb5669c178ec7778a33c59f
Parent: d71601d86993eed212cfc711a7e23bde60a3f83e
Base:   d71601d86993eed212cfc711a7e23bde60a3f83e
```

## Verification

- [x] `./gradlew :app:testNonRoot_gameDebugUnitTest` - full suite, 1268/1268 passing, confirmed via the JUnit XML result files' own `tests`/`skipped`/`failures`/`errors` attributes, not just a build-succeeded exit code - this repo's own gradle `--tests` filter is known to pass silently when nothing actually ran, so the two pre-existing source-guard test classes (`MediaCodecDecoderRendererStageTimingSourceGuardTest`, `MediaCodecDecoderRendererPerfStatsSourceGuardTest`) were independently re-confirmed by XML before the full-suite run: 5/5 passing, 0 failures - this change doesn't disturb their pinned invariants (bounded/synchronized `enqueueNsByPtsUs`, sampled-not-per-frame diagnostic logging, the two distinct reset call sites).
- [x] `./gradlew -PlintFailOnError=true lintNonRoot_gameDebug` (CI's own lint invocation) - 0 errors, 517 warnings/3 hints all pre-existing baseline noise.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): the adb-driven control path that actually calls `armBenchmarkCapture`/`stopBenchmarkCapture` (piece 4), and the frozen JSON export (piece 5).
