### PR TITLE
feat(video): add the adb-driven benchmark start/stop control path

### DIFF
--- a/app/src/benchmark/AndroidManifest.xml
+++ b/app/src/benchmark/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!--
+             Nordstern P0-4A control path (measurement-spec-v1.md 7.2).
+             exported="true" is required - see BenchmarkControlReceiver's
+             own doc comment for the empirical reachability finding.
+             Only merged into the benchmark build type (this manifest
+             lives under src/benchmark), so it never reaches release.
+        -->
+        <receiver
+            android:name=".BenchmarkControlReceiver"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/app/src/benchmark/java/com/papi/nova/BenchmarkControlReceiver.kt
+++ b/app/src/benchmark/java/com/papi/nova/BenchmarkControlReceiver.kt
@@ -1,0 +1,71 @@
+package com.papi.nova
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.papi.nova.binding.video.MediaCodecDecoderRenderer
+
+/**
+ * Nordstern P0-4A (measurement-spec-v1.md 7.2) adb-driven benchmark
+ * control path. Only present in the `benchmark` build type (this file
+ * lives under app/src/benchmark, not app/src/main) - structurally absent
+ * from release, dirty, and preRelease, so it is never a production
+ * control surface no matter its manifest flags.
+ *
+ * Must be android:exported="true" in the benchmark manifest overlay:
+ * verified empirically on a real device (RP6, a `user`-build, unrooted
+ * target - see nordstern-nova-benchmark-control-path-adb-reachability
+ * memory) that `adb shell am broadcast` cannot reach a non-exported
+ * manifest receiver even when explicitly targeted by component name, and
+ * that implicit (`-a <action> -p <package>`, no `-n`) broadcasts don't
+ * reach a manifest receiver at all regardless of exported - Android's
+ * post-O implicit-broadcast background restrictions block that
+ * independently of the exported flag. Callers must use explicit
+ * component targeting: `-n <applicationId>/com.papi.nova.BenchmarkControlReceiver`.
+ */
+class BenchmarkControlReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_START -> handleStart(intent)
+            ACTION_STOP -> handleStop()
+        }
+    }
+
+    private fun handleStart(intent: Intent) {
+        val runId = intent.getStringExtra(EXTRA_RUN_ID)
+        if (runId.isNullOrEmpty()) {
+            Log.w(TAG, "benchmark start ignored: missing $EXTRA_RUN_ID")
+            return
+        }
+        val expectedDurationNs = intent.getLongExtra(EXTRA_EXPECTED_DURATION_NS, -1L)
+        if (expectedDurationNs <= 0L) {
+            Log.w(TAG, "benchmark start ignored: missing/invalid $EXTRA_EXPECTED_DURATION_NS")
+            return
+        }
+        val armed = Game.armBenchmarkCapture(runId, expectedDurationNs)
+        Log.i(TAG, "benchmark start runId=$runId expectedDurationNs=$expectedDurationNs armed=$armed")
+    }
+
+    private fun handleStop() {
+        val result = Game.stopBenchmarkCapture()
+        lastResult = result
+        Log.i(TAG, "benchmark stop runId=${result?.runId} stopped=${result != null}")
+    }
+
+    companion object {
+        private const val TAG = "NovaBenchmarkCtrl"
+
+        const val ACTION_START = "com.papi.nova.action.BENCHMARK_START"
+        const val ACTION_STOP = "com.papi.nova.action.BENCHMARK_STOP"
+        const val EXTRA_RUN_ID = "run_id"
+        const val EXTRA_EXPECTED_DURATION_NS = "expected_duration_ns"
+
+        // Stashed here for piece 5 (frozen JSON export + adb run-as
+        // extraction) to read and serialize. Overwritten by the next
+        // stop; piece 5 owns exporting before the next run starts.
+        @Volatile
+        var lastResult: MediaCodecDecoderRenderer.BenchmarkRunResult? = null
+            private set
+    }
+}

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -6710,6 +6710,25 @@ companion object {
  @JvmField var instance:Game? = null
  @JvmField @Volatile var isStreamActive:Boolean = false
 
+ // Nordstern P0-4A (measurement-spec-v1.md 7.2) benchmark-only control
+ // path - BenchmarkControlReceiver (app/src/benchmark, never present in
+ // release) forwards adb-driven start/stop here. decoderRenderer is a
+ // private Game instance member, so this goes through `instance` - a
+ // companion object can reach another instance's private members
+ // because it's lexically nested inside the same class body, same as
+ // any other Game method.
+ @JvmStatic
+ fun armBenchmarkCapture(runId:String, expectedDurationNs:Long):Boolean {
+  val renderer = instance?.decoderRenderer ?: return false
+  renderer.armBenchmarkCapture(runId, expectedDurationNs)
+  return true
+ }
+
+ @JvmStatic
+ fun stopBenchmarkCapture():MediaCodecDecoderRenderer.BenchmarkRunResult? {
+  return instance?.decoderRenderer?.stopBenchmarkCapture()
+ }
+
  private const val REFERENCE_HORIZ_RES:Int = 1280
  private const val REFERENCE_VERT_RES:Int = 720
 

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -132,6 +132,7 @@ class MediaCodecDecoderRenderer(
         }
 
         logSampledStageTiming(presentationTimeUs)
+        recordBenchmarkSample(presentationTimeUs)
     }
 
     private var t3t4LogCounter = 0
@@ -273,6 +274,101 @@ class MediaCodecDecoderRenderer(
         minDecodeTime = Float.MAX_VALUE
         minDecodeTimeFullLog = ""
         enqueueNsByPtsUs.clear()
+    }
+
+    // Nordstern P0-4A (measurement-spec-v1.md 7.2). A single incrementing
+    // counter, bumped only at the "frame sequence restart" call site below
+    // (not at ordinary "stream setup"). stopBenchmarkCapture snapshots it
+    // as terminalStreamGeneration alongside the initialStreamGeneration
+    // captured at arm time, giving the exporter (piece 5) both
+    // initial_stream_generation/terminal_stream_generation and a
+    // generation_change_count derived from their difference, without this
+    // class tracking a third separate field.
+    private var benchmarkStreamGeneration = 0
+
+    /**
+     * One armed/active Nordstern P0-4A benchmark run. Nova's whole run
+     * lifecycle is far simpler than Polaris's own armed/active/draining/
+     * frozen/aborted/expired state machine: a run here is either being
+     * recorded into or it isn't - piece 4's adb-driven control path
+     * decides when to arm one and when to stop it.
+     *
+     * startedMonotonicNs uses System.nanoTime(), the same CLOCK_MONOTONIC
+     * domain presentationTimeUs (T3) and System.nanoTime() (T4) already
+     * share in logSampledStageTiming below - not
+     * SystemClock.elapsedRealtimeNanos(), a different Android clock
+     * (CLOCK_BOOTTIME, which includes sleep time) despite the superficially
+     * similar name.
+     */
+    private class BenchmarkRunState(
+        val runId: String,
+        val expectedDurationNs: Long,
+        val initialStreamGeneration: Int,
+    ) {
+        val capture = BenchmarkStageCapture()
+        val startedMonotonicNs: Long = System.nanoTime()
+    }
+
+    /**
+     * Frozen result of one stopped Nordstern P0-4A run: the capture buffer
+     * plus the immutable run_id and the initial/terminal stream-generation
+     * pair (measurement-spec-v1.md 7.2) the exporter (piece 5) needs to
+     * derive generation_change_count and decide whether the run aborts on
+     * a generation mismatch.
+     */
+    class BenchmarkRunResult(
+        val runId: String,
+        val capture: BenchmarkStageCapture,
+        val initialStreamGeneration: Int,
+        val terminalStreamGeneration: Int,
+    )
+
+    @Volatile
+    private var benchmarkRun: BenchmarkRunState? = null
+
+    /**
+     * Arm a new Nordstern P0-4A benchmark run (measurement-spec-v1.md 7.2).
+     * No-op outside BENCHMARK_BUILD - never reachable in a real release
+     * build. Replaces any already-armed run without freezing/exporting it
+     * first; the caller (piece 4's control path) owns sequencing arm/stop
+     * calls correctly.
+     */
+    fun armBenchmarkCapture(runId: String, expectedDurationNs: Long) {
+        if (!BuildConfig.BENCHMARK_BUILD) {
+            return
+        }
+        benchmarkRun = BenchmarkRunState(runId, expectedDurationNs, benchmarkStreamGeneration)
+    }
+
+    /**
+     * Stop the current benchmark run, if any, snapshotting
+     * terminalStreamGeneration at this moment - the spec's
+     * "terminal_stream_generation from the live stream owner after drain";
+     * Nova's simpler two-state model (see BenchmarkRunState's doc comment)
+     * has no separate drain step, so stop IS the drain point. Returns null
+     * if none was armed.
+     */
+    fun stopBenchmarkCapture(): BenchmarkRunResult? {
+        val run = benchmarkRun ?: return null
+        benchmarkRun = null
+        return BenchmarkRunResult(run.runId, run.capture, run.initialStreamGeneration, benchmarkStreamGeneration)
+    }
+
+    // Nordstern P0-4A gate-authoritative capture (measurement-spec-v1.md
+    // 7.2) - independent of logSampledStageTiming's own sampled diagnostic
+    // log below; records every accepted frame while a run is armed, not
+    // just every T3_T4_LOG_SAMPLE_INTERVAL-th one. A no-op whenever no run
+    // is armed (the overwhelmingly common case until piece 4's control path
+    // arms one), so this costs one null-check on every real frame until
+    // then.
+    private fun recordBenchmarkSample(presentationTimeUs: Long) {
+        val run = benchmarkRun ?: return
+        val t3Ns = presentationTimeUs * 1000L
+        val t4Ns = System.nanoTime()
+        val startOffsetUs = (t3Ns - run.startedMonotonicNs) / 1000L
+        val endOffsetUs = (t4Ns - run.startedMonotonicNs) / 1000L
+        val windowEndUs = run.expectedDurationNs / 1000L
+        run.capture.record(startOffsetUs, endOffsetUs, windowEndUs)
     }
 
     init {
@@ -1587,6 +1683,7 @@ class MediaCodecDecoderRenderer(
         val decodeData = decodeUnitData!!
         if (frameNumber < lastFrameNumber) {
             resetRollingPerfStatsForNewStream("frame sequence restart")
+            benchmarkStreamGeneration++
         }
 
         if (lastFrameNumber == 0) {


### PR DESCRIPTION
## Summary

Fourth of five pieces for P0-4A, Nova's side of the benchmark-run measurement system. Adds `BenchmarkControlReceiver`, a `BroadcastReceiver` in `app/src/benchmark/` (not `app/src/main/`) so it is structurally absent from `release`/`dirty`/`preRelease` regardless of its manifest flags - handling two actions (`BENCHMARK_START`/`BENCHMARK_STOP`) that forward to the existing `armBenchmarkCapture`/`stopBenchmarkCapture` on the live `MediaCodecDecoderRenderer`, via two new `Game` companion methods.

The spec (`measurement-spec-v1.md` §7.2) explicitly left the control mechanism open ("instrumentation or another app-private mechanism"). Chose a broadcast receiver over instrumentation and empirically verified the reachability rules on a real RP6 (a `user`-build, unrooted target) rather than assuming from general Android testing lore, since the first two assumptions both turned out wrong on this device: implicit `-p <package>` broadcasts never reach a manifest receiver at all (Android 8+'s background-broadcast restrictions, a separate mechanism from `exported`), and a non-exported receiver is unreachable even via explicit `-n` component targeting from adb shell. Only `exported="true"` + explicit component targeting works. Full findings, including an app-stopped-state gotcha and a costly Gradle configuration-cache staleness trap that briefly looked like a device/manifest bug, are preserved in a project memory for piece 5 and the eventual RP6 pilot to reuse.

`Game.armBenchmarkCapture`/`stopBenchmarkCapture` go through `instance` rather than the file's `decoderRenderer` directly - `decoderRenderer` is a private `Game` **instance** member (not file-scoped, despite its declaration site looking like other file-top-level vars at a glance), and a companion object reaches another instance's private members through a reference, same as any other `Game` method would.

`stopBenchmarkCapture`'s result is stashed in `BenchmarkControlReceiver.lastResult` for piece 5 (frozen JSON export + `adb run-as` extraction) to read; this piece only wires the control path, not the export.

## Exact candidate

```
Commit: c25684882eb8d0c71654a4469f5c4b0797a1721f
Tree:   e69ea89a6f8e7a5133d2de04f1443e4d2eabf036
Parent: eeecbc05b7846f5d90f747790ffa8f156c0c866d
Base:   eeecbc05b7846f5d90f747790ffa8f156c0c866d
```

## Verification

- [x] `./gradlew :app:testNonRoot_gameDebugUnitTest` - full suite, 1268/1268 passing (XML-counted, not exit-code-trusted); unaffected by this change since the debug variant doesn't compile the benchmark-only source set.
- [x] `./gradlew -PlintFailOnError=true lintNonRoot_gameDebug` (CI's own lint invocation) - 0 errors, matching baseline.
- [x] `./gradlew lintNonRoot_gameBenchmark` (beyond CI's own coverage, since CI never lints this variant) - caught and fixed a real `LongLogTag` violation (the class name alone is 24 chars, one over Android's 23-char `Log` tag limit); 0 errors after the fix.
- [x] Live on the RP6: `exported=true` + explicit component broadcasts reach the receiver and correctly log/forward in all four tested cases - START with no active stream (`armed=false`, safe no-op), STOP with no armed run (`stopped=false`), START with a missing `run_id`, and START with an invalid (negative) `expected_duration_ns`.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): the frozen JSON export and `adb run-as` extraction (piece 5), and a live end-to-end test with an actual armed run against a real stream (needs a connected Polaris host; the renderer-level arm/record/stop logic is already fully covered by pieces 2-3's unit tests, so this piece's own new logic - broadcast parsing and forwarding - was the thing worth device-verifying directly).
