### PR TITLE
feat(video): add the frozen JSON export and adb run-as extraction

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -262,6 +262,11 @@ android {
         // gate later pieces build the actual capture path behind.
         benchmark {
             initWith release
+            // adb run-as extraction (measurement-spec-v1.md 7.2) needs a
+            // debuggable package - run-as refuses non-debuggable ones
+            // outright, confirmed empirically (run-as: package not
+            // debuggable) before adding this.
+            debuggable true
             applicationIdSuffix ".benchmark"
             versionNameSuffix "-benchmark"
             resValue "string", "app_label", "Nova Benchmark"

--- a/app/src/benchmark/java/com/papi/nova/BenchmarkControlReceiver.kt
+++ b/app/src/benchmark/java/com/papi/nova/BenchmarkControlReceiver.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.papi.nova.binding.video.MediaCodecDecoderRenderer
+import com.papi.nova.binding.video.buildBenchmarkRunJson
+import java.io.File
+import java.io.IOException
 
 /**
  * Nordstern P0-4A (measurement-spec-v1.md 7.2) adb-driven benchmark
@@ -23,12 +26,15 @@ import com.papi.nova.binding.video.MediaCodecDecoderRenderer
  * post-O implicit-broadcast background restrictions block that
  * independently of the exported flag. Callers must use explicit
  * component targeting: `-n <applicationId>/com.papi.nova.BenchmarkControlReceiver`.
+ * The same memory also notes the app must not be in Android's "stopped
+ * state" (e.g. just force-stopped) or the broadcast won't wake it at all.
  */
 class BenchmarkControlReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_START -> handleStart(intent)
             ACTION_STOP -> handleStop()
+            ACTION_EXPORT -> handleExport(context)
         }
     }
 
@@ -43,8 +49,24 @@ class BenchmarkControlReceiver : BroadcastReceiver() {
             Log.w(TAG, "benchmark start ignored: missing/invalid $EXTRA_EXPECTED_DURATION_NS")
             return
         }
-        val armed = Game.armBenchmarkCapture(runId, expectedDurationNs)
-        Log.i(TAG, "benchmark start runId=$runId expectedDurationNs=$expectedDurationNs armed=$armed")
+        val durationToleranceNs = intent.getLongExtra(EXTRA_DURATION_TOLERANCE_NS, -1L)
+        if (durationToleranceNs <= 0L) {
+            Log.w(TAG, "benchmark start ignored: missing/invalid $EXTRA_DURATION_TOLERANCE_NS")
+            return
+        }
+        // Nova has no drain step of its own (see
+        // MediaCodecDecoderRenderer.BenchmarkRunState's doc comment) - this
+        // is pure pass-through for schema completeness, so an
+        // absent/negative value is coerced rather than rejected.
+        val drainGraceNs = intent.getLongExtra(EXTRA_DRAIN_GRACE_NS, 0L).coerceAtLeast(0L)
+        val manifestSha256 = intent.getStringExtra(EXTRA_MANIFEST_SHA256)
+
+        val armed = Game.armBenchmarkCapture(runId, expectedDurationNs, durationToleranceNs, drainGraceNs, manifestSha256)
+        Log.i(
+            TAG,
+            "benchmark start runId=$runId expectedDurationNs=$expectedDurationNs " +
+                "durationToleranceNs=$durationToleranceNs drainGraceNs=$drainGraceNs armed=$armed",
+        )
     }
 
     private fun handleStop() {
@@ -53,17 +75,52 @@ class BenchmarkControlReceiver : BroadcastReceiver() {
         Log.i(TAG, "benchmark stop runId=${result?.runId} stopped=${result != null}")
     }
 
+    /**
+     * Serializes the most recently stopped run (handleStop's lastResult,
+     * piece 4) to measurement-spec-v1.md 7.2's JSON schema and writes it
+     * under this app's private files dir, where `adb run-as
+     * <applicationId> cat files/benchmark_runs/<run_id>.json` can pull it
+     * (run-as works because the benchmark build type is debuggable - see
+     * app/build.gradle's `initWith release` override for this buildType).
+     * A separate action from stop rather than folded into it, so the
+     * harness can retry extraction without needing to re-run anything.
+     */
+    private fun handleExport(context: Context) {
+        val result = lastResult
+        if (result == null) {
+            Log.w(TAG, "benchmark export ignored: no stopped run available")
+            return
+        }
+        val json = buildBenchmarkRunJson(result, "nova-" + BuildConfig.VERSION_NAME)
+        val dir = File(context.filesDir, "benchmark_runs")
+        dir.mkdirs()
+        val file = File(dir, "${result.runId}.json")
+        try {
+            file.writeText(json)
+            Log.i(
+                TAG,
+                "benchmark export wrote runId=${result.runId} path=${file.absolutePath} bytes=${json.length}",
+            )
+        } catch (e: IOException) {
+            Log.e(TAG, "benchmark export failed runId=${result.runId}", e)
+        }
+    }
+
     companion object {
         private const val TAG = "NovaBenchmarkCtrl"
 
         const val ACTION_START = "com.papi.nova.action.BENCHMARK_START"
         const val ACTION_STOP = "com.papi.nova.action.BENCHMARK_STOP"
+        const val ACTION_EXPORT = "com.papi.nova.action.BENCHMARK_EXPORT"
         const val EXTRA_RUN_ID = "run_id"
         const val EXTRA_EXPECTED_DURATION_NS = "expected_duration_ns"
+        const val EXTRA_DURATION_TOLERANCE_NS = "duration_tolerance_ns"
+        const val EXTRA_DRAIN_GRACE_NS = "drain_grace_ns"
+        const val EXTRA_MANIFEST_SHA256 = "manifest_sha256"
 
-        // Stashed here for piece 5 (frozen JSON export + adb run-as
-        // extraction) to read and serialize. Overwritten by the next
-        // stop; piece 5 owns exporting before the next run starts.
+        // Stashed here by handleStop for handleExport (or a future retry)
+        // to read and serialize. Overwritten by the next stop; the caller
+        // owns exporting before starting the next run.
         @Volatile
         var lastResult: MediaCodecDecoderRenderer.BenchmarkRunResult? = null
             private set

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -6718,9 +6718,15 @@ companion object {
  // because it's lexically nested inside the same class body, same as
  // any other Game method.
  @JvmStatic
- fun armBenchmarkCapture(runId:String, expectedDurationNs:Long):Boolean {
+ fun armBenchmarkCapture(
+  runId:String,
+  expectedDurationNs:Long,
+  durationToleranceNs:Long,
+  drainGraceNs:Long,
+  manifestSha256:String?,
+ ):Boolean {
   val renderer = instance?.decoderRenderer ?: return false
-  renderer.armBenchmarkCapture(runId, expectedDurationNs)
+  renderer.armBenchmarkCapture(runId, expectedDurationNs, durationToleranceNs, drainGraceNs, manifestSha256)
   return true
  }
 

--- a/app/src/main/java/com/papi/nova/binding/video/BenchmarkRunExport.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/BenchmarkRunExport.kt
@@ -1,0 +1,86 @@
+package com.papi.nova.binding.video
+
+import kotlin.math.abs
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+private const val SCHEMA_VERSION = 2
+private const val MEASUREMENT_SPEC_ID = "nordstern-measurement-v1"
+private const val CLOCK_DOMAIN = "android_CLOCK_MONOTONIC"
+private const val STAGE = "reassembly_to_decoder_output"
+private const val ABORT_REASON_STREAM_GENERATION_CHANGED = "stream_generation_changed"
+
+/**
+ * Serializes one stopped Nordstern P0-4A run to measurement-spec-v1.md
+ * 7.2's exact JSON schema. Pure function, no Android framework dependency,
+ * so it is covered by the ordinary debug-variant unit test suite even
+ * though it is only ever called from the benchmark-only control path
+ * (app/src/benchmark/BenchmarkControlReceiver, piece 4). Every field below
+ * is hand-cross-checked against the spec's own literal example, in the
+ * same order it appears there - a wrong or missing JSON key compiles clean
+ * and nothing else catches it.
+ *
+ * Uses explicit put(key, JsonPrimitive(value)) / put(key, JsonNull)
+ * throughout rather than kotlinx.serialization's nullable convenience
+ * put() overloads, so every line has the same unambiguous shape and is
+ * trivially diffable against the spec field-by-field.
+ *
+ * state/abort_reason: the spec ties generation mismatch to aborting -
+ * "Any generation mismatch or nonzero change count transitions the
+ * collector to aborted... emits its terminal file and reason but never
+ * gate-authoritative percentiles." Nova's simpler run model (see
+ * MediaCodecDecoderRenderer.BenchmarkRunState's doc comment) has no other
+ * abort trigger to detect, so this is the only condition checked here.
+ */
+fun buildBenchmarkRunJson(result: MediaCodecDecoderRenderer.BenchmarkRunResult, collectorVersion: String): String {
+    val aborted = result.terminalStreamGeneration != result.initialStreamGeneration
+    val actualDurationNs = result.stoppedElapsedRealtimeNs - result.startedElapsedRealtimeNs
+    val withinTolerance = abs(actualDurationNs - result.expectedDurationNs) <= result.durationToleranceNs
+
+    val json = buildJsonObject {
+        put("schema_version", JsonPrimitive(SCHEMA_VERSION))
+        put("measurement_spec_id", JsonPrimitive(MEASUREMENT_SPEC_ID))
+        put("collector_version", JsonPrimitive(collectorVersion))
+        put("run_id", JsonPrimitive(result.runId))
+        put("manifest_sha256", result.manifestSha256?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("state", JsonPrimitive(if (aborted) "aborted" else "frozen"))
+        put("abort_reason", if (aborted) JsonPrimitive(ABORT_REASON_STREAM_GENERATION_CHANGED) else JsonNull)
+        put("initial_stream_generation", JsonPrimitive(result.initialStreamGeneration))
+        put("terminal_stream_generation", JsonPrimitive(result.terminalStreamGeneration))
+        put(
+            "generation_change_count",
+            JsonPrimitive(result.terminalStreamGeneration - result.initialStreamGeneration),
+        )
+        put("clock_domain", JsonPrimitive(CLOCK_DOMAIN))
+        put("stage", JsonPrimitive(STAGE))
+        put("start_offset_us", JsonArray(result.capture.startOffsetUs().map { JsonPrimitive(it) }))
+        put("end_offset_us", JsonArray(result.capture.endOffsetUs().map { JsonPrimitive(it) }))
+        put("duration_us", JsonArray(result.capture.durationUs().map { JsonPrimitive(it) }))
+        put("sample_count", JsonPrimitive(result.capture.acceptedCount))
+        put("excluded_started_before_window", JsonPrimitive(result.capture.excludedStartedBeforeWindow))
+        put("excluded_completed_after_window", JsonPrimitive(result.capture.excludedCompletedAfterWindow))
+        // Always 0: Nova's classifier, like Polaris's own equivalent, is
+        // only ever called once both boundary endpoints are already known,
+        // so there is no "waiting for the terminal timestamp" state to
+        // count separately.
+        put("started_in_window_without_terminal_count", JsonPrimitive(0))
+        put("missing_timestamp_count", JsonPrimitive(result.capture.missingTimestampCount))
+        put("invalid_duration_count", JsonPrimitive(result.capture.invalidDurationCount))
+        put("overflow_count", JsonPrimitive(result.capture.overflowCount))
+        put("started_elapsed_realtime_ns", JsonPrimitive(result.startedElapsedRealtimeNs))
+        put("stopped_elapsed_realtime_ns", JsonPrimitive(result.stoppedElapsedRealtimeNs))
+        // Nova has no separate drain/freeze step after stop (see
+        // BenchmarkRunResult's doc comment) - stop and freeze are the same
+        // instant here, so this reuses stoppedElapsedRealtimeNs rather than
+        // taking a further, functionally-redundant clock read.
+        put("frozen_elapsed_realtime_ns", JsonPrimitive(result.stoppedElapsedRealtimeNs))
+        put("expected_duration_ns", JsonPrimitive(result.expectedDurationNs))
+        put("actual_duration_ns", JsonPrimitive(actualDurationNs))
+        put("duration_tolerance_ns", JsonPrimitive(result.durationToleranceNs))
+        put("duration_within_tolerance", JsonPrimitive(withinTolerance))
+        put("drain_grace_ns", JsonPrimitive(result.drainGraceNs))
+    }
+    return json.toString()
+}

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -303,24 +303,46 @@ class MediaCodecDecoderRenderer(
     private class BenchmarkRunState(
         val runId: String,
         val expectedDurationNs: Long,
+        val durationToleranceNs: Long,
+        val drainGraceNs: Long,
+        val manifestSha256: String?,
         val initialStreamGeneration: Int,
     ) {
         val capture = BenchmarkStageCapture()
         val startedMonotonicNs: Long = System.nanoTime()
+
+        // measurement-spec-v1.md 7.2's started_elapsed_realtime_ns - a
+        // separate clock reading from startedMonotonicNs above.
+        // elapsedRealtimeNanos (CLOCK_BOOTTIME) is what the wire schema's
+        // *_elapsed_realtime_ns fields are named for, unlike the per-sample
+        // T3/T4 offsets which deliberately stay in System.nanoTime()'s
+        // CLOCK_MONOTONIC domain (see this class's own doc comment above).
+        // Only 3 scalar reads for the whole run (here and at stop), so the
+        // hot-path cost concern that drove that earlier choice doesn't
+        // apply to these.
+        val startedElapsedRealtimeNs: Long = SystemClock.elapsedRealtimeNanos()
     }
 
     /**
      * Frozen result of one stopped Nordstern P0-4A run: the capture buffer
-     * plus the immutable run_id and the initial/terminal stream-generation
-     * pair (measurement-spec-v1.md 7.2) the exporter (piece 5) needs to
-     * derive generation_change_count and decide whether the run aborts on
-     * a generation mismatch.
+     * plus everything the exporter (piece 5) needs to fill
+     * measurement-spec-v1.md 7.2's JSON schema - the immutable run_id,
+     * initial/terminal stream-generation pair (to derive
+     * generation_change_count and decide whether the run aborts on a
+     * mismatch), the harness-provided run parameters echoed back
+     * verbatim, and both elapsed-realtime endpoints.
      */
     class BenchmarkRunResult(
         val runId: String,
         val capture: BenchmarkStageCapture,
         val initialStreamGeneration: Int,
         val terminalStreamGeneration: Int,
+        val expectedDurationNs: Long,
+        val durationToleranceNs: Long,
+        val drainGraceNs: Long,
+        val manifestSha256: String?,
+        val startedElapsedRealtimeNs: Long,
+        val stoppedElapsedRealtimeNs: Long,
     )
 
     @Volatile
@@ -331,27 +353,55 @@ class MediaCodecDecoderRenderer(
      * No-op outside BENCHMARK_BUILD - never reachable in a real release
      * build. Replaces any already-armed run without freezing/exporting it
      * first; the caller (piece 4's control path) owns sequencing arm/stop
-     * calls correctly.
+     * calls correctly. durationToleranceNs/drainGraceNs/manifestSha256 are
+     * harness-provided and otherwise unused by this class - stored only to
+     * echo back in the frozen export (piece 5); Nova's simpler run model
+     * (see BenchmarkRunState's doc comment) has no drain step of its own,
+     * so drainGraceNs is never acted on here.
      */
-    fun armBenchmarkCapture(runId: String, expectedDurationNs: Long) {
+    fun armBenchmarkCapture(
+        runId: String,
+        expectedDurationNs: Long,
+        durationToleranceNs: Long,
+        drainGraceNs: Long,
+        manifestSha256: String?,
+    ) {
         if (!BuildConfig.BENCHMARK_BUILD) {
             return
         }
-        benchmarkRun = BenchmarkRunState(runId, expectedDurationNs, benchmarkStreamGeneration)
+        benchmarkRun = BenchmarkRunState(
+            runId,
+            expectedDurationNs,
+            durationToleranceNs,
+            drainGraceNs,
+            manifestSha256,
+            benchmarkStreamGeneration,
+        )
     }
 
     /**
      * Stop the current benchmark run, if any, snapshotting
-     * terminalStreamGeneration at this moment - the spec's
-     * "terminal_stream_generation from the live stream owner after drain";
-     * Nova's simpler two-state model (see BenchmarkRunState's doc comment)
-     * has no separate drain step, so stop IS the drain point. Returns null
-     * if none was armed.
+     * terminalStreamGeneration and stoppedElapsedRealtimeNs at this moment
+     * - the spec's "terminal_stream_generation from the live stream owner
+     * after drain"; Nova's simpler two-state model (see BenchmarkRunState's
+     * doc comment) has no separate drain step, so stop IS the drain point.
+     * Returns null if none was armed.
      */
     fun stopBenchmarkCapture(): BenchmarkRunResult? {
         val run = benchmarkRun ?: return null
         benchmarkRun = null
-        return BenchmarkRunResult(run.runId, run.capture, run.initialStreamGeneration, benchmarkStreamGeneration)
+        return BenchmarkRunResult(
+            runId = run.runId,
+            capture = run.capture,
+            initialStreamGeneration = run.initialStreamGeneration,
+            terminalStreamGeneration = benchmarkStreamGeneration,
+            expectedDurationNs = run.expectedDurationNs,
+            durationToleranceNs = run.durationToleranceNs,
+            drainGraceNs = run.drainGraceNs,
+            manifestSha256 = run.manifestSha256,
+            startedElapsedRealtimeNs = run.startedElapsedRealtimeNs,
+            stoppedElapsedRealtimeNs = SystemClock.elapsedRealtimeNanos(),
+        )
     }
 
     // Nordstern P0-4A gate-authoritative capture (measurement-spec-v1.md

--- a/app/src/test/java/com/papi/nova/binding/video/BenchmarkRunExportTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/video/BenchmarkRunExportTest.kt
@@ -1,0 +1,195 @@
+package com.papi.nova.binding.video
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Every field is checked against measurement-spec-v1.md 7.2's exact JSON
+ * schema, by key name, not just "the function doesn't crash" - the whole
+ * point of buildBenchmarkRunJson's own doc comment is that a wrong or
+ * missing key compiles clean and nothing else catches it.
+ */
+class BenchmarkRunExportTest {
+    private fun result(
+        runId: String = "run-1",
+        capture: BenchmarkStageCapture = BenchmarkStageCapture(),
+        initialStreamGeneration: Int = 1,
+        terminalStreamGeneration: Int = 1,
+        expectedDurationNs: Long = 120_000_000_000L,
+        durationToleranceNs: Long = 250_000_000L,
+        drainGraceNs: Long = 2_000_000_000L,
+        manifestSha256: String? = "a".repeat(64),
+        startedElapsedRealtimeNs: Long = 1_000_000_000_000L,
+        stoppedElapsedRealtimeNs: Long = 1_120_000_000_000L,
+    ) = MediaCodecDecoderRenderer.BenchmarkRunResult(
+        runId = runId,
+        capture = capture,
+        initialStreamGeneration = initialStreamGeneration,
+        terminalStreamGeneration = terminalStreamGeneration,
+        expectedDurationNs = expectedDurationNs,
+        durationToleranceNs = durationToleranceNs,
+        drainGraceNs = drainGraceNs,
+        manifestSha256 = manifestSha256,
+        startedElapsedRealtimeNs = startedElapsedRealtimeNs,
+        stoppedElapsedRealtimeNs = stoppedElapsedRealtimeNs,
+    )
+
+    private fun parse(json: String) = Json.parseToJsonElement(json).jsonObject
+
+    @Test
+    fun allScalarAndConstantFieldsMatchSpecExactly() {
+        val capture = BenchmarkStageCapture(capacity = 1)
+        capture.record(aOffsetUs = 10, bOffsetUs = 20, windowEndUs = 1_000) // accepted
+        capture.record(aOffsetUs = 30, bOffsetUs = 40, windowEndUs = 1_000) // overflow (capacity 1)
+        capture.record(aOffsetUs = -5, bOffsetUs = 5, windowEndUs = 1_000) // excluded before window
+        capture.record(aOffsetUs = 10, bOffsetUs = 1_000, windowEndUs = 1_000) // excluded after window
+        capture.record(aOffsetUs = 20, bOffsetUs = 10, windowEndUs = 1_000) // invalid non-monotonic
+        capture.recordMissing()
+
+        val obj = parse(
+            buildBenchmarkRunJson(
+                result(runId = "run-42", capture = capture),
+                collectorVersion = "nova-1.3.5-benchmark",
+            ),
+        )
+
+        assertEquals(2, obj["schema_version"]!!.jsonPrimitive.int)
+        assertEquals("nordstern-measurement-v1", obj["measurement_spec_id"]!!.jsonPrimitive.content)
+        assertEquals("nova-1.3.5-benchmark", obj["collector_version"]!!.jsonPrimitive.content)
+        assertEquals("run-42", obj["run_id"]!!.jsonPrimitive.content)
+        assertEquals("a".repeat(64), obj["manifest_sha256"]!!.jsonPrimitive.content)
+        assertEquals("frozen", obj["state"]!!.jsonPrimitive.content)
+        assertEquals(JsonNull, obj["abort_reason"])
+        assertEquals(1, obj["initial_stream_generation"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["terminal_stream_generation"]!!.jsonPrimitive.int)
+        assertEquals(0, obj["generation_change_count"]!!.jsonPrimitive.int)
+        assertEquals("android_CLOCK_MONOTONIC", obj["clock_domain"]!!.jsonPrimitive.content)
+        assertEquals("reassembly_to_decoder_output", obj["stage"]!!.jsonPrimitive.content)
+        assertEquals(1, obj["sample_count"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["excluded_started_before_window"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["excluded_completed_after_window"]!!.jsonPrimitive.int)
+        assertEquals(0, obj["started_in_window_without_terminal_count"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["missing_timestamp_count"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["invalid_duration_count"]!!.jsonPrimitive.int)
+        assertEquals(1, obj["overflow_count"]!!.jsonPrimitive.int)
+        assertEquals(1_000_000_000_000L, obj["started_elapsed_realtime_ns"]!!.jsonPrimitive.long)
+        assertEquals(1_120_000_000_000L, obj["stopped_elapsed_realtime_ns"]!!.jsonPrimitive.long)
+        assertEquals(1_120_000_000_000L, obj["frozen_elapsed_realtime_ns"]!!.jsonPrimitive.long)
+        assertEquals(120_000_000_000L, obj["expected_duration_ns"]!!.jsonPrimitive.long)
+        assertEquals(120_000_000_000L, obj["actual_duration_ns"]!!.jsonPrimitive.long)
+        assertEquals(250_000_000L, obj["duration_tolerance_ns"]!!.jsonPrimitive.long)
+        assertEquals(true, obj["duration_within_tolerance"]!!.jsonPrimitive.boolean)
+        assertEquals(2_000_000_000L, obj["drain_grace_ns"]!!.jsonPrimitive.long)
+    }
+
+    @Test
+    fun sampleArraysContainOnlyAcceptedObservationsInRecordOrder() {
+        val capture = BenchmarkStageCapture()
+        capture.record(aOffsetUs = 10, bOffsetUs = 25, windowEndUs = 1_000) // accepted, duration 15
+        capture.record(aOffsetUs = -1, bOffsetUs = 5, windowEndUs = 1_000) // excluded, not in arrays
+        capture.record(aOffsetUs = 100, bOffsetUs = 140, windowEndUs = 1_000) // accepted, duration 40
+
+        val obj = parse(buildBenchmarkRunJson(result(capture = capture), collectorVersion = "v"))
+
+        assertEquals(listOf(10, 100), obj["start_offset_us"]!!.jsonArray.map { it.jsonPrimitive.int })
+        assertEquals(listOf(25, 140), obj["end_offset_us"]!!.jsonArray.map { it.jsonPrimitive.int })
+        assertEquals(listOf(15, 40), obj["duration_us"]!!.jsonArray.map { it.jsonPrimitive.int })
+        assertEquals(2, obj["sample_count"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun emptyRunProducesEmptyArraysAndZeroCounters() {
+        val obj = parse(buildBenchmarkRunJson(result(capture = BenchmarkStageCapture()), collectorVersion = "v"))
+
+        assertTrue(obj["start_offset_us"]!!.jsonArray.isEmpty())
+        assertTrue(obj["end_offset_us"]!!.jsonArray.isEmpty())
+        assertTrue(obj["duration_us"]!!.jsonArray.isEmpty())
+        assertEquals(0, obj["sample_count"]!!.jsonPrimitive.int)
+        assertEquals(0, obj["missing_timestamp_count"]!!.jsonPrimitive.int)
+        assertEquals(0, obj["invalid_duration_count"]!!.jsonPrimitive.int)
+        assertEquals(0, obj["overflow_count"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun abortedWhenTerminalGenerationDiffersFromInitial() {
+        val obj = parse(
+            buildBenchmarkRunJson(
+                result(initialStreamGeneration = 2, terminalStreamGeneration = 5),
+                collectorVersion = "v",
+            ),
+        )
+
+        assertEquals("aborted", obj["state"]!!.jsonPrimitive.content)
+        assertEquals("stream_generation_changed", obj["abort_reason"]!!.jsonPrimitive.content)
+        assertEquals(3, obj["generation_change_count"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun frozenWhenTerminalGenerationMatchesInitial() {
+        val obj = parse(
+            buildBenchmarkRunJson(
+                result(initialStreamGeneration = 4, terminalStreamGeneration = 4),
+                collectorVersion = "v",
+            ),
+        )
+
+        assertEquals("frozen", obj["state"]!!.jsonPrimitive.content)
+        assertEquals(JsonNull, obj["abort_reason"])
+        assertEquals(0, obj["generation_change_count"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun manifestSha256IsJsonNullWhenNotProvided() {
+        val obj = parse(buildBenchmarkRunJson(result(manifestSha256 = null), collectorVersion = "v"))
+
+        assertEquals(JsonNull, obj["manifest_sha256"])
+        assertNull(obj["manifest_sha256"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun durationWithinToleranceTrueAtExactBoundary() {
+        // actual - expected == tolerance exactly: spec's rule is <=, not <.
+        val obj = parse(
+            buildBenchmarkRunJson(
+                result(
+                    expectedDurationNs = 100_000_000_000L,
+                    durationToleranceNs = 250_000_000L,
+                    startedElapsedRealtimeNs = 0L,
+                    stoppedElapsedRealtimeNs = 100_250_000_000L,
+                ),
+                collectorVersion = "v",
+            ),
+        )
+
+        assertEquals(100_250_000_000L, obj["actual_duration_ns"]!!.jsonPrimitive.long)
+        assertEquals(true, obj["duration_within_tolerance"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun durationWithinToleranceFalseJustOutsideBoundary() {
+        val obj = parse(
+            buildBenchmarkRunJson(
+                result(
+                    expectedDurationNs = 100_000_000_000L,
+                    durationToleranceNs = 250_000_000L,
+                    startedElapsedRealtimeNs = 0L,
+                    stoppedElapsedRealtimeNs = 100_250_000_001L,
+                ),
+                collectorVersion = "v",
+            ),
+        )
+
+        assertEquals(false, obj["duration_within_tolerance"]!!.jsonPrimitive.boolean)
+    }
+}


### PR DESCRIPTION
## Summary

Fifth and final piece for P0-4A, Nova's side of the benchmark-run measurement system. Adds `buildBenchmarkRunJson` (pure function, `app/src/main` so it stays covered by the ordinary debug-variant unit test suite even though only the benchmark-only control path ever calls it) serializing one stopped run to `measurement-spec-v1.md` §7.2's exact JSON schema, plus a new `BENCHMARK_EXPORT` action on `BenchmarkControlReceiver` that writes it under the app's private files dir for `adb run-as <applicationId> cat files/benchmark_runs/<run_id>.json` to pull - a separate action from stop, so the harness can retry extraction without re-running anything.

Extended `armBenchmarkCapture`/`BenchmarkRunState`/`BenchmarkRunResult` to carry three new harness-provided parameters through to the export (`duration_tolerance_ns`, `drain_grace_ns`, `manifest_sha256`), and added a second clock reading at arm/stop time: `SystemClock.elapsedRealtimeNanos()` for the three `*_elapsed_realtime_ns` fields, deliberately separate from the `System.nanoTime()` domain the per-sample T3/T4 offsets already use. The wire schema's own field names call for `CLOCK_BOOTTIME` specifically here; the hot-path cost concern that motivated `CLOCK_MONOTONIC` for the per-frame offsets doesn't apply to three scalar reads per run.

`state`/`abort_reason` implements the spec's generation-mismatch rule ("Any generation mismatch... transitions the collector to aborted") - the only abort trigger Nova's simpler run model has to detect, unlike Polaris's fuller state machine.

**Real gap found empirically, not by reasoning:** `adb run-as` refused the first working build outright ("package not debuggable"), because the `benchmark` build type's `initWith release` inherits `debuggable=false`. The spec's own extraction method can't work without it, so this piece adds `debuggable true` to the `benchmark` build type - free of production exposure since the flag only ever applies to a build variant that never ships.

## Exact candidate

```
Commit: 7db9b875c8fdda6f55ef4321c148705f9687ebc4
Tree:   90b4a79b0e535d56d0896fd9c15f47d20ccb25c5
Parent: e52196fdfd199552f732e0788f9d807239dc972e
Base:   e52196fdfd199552f732e0788f9d807239dc972e
```

## Verification

- [x] `./gradlew :app:testNonRoot_gameDebugUnitTest` - full suite, 1276/1276 passing (XML-counted): 8 new `BenchmarkRunExportTest` cases hand-cross-checking every one of the schema's 29 fields against the spec's literal example (constants, both `state` branches, empty vs. populated sample arrays, the duration-within-tolerance boundary at exactly the tolerance value and one nanosecond past it, null vs. present `manifest_sha256`), plus the two pre-existing source-guard test classes re-confirmed undisturbed.
- [x] `./gradlew -PlintFailOnError=true lintNonRoot_gameDebug` (CI's own lint invocation) - 0 errors, matching baseline.
- [x] `./gradlew lintNonRoot_gameBenchmark` (beyond CI's own coverage, since CI never lints this variant) - 0 errors.
- [x] Live on the RP6, full loop with a temporary, reverted-before-commit stub standing in for a real armed run (no live Polaris stream was set up for this piece - the renderer-level arm/record/stop/capture logic is already fully covered by pieces 2-3's unit tests and piece 4's live device tests, so this piece's own new logic - JSON serialization and file I/O - was the thing worth device-verifying directly): STOP -> EXPORT -> file written under `files/benchmark_runs/` -> `adb run-as ... cat` returned the exact expected JSON, byte for byte matching what the unit tests predict for that fixture. This is what caught the `debuggable` gap above - a class of bug no JVM unit test could reach.

**This completes P0-4A** (all 5 pieces: benchmark build type, capture buffer, decoder wiring, adb control path, JSON export). **Not covered by any P0-4A piece** (deliberately, out of scope for this phase): a live end-to-end run against a real connected Polaris host, the manifest/evidence writer/validator/analyzer, an RP6 pilot, and the P0-5 gate matrix.
