### PR TITLE
fix(play-setup): push the resolved mode at launch and make picker cards controller-selectable

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisStreamDisplayMode.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisStreamDisplayMode.kt
@@ -32,8 +32,19 @@ object PolarisStreamDisplayMode {
         PolarisClientSettings.MODE_GPU_NATIVE_TEST
     )
 
-    fun preflightModeForLaunch(usesVirtualDisplay: Boolean, settings: PolarisClientSettings?): String {
+    fun preflightModeForLaunch(
+        usesVirtualDisplay: Boolean,
+        settings: PolarisClientSettings?,
+        resolvedMode: String = "",
+    ): String {
         if (usesVirtualDisplay) return PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY
+
+        // A launch that resolved to a concrete canonical mode pushes exactly that mode.
+        // The boolean pair above and the family fallbacks below cannot express the
+        // registry ids beyond the classic pair (gamescope_stream, headless_dongle), so
+        // those selections silently collapsed to the private-family default before.
+        val resolved = normalize(resolvedMode)
+        if (resolved.isNotEmpty()) return resolved
 
         val desired = normalize(settings?.desired?.streamDisplayMode)
         if (isPrivateFamily(desired)) return desired

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -138,8 +138,8 @@ class NovaGameDetailActivity : NovaActivity() {
      * shape lets the body below stay the code that was reviewed as a bottom sheet,
      * rather than a rewrite that happens to compile.
      */
-    private val onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, JSONObject?) -> Unit)? =
-        { game, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, preflight ->
+    private val onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, String, JSONObject?) -> Unit)? =
+        { game, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, streamMode, preflight ->
             setResult(
                 RESULT_OK,
                 Intent().putExtra(
@@ -149,6 +149,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         .put(RESULT_KEY_MIRROR_DESKTOP, mirrorDesktop)
                         .put(RESULT_KEY_FORCE_PRIVATE, forcePrivateAfterSteamClose)
                         .put(RESULT_KEY_PROFILE_PREFERENCE, profilePreference)
+                        .put(RESULT_KEY_STREAM_MODE, streamMode)
                         .put(RESULT_KEY_PREFLIGHT, preflight ?: JSONObject.NULL)
                         .toString(),
                 )
@@ -510,6 +511,7 @@ class NovaGameDetailActivity : NovaActivity() {
                 mirrorDesktop,
                 forcePrivateAfterSteamClose,
                 profilePreference,
+                uiState.playMode,
                 launchOptimization()
             )
             finish()
@@ -574,7 +576,7 @@ class NovaGameDetailActivity : NovaActivity() {
             lifecycleScope.launch {
                 optimizationState = try {
                     val opt = withContext(Dispatchers.IO) {
-                        syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, usesVirtualDisplay, clientSettings)?.let {
+                        syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, usesVirtualDisplay, clientSettings, uiState.playMode)?.let {
                             clientSettings = it
                         }
                         apiClient.getOptimization(deviceName, currentGame.name, preference, mode = uiState.playMode)
@@ -625,7 +627,7 @@ class NovaGameDetailActivity : NovaActivity() {
             lifecycleScope.launch {
                 optimizationState = try {
                     val opt = withContext(Dispatchers.IO) {
-                        syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, uiState.playUsesVirtualDisplay, clientSettings)?.let {
+                        syncLaunchPreflightSettings(this@NovaGameDetailActivity, apiClient, uiState.playUsesVirtualDisplay, clientSettings, uiState.playMode)?.let {
                             clientSettings = it
                         }
                         apiClient.getOptimization(deviceName, currentGame.name, profilePreference, "high_fps", mode = uiState.playMode)
@@ -1391,13 +1393,15 @@ class NovaGameDetailActivity : NovaActivity() {
         context: Context,
         apiClient: PolarisApiClient,
         usesVirtualDisplay: Boolean,
-        clientSettings: PolarisClientSettings?
+        clientSettings: PolarisClientSettings?,
+        resolvedMode: String = ""
     ): PolarisClientSettings? {
         val preferences = PreferenceConfiguration.readPreferences(context)
         return NovaLaunchPreflight.push(
             apiClient = apiClient,
             clientSettings = clientSettings,
             usesVirtualDisplay = usesVirtualDisplay,
+            resolvedMode = resolvedMode,
             width = preferences.width,
             height = preferences.height,
             fps = preferences.fps,
@@ -1805,6 +1809,7 @@ class NovaGameDetailActivity : NovaActivity() {
         const val RESULT_KEY_MIRROR_DESKTOP = "mirrorDesktop"
         const val RESULT_KEY_FORCE_PRIVATE = "forcePrivateAfterSteamClose"
         const val RESULT_KEY_PROFILE_PREFERENCE = "profilePreference"
+        const val RESULT_KEY_STREAM_MODE = "streamDisplayMode"
         const val RESULT_KEY_PREFLIGHT = "preflightOptimization"
 
         private const val DEFAULT_HTTPS_PORT = 47984

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
@@ -22,6 +22,7 @@ object NovaLaunchPreflight {
         clientSettings: PolarisClientSettings?,
         usesVirtualDisplay: Boolean,
         mirrorDesktop: Boolean = false,
+        resolvedMode: String = "",
         width: Int,
         height: Int,
         fps: Float,
@@ -30,7 +31,7 @@ object NovaLaunchPreflight {
         streamDisplayMode = if (mirrorDesktop) {
             PolarisClientSettings.MODE_DESKTOP_DISPLAY
         } else {
-            PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings)
+            PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings, resolvedMode)
         },
         displayMode = PreferenceConfiguration.formatStreamingDisplayMode(width, height, fps),
         targetBitrateKbps = bitrateKbps?.takeIf { it > 0 },

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -835,6 +835,7 @@ class NovaLibraryActivity : NovaActivity() {
             mirrorDesktop = request.optBoolean(NovaGameDetailActivity.RESULT_KEY_MIRROR_DESKTOP),
             forcePrivateAfterSteamClose = request.optBoolean(NovaGameDetailActivity.RESULT_KEY_FORCE_PRIVATE),
             profilePreference = request.optString(NovaGameDetailActivity.RESULT_KEY_PROFILE_PREFERENCE, "auto"),
+            resolvedMode = request.optString(NovaGameDetailActivity.RESULT_KEY_STREAM_MODE, ""),
             preflightOptimization = request.optJSONObject(NovaGameDetailActivity.RESULT_KEY_PREFLIGHT),
         )
     }
@@ -843,6 +844,7 @@ class NovaLibraryActivity : NovaActivity() {
         game: PolarisGame,
         withVirtualDisplay: Boolean,
         mirrorDesktop: Boolean = false,
+        resolvedMode: String = "",
         forcePrivateAfterSteamClose: Boolean = false,
         profilePreference: String = "auto",
         preflightOptimization: org.json.JSONObject? = null
@@ -910,6 +912,7 @@ class NovaLibraryActivity : NovaActivity() {
                         clientSettings = clientSettings,
                         usesVirtualDisplay = withVirtualDisplay,
                         mirrorDesktop = mirrorDesktop,
+                        resolvedMode = resolvedMode,
                         width = launchResolution.width,
                         height = launchResolution.height,
                         fps = launchFps,

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
@@ -261,12 +261,16 @@ private fun NovaPlaySetupModeCard(
                     onFocusedDetail(choice.detail)
                 }
             }
-            .focusable()
+            // One focus target per card: clickable() brings its own, and stacking a
+            // bare focusable() in front of it gave the d-pad a second, click-less stop.
+            // Focus parked there, so A/DPAD_CENTER activated nothing and traversal
+            // stepped twice per card. Disabled cards keep the plain focusable() so a
+            // controller can still read the host's reason in the footer.
             .then(
                 if (choice.enabled) {
                     Modifier.clickable(role = Role.Button) { onPick() }
                 } else {
-                    Modifier
+                    Modifier.focusable()
                 }
             )
             .heightIn(min = NovaGameDetailActionHeight)
@@ -346,7 +350,6 @@ private fun NovaPlaySetupModeHostDefaultCard(
                     onFocusedDetail(detail)
                 }
             }
-            .focusable()
             .clickable(role = Role.Button) { onPick() }
             .clip(shape)
             .background(if (current) colors.accentSurface else surfaces.tile)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -950,7 +950,7 @@
     <string name="nova_quick_menu_controls">Controls</string>
     <string name="nova_quick_menu_session">Session</string>
     <string name="nova_quick_menu_nova_hud">Nova HUD</string>
-    <string name="nova_quick_menu_nova_hud_caption">Tap HUD to cycle modes; long-press to open Command Center.</string>
+    <string name="nova_quick_menu_nova_hud_caption">Long-press the HUD for Command Center; hold Guide and press Y to cycle HUD modes.</string>
     <string name="nova_quick_menu_menu_opacity">Menu Opacity</string>
     <string name="nova_quick_menu_menu_opacity_caption">Adjust Nova menus, drawers, options, and session glass without dimming text or focus cues.</string>
     <string name="nova_quick_menu_menu_opacity_preset_cd">Set menu opacity to %1$d percent</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisStreamDisplayModeTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisStreamDisplayModeTest.kt
@@ -58,4 +58,41 @@ class PolarisStreamDisplayModeTest {
         assertTrue(PolarisStreamDisplayMode.isPrivateFamily(PolarisClientSettings.MODE_GPU_NATIVE_TEST))
         assertTrue(PolarisStreamDisplayMode.isPrivateFamily(PolarisClientSettings.MODE_DESKTOP_DISPLAY))
     }
+
+    @Test
+    fun preflightPushesResolvedCanonicalMode() {
+        val settings = PolarisClientSettings(
+            desired = PolarisClientSettings.Desired(streamDisplayMode = PolarisClientSettings.MODE_HEADLESS_STREAM),
+            effective = PolarisClientSettings.Effective(streamDisplayMode = PolarisClientSettings.MODE_HEADLESS_STREAM)
+        )
+
+        // Registry ids beyond the legacy pair collapsed to the private-family default
+        // before; the resolved mode must survive the preflight verbatim.
+        assertEquals(
+            PolarisClientSettings.MODE_GAMESCOPE_STREAM,
+            PolarisStreamDisplayMode.preflightModeForLaunch(
+                usesVirtualDisplay = false,
+                settings = settings,
+                resolvedMode = PolarisClientSettings.MODE_GAMESCOPE_STREAM
+            )
+        )
+        // The virtual-display flag stays the strongest signal.
+        assertEquals(
+            PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY,
+            PolarisStreamDisplayMode.preflightModeForLaunch(
+                usesVirtualDisplay = true,
+                settings = settings,
+                resolvedMode = PolarisClientSettings.MODE_GAMESCOPE_STREAM
+            )
+        )
+        // A blank resolved mode keeps the legacy family-preserving behavior.
+        assertEquals(
+            PolarisClientSettings.MODE_HEADLESS_STREAM,
+            PolarisStreamDisplayMode.preflightModeForLaunch(
+                usesVirtualDisplay = false,
+                settings = settings,
+                resolvedMode = ""
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -234,7 +234,7 @@ class NovaLaunchSourceGuardTest {
         assertTrue(displayMode.contains("PolarisClientSettings.MODE_HEADLESS_STREAM"))
         // All launch surfaces ride the one preflight helper, which itself resolves
         // through preflightModeForLaunch and uses the contract constant for mirror.
-        assertTrue(preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings)"))
+        assertTrue(preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings, resolvedMode)"))
         assertTrue(preflightHelper.contains("PolarisClientSettings.MODE_DESKTOP_DISPLAY"))
         assertTrue(detail.contains("NovaLaunchPreflight.push("))
         assertTrue(trampoline.contains("NovaLaunchPreflight.push("))


### PR DESCRIPTION
## Summary

Selecting Gamescope Stream (or any mode beyond the classic pair) never reached the host, and controller users could not select any card in the mode picker at all. Two independent defects stacked:

- **The launch preflight still spoke the legacy two-boolean vocabulary.** `NovaLaunchPreflight.push` carried only `usesVirtualDisplay`/`mirrorDesktop`, and `preflightModeForLaunch` could only ever answer with the virtual display or a private-family mode — so a resolved `gamescope_stream`/`headless_dongle` silently collapsed to the private-family default on its way to the host. The picker showed Gamescope, the optimize request said Gamescope, the host launched labwc. Worse, launching *any* game while the host default was gamescope clobbered that default back to `headless_stream`.
- **Picker cards stacked `focusable()` in front of `clickable()`.** Two focus targets per card: the d-pad parked on the bare, click-less one, so A/DPAD_CENTER activated nothing and traversal stepped erratically (dead RIGHT, diagonal DOWN). Reproduced with keyevents on the RP6 before the fix.

`preflightModeForLaunch` now accepts the resolved canonical mode and pushes it verbatim when present; blank keeps the legacy family-preserving fallbacks byte-for-byte and the virtual-display flag stays the strongest signal. The resolved mode travels the game-detail result payload (new `streamDisplayMode` key) so the library's own preflight push stops re-collapsing what the detail screen resolved. Picker cards keep exactly one focus target — `clickable()` when enabled, plain `focusable()` when disabled so a controller can still read the host's reason in the footer. The Command Center caption that still advertised the tap-to-cycle gesture removed in #199 now describes the real gestures (long-press for Command Center, Guide + Y to cycle).

ShortcutTrampoline intentionally keeps the legacy path (blank resolved mode): shortcuts carry only the boolean today, and their behavior is unchanged.

## Exact candidate

`1937633c` — fix(play-setup): push the resolved mode at launch and make picker cards controller-selectable

## Verification

- Unit suite green, including new `preflightPushesResolvedCanonicalMode` coverage: resolved gamescope pushed verbatim, the virtual-display flag wins over it, blank keeps legacy behavior bit-for-bit.
- `NovaLaunchSourceGuardTest` re-pinned to the three-argument helper (same intent: every launch surface rides the one preflight helper).
- `assembleNonRoot_gameDebug` + `assembleNonRoot_gameDebugAndroidTest` compile.
- On-device (RP6, live host): host default `gamescope_stream` **survives a Control launch** with conf checked before/after — the previous build clobbered it back to `headless_stream` on the same flow. Detail launch button now reads "Launch Gamescope Stream" for the resolved mode.
- On-device controller pass in the Every Game picker: D-pad LEFT walks Gamescope → GPU-native → Private Stream with visible focus, A selects, picker dismisses, "Saved to Polaris" toast, and the host conf flips to `headless_stream` — all previously impossible with a controller.
