### PR TITLE
fix(launch): stop a per-game launch from rewriting the host stream mode

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
@@ -2,19 +2,26 @@ package com.papi.nova.ui
 
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.api.PolarisClientSettings
-import com.papi.nova.api.PolarisStreamDisplayMode
 import com.papi.nova.preferences.PreferenceConfiguration
 
 /**
- * The one place a launch pushes its display intent to the host before starting.
+ * The one place a launch pushes its per-client display intent to the host before starting.
  *
  * Three surfaces launch games (game detail, the library result path, and shortcut
- * trampolines) and each used to carry its own copy of this POST; a change to how
- * the mode travels had to find all three. Mirror wins outright because it is a
- * session-scoped request, not a persistent host mode; everything else resolves
- * through preflightModeForLaunch so a private-family host default survives the
- * launch untouched.
+ * trampolines) and each used to carry its own copy of this POST.
+ *
+ * Staged fix (step 1): a per-game launch must NOT rewrite the host-wide stream mode.
+ * This helper no longer pushes stream_display_mode: the host durably persists that field
+ * (apply_stream_display_mode_selection), so a per-game override — or a stale per-game
+ * cache — silently flipped the host's use_cage_compositor/headless flags, stopped the
+ * private compositor from spawning, and made capture fall through to the desktop and
+ * hard-fail. Only per-client display/bitrate are pushed here now; mirror and virtual
+ * display still travel session-scoped on the /launch URL. The per-session stream mode
+ * returns via a /launch streamMode param in step 2, which is why usesVirtualDisplay,
+ * mirrorDesktop, resolvedMode and clientSettings are retained in the signature (the
+ * call sites also use them for the /optimize mode hint and the /launch URL today).
  */
+@Suppress("UNUSED_PARAMETER")
 object NovaLaunchPreflight {
 
     fun push(
@@ -28,11 +35,8 @@ object NovaLaunchPreflight {
         fps: Float,
         bitrateKbps: Int?,
     ): PolarisClientSettings? = apiClient.updateClientSettings(
-        streamDisplayMode = if (mirrorDesktop) {
-            PolarisClientSettings.MODE_DESKTOP_DISPLAY
-        } else {
-            PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings, resolvedMode)
-        },
+        // No stream_display_mode: see the class doc — a launch must not rewrite the
+        // host-wide stream mode. Only per-client display/bitrate travel here.
         displayMode = PreferenceConfiguration.formatStreamingDisplayMode(width, height, fps),
         targetBitrateKbps = bitrateKbps?.takeIf { it > 0 },
     )

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -232,10 +232,16 @@ class NovaLaunchSourceGuardTest {
         assertTrue(displayMode.contains("fun preflightModeForLaunch("))
         assertTrue(displayMode.contains("PolarisClientSettings.MODE_HOST_VIRTUAL_DISPLAY"))
         assertTrue(displayMode.contains("PolarisClientSettings.MODE_HEADLESS_STREAM"))
-        // All launch surfaces ride the one preflight helper, which itself resolves
-        // through preflightModeForLaunch and uses the contract constant for mirror.
-        assertTrue(preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch(usesVirtualDisplay, clientSettings, resolvedMode)"))
-        assertTrue(preflightHelper.contains("PolarisClientSettings.MODE_DESKTOP_DISPLAY"))
+        // All launch surfaces ride the one preflight helper. Staged fix step 1: a
+        // per-game launch must NOT push a host stream mode (that durably clobbered the
+        // host-wide default). The helper pushes only per-client display/bitrate now; the
+        // per-session mode returns via /launch in step 2.
+        assertTrue(preflightHelper.contains("apiClient.updateClientSettings("))
+        assertTrue(preflightHelper.contains("displayMode = PreferenceConfiguration.formatStreamingDisplayMode"))
+        assertTrue(
+            "launch preflight must not push stream_display_mode",
+            !preflightHelper.contains("streamDisplayMode ="),
+        )
         assertTrue(detail.contains("NovaLaunchPreflight.push("))
         assertTrue(trampoline.contains("NovaLaunchPreflight.push("))
     }
@@ -680,7 +686,7 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
-    fun gameDetailPreflightPreservesExplicitPolarisNonVirtualMode() {
+    fun gameDetailLaunchDoesNotRewriteHostStreamMode() {
         val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt")
         val preflight = detail.section(
             "private fun syncLaunchPreflightSettings(",
@@ -690,28 +696,28 @@ class NovaLaunchSourceGuardTest {
         val preflightHelper = readSource("src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt")
 
         assertTrue(
-            "Game detail preflight must use the full Polaris stream display mode helper, not collapse every non-virtual launch to headless_stream",
+            "Staged fix step 1: a game-detail launch rides the single preflight helper but must NOT push a host stream mode (that durably clobbered the host-wide default), and must not resurrect the old 2-value collapse",
             preflight.contains("NovaLaunchPreflight.push") &&
-                preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
+                !preflightHelper.contains("streamDisplayMode =") &&
                 !preflightHelper.contains("if (usesVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )
     }
 
     @Test
-    fun libraryAndShortcutLaunchPreflightPreservePolarisNonVirtualMode() {
+    fun libraryAndShortcutLaunchDoNotRewriteHostStreamMode() {
         val library = readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
         val shortcut = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
 
         val preflightHelper = readSource("src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt")
 
         assertTrue(
-            "Library launch should preserve the selected full Polaris stream display mode",
+            "Staged fix step 1: a library launch rides the preflight helper but must NOT push a host stream mode, and must not resurrect the old 2-value collapse",
             library.contains("NovaLaunchPreflight.push") &&
-                preflightHelper.contains("PolarisStreamDisplayMode.preflightModeForLaunch") &&
+                !preflightHelper.contains("streamDisplayMode =") &&
                 !library.contains("if (withVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )
         assertTrue(
-            "Shortcut launch should preserve the selected full Polaris stream display mode",
+            "Staged fix step 1: a shortcut launch rides the preflight helper and must not resurrect the old 2-value collapse",
             shortcut.contains("NovaLaunchPreflight.push") &&
                 !shortcut.contains("if (withVirtualDisplay) \"host_virtual_display\" else \"headless_stream\"")
         )


### PR DESCRIPTION
## Summary

A per-game launch was durably rewriting the **host-wide** stream mode.
`NovaLaunchPreflight.push()` POSTed the resolved `stream_display_mode` to
`/polaris/v1/client-settings`, which the host persists to `polaris.conf`
(`apply_stream_display_mode_selection` writes `linux_stream_mode`,
`linux_use_cage_compositor`, `headless_mode`, `linux_prefer_gpu_native_capture`
and `linux_private_runtime`). So launching a game whose resolved mode differed
from the host default — or one carrying a stale/poisoned per-game cache —
silently overwrote the host-wide default.

In practice this flipped `linux_use_cage_compositor` to `false`, so the private
labwc compositor never spawned (the host gates that spawn on
`use_cage_compositor_for_session`), capture fell through to the KDE desktop
compositor (which cannot advertise `wlr-export-dmabuf`), and the session
hard-failed at the encoder probe (503, "Unable to find display or encoder during
startup"). It also made a "verified good" host mode fail to survive its own
launch, which read as random config drift.

Step 1 of a staged fix (approved shape: stopgap now, session-scoped mode next).

## Exact candidate

`NovaLaunchPreflight.push()` no longer passes `stream_display_mode` to
`updateClientSettings` — it pushes only the per-client display mode + bitrate,
which the host stores per client, not as the host-wide default. The host-wide
stream mode is now changed solely by the explicit Every Game path
(`NovaPolarisSyncEngine`), so launching a game can no longer rewrite it. Mirror
and virtual display still travel session-scoped on the `/launch` URL.

`usesVirtualDisplay` / `mirrorDesktop` / `resolvedMode` / `clientSettings` stay
in the signature for step 2 (a session-scoped `/launch streamMode` param) and
for the call sites' existing `/optimize` mode hint and `/launch` URL use.

**Tradeoff (accepted for the staged plan):** a per-game private-mode override
does not take effect until step 2; until then the host default is used and, more
importantly, preserved.

Files: `NovaLaunchPreflight.kt` (drop the mode push, unused import, KDoc);
`NovaLaunchSourceGuardTest.kt` (re-pin three source guards to the new invariant —
each launch surface rides the single preflight helper, pushes no host stream
mode, and the old 2-value headless/virtual collapse stays gone).

## Verification

- `testNonRoot_gameDebugUnitTest` — green (1277 tests; the two previously-failing
  `NovaLaunchSourceGuardTest` cases were re-pinned to the new invariant, not
  deleted).
- `assembleNonRoot_gameDebugAndroidTest` — compiles.
- `lintNonRoot_gameDebug` — clean.
- **On-device: deferred.** The behavioral check — launch a per-game-override
  title and confirm `polaris.conf` `linux_use_cage_compositor` /
  `linux_stream_mode` are unchanged afterward — is queued for the next
  coordinated device window. The shared host's private-capture pipeline is
  currently degraded for an unrelated reason (headless cage renderer), which
  blocks a full end-to-end stream check regardless of this change.
