### PR TITLE
feat(launch): send the per-game stream mode session-scoped on the launch URL

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -256,6 +256,7 @@ com.papi.nova.manager.ClientProfileProvenance(com.papi.nova.manager.ClientProfil
 private var launchProfilePreference:String = "auto"
 private var launchOptimizationJson:String? = null
 private var mirrorDesktop:Boolean = false
+private var streamMode:String = ""
 private var forcePrivateAfterSteamClose:Boolean = false
 private var clientPresentationReportInFlight:AtomicBoolean = AtomicBoolean(false)
 private var cursorVisibilitySyncLock:Any = Any()
@@ -1037,6 +1038,7 @@ uniqueId = this@Game.getIntent().getStringExtra(EXTRA_UNIQUEID)
 vDisplay = this@Game.getIntent().getBooleanExtra(EXTRA_VDISPLAY, false)
 var displayModeExplicit:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_DISPLAY_MODE_EXPLICIT, false)
 mirrorDesktop = this@Game.getIntent().getBooleanExtra(EXTRA_MIRROR_DESKTOP, false)
+streamMode = this@Game.getIntent().getStringExtra(EXTRA_STREAM_MODE) ?: ""
 forcePrivateAfterSteamClose = this@Game.getIntent().getBooleanExtra(EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, false)
 launchProfilePreference = this@Game.getIntent().getStringExtra(EXTRA_AI_PROFILE_PREFERENCE) ?: ""
 launchOptimizationJson = this@Game.getIntent().getStringExtra(EXTRA_LAUNCH_OPTIMIZATION)
@@ -1429,6 +1431,7 @@ displayHeight
 .setVirtualDisplay(vDisplay)
 .setDisplayModeExplicit(displayModeExplicit)
 .setMirrorDesktop(mirrorDesktop)
+.setStreamMode(streamMode)
 .setForcePrivateAfterSteamClose(forcePrivateAfterSteamClose)
 .setResolutionScaleFactor(prefConfig!!.resolutionScaleFactor)
 .setApp(app)
@@ -6763,6 +6766,7 @@ companion object {
  const val EXTRA_APP_HDR:String = "HDR"
  const val EXTRA_SERVER_CERT:String = "ServerCert"
  const val EXTRA_VDISPLAY:String = "VirtualDisplay"
+ const val EXTRA_STREAM_MODE:String = "StreamMode"
  const val EXTRA_DISPLAY_MODE_EXPLICIT:String = "DisplayModeExplicit"
  const val EXTRA_MIRROR_DESKTOP:String = "MirrorDesktop"
 const val EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE:String = "ForcePrivateAfterSteamClose"

--- a/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
@@ -29,6 +29,7 @@ class StreamConfiguration private constructor() {
     private var forceFreshLaunch = false
     private var profilePreference = "auto"
     private var mirrorDesktop = false
+    private var streamMode = ""
     private var forcePrivateAfterSteamClose = false
 
     class Builder {
@@ -165,6 +166,12 @@ class StreamConfiguration private constructor() {
             return this
         }
 
+        fun setStreamMode(streamMode: String?): Builder {
+            // Canonical stream path registry id, or blank for the host default.
+            config.streamMode = streamMode?.trim().orEmpty()
+            return this
+        }
+
         fun setForcePrivateAfterSteamClose(enable: Boolean): Builder {
             config.forcePrivateAfterSteamClose = enable
             return this
@@ -234,6 +241,8 @@ class StreamConfiguration private constructor() {
     fun getProfilePreference(): String = profilePreference
 
     fun getMirrorDesktop(): Boolean = mirrorDesktop
+
+    fun getStreamMode(): String = streamMode
 
     fun getForcePrivateAfterSteamClose(): Boolean = forcePrivateAfterSteamClose
 

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -663,6 +663,13 @@ class NvHTTP @Throws(IOException::class) constructor(
             ?: ""
         val mirrorDesktop = streamConfig.getMirrorDesktop()
         val forcePrivateAfterSteamClose = streamConfig.getForcePrivateAfterSteamClose()
+        // Session-scoped stream-mode override: rides only this /launch URL, the
+        // host applies it for the session and never persists it. Blank = host
+        // default; mirrorDesktop wins on the host side.
+        val streamModeParam = streamConfig.getStreamMode()
+            .takeIf { it.isNotBlank() }
+            ?.let { "&streamMode=" + URLEncoder.encode(it, "UTF-8") }
+            ?: ""
 
         val xmlStr = openHttpConnectionToString(
             httpClientLongConnectNoReadTimeout,
@@ -683,6 +690,7 @@ class NvHTTP @Throws(IOException::class) constructor(
                 "&mirrorDesktop=" + (if (mirrorDesktop) 1 else 0) +
                 (if (mirrorDesktop) "&launchMode=mirror_desktop" else "") +
                 (if (forcePrivateAfterSteamClose) "&closeDesktopSteamForPrivate=1&launchMode=force_private_stream" else "") +
+                streamModeParam +
                 profilePreference +
                 "&localAudioPlayMode=" + (if (streamConfig.getPlayLocalAudio()) 1 else 0) +
                 "&surroundAudioInfo=" + streamConfig.getAudioConfiguration()!!.getSurroundAudioInfo() +

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchPreflight.kt
@@ -17,9 +17,10 @@ import com.papi.nova.preferences.PreferenceConfiguration
  * private compositor from spawning, and made capture fall through to the desktop and
  * hard-fail. Only per-client display/bitrate are pushed here now; mirror and virtual
  * display still travel session-scoped on the /launch URL. The per-session stream mode
- * returns via a /launch streamMode param in step 2, which is why usesVirtualDisplay,
+ * travels the same way (step 2): the resolved override rides the /launch streamMode
+ * param via ServerHelper -> Game -> NvHTTP, which is why usesVirtualDisplay,
  * mirrorDesktop, resolvedMode and clientSettings are retained in the signature (the
- * call sites also use them for the /optimize mode hint and the /launch URL today).
+ * call sites also use them for the /optimize mode hint and the /launch URL).
  */
 @Suppress("UNUSED_PARAMETER")
 object NovaLaunchPreflight {

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -944,7 +944,8 @@ class NovaLibraryActivity : NovaActivity() {
                     aiProfilePreference = profilePreference,
                     launchOptimizationJson = preflightOptimization?.toString(),
                     mirrorDesktop = mirrorDesktop,
-                    forcePrivateAfterSteamClose = forcePrivateAfterSteamClose
+                    forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
+                    streamMode = resolvedMode
                 )
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -172,6 +172,7 @@ object ServerHelper {
         launchOptimizationJson: String? = null,
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
+        streamMode: String = "",
     ): Intent {
         val prefConfig = PreferenceConfiguration.readPreferences(parent)
         val selectedAndroidDisplay = if (prefConfig.enableFullExDisplay) {
@@ -212,6 +213,9 @@ object ServerHelper {
         gameIntent.putExtra(Game.EXTRA_VDISPLAY, withVDisplay)
         gameIntent.putExtra(Game.EXTRA_DISPLAY_MODE_EXPLICIT, displayModeExplicit)
         gameIntent.putExtra(Game.EXTRA_MIRROR_DESKTOP, mirrorDesktop)
+        if (streamMode.isNotBlank()) {
+            gameIntent.putExtra(Game.EXTRA_STREAM_MODE, streamMode)
+        }
         gameIntent.putExtra(Game.EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, forcePrivateAfterSteamClose)
         gameIntent.putExtra(Game.EXTRA_WATCH_ONLY, watchOnly)
         if (streamWidth > 0 && streamHeight > 0) {
@@ -393,6 +397,7 @@ object ServerHelper {
         launchOptimizationJson: String? = null,
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
+        streamMode: String = "",
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -419,6 +424,7 @@ object ServerHelper {
             launchOptimizationJson,
             mirrorDesktop,
             forcePrivateAfterSteamClose,
+            streamMode = streamMode,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)
@@ -484,6 +490,7 @@ object ServerHelper {
         launchOptimizationJson: String? = null,
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
+        streamMode: String = "",
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -507,6 +514,7 @@ object ServerHelper {
             launchOptimizationJson = launchOptimizationJson,
             mirrorDesktop = mirrorDesktop,
             forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
+            streamMode = streamMode,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -704,6 +704,22 @@ class NovaLaunchSourceGuardTest {
     }
 
     @Test
+    fun perGameOverrideTravelsSessionScopedOnLaunchUrl() {
+        val nvhttp = readSource("src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt")
+        val serverHelper = readSource("src/main/java/com/papi/nova/utils/ServerHelper.kt")
+        val library = readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+        val streamConfig = readSource("src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt")
+
+        assertTrue(
+            "step 2: a per-game override rides the /launch URL session-scoped (never client-settings)",
+            nvhttp.contains("\"&streamMode=\" + URLEncoder.encode(") &&
+                streamConfig.contains("fun getStreamMode(): String") &&
+                serverHelper.contains("gameIntent.putExtra(Game.EXTRA_STREAM_MODE, streamMode)") &&
+                library.contains("streamMode = resolvedMode")
+        )
+    }
+
+    @Test
     fun libraryAndShortcutLaunchDoNotRewriteHostStreamMode() {
         val library = readSource("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
         val shortcut = readSource("src/main/java/com/papi/nova/ShortcutTrampoline.kt")


### PR DESCRIPTION
## Summary

Step 2 (Nova half) of the staged launch-mode fix. Step 1 (#222) stopped a
per-game launch from durably rewriting the host-wide stream mode — which also
meant per-game overrides had no effect. This restores them the correct way: the
resolved override rides the `/launch` URL itself as
`streamMode=<stream path registry id>`, which the host (polaris#349) validates,
applies **for that session only**, and restores at teardown. The host default
never changes, on disk or in memory.

## Exact candidate

- `NovaLibraryActivity.launchGame` passes its `resolvedMode` (the detail
  picker's `RESULT_KEY_STREAM_MODE` result; blank for plain library launches)
  into `ServerHelper.doStart` — the one Nova-UI launch site.
- `ServerHelper` (`doStart` ×2 + private `createStartIntent`): new
  `streamMode: String = ""` default parameter, `putExtra(EXTRA_STREAM_MODE)`
  only when non-blank. Kotlin defaults keep every legacy caller (AppView,
  PcView, trampolines, resume) compiling unchanged and sending nothing — those
  launches ride the host default, and an old host ignores the parameter. The
  computer-based `createStartIntent` overload is deliberately not extended.
- `Game` reads the extra into `StreamConfiguration.setStreamMode`.
- `NvHTTP` appends `&streamMode=` (URL-encoded) to the launch URL only when
  set, mirroring the `profilePreference` optional-param shape. `mirrorDesktop`
  precedence is enforced host-side.
- No translation layer: Nova's resolved ids (`PolarisClientSettings.MODE_*`)
  are already canonical registry ids (`windowed_stream`, `gamescope_stream`, …).
- `NovaLaunchPreflight` KDoc updated to describe the now-real step-2 path.
- Deliberately out of scope: wiring the shortcut trampoline to per-game
  overrides (it keeps host-default behavior until its own resolution path is
  built).

## Verification

- `testNonRoot_gameDebugUnitTest` green — including the new source guard
  `perGameOverrideTravelsSessionScopedOnLaunchUrl`, which pins the whole
  pipeline (NvHTTP URL param ← StreamConfiguration ← ServerHelper extra ←
  library passes `resolvedMode`), and the step-1 guards still proving the
  launch path never pushes `stream_display_mode` to client-settings.
- `assembleNonRoot_gameDebugAndroidTest` compiles; `lintNonRoot_gameDebug`
  clean.
- **On-device: deferred to the next coordinated device window**, paired with
  polaris#349: (a) per-game gamescope override over a windowed host default
  launches gamescope and the conf survives; (b) no-override launch behaves
  identically to today; (c) old-host degradation (parameter ignored).

Depends on polaris#349 for effect; safe to merge independently (an old host
ignores the parameter and behavior matches step 1).
