### PR TITLE
fix(launch): send streamMode only for an explicit per-game override

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -511,7 +511,14 @@ class NovaGameDetailActivity : NovaActivity() {
                 mirrorDesktop,
                 forcePrivateAfterSteamClose,
                 profilePreference,
-                uiState.playMode,
+                // Session-scoped streamMode travels ONLY for an explicit per-game
+                // override. Passing the resolved playMode here froze a (possibly
+                // stale) host default into the launch and overrode it per-session;
+                // a host-default launch must send nothing and ride the host's
+                // current mode instead.
+                PolarisStreamDisplayMode.normalize(
+                    NovaLaunchModeOverrides.load(this@NovaGameDetailActivity, currentGame).orEmpty()
+                ),
                 launchOptimization()
             )
             finish()

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchSourceGuardTest.kt
@@ -717,6 +717,13 @@ class NovaLaunchSourceGuardTest {
                 serverHelper.contains("gameIntent.putExtra(Game.EXTRA_STREAM_MODE, streamMode)") &&
                 library.contains("streamMode = resolvedMode")
         )
+
+        val detail = readSource("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt")
+        assertTrue(
+            "a launch sends streamMode only for an EXPLICIT per-game override; resolving the host default into the launch froze stale modes into sessions",
+            detail.contains("NovaLaunchModeOverrides.load(this@NovaGameDetailActivity, currentGame).orEmpty()") &&
+                !detail.contains("uiState.playMode,\n                launchOptimization()")
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
Device-matrix finding from the step-2 verification: the sender passed `uiState.playMode` (the **resolved** play mode) as `streamMode`, so an override-free game collapsed the host default into a concrete id — resolved against **cached** client settings at that. Observed on hardware: Control (no override) launched as `gamescope_stream` right after an STS2 gamescope session, because the cache still carried the prior session state. Host-side harmless (nothing persists, restore ran), but not the contract: a host-default launch must send nothing.

## Exact candidate
`launchConfirmed` reads the explicit override store directly (`NovaLaunchModeOverrides.load`, normalized, `""` when unset) instead of the resolved `playMode`. Library/trampoline paths unchanged (they forward what the detail result carries / send nothing). Source guard re-pinned: streamMode travels only for an explicit per-game override.

## Verification
- Full `testNonRoot_gameDebugUnitTest` + lint green; source guard `perGameOverrideTravelsSessionScopedOnLaunchUrl` extended and passing.
- On-device: queued for the next coordinated window — override-free launch must show no streamMode in the host journal; STS2 (explicit override) must still send `gamescope_stream`.