### PR TITLE
fix(nvhttp): don't crash the app when a host response omits status_code

### DIFF
--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -929,8 +929,17 @@ class NvHTTP @Throws(IOException::class) constructor(
 
         @Throws(HostHttpResponseException::class)
         private fun verifyResponseStatus(xpp: XmlPullParser) {
-            var statusCode = xpp.getAttributeValue(XmlPullParser.NO_NAMESPACE, "status_code").toLong().toInt()
+            // A well-formed host <root> carries status_code (and usually
+            // status_message). A missing or non-numeric status_code — seen from a
+            // truncated or otherwise malformed launch response — must NOT crash the
+            // connection thread with an NPE (getAttributeValue returns null, and the
+            // old .toLong() threw). It is just another error status, so surface it as
+            // the HostHttpResponseException the connect/launch path already catches
+            // (displayMessage + stageFailed + retry) instead of taking down the app.
             var statusMsg = xpp.getAttributeValue(XmlPullParser.NO_NAMESPACE, "status_message")
+                ?: "Unknown error (host response was missing status_message)"
+            var statusCode = xpp.getAttributeValue(XmlPullParser.NO_NAMESPACE, "status_code")?.toLongOrNull()?.toInt()
+                ?: throw HostHttpResponseException(418, "Malformed response from host (missing status_code): $statusMsg")
             if (statusCode != 200) {
                 if (statusCode == -1 && statusMsg == "Invalid") {
                     statusCode = 418

--- a/app/src/test/java/com/papi/nova/nvstream/http/NvHttpServerInfoParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/nvstream/http/NvHttpServerInfoParsingTest.kt
@@ -127,4 +127,45 @@ class NvHttpServerInfoParsingTest {
 
         assertFalse(NvHTTP.parseCurrentGameOwned(serverInfo)!!)
     }
+
+    // A <root> without a status_code used to crash the whole app with an NPE on the
+    // connection thread (verifyResponseStatus called .toLong() on the null attribute),
+    // which is how a malformed launch response took down the benchmark client. It must
+    // now surface as a HostHttpResponseException the connect/launch path already handles.
+    @Test(expected = HostHttpResponseException::class)
+    fun rootWithoutStatusCodeThrowsHostHttpResponseExceptionNotNpe() {
+        NvHTTP.getXmlString("<root><sessionUrl0>x</sessionUrl0></root>", "sessionUrl0", false)
+    }
+
+    @Test(expected = HostHttpResponseException::class)
+    fun rootWithNonNumericStatusCodeThrowsHostHttpResponseException() {
+        NvHTTP.getXmlString("<root status_code=\"not-a-number\"></root>", "sessionUrl0", false)
+    }
+
+    @Test
+    fun rootWithoutStatusCodeReportsMissingStatusCode() {
+        try {
+            NvHTTP.getXmlString("<root></root>", "sessionUrl0", false)
+            throw AssertionError("expected HostHttpResponseException")
+        } catch (e: HostHttpResponseException) {
+            assertTrue(e.getErrorMessage().contains("status_code"))
+        }
+    }
+
+    @Test
+    fun rootWithErrorStatusCodeButNoMessageStillThrowsWithoutNpe() {
+        try {
+            NvHTTP.getXmlString("<root status_code=\"401\"></root>", "sessionUrl0", false)
+            throw AssertionError("expected HostHttpResponseException")
+        } catch (e: HostHttpResponseException) {
+            assertEquals(401, e.getErrorCode())
+        }
+    }
+
+    @Test
+    fun wellFormedSuccessRootParsesTheRequestedField() {
+        val body = "<root status_code=\"200\"><sessionUrl0>rtsp://host</sessionUrl0></root>"
+
+        assertEquals("rtsp://host", NvHTTP.getXmlString(body, "sessionUrl0", false))
+    }
 }


### PR DESCRIPTION
## Summary

The RP6 benchmark client crashed intermittently mid-launch ("Application Error", a FATAL `NullPointerException` at `NvHTTP.verifyResponseStatus` during `launchApp`). Root cause: `verifyResponseStatus` called `.toLong()` directly on the `status_code` attribute of the host `<root>`, and `getAttributeValue` returns **null** when that attribute is absent — which happens on a truncated/malformed launch response. The resulting NPE is *unchecked*, so it escapes the `catch (HostHttpResponseException)` in `NvConnection.start()` that already handles launch errors gracefully (displayMessage + stageFailed + retry) and takes down the whole app instead. That also explains the intermittency: a well-formed response streams fine.

Fix: `verifyResponseStatus` is now null-safe — a missing/non-numeric `status_code` and a null `status_message` are surfaced as the checked `HostHttpResponseException` the connect/launch path already recovers from, never an NPE. The `-1`/"Invalid" audio-device special case is unchanged. Covers both callers (`getXmlString` and `getXmlArray`).

## Exact candidate

`3f236b0f` on `fix/nvhttp-verify-status-npe` off `origin/master` `a98320b5`. Two files: `NvHTTP.kt` (the guard) + `NvHttpServerInfoParsingTest.kt` (tests).

**Not** the SemWindowManager `ClassNotFoundException` that also appears in the logcat around this crash — that one is already caught in `Game.setMetaKeyCaptureState` (a harmless System.err warning during `onPause`), not the fatal.

## Verification

- `testNonRoot_gameDebugUnitTest --tests NvHttpServerInfoParsingTest`: 15/15 (10 existing + 5 new), XML-confirmed. New cases: `<root>` with no status_code, non-numeric status_code, error status_code with no status_message, and a well-formed success root — asserting `HostHttpResponseException` (never NPE) and correct codes/messages.
- `lintNonRoot_gameDebug` with `lintFailOnError=true`: 0 errors.
- `NovaLaunchSourceGuardTest` + siblings: 25/25, no pinned invariant disturbed.
- Change is in the main source set, so it's compiled by every variant (incl. benchmark), not just debug.

## Impact

Unblocks the Nordstern synthetic-workload pilot: this crash is what made the benchmark client fail intermittently on launch/attach. With it fixed, a malformed launch response becomes a retryable failure instead of a hard crash.