### PR TITLE
fix(game-detail): let Play hold first focus on a cached profile

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
@@ -70,11 +70,13 @@ import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
+import com.papi.nova.ui.compose.NOVA_FIRST_FOCUS_SETTLE_MS
 import com.papi.nova.ui.compose.NovaActionButton
 import com.papi.nova.ui.compose.NovaChromeType
 import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaRadius
+import kotlinx.coroutines.delay
 
 /** Where the detail window currently is. Back unwinds one level before leaving. */
 /**
@@ -463,9 +465,18 @@ private fun NovaGameDetailActions(
         // Keyed on enabled, because that is the moment the primary becomes reachable.
         // The request is allowed to fail: while a destination is open the Overview is a
         // focusProperties { canFocus = false } group, and asking then must not throw.
+        //
+        // Settle first, for the same reason novaHoldsFirstFocus does: when the profile
+        // is already cached, playEnabled is true on the first composition, so this
+        // effect runs before Play is placed -- the request lands on nothing, runCatching
+        // swallows it, and focus falls to the first focusable above Play (the launch-
+        // profile row). Waiting one settle lets layout happen so the request lands on
+        // Play. On the slow-profile path playEnabled flips true after layout, so the
+        // wait costs nothing there.
         val playFocusable = uiState.playEnabled || activeSession != null
         LaunchedEffect(playFocusable) {
             if (playFocusable) {
+                delay(NOVA_FIRST_FOCUS_SETTLE_MS)
                 runCatching { playFocusRequester.requestFocus() }
             }
         }

--- a/app/src/test/java/com/papi/nova/ui/NovaGameDetailFirstFocusSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaGameDetailFirstFocusSourceGuardTest.kt
@@ -1,0 +1,44 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * The game-detail Overview must let Play hold first focus reliably.
+ *
+ * When the launch profile is already cached, playEnabled is true on the very first
+ * composition, so the focus effect runs before Play has been placed. A bare request
+ * lands on nothing, runCatching swallows it, and framework default focus falls to the
+ * first focusable above Play -- the launch-profile row. Observed on device (both the
+ * debug and benchmark builds): the first A-press on a game's detail screen activated the
+ * stats/"more details" row instead of the highlighted Launch button.
+ *
+ * The request must settle first, exactly the way the shared novaHoldsFirstFocus helper
+ * does, so it lands on Play once layout has happened. This guards that invariant at the
+ * source, since the timing is not reachable from a JVM unit test.
+ */
+class NovaGameDetailFirstFocusSourceGuardTest {
+    @Test
+    fun playFocusRequestSettlesBeforeAskingSoItLandsOnPlayNotTheRowAbove() {
+        val source = File("src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt").readText()
+
+        val effectStart = source.indexOf("LaunchedEffect(playFocusable)")
+        assertTrue(
+            "Overview must request Play focus in a LaunchedEffect keyed on playFocusable.",
+            effectStart >= 0,
+        )
+        val requestIndex = source.indexOf("playFocusRequester.requestFocus()", effectStart)
+        assertTrue(
+            "Overview must request focus on playFocusRequester.",
+            requestIndex >= 0,
+        )
+        val settleIndex = source.indexOf("delay(NOVA_FIRST_FOCUS_SETTLE_MS)", effectStart)
+        assertTrue(
+            "Play focus must settle (delay(NOVA_FIRST_FOCUS_SETTLE_MS)) before requesting it. Without " +
+                "the settle, a cached profile makes the request fire before Play is placed, and first " +
+                "focus falls to the launch-profile row above Play.",
+            settleIndex in effectStart until requestIndex,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

On a game's detail screen the first A-press activated the launch-profile / stats row instead of the highlighted **Launch** button — reproduced on both the debug and benchmark builds while driving the Retroid.

**Root cause:** the Overview requests focus for Play in a `LaunchedEffect(playFocusable)`, but with **no settle delay**. When the launch profile is already cached, `playEnabled` is true on the very first composition, so the effect runs *before* Play is placed. The request lands on nothing, `runCatching` swallows it, and framework default focus falls to the first focusable above Play. The shared `novaHoldsFirstFocus` helper waits `NOVA_FIRST_FOCUS_SETTLE_MS` (120 ms) for exactly this "request lands on nothing before layout" reason; the Overview's request didn't.

It was **invisible** because the primary button's fill is its default styling, not a focus indicator — a mis-seeded focus looked identical to a focused button.

## Fix

Settle before requesting, matching `novaHoldsFirstFocus`:

```kotlin
LaunchedEffect(playFocusable) {
    if (playFocusable) {
        delay(NOVA_FIRST_FOCUS_SETTLE_MS)
        runCatching { playFocusRequester.requestFocus() }
    }
}
```

On the slow-profile path `playEnabled` flips true only after layout, so the wait costs nothing there.

## Verification

- `NovaGameDetailFirstFocusSourceGuardTest` pins the settle-before-request ordering (the timing is not reachable from a JVM unit test), following the repo's source-guard convention.
- `testNonRoot_gameDebugUnitTest` green locally (compiles the Compose change + runs the guard); CI on this PR.
- **Deferred to a free RP6:** open a game whose profile is cached and confirm the first A-press launches. (The RP6 is mid-benchmark-stream right now.)
