### PR TITLE
fix(library): settle, declare keyboard intent, and retry poster first focus

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -128,6 +128,7 @@ import com.papi.nova.NovaSessionEndSignal
 import com.papi.nova.R
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.api.PolarisGameJson
+import com.papi.nova.ui.compose.NOVA_FIRST_FOCUS_SETTLE_MS
 import com.papi.nova.ui.compose.NovaBadge
 import com.papi.nova.ui.compose.NovaChromeType
 import com.papi.nova.ui.compose.NovaRadius
@@ -2530,15 +2531,26 @@ class NovaLibraryActivity : NovaActivity() {
         val inputModeManager = LocalInputModeManager.current
         var restoreAttempted by remember { mutableStateOf(false) }
         LaunchedEffect(restoreFocus, coldStartFocus) {
-            if (restoreFocus && !restoreAttempted) {
-                restoreAttempted = focusRequester.requestFocus()
-            } else if (coldStartFocus && !restoreAttempted) {
-                // A cold start composes with nothing focused, so the first dpad press was
-                // being consumed just establishing focus. Declare keyboard intent and land
-                // it on the first card so the ring is visible immediately.
-                withFrameNanos { }
+            if ((restoreFocus || coldStartFocus) && !restoreAttempted) {
+                // Settle first, for the same reason novaHoldsFirstFocus does: this effect
+                // runs on the card's first composition, before the grid has placed it, so
+                // an immediate request lands on nothing -- and a false return was recorded
+                // as "attempted" and never retried. One frame (the old cold-start wait) is
+                // not enough while the grid is still measuring a cold library.
+                delay(NOVA_FIRST_FOCUS_SETTLE_MS)
+                // Declare keyboard intent so the ring is visible immediately and the first
+                // dpad press moves focus instead of being consumed revealing it. Restores
+                // after a tap-opened detail want this just as much as a cold start does.
                 inputModeManager.requestInputMode(InputMode.Keyboard)
                 restoreAttempted = focusRequester.requestFocus()
+                // Still unplaced after the settle: give layout a few more frames rather
+                // than silently surrendering the session's first press.
+                var retriesLeft = 8
+                while (!restoreAttempted && retriesLeft > 0) {
+                    withFrameNanos { }
+                    restoreAttempted = focusRequester.requestFocus()
+                    retriesLeft--
+                }
             } else if (!restoreFocus && !coldStartFocus) {
                 restoreAttempted = false
             }

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -817,11 +817,12 @@ class NovaComposeSourceGuardTest {
                 source.contains("onPrimaryFilterFocused = { lastFocusedPrimaryFilter = it }")
         )
         assertTrue(
-            "shared poster call sites should request focus when they match the remembered game",
+            "shared poster call sites should request focus once when they match the remembered game " +
+                "(restore and cold start share the settled request path)",
             source.windowed("rememberLibraryPosterFocusRequester(".length)
                 .count { it == "rememberLibraryPosterFocusRequester(" } == 3 &&
                 posterFocus.contains("val focusRequester = remember { FocusRequester() }") &&
-                posterFocus.contains("if (restoreFocus && !restoreAttempted)") &&
+                posterFocus.contains("if ((restoreFocus || coldStartFocus) && !restoreAttempted)") &&
                 posterFocus.contains("focusRequester.requestFocus()")
         )
         assertTrue(

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryFirstFocusSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryFirstFocusSourceGuardTest.kt
@@ -1,0 +1,68 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * The library grid must land first focus on a poster card reliably, with the ring visible.
+ *
+ * The poster focus requester runs on the card's first composition, before the grid has
+ * placed it. A bare request lands on nothing, and its false return was recorded as
+ * "attempted", so it was never retried: a cold start showed no focus ring at all, and the
+ * session's first d-pad press blind-scrolled the grid. Restores after a tap-opened detail
+ * additionally never declared keyboard intent, so focus existed but no ring showed until a
+ * press was spent revealing it.
+ *
+ * The request must settle first (the shared novaHoldsFirstFocus wait), declare keyboard
+ * input mode, and retry a placed-too-late request across a few frames. This guards those
+ * invariants at the source, since the timing is not reachable from a JVM unit test.
+ */
+class NovaLibraryFirstFocusSourceGuardTest {
+    private fun effectSource(): Pair<String, Int> {
+        val source = File("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt").readText()
+        val effectStart = source.indexOf("LaunchedEffect(restoreFocus, coldStartFocus)")
+        assertTrue(
+            "The poster focus requester must ask in a LaunchedEffect keyed on restoreFocus and coldStartFocus.",
+            effectStart >= 0,
+        )
+        return source to effectStart
+    }
+
+    @Test
+    fun posterFocusRequestSettlesBeforeAskingSoItLandsOnAPlacedCard() {
+        val (source, effectStart) = effectSource()
+        val requestIndex = source.indexOf("focusRequester.requestFocus()", effectStart)
+        assertTrue("The effect must request focus on the poster's requester.", requestIndex >= 0)
+        val settleIndex = source.indexOf("delay(NOVA_FIRST_FOCUS_SETTLE_MS)", effectStart)
+        assertTrue(
+            "Poster focus must settle (delay(NOVA_FIRST_FOCUS_SETTLE_MS)) before requesting it. Without " +
+                "the settle, the request fires before the grid places the card and first focus is lost.",
+            settleIndex in effectStart until requestIndex,
+        )
+    }
+
+    @Test
+    fun posterFocusDeclaresKeyboardIntentSoTheRingShowsWithoutSpendingAPress()  {
+        val (source, effectStart) = effectSource()
+        val requestIndex = source.indexOf("focusRequester.requestFocus()", effectStart)
+        val inputModeIndex = source.indexOf("requestInputMode(InputMode.Keyboard)", effectStart)
+        assertTrue(
+            "Poster focus must declare keyboard input mode before requesting, for restores as well as " +
+                "cold starts, or the ring stays hidden and the first press is consumed revealing it.",
+            inputModeIndex in effectStart until requestIndex,
+        )
+    }
+
+    @Test
+    fun posterFocusRetriesAFailedRequestInsteadOfRecordingItAsAttempted() {
+        val (source, effectStart) = effectSource()
+        val effectEnd = source.indexOf("return focusRequester", effectStart)
+        val body = source.substring(effectStart, effectEnd)
+        assertTrue(
+            "A false requestFocus() return means the card was not placed yet; the effect must retry " +
+                "across frames (withFrameNanos + re-request) instead of surrendering the first press.",
+            body.contains("while (!restoreAttempted") && body.contains("withFrameNanos"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- The library grid's poster focus requester ran on the card's first composition, before the grid had placed it: the request landed on nothing and its false return was recorded as "attempted" and never retried. A cold start showed no focus ring at all, and the session's first d-pad press blind-scrolled the grid; returning from a tap-opened detail restored focus without declaring keyboard intent, so the ring stayed hidden until a press was spent revealing it.
- Restore and cold start now share one settled path: wait `NOVA_FIRST_FOCUS_SETTLE_MS` (the same settle the shared `novaHoldsFirstFocus` helper and the game-detail Play fix use), declare keyboard input mode so the ring shows without consuming a press, request focus, and retry across up to eight frames while the request still reports the node unplaced.
- The one-shot `restoreAttempted` gate keeps its meaning; `NovaComposeSourceGuardTest`'s pin moves to the merged condition in the same commit. New `NovaLibraryFirstFocusSourceGuardTest` pins settle-before-request, the keyboard-intent declaration, and the frame-retry loop at the source, since the timing is not reachable from a JVM unit test.

## Exact candidate

`Commit:` `a4f3fecfd7d4e79851915f8796af5642e3bc1495`
`Tree:` `f5288c647db41fcae788c9a94afc5ae6f896db13`
`Parent:` `f0ff1e4b8482ca0eb225497b223b255accc6ad58`
`Base:` `f0ff1e4b8482ca0eb225497b223b255accc6ad58` (origin/master)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1287/1287 (XML-counted; 1284 carried + 3 new source guards)
- [x] `:app:lintNonRoot_gameDebug` with `-PlintFailOnError=true` — 0 new errors (517 warnings / 3 hints are the pre-existing baseline)
- [x] `:app:assembleNonRoot_gameDebugAndroidTest` — compiles
- [ ] Device QA on the RP6 (cold-start ring on first tile, ring restored after tap-opened detail, first press moves focus) — batched into this arc's single end-of-arc device pass
