### PR TITLE
fix(play-setup): trail the app-default note instead of leading What Will Happen

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -1518,9 +1518,6 @@ class NovaGameDetailActivity : NovaActivity() {
 
     private fun buildLaunchIntro(uiState: NovaGameDetailUiState): String {
         val parts = mutableListOf<String>()
-        if (uiState.preferredMode != uiState.recommendedMode) {
-            parts += getString(R.string.nova_library_launch_preferred_mode_format, modeLabel(uiState.preferredMode))
-        }
         if (uiState.hostStreamDisplayMode in setOf(
                 PolarisClientSettings.MODE_DESKTOP_DISPLAY,
                 PolarisClientSettings.MODE_GPU_NATIVE_TEST
@@ -1547,6 +1544,13 @@ class NovaGameDetailActivity : NovaActivity() {
             uiState.game.launchMode?.modeReason?.isNotBlank() == true -> uiState.game.launchMode?.modeReason.orEmpty()
             uiState.recommendedMode == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY -> getString(R.string.nova_library_launch_intro_virtual_default)
             else -> getString(R.string.nova_library_launch_intro_headless_default)
+        }
+        // The app's own preference trails the description rather than leading it: this
+        // paragraph sits under "What will happen", and opening it with a mode that will
+        // NOT happen ("App default: Host Virtual Display." over a Private Stream plan)
+        // made the headline and its first sentence contradict each other.
+        if (uiState.preferredMode != uiState.recommendedMode) {
+            parts += getString(R.string.nova_library_launch_preferred_mode_format, modeLabel(uiState.preferredMode))
         }
         return parts.joinToString(" ")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,7 +440,7 @@
     <string name="nova_desktop_steam_cancel">Cancel</string>
     <string name="nova_library_launch_mode_default_format">%1$s · Default</string>
     <string name="nova_library_launch_recommended_mode_badge">Rec. %1$s</string>
-    <string name="nova_library_launch_preferred_mode_format">App default: %1$s.</string>
+    <string name="nova_library_launch_preferred_mode_format">This app’s default is %1$s.</string>
     <string name="nova_library_launch_mode_unavailable_format">%1$s · Unavailable</string>
     <string name="nova_library_launching_mode">Launching %1$s in %2$s…</string>
     <string name="nova_steam_launch_detail_label">Steam Launch</string>


### PR DESCRIPTION
## Summary

- Play Setup's "What will happen" column opened its paragraph with the app's own mode preference ("App default: Host Virtual Display.") even when the resolved plan headline directly above it said Private Stream — the one mode the paragraph led with was the one that will not happen.
- `buildLaunchIntro` now appends the preference note after the resolved-mode description, rephrased as "This app's default is X." so it reads as the footnote it is. The game-detail overview consumes the same intro and picks up the same ordering.
- The note's trigger is unchanged: it still appears only when the app's preferred mode differs from the recommended one.

## Exact candidate

`Commit:` `ea3492d312e8558364e135db7a776c9ba4cd7228`
`Tree:` `a11f9c2ff89f5d5e4f966e59dec599eeb8ba7873`
`Parent:` `f0ff1e4b8482ca0eb225497b223b255accc6ad58`
`Base:` `f0ff1e4b8482ca0eb225497b223b255accc6ad58` (origin/master)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1284/1284 (XML-counted)
- [x] `:app:lintNonRoot_gameDebug` with `-PlintFailOnError=true` — 0 new errors (517 warnings / 3 hints are the pre-existing baseline)
- [ ] On-screen copy check (Play Setup pane for a game whose app default differs from the resolved mode) — batched into this arc's single end-of-arc RP6 device pass
