### PR TITLE
Add Ctrl+1 / Ctrl+2 to Quick Keys and More Keys

### DIFF
--- a/app/src/main/java/com/papi/nova/GameMenu.kt
+++ b/app/src/main/java/com/papi/nova/GameMenu.kt
@@ -262,6 +262,12 @@ class GameMenu @JvmOverloads constructor(
                     ),
                 )
             }))
+            options.add(MenuOption(getString(R.string.game_menu_send_keys_ctrl_1), Runnable {
+                sendKeys(shortArrayOf(KeyboardTranslator.VK_LCONTROL.toShort(), KeyboardTranslator.VK_1.toShort()))
+            }))
+            options.add(MenuOption(getString(R.string.game_menu_send_keys_ctrl_2), Runnable {
+                sendKeys(shortArrayOf(KeyboardTranslator.VK_LCONTROL.toShort(), KeyboardTranslator.VK_2.toShort()))
+            }))
         }
 
         val preferences = game.getSharedPreferences(PREF_NAME, Activity.MODE_PRIVATE)

--- a/app/src/main/java/com/papi/nova/binding/input/KeyboardTranslator.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/KeyboardTranslator.kt
@@ -182,6 +182,8 @@ class KeyboardTranslator(private val prefConfig: PreferenceConfiguration) : Inpu
         private const val KEY_PREFIX = 0x80
 
         const val VK_0 = 48
+        const val VK_1 = 49
+        const val VK_2 = 50
         const val VK_9 = 57
         const val VK_A = 65
         const val VK_Z = 90

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -385,6 +385,8 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 NovaQuickMenuActionId.QUICK_INSERT -> keys(KeyboardTranslator.VK_INSERT)
                 NovaQuickMenuActionId.QUICK_META -> keys(KeyboardTranslator.VK_LWIN)
                 NovaQuickMenuActionId.QUICK_CTRL_V -> keys(KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_V)
+                NovaQuickMenuActionId.QUICK_CTRL_1 -> keys(KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_1)
+                NovaQuickMenuActionId.QUICK_CTRL_2 -> keys(KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_2)
                 else -> return
             }
             dismiss()

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -109,7 +109,9 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_F11,
             NovaQuickMenuActionId.QUICK_INSERT,
             NovaQuickMenuActionId.QUICK_META,
-            NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)
+            NovaQuickMenuActionId.QUICK_CTRL_V,
+            NovaQuickMenuActionId.QUICK_CTRL_1,
+            NovaQuickMenuActionId.QUICK_CTRL_2 -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,
             NovaQuickMenuActionId.PERF_STATS,
             NovaQuickMenuActionId.DIAGNOSE_STREAM,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -29,6 +29,8 @@ enum class NovaQuickMenuActionId {
     QUICK_INSERT,
     QUICK_META,
     QUICK_CTRL_V,
+    QUICK_CTRL_1,
+    QUICK_CTRL_2,
     NOVA_HUD,
     PERF_STATS,
     DIAGNOSE_STREAM,
@@ -892,6 +894,14 @@ data class NovaQuickMenuUiState(
             NovaQuickMenuAction(
                 id = NovaQuickMenuActionId.QUICK_CTRL_V,
                 label = context.getString(R.string.game_menu_send_keys_ctrl_v)
+            ),
+            NovaQuickMenuAction(
+                id = NovaQuickMenuActionId.QUICK_CTRL_1,
+                label = context.getString(R.string.game_menu_send_keys_ctrl_1)
+            ),
+            NovaQuickMenuAction(
+                id = NovaQuickMenuActionId.QUICK_CTRL_2,
+                label = context.getString(R.string.game_menu_send_keys_ctrl_2)
             )
         )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -889,6 +889,8 @@
     <string name="game_menu_send_keys_insert">Insert</string>
     <string name="game_menu_send_keys_alt_f4">Alt + F4</string>
     <string name="game_menu_send_keys_ctrl_v">Ctrl + V</string>
+    <string name="game_menu_send_keys_ctrl_1">Ctrl + 1</string>
+    <string name="game_menu_send_keys_ctrl_2">Ctrl + 2</string>
     <string name="game_menu_send_keys_win">Win (Meta)</string>
     <string name="game_menu_send_keys_win_d">Win + D</string>
     <string name="game_menu_send_keys_alt_b">ALT + B</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -162,6 +162,8 @@ class NovaQuickMenuUiStateTest {
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_ESC && it.label == "ESC" })
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_CTRL_V && it.label == "Ctrl + V" })
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_INSERT && it.label == "Insert" })
+        assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_CTRL_1 && it.label == "Ctrl + 1" })
+        assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_CTRL_2 && it.label == "Ctrl + 2" })
         assertTrue(state.overlayRows.any { it.id == NovaQuickMenuActionId.PERF_STATS && it.label == "Stats Overlay" })
         assertTrue(state.advancedRows.any { it.id == NovaQuickMenuActionId.MANGOHUD && it.label == "MangoHud" })
         assertTrue(state.sessionRows.any { it.id == NovaQuickMenuActionId.MORE_KEYS && it.label == "More Keys" })


### PR DESCRIPTION
## Summary

Adds **Ctrl+1** and **Ctrl+2** as bindable shortcuts, in both:
- the Command Center **Quick Keys** row (`NovaQuickMenuUiState.kt` / `NovaQuickMenu.kt` / `NovaQuickMenuContent.kt`)
- the classic **More Keys / Special Keys** sheet (`GameMenu.kt`)

Following the existing `Ctrl+V` pattern in both places.

## Motivation

On SteamOS / Steam Big Picture hosts:
- **Ctrl+1** opens the Big Picture menu
- **Ctrl+2** opens the Quick Access Menu (Decky Loader, volume, chat, etc.)

Both are otherwise only reachable via the physical Xbox Button + A chord on the host, which most controllers/remotes streaming through Nova have no way to send. Having these as on-screen Quick Keys makes Big Picture / Decky Loader fully usable from a Nova session without needing to touch the host.

## Changes

- `KeyboardTranslator.kt`: added `VK_1` / `VK_2` constants (`0x31` / `0x32`), matching the existing `VK_0`/`VK_9` style.
- `NovaQuickMenuUiState.kt`: added `QUICK_CTRL_1` / `QUICK_CTRL_2` to `NovaQuickMenuActionId` and to `quickKeyActions()`.
- `NovaQuickMenu.kt`: added the two new cases to `sendQuickKey()`'s key mapping.
- `NovaQuickMenuContent.kt`: added the two new IDs to the exhaustive `when` in `NovaQuickMenuCallbacks.perform()` (required for compilation).
- `GameMenu.kt`: added matching `MenuOption` entries to `showSpecialKeysMenu()`.
- `strings.xml`: added `game_menu_send_keys_ctrl_1` = "Ctrl + 1", `game_menu_send_keys_ctrl_2` = "Ctrl + 2".
- `NovaQuickMenuUiStateTest.kt`: extended the existing quick-keys preview-state assertions to cover the two new entries.

## Validation

- `nonRoot_game` debug build compiles and installs cleanly (arm64-v8a).
- Tested live on an AYN Thor against a Polaris host: both **Ctrl + 1** and **Ctrl + 2** fire correctly from Quick Keys and from More Keys during an active stream, confirmed opening Big Picture menu / Quick Access Menu on the host.
