### PR TITLE
Re-pin the Insert quick-key source guard to the callback bucket

### DIFF
--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2196,10 +2196,11 @@ class NovaComposeSourceGuardTest {
             state.contains("QUICK_INSERT") &&
                 state.contains("R.string.game_menu_send_keys_insert")
         )
+        val quickKeyBucket = content.substringAfter("NovaQuickMenuActionId.QUICK_ESC,", "")
+            .substringBefore("-> onQuickKey(action.id)", "")
         assertTrue(
             "Insert quick key should route through the same Command Center quick-key callback bucket as the other special keys",
-            content.contains("NovaQuickMenuActionId.QUICK_INSERT,") &&
-                content.contains("NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)")
+            quickKeyBucket.contains("NovaQuickMenuActionId.QUICK_INSERT,")
         )
         assertTrue(
             "Insert quick key should route through the existing Windows VK_INSERT translator path",


### PR DESCRIPTION
## Summary
- #237 added Ctrl+1 and Ctrl+2 to the Command Center quick keys, which appended two ids to the fall-through group in `NovaQuickMenuCallbacks.perform()`. The `NovaComposeSourceGuardTest` Insert guard asserted on the literal `NovaQuickMenuActionId.QUICK_CTRL_V -> onQuickKey(action.id)`, a string that only existed while Ctrl+V happened to be the last id in that group, so the arm moving onto `QUICK_CTRL_2` turned master red even though Insert still routes exactly as the guard intends.
- The guard now asserts the invariant it actually carries: Insert sits inside the bucket whose arm calls `onQuickKey`. It slices between the `QUICK_ESC` entry and the `onQuickKey` arm and looks for Insert in the slice. Both substring calls pass an empty missing-delimiter value, so losing either anchor empties the slice and fails the assertion rather than silently matching the rest of the file. Adding a further quick key no longer requires a guard edit.
- Test-only change. No production source or behavior touched.

## Verification
- `./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest` green on pc-papi: 1318 tests across 161 classes, 0 failures.
- Red first, on merged master at ee946de9 before this commit: `NovaComposeSourceGuardTest` 80 tests, 1 failure, `commandCenterExposesInsertThroughExistingSpecialKeyTranslator`, message "Insert quick key should route through the same Command Center quick-key callback bucket as the other special keys". Same class is 80 tests, 0 failures with the re-pin.
- `./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug` green.
- `python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight` green, 51 tests.
