### PR TITLE
fix(play-setup): stop offering a mode the host will not take per session

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -516,7 +516,8 @@ class PolarisApiClient @JvmOverloads constructor(
                         restartRequired = mode.optBoolean("restart_required", true),
                         reason = mode.optString("reason", ""),
                         group = mode.optString("group", ""),
-                        unavailableReason = mode.optString("unavailable_reason", "")
+                        unavailableReason = mode.optString("unavailable_reason", ""),
+                        sessionOverridable = mode.optBoolean("session_overridable", true)
                     )
                 }
             }

--- a/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
@@ -54,7 +54,14 @@ data class PolarisClientSettings(
         /** Registry grouping: "private" (desktop untouched) or "host" (uses/swaps the host screen). */
         val group: String = "",
         /** Host-supplied explanation served when available is false. */
-        val unavailableReason: String = ""
+        val unavailableReason: String = "",
+        /**
+         * Whether a client may select this mode for a single session. A mode can be
+         * perfectly available as the host's default and still be refused per-session,
+         * which is why this is separate from [available]. Defaults true so hosts that
+         * predate the field keep today's behaviour.
+         */
+        val sessionOverridable: Boolean = true
     )
 
     val desiredModeLabel: String

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -1043,6 +1043,7 @@ class NovaGameDetailActivity : NovaActivity() {
                                         getString(R.string.nova_polaris_sync_unset)
                                     },
                                 ),
+                                hostDefaultOnlyDetail = getString(R.string.nova_play_setup_mode_host_default_only),
                             )
                         }
                     } else {

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetupModePicker.kt
@@ -137,6 +137,7 @@ internal fun buildGameModePickerState(
     title: String,
     hostDefaultLabel: String,
     aiRecommendedMode: String = "",
+    hostDefaultOnlyDetail: String = "",
 ): NovaPlaySetupModePickerState {
     val allowed = allowedModes.map { PolarisGame.normalizeLaunchMode(it) }.toSet()
     return NovaPlaySetupModePickerState(
@@ -149,17 +150,20 @@ internal fun buildGameModePickerState(
                 NovaPlaySetupModeChoice(
                     id = mode.mode,
                     label = mode.label,
-                    detail = if (!mode.available && mode.unavailableReason.isNotBlank()) {
-                        mode.unavailableReason
-                    } else {
-                        mode.reason
+                    detail = when {
+                        !mode.available && mode.unavailableReason.isNotBlank() -> mode.unavailableReason
+                        // Available, but the host will not take it for one session. Saying
+                        // so beats offering a pick the host silently drops on launch.
+                        !mode.sessionOverridable && hostDefaultOnlyDetail.isNotBlank() ->
+                            hostDefaultOnlyDetail
+                        else -> mode.reason
                     },
                     group = mode.group,
                     current = hasExplicitOverride && mode.mode == playMode,
                     active = mode.mode == playMode && !hasExplicitOverride,
-                    enabled = mode.available,
-                    aiRecommended = mode.available && aiRecommendedMode.isNotBlank() &&
-                        mode.mode == aiRecommendedMode,
+                    enabled = mode.available && mode.sessionOverridable,
+                    aiRecommended = mode.available && mode.sessionOverridable &&
+                        aiRecommendedMode.isNotBlank() && mode.mode == aiRecommendedMode,
                 )
             },
     )

--- a/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPolarisSyncUiState.kt
@@ -25,7 +25,9 @@ data class NovaPolarisModeUiState(
     /** Registry grouping from the host catalog: "private" or "host"; blank on legacy hosts. */
     val group: String = "",
     /** Host-supplied explanation for an unavailable mode; blank when available. */
-    val unavailableReason: String = ""
+    val unavailableReason: String = "",
+    /** Whether the host will accept this mode as a per-session override. */
+    val sessionOverridable: Boolean = true
 )
 
 data class NovaPolarisSyncUiState(
@@ -132,6 +134,7 @@ object NovaPolarisSyncUiStateMapper {
                     selectedEffective = effectiveSelected,
                     enabled = settings != null && available && !busy,
                     available = available,
+                    sessionOverridable = option?.sessionOverridable ?: true,
                     reason = option?.reason.orEmpty(),
                     group = option?.group.orEmpty(),
                     unavailableReason = option?.unavailableReason.orEmpty(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,7 @@
     <string name="nova_play_setup_granted_format">Granted: %1$s</string>
     <string name="nova_play_setup_compare_where">If you changed where it runs</string>
     <string name="nova_play_setup_fact_host_default">Host default</string>
+    <string name="nova_play_setup_mode_host_default_only">Set by the host. This one rearranges the host displays, so it cannot be chosen for a single session.</string>
     <string name="nova_play_setup_band_private">Private — your desktop stays untouched</string>
     <string name="nova_play_setup_band_host">Host display — uses or swaps the host screen</string>
     <string name="nova_play_setup_host_default_entry_detail">Follow the host\'s Default Display — currently %1$s</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaPlaySetupModePickerTest.kt
@@ -21,6 +21,7 @@ class NovaPlaySetupModePickerTest {
         label: String = id,
         reason: String = "",
         unavailableReason: String = "",
+        sessionOverridable: Boolean = true,
     ) = NovaPolarisModeUiState(
         mode = id,
         label = label,
@@ -34,6 +35,7 @@ class NovaPlaySetupModePickerTest {
         statusLabel = "",
         group = group,
         unavailableReason = unavailableReason,
+        sessionOverridable = sessionOverridable,
     )
 
     @Test
@@ -199,5 +201,59 @@ class NovaPlaySetupModePickerTest {
         )
 
         assertTrue(unavailablePick.choices.none { it.aiRecommended })
+    }
+
+    @Test
+    fun perSessionPickerDisablesAModeTheHostWillNotTakeForOneSession() {
+        val modes = listOf(
+            mode("headless_stream", group = "private"),
+            mode("headless_dongle", group = "host", sessionOverridable = false),
+        )
+
+        val game = buildGameModePickerState(
+            modes = modes,
+            allowedModes = emptyList(),
+            playMode = "headless_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Host default",
+            hostDefaultOnlyDetail = "Set by the host.",
+        )
+
+        val dongle = game.choices.single { it.id == "headless_dongle" }
+        // Available, but not selectable for one launch: offering it would let the
+        // user pick something the host drops on the way through.
+        assertFalse(dongle.enabled)
+        assertEquals("Set by the host.", dongle.detail)
+
+        assertTrue(game.choices.single { it.id == "headless_stream" }.enabled)
+    }
+
+    @Test
+    fun hostDefaultPickerStillOffersIt() {
+        // Choosing the host's Default Display is exactly where this mode is valid,
+        // so the restriction must not leak into that picker.
+        val host = buildHostModePickerState(
+            modes = listOf(mode("headless_dongle", group = "host", sessionOverridable = false)),
+            title = "Default Display",
+        )
+
+        assertTrue(host.choices.single { it.id == "headless_dongle" }.enabled)
+    }
+
+    @Test
+    fun hostsThatPredateTheFlagKeepEveryModeSelectable() {
+        // The parser defaults sessionOverridable to true, so an older host behaves
+        // exactly as it does today rather than losing its whole catalog.
+        val game = buildGameModePickerState(
+            modes = listOf(mode("headless_stream"), mode("desktop_display")),
+            allowedModes = emptyList(),
+            playMode = "headless_stream",
+            hasExplicitOverride = false,
+            title = "Where It Runs",
+            hostDefaultLabel = "Host default",
+        )
+
+        assertTrue(game.choices.all { it.enabled })
     }
 }


### PR DESCRIPTION
## Summary

Nova offers Headless Dongle as a per-session choice in Play Setup. Polaris refuses it, launches the host default instead, and the stream comes up anyway, so nothing tells the user their pick was dropped.

Found while running the Polaris v1.3.10 mode matrix on real hardware: selecting Headless Dongle produced `session_runtime: path=headless_stream`.

## Why Polaris refuses it

`headless_dongle` swaps the host's primary output. That rearranges the machine's physical display arrangement, which is a host decision rather than something one client turns on for one launch. Polaris logged the refusal on its own side and said nothing to the client.

papi-ux/polaris#459 makes that rule visible: the served mode catalog now carries `session_overridable` next to `available`. They are different questions. A dongle swap is a perfectly good host default while still being something a client must not select for a single session.

## What changed here

The picker already had the shape for this. `NovaPlaySetupModeChoice` carries an `enabled` flag and a `detail` line documented as *"when unavailable, the host's reason it cannot be"*. It was never given anything to put there.

- `ModeOption` and `NovaPolarisModeUiState` carry `sessionOverridable`, parsed from `session_overridable` and **defaulting to true** so a host that predates the field behaves exactly as it does today rather than losing its whole catalog.
- The **per-session** picker disables a restricted mode and shows the reason. The AI recommendation will not land on one either.
- The **Every Game** picker is deliberately untouched: choosing the host's Default Display is precisely where these modes are valid, so the restriction must not leak into it.

## Verification

`./gradlew :app:testNonRoot_gameDebugUnitTest --tests "*NovaPlaySetupModePickerTest*"`

11 tests, 0 failures. Confirmed from the XML report that they actually ran rather than trusting the exit code, since a `--tests` filter can pass silently:

```
tests=11 failures=0 errors=0 skipped=0
```

Three are new:

- `perSessionPickerDisablesAModeTheHostWillNotTakeForOneSession`
- `hostDefaultPickerStillOffersIt`
- `hostsThatPredateTheFlagKeepEveryModeSelectable`

The eight pre-existing tests in that class still pass unchanged.

## Depends on

papi-ux/polaris#459 for the field. Until a host ships it, `sessionOverridable` defaults true and this changes nothing, so the two can land in either order.

## Seen but not fixed here

While testing I saw the Play Setup "What will happen" heading read **Private Stream** while Where It Runs read **Headless Dongle**. The label logic already handles that case explicitly, and my sighting was seconds after changing the host default and restarting Polaris mid-session, so it looks like a transient stale `playMode` against a freshly refreshed host label rather than a standing bug. Not reproducible cleanly, so it is reported rather than patched.
