### PR TITLE
feat(diagnostics): give Nova something worth reporting, and a way to send it

### DIFF
--- a/app/src/main/java/com/papi/nova/LimeLog.kt
+++ b/app/src/main/java/com/papi/nova/LimeLog.kt
@@ -3,6 +3,7 @@ package com.papi.nova
 import java.io.IOException
 import java.util.logging.FileHandler
 import java.util.logging.Logger
+import java.util.logging.SimpleFormatter
 
 object LimeLog {
     private val logger: Logger = Logger.getLogger(LimeLog::class.java.name)
@@ -26,5 +27,26 @@ object LimeLog {
     @Throws(IOException::class)
     fun setFileHandler(fileName: String) {
         logger.addHandler(FileHandler(fileName))
+    }
+
+    /**
+     * Log to a size-bounded, rotating file.
+     *
+     * The unbounded [setFileHandler] is kept for callers that want one file, but
+     * a handheld cannot afford a log that grows for the life of the install, and
+     * an unbounded log is also unattachable to a bug report. The default
+     * formatter here is XML, which no one reading a support report wants, so
+     * this uses the plain one.
+     *
+     * @param pathPrefix Base path; rotation suffixes are appended to it.
+     * @param maxBytes Size bound per file.
+     * @param fileCount How many rotated files to retain.
+     */
+    @JvmStatic
+    @Throws(IOException::class)
+    fun setRotatingFileHandler(pathPrefix: String, maxBytes: Int, fileCount: Int) {
+        val handler = FileHandler("$pathPrefix.%g", maxBytes, fileCount, true)
+        handler.formatter = SimpleFormatter()
+        logger.addHandler(handler)
     }
 }

--- a/app/src/main/java/com/papi/nova/NovaApplication.kt
+++ b/app/src/main/java/com/papi/nova/NovaApplication.kt
@@ -3,11 +3,17 @@ package com.papi.nova
 import android.app.Application
 import android.os.StrictMode
 import android.widget.Toast
+import com.papi.nova.diagnostics.NovaDiagnostics
 import com.papi.nova.profiles.ProfilesManager
 
 class NovaApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        // Diagnostics first: a crash during startup is exactly the one worth
+        // recording, and it would be missed if this were installed after the
+        // work below.
+        NovaDiagnostics.install(this, BuildConfig.VERSION_NAME)
+
         // Debug-only: surface main-thread IO and leaked resources in logcat. Installed before
         // the ProfilesManager load below so its synchronous disk read is observed too.
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -1880,6 +1880,7 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
         super.onResume()
         if (recreateForThemeChangeIfNeeded()) return
 
+        UiHelper.showCrashReportDialog(this)
         UiHelper.showDecoderCrashDialog(this)
         refreshProfileButton()
 

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -1404,6 +1404,37 @@ class PolarisApiClient @JvmOverloads constructor(
      * Probe the server for Polaris capabilities.
      * Returns null if the server is not a Polaris server (404) or unreachable.
      */
+    /**
+     * Post this device's half of a support report to the paired host.
+     *
+     * The host holds it alongside its own evidence so both halves land in one
+     * bundle. A streaming bug needs both, and a user should not have to export
+     * from two devices and keep the two matched.
+     *
+     * @param payload Already-redacted JSON body; see NovaSupportReport.hostPayload.
+     * @return true when the host accepted it. A host predating this endpoint
+     *         answers 404 and returns false, which is why the caller always has a
+     *         share-sheet fallback rather than treating this as the only route.
+     */
+    fun submitSupportReport(payload: String): Boolean {
+        return try {
+            val request = Request.Builder()
+                .url("$baseUrl/support/client-report")
+                .post(okhttp3.RequestBody.create("application/json".toMediaTypeOrNull(), payload))
+                .build()
+            executeWithTransientRetry(request).use { response ->
+                if (response.code != 200) {
+                    LimeLog.warning("Nova: host rejected the support report code=${response.code}")
+                    return false
+                }
+                true
+            }
+        } catch (e: Exception) {
+            LimeLog.warning("Nova: could not send the support report to the host: ${errorMessage(e)}")
+            false
+        }
+    }
+
     fun getCapabilities(): PolarisCapabilities? {
         return try {
             val request = Request.Builder().url("$baseUrl/capabilities").build()

--- a/app/src/main/java/com/papi/nova/diagnostics/CrashMarker.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/CrashMarker.kt
@@ -1,0 +1,93 @@
+package com.papi.nova.diagnostics
+
+/**
+ * What Nova knew about itself at the moment it died.
+ */
+data class CrashRecord(
+    val occurredAt: String,
+    val version: String,
+    val device: String,
+    val androidRelease: String,
+    val thread: String,
+    val stackTrace: String,
+)
+
+/**
+ * The on-disk crash marker, written as the process is going down and read back
+ * on the next launch.
+ *
+ * Nova had no persistent record of a crash at all. The decoder tombstone
+ * counted MediaCodec failures and nothing else, so an ordinary uncaught
+ * exception left the user with a system "app has stopped" dialog and left the
+ * host with nothing to correlate against.
+ *
+ * Format and parse are pure and symmetric so the round trip can be tested
+ * without staging a real crash on a device.
+ */
+object CrashMarker {
+    const val MAGIC = "nova-crash-v1"
+    const val FILE_NAME = "last_crash.txt"
+
+    /** Bound on what is retained, so a recursive stack cannot fill the device. */
+    const val MAX_STACK_TRACE_CHARS = 32 * 1024
+
+    private const val OCCURRED_AT = "occurred_at:"
+    private const val VERSION = "version:"
+    private const val DEVICE = "device:"
+    private const val ANDROID = "android:"
+    private const val THREAD = "thread:"
+    private const val STACK_TRACE = "stacktrace:"
+
+    @JvmStatic
+    fun format(record: CrashRecord): String {
+        // Everything is redacted on the way in rather than on the way out. The
+        // marker sits on disk until someone reads it, and an exception message
+        // is a very ordinary place for a token to end up.
+        val stack = DiagnosticsRedaction.redact(record.stackTrace).let {
+            if (it.length > MAX_STACK_TRACE_CHARS) it.take(MAX_STACK_TRACE_CHARS) + "\n[truncated]" else it
+        }
+        return buildString {
+            appendLine(MAGIC)
+            appendLine("$OCCURRED_AT ${single(record.occurredAt)}")
+            appendLine("$VERSION ${single(record.version)}")
+            appendLine("$DEVICE ${single(record.device)}")
+            appendLine("$ANDROID ${single(record.androidRelease)}")
+            appendLine("$THREAD ${single(record.thread)}")
+            appendLine(STACK_TRACE)
+            append(stack)
+        }
+    }
+
+    @JvmStatic
+    fun parse(text: String?): CrashRecord? {
+        if (text.isNullOrBlank()) return null
+        val lines = text.lines()
+        if (lines.firstOrNull()?.trim() != MAGIC) return null
+
+        val stackStart = lines.indexOfFirst { it.trim() == STACK_TRACE }
+        if (stackStart < 0) return null
+
+        val header = lines.subList(1, stackStart)
+        val stack = lines.subList(stackStart + 1, lines.size).joinToString("\n")
+
+        return CrashRecord(
+            occurredAt = field(header, OCCURRED_AT),
+            version = field(header, VERSION),
+            device = field(header, DEVICE),
+            androidRelease = field(header, ANDROID),
+            thread = field(header, THREAD),
+            stackTrace = stack,
+        )
+    }
+
+    /** Header values are one line each, so a newline in a value would corrupt the record. */
+    private fun single(value: String?): String =
+        (value ?: "").replace('\n', ' ').replace('\r', ' ').trim()
+
+    private fun field(header: List<String>, label: String): String =
+        header.firstOrNull { it.trimStart().startsWith(label) }
+            ?.trimStart()
+            ?.removePrefix(label)
+            ?.trim()
+            ?: ""
+}

--- a/app/src/main/java/com/papi/nova/diagnostics/DiagnosticsRedaction.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/DiagnosticsRedaction.kt
@@ -1,0 +1,58 @@
+package com.papi.nova.diagnostics
+
+/**
+ * Client-side redaction for anything Nova is about to hand to a human or a host.
+ *
+ * This deliberately mirrors the rules in the Polaris Web UI's diagnostics-export.js
+ * rather than trusting the host to clean up after the client. A report can leave
+ * this device by a route that never touches Polaris, such as the Android share
+ * sheet, so the guarantee has to hold here on its own.
+ *
+ * The sensitive word may be one segment of a longer identifier, because
+ * `auth_token=` and `api-key=` are the common shapes in a log line. The segment
+ * still has to be delimited, so ordinary words that merely contain one of these
+ * (keyboard, monkey) survive: over-redaction quietly destroys the diagnostics
+ * the report exists to carry.
+ */
+object DiagnosticsRedaction {
+    const val REDACTED = "[redacted]"
+
+    private val URL_CREDENTIAL = Regex(
+        """(https?://)([^\s/@:]+):([^\s/@]+)@""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val AUTH_HEADER = Regex(
+        """\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val COOKIE_HEADER = Regex(
+        """\b(cookie|set-cookie)(\s*[:=]\s*)[^\n;]+""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val SENSITIVE_ASSIGNMENT = Regex(
+        """\b((?:[\w.\-]*[._\-])?(?:password|token|secret|key|cookie|auth|credential)(?:[._\-][\w.\-]*)?)(\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;)}\]]+)""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Field names whose entire value is replaced, matching the host's rules. */
+    private val SENSITIVE_FIELD = Regex(
+        """(password|token|secret|key|cookie|auth|credential)""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    @JvmStatic
+    fun redact(value: String?): String {
+        if (value.isNullOrEmpty()) return ""
+        return value
+            .replace(URL_CREDENTIAL) { "${it.groupValues[1]}$REDACTED:$REDACTED@" }
+            .replace(AUTH_HEADER) { "${it.groupValues[1]} $REDACTED" }
+            .replace(COOKIE_HEADER) { "${it.groupValues[1]}${it.groupValues[2]}$REDACTED" }
+            .replace(SENSITIVE_ASSIGNMENT) { "${it.groupValues[1]}${it.groupValues[2]}$REDACTED" }
+    }
+
+    @JvmStatic
+    fun isSensitiveFieldName(name: String?): Boolean {
+        if (name.isNullOrEmpty()) return false
+        return SENSITIVE_FIELD.containsMatchIn(name)
+    }
+}

--- a/app/src/main/java/com/papi/nova/diagnostics/DiagnosticsRedaction.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/DiagnosticsRedaction.kt
@@ -3,56 +3,260 @@ package com.papi.nova.diagnostics
 /**
  * Client-side redaction for anything Nova is about to hand to a human or a host.
  *
- * This deliberately mirrors the rules in the Polaris Web UI's diagnostics-export.js
- * rather than trusting the host to clean up after the client. A report can leave
- * this device by a route that never touches Polaris, such as the Android share
- * sheet, so the guarantee has to hold here on its own.
+ * This mirrors the rules in the Polaris Web UI's diagnostics-export.js rather
+ * than trusting the host to clean up after the client, because a report can
+ * leave this device by a route that never touches Polaris, such as the Android
+ * share sheet. Two implementations in two languages can drift, so the tests here
+ * deliberately use the same cases as the host's.
  *
- * The sensitive word may be one segment of a longer identifier, because
- * `auth_token=` and `api-key=` are the common shapes in a log line. The segment
- * still has to be delimited, so ordinary words that merely contain one of these
- * (keyboard, monkey) survive: over-redaction quietly destroys the diagnostics
- * the report exists to carry.
+ * Three shapes of credential name all have to be caught, and the first version
+ * of this file caught only the first:
+ *
+ *  - separated:      auth_token=, api-key=, session.secret=
+ *  - camelCase:      apiKey=, authToken=, accessToken=
+ *  - run together:   apikey=, authtoken=, clientsecret=
+ *
+ * And ordinary words that merely contain one of these have to survive, or
+ * redaction quietly destroys the diagnostics a report exists to carry.
  */
 object DiagnosticsRedaction {
     const val REDACTED = "[redacted]"
 
-    private val URL_CREDENTIAL = Regex(
-        """(https?://)([^\s/@:]+):([^\s/@]+)@""",
-        RegexOption.IGNORE_CASE,
-    )
-    private val AUTH_HEADER = Regex(
-        """\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+""",
-        RegexOption.IGNORE_CASE,
-    )
-    private val COOKIE_HEADER = Regex(
-        """\b(cookie|set-cookie)(\s*[:=]\s*)[^\n;]+""",
-        RegexOption.IGNORE_CASE,
-    )
-    private val SENSITIVE_ASSIGNMENT = Regex(
-        """\b((?:[\w.\-]*[._\-])?(?:password|token|secret|key|cookie|auth|credential)(?:[._\-][\w.\-]*)?)(\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;)}\]]+)""",
-        RegexOption.IGNORE_CASE,
+    /** Words that mean "secret" wherever they appear as a whole segment. */
+    private val SENSITIVE_SEGMENT_WORDS = listOf(
+        "password", "passwd", "token", "secret", "cookie", "auth", "authorization", "credential",
     )
 
-    /** Field names whose entire value is replaced, matching the host's rules. */
-    private val SENSITIVE_FIELD = Regex(
-        """(password|token|secret|key|cookie|auth|credential)""",
-        RegexOption.IGNORE_CASE,
+    /**
+     * "key" is judged rather than matched. On its own it is a map key or a label
+     * far more often than a credential, and it counts only when something
+     * qualifies it and that qualifier comes first: apiKey is a credential,
+     * keyName names one.
+     */
+    private val QUALIFIED_ONLY_WORDS = listOf("key")
+
+    /**
+     * Qualifiers that make a run-together segment a credential name. `apikey` has
+     * no separator and no camelCase hump, and English gives no structural way to
+     * tell it from `monkey`: both are a prefix followed by "key". The list is
+     * explicit because the distinction is semantic. Polaris made the same call
+     * for the same string in its artwork request sanitiser.
+     */
+    private val CREDENTIAL_QUALIFIERS = listOf(
+        "api", "app", "access", "auth", "bearer", "client", "db", "master", "oauth",
+        "private", "public", "refresh", "secret", "session", "user",
     )
+
+    private val URL_CREDENTIAL = Regex("""(https?://)([^\s/@:]+):([^\s/@]+)@""", RegexOption.IGNORE_CASE)
+    private val AUTH_HEADER = Regex("""\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+""", RegexOption.IGNORE_CASE)
+    private val COOKIE_HEADER = Regex("""\b(cookie|set-cookie)(\s*[:=]\s*)[^\n;]+""", RegexOption.IGNORE_CASE)
+    private val AUTH_SCHEME_VALUE = Regex("""^(Bearer|Basic)$""", RegexOption.IGNORE_CASE)
+
+    /**
+     * A name immediately followed by a separator. The value is deliberately not
+     * part of this pattern: consuming it made an innocent pair swallow a
+     * sensitive one, and truncating it at a `]` left a stray bracket behind that
+     * accumulated on every pass.
+     *
+     * Which names are sensitive is decided by [isSensitiveIdentifier] and not by
+     * a second list encoded in a regex: two independent definitions is what let
+     * apiKey= leak on the host side while a field named apiKey was redacted.
+     *
+     * A closing delimiter may sit between the name and its separator, which is
+     * what every quoted JSON key looks like. Requiring the two to be adjacent
+     * meant {"api_key": "..."} was never recognised, and Nova parses API
+     * responses, so it meets real JSON more than the host does.
+     */
+    private val NAME_BEFORE_SEPARATOR = Regex("""\b([A-Za-z][\w.\-]*)["')\]]?\s*[:=]\s*""")
+
+    /**
+     * A value that is neither a quoted string nor a structure.
+     *
+     * Structures are measured by balancing rather than by pattern, because a
+     * regex cannot see where a nested object ends, and stopping early is worse
+     * than not matching at all: it replaces the opening fragment and leaves the
+     * secret behind, while reading as though the whole subtree was handled.
+     */
+    private val BARE_VALUE_AT_START = Regex("""^[^\s,;)}\]]+""")
+
+    private val STRUCTURE_CLOSERS = mapOf('{' to '}', '[' to ']')
+
+    /** Length of a quoted string starting at [start], or 0 if it never closes. */
+    private fun quotedExtent(source: String, start: Int): Int {
+        val quote = source[start]
+        var index = start + 1
+        while (index < source.length) {
+            if (source[index] == '\\') {
+                index += 2
+                continue
+            }
+            if (source[index] == quote) return index - start + 1
+            index += 1
+        }
+        return 0
+    }
+
+    /**
+     * Length of a balanced object or array starting at [start], or 0 if unbalanced.
+     *
+     * Quoted spans are skipped so a brace inside a string cannot unbalance it.
+     */
+    private fun structuredExtent(source: String, start: Int): Int {
+        val stack = ArrayDeque<Char>()
+        // Nullable rather than a sentinel character: a sentinel has to be a value
+        // that cannot appear in the text, and getting that wrong is silent.
+        var quote: Char? = null
+        var index = start
+
+        while (index < source.length) {
+            val character = source[index]
+            if (quote != null) {
+                if (character == '\\') {
+                    index += 2
+                    continue
+                }
+                if (character == quote) quote = null
+                index += 1
+                continue
+            }
+            when {
+                character == '"' || character == '\'' -> quote = character
+                STRUCTURE_CLOSERS.containsKey(character) -> stack.addLast(STRUCTURE_CLOSERS.getValue(character))
+                stack.isNotEmpty() && character == stack.last() -> {
+                    stack.removeLast()
+                    if (stack.isEmpty()) return index - start + 1
+                }
+            }
+            index += 1
+        }
+        return 0
+    }
+
+    /**
+     * The value that follows a separator, as text.
+     *
+     * A value that opens a quote or a structure and never closes it is taken to
+     * run to the end of the line. The usual cause is a truncated log line, where
+     * everything after the opener is still part of the value, and stopping at the
+     * first bare token would leave most of the secret in place. Over-redacting a
+     * malformed line is the safe direction.
+     */
+    private fun valueAt(source: String, start: Int): String {
+        if (start >= source.length) return ""
+        val first = source[start]
+        val opensSomething = first == '"' || first == '\'' || STRUCTURE_CLOSERS.containsKey(first)
+
+        if (opensSomething) {
+            val extent = if (first == '"' || first == '\'') {
+                quotedExtent(source, start)
+            } else {
+                structuredExtent(source, start)
+            }
+            if (extent > 0) return source.substring(start, start + extent)
+
+            val lineEnd = source.indexOf('\n', start)
+            return source.substring(start, if (lineEnd == -1) source.length else lineEnd)
+        }
+
+        return BARE_VALUE_AT_START.find(source.substring(start))?.value ?: ""
+    }
+
+    private fun identifierSegments(name: String?): List<String> =
+        (name ?: "")
+            .replace(Regex("""([a-z0-9])([A-Z])"""), "$1 $2")
+            .split(Regex("""[^A-Za-z0-9]+"""))
+            .filter { it.isNotEmpty() }
+            .map { it.lowercase() }
+
+    private fun segmentMatches(segment: String, words: List<String>): Boolean =
+        words.any { segment == it || segment == "${it}s" }
+
+    private fun isConcatenatedCredential(segment: String): Boolean =
+        (SENSITIVE_SEGMENT_WORDS + QUALIFIED_ONLY_WORDS).any { word ->
+            listOf(word, "${word}s").any { ending ->
+                segment.length > ending.length &&
+                    segment.endsWith(ending) &&
+                    CREDENTIAL_QUALIFIERS.contains(segment.dropLast(ending.length))
+            }
+        }
+
+    private fun segmentIsSensitive(segment: String): Boolean =
+        segmentMatches(segment, SENSITIVE_SEGMENT_WORDS) || isConcatenatedCredential(segment)
+
+    private fun isSensitiveIdentifier(name: String?, bareQualifiedCounts: Boolean): Boolean {
+        val segments = identifierSegments(name)
+        if (segments.isEmpty()) return false
+        if (segments.any(::segmentIsSensitive)) return true
+        if (bareQualifiedCounts && segments.size == 1) {
+            return segmentMatches(segments[0], QUALIFIED_ONLY_WORDS)
+        }
+        return segments.drop(1).any { segmentMatches(it, QUALIFIED_ONLY_WORDS) }
+    }
+
+    /**
+     * Redact every `name = value` pair whose name reads as a credential.
+     *
+     * Walks names without consuming their values, so an innocent pair cannot
+     * swallow a sensitive one that follows it: `Error: auth_token=abc` is the
+     * ordinary shape of a log line, and the credential has to still be visible
+     * to the scan after the label in front of it has been skipped.
+     *
+     * Leaving values unconsumed also makes this idempotent. Nova redacts before
+     * it posts a report and the host redacts again on export, so two passes over
+     * the same bytes is the normal path rather than an edge case, and a user
+     * should not be able to tell how many times it ran by counting brackets.
+     *
+     * Free text is also the one place a bare `key=` counts as a credential. In a
+     * structured payload the surrounding object says what a `key` field is; in a
+     * log line nothing does, and losing one diagnostic line costs far less than
+     * exporting a secret.
+     */
+    private fun redactAssignments(text: String): String {
+        val output = StringBuilder()
+        var cursor = 0
+        var searchFrom = 0
+
+        while (true) {
+            val match = NAME_BEFORE_SEPARATOR.find(text, searchFrom) ?: break
+            val label = match.groupValues[1]
+            val valueStart = match.range.last + 1
+            val value = valueAt(text, valueStart)
+
+            // Skipping without consuming is what lets the scan find a credential
+            // that sits inside an innocent pair's value.
+            if (value.isEmpty() ||
+                value == REDACTED ||
+                AUTH_SCHEME_VALUE.matches(value) ||
+                !isSensitiveIdentifier(label, true)
+            ) {
+                searchFrom = valueStart
+                continue
+            }
+
+            output.append(text, cursor, valueStart).append(REDACTED)
+            cursor = valueStart + value.length
+            searchFrom = cursor
+        }
+
+        return output.append(text, cursor, text.length).toString()
+    }
 
     @JvmStatic
     fun redact(value: String?): String {
         if (value.isNullOrEmpty()) return ""
-        return value
-            .replace(URL_CREDENTIAL) { "${it.groupValues[1]}$REDACTED:$REDACTED@" }
-            .replace(AUTH_HEADER) { "${it.groupValues[1]} $REDACTED" }
-            .replace(COOKIE_HEADER) { "${it.groupValues[1]}${it.groupValues[2]}$REDACTED" }
-            .replace(SENSITIVE_ASSIGNMENT) { "${it.groupValues[1]}${it.groupValues[2]}$REDACTED" }
+        return redactAssignments(
+            value
+                .replace(URL_CREDENTIAL) { "${it.groupValues[1]}$REDACTED:$REDACTED@" }
+                .replace(AUTH_HEADER) { "${it.groupValues[1]} $REDACTED" }
+                .replace(COOKIE_HEADER) { "${it.groupValues[1]}${it.groupValues[2]}$REDACTED" }
+        )
     }
 
+    /**
+     * Whether an object field should have its value replaced.
+     *
+     * A bare `key` is a label here, matching the host's rule for the same reason.
+     */
     @JvmStatic
-    fun isSensitiveFieldName(name: String?): Boolean {
-        if (name.isNullOrEmpty()) return false
-        return SENSITIVE_FIELD.containsMatchIn(name)
-    }
+    fun isSensitiveFieldName(name: String?): Boolean = isSensitiveIdentifier(name, false)
 }

--- a/app/src/main/java/com/papi/nova/diagnostics/NovaCrashHandler.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/NovaCrashHandler.kt
@@ -1,0 +1,60 @@
+package com.papi.nova.diagnostics
+
+import java.io.File
+
+/**
+ * Records an uncaught exception before the process goes down, then hands the
+ * crash back to whoever was handling it before.
+ *
+ * Delegating rather than swallowing matters: Android's own handler is what
+ * shows the user the crash dialog and reports to the platform. This only adds a
+ * durable local record so the next launch can offer to report it, and so a
+ * client-side crash has something a host bundle can be correlated against.
+ *
+ * Everything here is defensive. A failure while recording a crash must never
+ * replace the original crash, because the original one is the useful one.
+ */
+class NovaCrashHandler(
+    private val markerFile: File,
+    private val describe: () -> CrashContext,
+    private val previous: Thread.UncaughtExceptionHandler?,
+    private val clock: () -> String,
+) : Thread.UncaughtExceptionHandler {
+
+    override fun uncaughtException(thread: Thread, error: Throwable) {
+        try {
+            val context = describe()
+            val record = CrashRecord(
+                occurredAt = clock(),
+                version = context.version,
+                device = context.device,
+                androidRelease = context.androidRelease,
+                thread = thread.name ?: "",
+                stackTrace = stackTraceOf(error),
+            )
+            markerFile.parentFile?.mkdirs()
+            markerFile.writeText(CrashMarker.format(record))
+        } catch (ignored: Throwable) {
+            // Recording is best effort. Losing the marker is survivable; losing
+            // the platform's own crash handling is not.
+        } finally {
+            previous?.uncaughtException(thread, error)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun stackTraceOf(error: Throwable): String {
+            val writer = java.io.StringWriter()
+            java.io.PrintWriter(writer).use { error.printStackTrace(it) }
+            return writer.toString()
+        }
+    }
+}
+
+/** The device facts worth recording alongside a crash. */
+data class CrashContext(
+    val version: String,
+    val device: String,
+    val androidRelease: String,
+)

--- a/app/src/main/java/com/papi/nova/diagnostics/NovaDiagnostics.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/NovaDiagnostics.kt
@@ -1,0 +1,135 @@
+package com.papi.nova.diagnostics
+
+import android.content.Context
+import android.os.Build
+import com.papi.nova.LimeLog
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Wires Nova's local evidence: a bounded log file and a crash marker.
+ *
+ * Nova kept no log of its own. LimeLog wrote to java.util.logging with no file
+ * handler ever installed, so everything went to logcat and vanished, and a user
+ * reporting a bug had nothing to attach unless they owned a computer and knew
+ * about adb. A report with a stack trace and no log around it says what broke
+ * and not what led to it.
+ */
+object NovaDiagnostics {
+    /** Two files at this size is enough to hold a session without filling a handheld. */
+    const val LOG_MAX_BYTES = 512 * 1024
+    const val LOG_FILE_COUNT = 2
+    const val LOG_DIRECTORY = "diagnostics"
+    const val LOG_BASE_NAME = "nova.log"
+
+    private var installed = false
+
+    /**
+     * Install the log file and crash handler. Safe to call more than once.
+     *
+     * @param context Application context; its private files directory is used so
+     *                nothing here is world readable.
+     * @param version Version name to record against a crash.
+     */
+    @JvmStatic
+    @Synchronized
+    fun install(context: Context, version: String) {
+        if (installed) return
+        installed = true
+
+        val directory = diagnosticsDirectory(context)
+        try {
+            directory.mkdirs()
+            LimeLog.setRotatingFileHandler(
+                File(directory, LOG_BASE_NAME).path,
+                LOG_MAX_BYTES,
+                LOG_FILE_COUNT,
+            )
+        } catch (error: Throwable) {
+            // A device that will not give us a log file is not a reason to fail
+            // startup, and the crash handler below is still worth having.
+            LimeLog.warning("Diagnostics: could not open the local log file: ${error.message}")
+        }
+
+        val markerFile = crashMarkerFile(context)
+        Thread.setDefaultUncaughtExceptionHandler(
+            NovaCrashHandler(
+                markerFile = markerFile,
+                describe = {
+                    CrashContext(
+                        version = version,
+                        device = "${Build.MANUFACTURER} ${Build.MODEL}",
+                        androidRelease = Build.VERSION.RELEASE ?: "",
+                    )
+                },
+                previous = Thread.getDefaultUncaughtExceptionHandler(),
+                clock = { utcTimestamp() },
+            )
+        )
+    }
+
+    @JvmStatic
+    fun diagnosticsDirectory(context: Context): File = File(context.filesDir, LOG_DIRECTORY)
+
+    @JvmStatic
+    fun crashMarkerFile(context: Context): File =
+        File(diagnosticsDirectory(context), CrashMarker.FILE_NAME)
+
+    /**
+     * The crash recorded by the previous run, if there was one.
+     */
+    @JvmStatic
+    fun previousCrash(context: Context): CrashRecord? {
+        val file = crashMarkerFile(context)
+        return try {
+            if (!file.isFile) null else CrashMarker.parse(file.readText())
+        } catch (error: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Forget the recorded crash once the user has been offered it.
+     *
+     * Unlike the host, the marker is consumed here. Nova has no run-state to
+     * match it against, so leaving it in place would re-offer the same crash on
+     * every launch.
+     */
+    @JvmStatic
+    fun clearPreviousCrash(context: Context) {
+        try {
+            crashMarkerFile(context).delete()
+        } catch (ignored: Throwable) {
+            // Nothing useful to do; the prompt is already dismissed.
+        }
+    }
+
+    /**
+     * The current bounded log, redacted, for attaching to a report.
+     */
+    @JvmStatic
+    fun readLogTail(context: Context, maxChars: Int = LOG_MAX_BYTES): String {
+        val directory = diagnosticsDirectory(context)
+        val text = try {
+            directory.listFiles { file -> file.name.startsWith(LOG_BASE_NAME) }
+                ?.sortedByDescending { it.lastModified() }
+                ?.take(LOG_FILE_COUNT)
+                ?.joinToString("\n") { it.readText() }
+                ?: ""
+        } catch (error: Throwable) {
+            ""
+        }
+        val bounded = if (text.length > maxChars) text.takeLast(maxChars) else text
+        return DiagnosticsRedaction.redact(bounded)
+    }
+
+    @JvmStatic
+    fun utcTimestamp(): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+        format.timeZone = TimeZone.getTimeZone("UTC")
+        return format.format(Date())
+    }
+}

--- a/app/src/main/java/com/papi/nova/diagnostics/NovaSupportReport.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/NovaSupportReport.kt
@@ -1,5 +1,7 @@
 package com.papi.nova.diagnostics
 
+import org.json.JSONObject
+
 /**
  * The report a Nova user hands to someone who can fix the problem.
  *
@@ -67,6 +69,40 @@ object NovaSupportReport {
                 "the client saw."
         )
     }
+
+
+    /**
+     * The JSON body Polaris expects at /polaris/v1/support/client-report.
+     *
+     * Built here rather than at the call site so the field names live next to
+     * the text report that carries the same facts, and so redaction happens once
+     * on the way in. Field names match the host's parser; changing one without
+     * changing the other is silent on both sides, which is why the host treats a
+     * missing field as absent rather than fatal.
+     *
+     * Deliberately does not include an identity claim. The host attributes the
+     * report to the client certificate it was posted with, so anything this said
+     * about who it is would be ignored at best.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun hostPayload(
+        version: String,
+        device: String,
+        androidRelease: String,
+        occurredAt: String,
+        crash: CrashRecord? = null,
+        logTail: String = "",
+        userNotes: String = "",
+    ): String = JSONObject().apply {
+        put("nova_version", DiagnosticsRedaction.redact(version))
+        put("device", DiagnosticsRedaction.redact(device))
+        put("android_release", DiagnosticsRedaction.redact(androidRelease))
+        put("occurred_at", DiagnosticsRedaction.redact(occurredAt))
+        put("notes", DiagnosticsRedaction.redact(userNotes))
+        put("crash", if (crash == null) "" else DiagnosticsRedaction.redact(crash.stackTrace))
+        put("log_tail", DiagnosticsRedaction.redact(logTail))
+    }.toString()
 
     private fun clean(value: String?): String =
         DiagnosticsRedaction.redact(value).replace('\n', ' ').trim().ifEmpty { "unknown" }

--- a/app/src/main/java/com/papi/nova/diagnostics/NovaSupportReport.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/NovaSupportReport.kt
@@ -1,0 +1,73 @@
+package com.papi.nova.diagnostics
+
+/**
+ * The report a Nova user hands to someone who can fix the problem.
+ *
+ * Pure, so its shape and its redaction can be tested without a device. Every
+ * value that reaches it is redacted on the way in rather than trusting the
+ * caller, because this text leaves the device by routes Nova does not control.
+ */
+object NovaSupportReport {
+    const val KIND = "nova-support-report-v1"
+
+    @JvmStatic
+    @JvmOverloads
+    fun build(
+        generatedAt: String,
+        version: String,
+        device: String,
+        androidRelease: String,
+        crash: CrashRecord? = null,
+        logTail: String = "",
+        userNotes: String = "",
+        host: String = "",
+    ): String = buildString {
+        appendLine("# Nova support report")
+        appendLine()
+        appendLine("> Generated on the device. Nothing was sent automatically.")
+        appendLine()
+        appendLine("- Kind: $KIND")
+        appendLine("- Generated: ${clean(generatedAt)}")
+        appendLine("- Nova version: ${clean(version)}")
+        appendLine("- Device: ${clean(device)}")
+        appendLine("- Android: ${clean(androidRelease)}")
+        if (host.isNotBlank()) appendLine("- Paired host: ${clean(host)}")
+
+        appendLine()
+        appendLine("## What went wrong")
+        appendLine(if (userNotes.isBlank()) "Not provided." else DiagnosticsRedaction.redact(userNotes))
+
+        if (crash != null) {
+            appendLine()
+            appendLine("## Last crash")
+            appendLine("- Occurred: ${clean(crash.occurredAt)}")
+            appendLine("- Thread: ${clean(crash.thread)}")
+            appendLine("- Version that crashed: ${clean(crash.version)}")
+            appendLine()
+            appendLine("```")
+            appendLine(DiagnosticsRedaction.redact(crash.stackTrace).trimEnd())
+            appendLine("```")
+        }
+
+        appendLine()
+        appendLine("## Recent Nova log")
+        if (logTail.isBlank()) {
+            appendLine("No local log was available.")
+        } else {
+            appendLine("```")
+            appendLine(DiagnosticsRedaction.redact(logTail).trimEnd())
+            appendLine("```")
+        }
+
+        appendLine()
+        appendLine("## Host side")
+        appendLine(
+            "Export the Polaris support bundle from the host's Troubleshooting screen and attach it " +
+                "too. The host half is what says why a stream looked wrong; this half only says what " +
+                "the client saw."
+        )
+    }
+
+    private fun clean(value: String?): String =
+        DiagnosticsRedaction.redact(value).replace('\n', ' ').trim().ifEmpty { "unknown" }
+}

--- a/app/src/main/java/com/papi/nova/diagnostics/SupportReportSharing.kt
+++ b/app/src/main/java/com/papi/nova/diagnostics/SupportReportSharing.kt
@@ -1,0 +1,67 @@
+package com.papi.nova.diagnostics
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.FileProvider
+import com.papi.nova.LimeLog
+import java.io.File
+
+/**
+ * Hands a support report to the user, and only to the user.
+ *
+ * The report is written into the app's cache and offered through the system
+ * share sheet, so the destination is always the user's choice. Nova never picks
+ * a recipient, which is what keeps this a handoff rather than telemetry.
+ */
+object SupportReportSharing {
+    const val REPORT_FILE_NAME = "nova-support-report.md"
+    const val MIME_TYPE = "text/markdown"
+
+    /**
+     * Build the current report text for this device.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun buildReport(activity: Activity, version: String, userNotes: String = ""): String =
+        NovaSupportReport.build(
+            generatedAt = NovaDiagnostics.utcTimestamp(),
+            version = version,
+            device = "${Build.MANUFACTURER} ${Build.MODEL}",
+            androidRelease = Build.VERSION.RELEASE ?: "",
+            crash = NovaDiagnostics.previousCrash(activity),
+            logTail = NovaDiagnostics.readLogTail(activity),
+            userNotes = userNotes,
+        )
+
+    /**
+     * Write the report and open the share sheet.
+     *
+     * @return true when a chooser was launched.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun share(activity: Activity, version: String, userNotes: String = ""): Boolean {
+        return try {
+            val file = File(activity.cacheDir, REPORT_FILE_NAME)
+            file.writeText(buildReport(activity, version, userNotes))
+
+            val uri = FileProvider.getUriForFile(
+                activity,
+                "${activity.packageName}.fileprovider",
+                file,
+            )
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = MIME_TYPE
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_SUBJECT, "Nova support report")
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            activity.startActivity(Intent.createChooser(intent, "Send Nova support report"))
+            true
+        } catch (error: Throwable) {
+            LimeLog.warning("Diagnostics: could not share the support report: ${error.message}")
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -202,6 +202,10 @@ class StreamSettings : NovaActivity() {
         when (definition.key) {
             "nova_app_version" -> Unit
             "pref_debug_info" -> startActivity(Intent(this, DebugInfoActivity::class.java))
+            "nova_report_problem" -> com.papi.nova.diagnostics.SupportReportSharing.share(
+                this,
+                com.papi.nova.BuildConfig.VERSION_NAME,
+            )
             "option_software_release" -> checkForNovaUpdate()
             "option_follow_update" -> HelpLauncher.launchUrl(this, getString(R.string.obtainium_app_url))
             else -> {
@@ -1081,6 +1085,16 @@ class StreamSettings : NovaActivity() {
             findPreference<Preference>("pref_debug_info")?.setOnPreferenceClickListener {
                 val intent = Intent(requireActivity(), DebugInfoActivity::class.java)
                 requireActivity().startActivity(intent)
+                false
+            }
+
+            // Reachable at any time rather than only after a crash, because the
+            // failure worth reporting is often one where nothing crashed at all.
+            findPreference<Preference>("nova_report_problem")?.setOnPreferenceClickListener {
+                com.papi.nova.diagnostics.SupportReportSharing.share(
+                    requireActivity(),
+                    com.papi.nova.BuildConfig.VERSION_NAME,
+                )
                 false
             }
 

--- a/app/src/main/java/com/papi/nova/utils/HelpLauncher.kt
+++ b/app/src/main/java/com/papi/nova/utils/HelpLauncher.kt
@@ -47,7 +47,7 @@ object HelpLauncher {
 
     @JvmStatic
     fun launchTroubleshooting(context: Context) {
-        launchUrl(context, "https://github.com/moonlight-stream/moonlight-docs/wiki/Troubleshooting")
+        launchUrl(context, "https://papi-ux.com/docs/troubleshooting/")
     }
 
     @JvmStatic

--- a/app/src/main/java/com/papi/nova/utils/UiHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/UiHelper.kt
@@ -204,6 +204,36 @@ object UiHelper {
         }
     }
 
+    /**
+     * Offer the crash Nova recorded last time it went down.
+     *
+     * Separate from the decoder tombstone below, which only ever counted
+     * MediaCodec failures. An ordinary uncaught exception left the user with the
+     * system's "app has stopped" dialog and left Nova with nothing to report.
+     *
+     * The marker is consumed whether or not the user sends it, so a single crash
+     * is offered once rather than on every launch.
+     */
+    @JvmStatic
+    fun showCrashReportDialog(activity: Activity) {
+        val crash = com.papi.nova.diagnostics.NovaDiagnostics.previousCrash(activity) ?: return
+        com.papi.nova.diagnostics.NovaDiagnostics.clearPreviousCrash(activity)
+
+        Dialog.displayDialog(
+            activity,
+            activity.resources.getString(R.string.title_crash_report),
+            activity.resources.getString(R.string.message_crash_report, crash.occurredAt),
+            false,
+            activity.resources.getString(R.string.action_send_crash_report),
+            Runnable {
+                com.papi.nova.diagnostics.SupportReportSharing.share(
+                    activity,
+                    com.papi.nova.BuildConfig.VERSION_NAME,
+                )
+            },
+        )
+    }
+
     @JvmStatic
     fun showDecoderCrashDialog(activity: Activity) {
         val prefs = activity.getSharedPreferences("DecoderTombstone", 0)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,6 +566,9 @@
     <string name="error_404">GFE returned an HTTP 404 error. Make sure your PC is running a supported GPU.
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
+    <string name="title_crash_report">Nova stopped unexpectedly</string>
+    <string name="message_crash_report">Nova recorded what happened when it stopped on %1$s. You can send that report now, or dismiss this and send it later from Settings.</string>
+    <string name="action_send_crash_report">Send report</string>
     <string name="title_decoding_error">Video Decoder Crashed</string>
     <string name="message_decoding_error">Nova has crashed due to an incompatibility with this device\'s video decoder. Try adjusting the streaming settings if the crashes continue.</string>
     <string name="title_decoding_reset">Video Settings Reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,6 +566,8 @@
     <string name="error_404">GFE returned an HTTP 404 error. Make sure your PC is running a supported GPU.
 	    Using remote desktop software can also cause this error. Try rebooting your machine or reinstalling GFE.
     </string>
+    <string name="title_report_problem">Report a problem</string>
+    <string name="summary_report_problem">Build a redacted report of what Nova saw and choose where to send it. Nothing is sent until you pick a destination.</string>
     <string name="title_crash_report">Nova stopped unexpectedly</string>
     <string name="message_crash_report">Nova recorded what happened when it stopped on %1$s. You can send that report now, or dismiss this and send it later from Settings.</string>
     <string name="action_send_crash_report">Send report</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -957,6 +957,11 @@
             android:title="@string/title_import_special_button"
             app:iconSpaceReserved="false" />
         <Preference
+            android:key="nova_report_problem"
+            android:summary="@string/summary_report_problem"
+            android:title="@string/title_report_problem"
+            app:iconSpaceReserved="false" />
+        <Preference
             android:key="pref_debug_info"
             android:summary="@string/summary_debug_info"
             android:title="@string/title_debug_info"

--- a/app/src/test/java/com/papi/nova/diagnostics/CrashEvidenceTest.kt
+++ b/app/src/test/java/com/papi/nova/diagnostics/CrashEvidenceTest.kt
@@ -1,0 +1,189 @@
+package com.papi.nova.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class DiagnosticsRedactionTest {
+
+    @Test
+    fun redactsCredentialsWhoseNameCarriesAPrefix() {
+        // The host had this exact gap: anchoring on a word boundary matched
+        // token= and missed auth_token=, and prefixed names are the common case.
+        val redacted = DiagnosticsRedaction.redact(
+            "auth_token=hunter2 api-key=abc123 session.secret=xyz789 password=\"pw\""
+        )
+
+        assertFalse(redacted.contains("hunter2"))
+        assertFalse(redacted.contains("abc123"))
+        assertFalse(redacted.contains("xyz789"))
+        assertFalse(redacted.contains("pw"))
+        assertTrue(redacted.contains("auth_token=${DiagnosticsRedaction.REDACTED}"))
+    }
+
+    @Test
+    fun leavesOrdinaryWordsThatMerelyContainAKeywordAlone() {
+        // Over-redaction destroys the diagnostics the report exists to carry.
+        val redacted = DiagnosticsRedaction.redact("keyboard=us monkey=banana bitrate=45000 fps=120")
+
+        assertEquals("keyboard=us monkey=banana bitrate=45000 fps=120", redacted)
+    }
+
+    @Test
+    fun redactsAuthHeadersCookiesAndUrlCredentials() {
+        assertFalse(DiagnosticsRedaction.redact("Authorization: Bearer ey.secret").contains("ey.secret"))
+        assertFalse(DiagnosticsRedaction.redact("Cookie: sessionid=abc123").contains("abc123"))
+        assertFalse(DiagnosticsRedaction.redact("https://user:pw@host/path").contains("pw@"))
+    }
+
+    @Test
+    fun toleratesNullAndEmptyInput() {
+        assertEquals("", DiagnosticsRedaction.redact(null))
+        assertEquals("", DiagnosticsRedaction.redact(""))
+    }
+
+    @Test
+    fun recognisesSensitiveFieldNames() {
+        assertTrue(DiagnosticsRedaction.isSensitiveFieldName("api_token"))
+        assertTrue(DiagnosticsRedaction.isSensitiveFieldName("Password"))
+        assertFalse(DiagnosticsRedaction.isSensitiveFieldName("bitrate"))
+        assertFalse(DiagnosticsRedaction.isSensitiveFieldName(null))
+    }
+}
+
+class CrashMarkerTest {
+
+    private fun record(stack: String = "java.lang.IllegalStateException: boom\n\tat com.papi.nova.Game.run(Game.kt:1)") =
+        CrashRecord(
+            occurredAt = "2026-08-17T10:00:00Z",
+            version = "1.1.3",
+            device = "Retroid Pocket 6",
+            androidRelease = "13",
+            thread = "main",
+            stackTrace = stack,
+        )
+
+    @Test
+    fun roundTripsARecord() {
+        val parsed = CrashMarker.parse(CrashMarker.format(record()))
+
+        assertNotNull(parsed)
+        assertEquals("2026-08-17T10:00:00Z", parsed!!.occurredAt)
+        assertEquals("1.1.3", parsed.version)
+        assertEquals("Retroid Pocket 6", parsed.device)
+        assertEquals("13", parsed.androidRelease)
+        assertEquals("main", parsed.thread)
+        assertTrue(parsed.stackTrace.contains("IllegalStateException"))
+        assertTrue(parsed.stackTrace.contains("at com.papi.nova.Game.run"))
+    }
+
+    @Test
+    fun redactsSecretsCarriedInAnExceptionMessage() {
+        // An exception message is a very ordinary place for a token to end up,
+        // and the marker sits on disk until someone reads it.
+        val formatted = CrashMarker.format(
+            record("java.io.IOException: POST failed auth_token=hunter2\n\tat Http.send(Http.kt:9)")
+        )
+
+        assertFalse(formatted.contains("hunter2"))
+        assertTrue(formatted.contains(DiagnosticsRedaction.REDACTED))
+    }
+
+    @Test
+    fun boundsAStackTraceThatWillNotStop() {
+        val runaway = "at com.papi.nova.Loop.spin(Loop.kt:1)\n".repeat(20000)
+
+        val formatted = CrashMarker.format(record(runaway))
+
+        assertTrue(formatted.length < CrashMarker.MAX_STACK_TRACE_CHARS + 1024)
+        assertTrue(formatted.contains("[truncated]"))
+    }
+
+    @Test
+    fun keepsAMultiLineValueFromCorruptingTheHeader() {
+        val parsed = CrashMarker.parse(
+            CrashMarker.format(record().copy(device = "Weird\nDevice"))
+        )
+
+        assertNotNull(parsed)
+        assertEquals("Weird Device", parsed!!.device)
+        assertTrue(parsed.stackTrace.contains("IllegalStateException"))
+    }
+
+    @Test
+    fun rejectsAnythingThatIsNotOurMarker() {
+        assertNull(CrashMarker.parse(null))
+        assertNull(CrashMarker.parse(""))
+        assertNull(CrashMarker.parse("some other tool's crash file\nstacktrace:\nboom"))
+        assertNull(CrashMarker.parse("${CrashMarker.MAGIC}\nversion: 1.0"))
+    }
+}
+
+class NovaCrashHandlerTest {
+
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    private fun context() = CrashContext(version = "1.1.3", device = "RP6", androidRelease = "13")
+
+    @Test
+    fun writesAMarkerAndStillDelegatesToThePlatform() {
+        val marker = File(folder.newFolder(), "last_crash.txt")
+        var delegated = false
+        val handler = NovaCrashHandler(
+            markerFile = marker,
+            describe = { context() },
+            previous = { _, _ -> delegated = true },
+            clock = { "2026-08-17T10:00:00Z" },
+        )
+
+        handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+        // Both halves matter: losing the marker costs a report, but swallowing
+        // the crash costs the user their crash dialog and the platform its report.
+        assertTrue(marker.isFile)
+        assertTrue(delegated)
+        val parsed = CrashMarker.parse(marker.readText())
+        assertNotNull(parsed)
+        assertTrue(parsed!!.stackTrace.contains("boom"))
+        assertEquals("1.1.3", parsed.version)
+    }
+
+    @Test
+    fun stillDelegatesWhenTheMarkerCannotBeWritten() {
+        // A failure while recording a crash must never replace the crash.
+        val unwritable = File(folder.newFile("occupied"), "nested/last_crash.txt")
+        var delegated = false
+        val handler = NovaCrashHandler(
+            markerFile = unwritable,
+            describe = { throw IllegalStateException("device lookup exploded") },
+            previous = { _, _ -> delegated = true },
+            clock = { "2026-08-17T10:00:00Z" },
+        )
+
+        handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+        assertTrue(delegated)
+    }
+
+    @Test
+    fun survivesHavingNoPreviousHandler() {
+        val marker = File(folder.newFolder(), "last_crash.txt")
+        val handler = NovaCrashHandler(
+            markerFile = marker,
+            describe = { context() },
+            previous = null,
+            clock = { "2026-08-17T10:00:00Z" },
+        )
+
+        handler.uncaughtException(Thread.currentThread(), IllegalStateException("boom"))
+
+        assertTrue(marker.isFile)
+    }
+}

--- a/app/src/test/java/com/papi/nova/diagnostics/CrashEvidenceTest.kt
+++ b/app/src/test/java/com/papi/nova/diagnostics/CrashEvidenceTest.kt
@@ -187,3 +187,149 @@ class NovaCrashHandlerTest {
         assertTrue(marker.isFile)
     }
 }
+
+class DiagnosticsRedactionParityTest {
+
+    // The same cases the host's suite uses, so the two implementations are held
+    // to one standard rather than each to its own.
+
+    @Test
+    fun redactsSeparatedCamelCaseAndRunTogetherNames() {
+        val redacted = DiagnosticsRedaction.redact(
+            "auth_token=aaa1 api-key=bbb2 apiKey=ccc3 authToken=ddd4 apikey=eee5 clientsecret=fff6 credentials=ggg7"
+        )
+
+        for (leaked in listOf("aaa1", "bbb2", "ccc3", "ddd4", "eee5", "fff6", "ggg7")) {
+            assertFalse(leaked, redacted.contains(leaked))
+        }
+    }
+
+    @Test
+    fun leavesDiagnosticsAlone() {
+        val survives = "keyboard=us monkey=banana turnkey=yes capture_path=dmabuf packet_loss=2.5 bitrate=45000"
+
+        assertEquals(survives, DiagnosticsRedaction.redact(survives))
+    }
+
+    @Test
+    fun keepsTheAuthSchemeWhileRedactingItsCredential() {
+        val redacted = DiagnosticsRedaction.redact("Authorization: Bearer ey.secret.value")
+
+        assertTrue(redacted.contains("Bearer ${DiagnosticsRedaction.REDACTED}"))
+        assertFalse(redacted.contains("ey.secret.value"))
+    }
+
+    @Test
+    fun treatsBareKeyAsALabelInFieldsAndACredentialInText() {
+        assertFalse(DiagnosticsRedaction.isSensitiveFieldName("key"))
+        assertFalse(DiagnosticsRedaction.redact("key=barevalue").contains("barevalue"))
+    }
+
+    @Test
+    fun redactsACredentialThatFollowsAnInnocentLabel() {
+        // The ordinary shape of a log line is "Something: detail". Matching the
+        // outer pair and stopping consumed the credential as someone else's value.
+        val redacted = DiagnosticsRedaction.redact(
+            "java.io.IOException: auth_token=hunter2\nError at Foo.bar: apikey=abc123\na: b: c: token=deep"
+        )
+
+        for (leaked in listOf("hunter2", "abc123", "deep")) {
+            assertFalse(leaked, redacted.contains(leaked))
+        }
+    }
+
+    @Test
+    fun redactsACredentialBehindAQuotedJsonKey() {
+        // Nova parses API responses, so it meets real JSON more than the host
+        // does. JSON always quotes its keys, and requiring the name to reach its
+        // separator directly missed every one of them.
+        val redacted = DiagnosticsRedaction.redact(
+            "{\"api_key\": \"abc123\"}\n{'apiKey': 'x9'}\n{\"auth_token\":\"t1\"}\n(client_secret): cs9"
+        )
+
+        for (leaked in listOf("abc123", "x9", "t1", "cs9")) {
+            assertFalse(leaked, redacted.contains(leaked))
+        }
+    }
+
+    @Test
+    fun redactsASensitiveNameWhoseValueIsAStructure() {
+        // Stopping early is worse than not matching: it leaves the secret behind
+        // while "auth": [redacted] reads as though the subtree was handled.
+        assertEquals(
+            "{\"auth\": ${DiagnosticsRedaction.REDACTED}}",
+            DiagnosticsRedaction.redact("{\"auth\": {\"api_key\": \"abc123\"}}")
+        )
+        assertFalse(DiagnosticsRedaction.redact("{\"cfg\": {\"auth\": {\"api_key\": \"x9\"}}}").contains("x9"))
+        assertEquals(
+            "{\"tokens\": ${DiagnosticsRedaction.REDACTED}}",
+            DiagnosticsRedaction.redact("{\"tokens\": [\"t1\", \"t2\"]}")
+        )
+    }
+
+    @Test
+    fun stillReachesACredentialNestedUnderAnInnocentName() {
+        assertEquals(
+            "{\"cfg\": {\"api_key\": ${DiagnosticsRedaction.REDACTED}}}",
+            DiagnosticsRedaction.redact("{\"cfg\": {\"api_key\": \"x\"}}")
+        )
+    }
+
+    @Test
+    fun isNotConfusedByABraceInsideAQuotedString() {
+        assertEquals(
+            "{\"auth\": ${DiagnosticsRedaction.REDACTED}}",
+            DiagnosticsRedaction.redact("{\"auth\": {\"note\": \"a } brace\", \"api_key\": \"k1\"}}")
+        )
+    }
+
+    @Test
+    fun redactsToEndOfLineWhenAStructureNeverCloses() {
+        // Degenerate input must not become a reason to leave a secret alone.
+        assertFalse(DiagnosticsRedaction.redact("api_key={\"a\": \"b\"").contains("\"b\""))
+        assertEquals("token=${DiagnosticsRedaction.REDACTED}", DiagnosticsRedaction.redact("token=["))
+    }
+
+    @Test
+    fun leavesInnocentQuotedKeysAlone() {
+        val survives = "{\"level\": \"info\", \"capture_path\": \"dmabuf\", \"keyName\": \"readable\"}"
+
+        assertEquals(survives, DiagnosticsRedaction.redact(survives))
+    }
+
+    @Test
+    fun isIdempotentAcrossRepeatedPasses() {
+        // Nova redacts before it posts and the host redacts again on export, so
+        // two passes over the same bytes is the normal path for a real report.
+        var text = "Warning: auth_token=hunter2 apiKey=abc123"
+        val passes = mutableListOf<String>()
+        repeat(5) {
+            text = DiagnosticsRedaction.redact(text)
+            passes.add(text)
+        }
+
+        assertEquals(1, passes.toSet().size)
+        assertFalse(passes[0].contains("hunter2"))
+        assertFalse(passes[0].contains("]]"))
+    }
+
+    @Test
+    fun capturesABracketedValueWhole() {
+        assertEquals("token=${DiagnosticsRedaction.REDACTED}", DiagnosticsRedaction.redact("token=[abc]"))
+        assertEquals("note=[abc]", DiagnosticsRedaction.redact("note=[abc]"))
+    }
+
+    @Test
+    fun leavesAnInnocentPairIntact() {
+        val survives = "Info: capture_path=dmabuf\nlevel: info"
+
+        assertEquals(survives, DiagnosticsRedaction.redact(survives))
+    }
+
+    @Test
+    fun doesNotTreatKeyAsACredentialWhenItLeadsTheName() {
+        assertFalse(DiagnosticsRedaction.isSensitiveFieldName("keyName"))
+        assertTrue(DiagnosticsRedaction.isSensitiveFieldName("apiKey"))
+        assertTrue(DiagnosticsRedaction.isSensitiveFieldName("publicKey"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/diagnostics/NovaHostPayloadTest.kt
+++ b/app/src/test/java/com/papi/nova/diagnostics/NovaHostPayloadTest.kt
@@ -1,0 +1,84 @@
+package com.papi.nova.diagnostics
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NovaHostPayloadTest {
+
+    private val crash = CrashRecord(
+        occurredAt = "2026-08-17T10:00:00Z",
+        version = "1.1.3",
+        device = "Retroid Pocket 6",
+        androidRelease = "13",
+        thread = "main",
+        stackTrace = "java.lang.IllegalStateException: boom",
+    )
+
+    private fun payload(
+        crash: CrashRecord? = null,
+        logTail: String = "",
+        userNotes: String = "",
+    ) = JSONObject(
+        NovaSupportReport.hostPayload(
+            version = "1.1.3",
+            device = "Retroid Pocket 6",
+            androidRelease = "13",
+            occurredAt = "2026-08-17T11:00:00Z",
+            crash = crash,
+            logTail = logTail,
+            userNotes = userNotes,
+        )
+    )
+
+    @Test
+    fun usesTheFieldNamesTheHostParses() {
+        // These names are the contract with client_support_report.cpp. A rename on
+        // either side is silent, so this test is the record of what they are.
+        val body = payload(crash = crash, logTail = "line", userNotes = "froze")
+
+        for (field in listOf("nova_version", "device", "android_release", "occurred_at", "notes", "crash", "log_tail")) {
+            assertTrue(field, body.has(field))
+        }
+        assertEquals("1.1.3", body.getString("nova_version"))
+        assertEquals("Retroid Pocket 6", body.getString("device"))
+    }
+
+    @Test
+    fun claimsNoIdentity() {
+        // The host attributes a report to the client certificate it arrived on, so
+        // an identity claim here would be ignored at best and misleading at worst.
+        val body = payload(crash = crash)
+
+        assertFalse(body.has("client_id"))
+    }
+
+    @Test
+    fun redactsEveryFieldOnTheWayIn() {
+        val body = payload(
+            crash = crash.copy(stackTrace = "java.io.IOException: auth_token=hunter2"),
+            logTail = "POST apikey=abc123",
+            userNotes = "my password=letmein broke",
+        )
+
+        val whole = body.toString()
+        assertFalse(whole.contains("hunter2"))
+        assertFalse(whole.contains("abc123"))
+        assertFalse(whole.contains("letmein"))
+    }
+
+    @Test
+    fun sendsAnEmptyCrashFieldRatherThanOmittingIt() {
+        // The host treats a missing field as absent, but an explicit empty string
+        // distinguishes "no crash" from "this client does not send crashes".
+        val body = payload(crash = null)
+
+        assertTrue(body.has("crash"))
+        assertEquals("", body.getString("crash"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/diagnostics/NovaSupportReportTest.kt
+++ b/app/src/test/java/com/papi/nova/diagnostics/NovaSupportReportTest.kt
@@ -1,0 +1,77 @@
+package com.papi.nova.diagnostics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovaSupportReportTest {
+
+    private val crash = CrashRecord(
+        occurredAt = "2026-08-17T10:00:00Z",
+        version = "1.1.3",
+        device = "Retroid Pocket 6",
+        androidRelease = "13",
+        thread = "main",
+        stackTrace = "java.lang.IllegalStateException: boom\n\tat com.papi.nova.Game.run(Game.kt:1)",
+    )
+
+    private fun report(
+        crash: CrashRecord? = null,
+        logTail: String = "",
+        userNotes: String = "",
+    ) = NovaSupportReport.build(
+        generatedAt = "2026-08-17T11:00:00Z",
+        version = "1.1.3",
+        device = "Retroid Pocket 6",
+        androidRelease = "13",
+        crash = crash,
+        logTail = logTail,
+        userNotes = userNotes,
+    )
+
+    @Test
+    fun statesPlainlyThatNothingWasSent() {
+        // The user has to be able to see that this is a handoff and not telemetry.
+        assertTrue(report().contains("Nothing was sent automatically"))
+    }
+
+    @Test
+    fun carriesTheCrashAndItsStackTrace() {
+        val text = report(crash = crash)
+
+        assertTrue(text.contains("## Last crash"))
+        assertTrue(text.contains("IllegalStateException"))
+        assertTrue(text.contains("at com.papi.nova.Game.run"))
+    }
+
+    @Test
+    fun leavesTheCrashSectionOutWhenThereWasNoCrash() {
+        assertFalse(report().contains("## Last crash"))
+    }
+
+    @Test
+    fun redactsSecretsFromEveryInput() {
+        val text = report(
+            crash = crash.copy(stackTrace = "java.io.IOException: auth_token=hunter2"),
+            logTail = "POST /api api_key=abc123",
+            userNotes = "my password=letmein stopped working",
+        )
+
+        assertFalse(text.contains("hunter2"))
+        assertFalse(text.contains("abc123"))
+        assertFalse(text.contains("letmein"))
+        assertTrue(text.contains(DiagnosticsRedaction.REDACTED))
+    }
+
+    @Test
+    fun saysSoWhenThereIsNoLocalLog() {
+        assertTrue(report().contains("No local log was available."))
+    }
+
+    @Test
+    fun tellsTheUserTheHostHalfIsAlsoNeeded() {
+        // A client-only report is exactly the shape that produces a follow-up
+        // question instead of a fix.
+        assertTrue(report().contains("Polaris support bundle"))
+    }
+}


### PR DESCRIPTION
## Summary

Nova kept no record of anything.

`LimeLog` wrote to `java.util.logging` with **no file handler ever installed**, so every line went to logcat and vanished. The only crash tracking in the app was the decoder tombstone, which counts MediaCodec failures and nothing else. An ordinary uncaught exception gave the user the system's "app has stopped" dialog, gave Nova nothing to report, and gave the host nothing to correlate a bad session against.

A user who wanted to help could not, unless they owned a computer and knew about `adb`.

Three commits: the local evidence, sending it to the paired host, and a way to report when nothing crashed at all.

## Local evidence

A bounded rotating log (two files, 512 KB each, app-private) and a crash marker written as the process goes down.

**The crash handler delegates to whatever handler was installed before it.** That is the important half. Recording the crash is best effort and losing the marker is survivable; swallowing the crash would cost the user their crash dialog and the platform its own report. The recording is wrapped so that a failure while recording can never replace the crash being recorded, and a test pins that a `describe` callback which throws still results in delegation.

The marker is **consumed on read**, unlike the host's, which matches by `run_id`. Nova has no run-state to match against, so leaving it would re-offer the same crash on every launch. It is offered once, on the next start, through the same dialog path the decoder tombstone already used.

## Sending it to the host

Nova posts its half to the paired host's `/polaris/v1/support/client-report`, which holds it alongside its own evidence so both land in one bundle.

The payload carries **no identity claim on purpose**: the host attributes a report to the client certificate it arrived on, so anything Nova said about who it is would be ignored at best.

Nova does **not** feature-detect for this. A host predating the endpoint answers 404 and submission returns false, and the share sheet is the fallback. Attempting and falling back reaches the same outcome with fewer moving parts and works against any host with no capability plumbing on either side.

## Redaction is ported, not assumed

A report can leave this device by a route Polaris never sees, such as the Android share sheet, so the guarantee has to hold here on its own.

Writing it a second time in a second language reproduced **every** defect the host copy had before it was fixed, which is worth stating plainly. It now mirrors the corrected rules: separated, camelCase and run-together credential names all redact; plurals and `authorization` are caught; a bare `key` is a label in a structured field and a credential in raw log text; ordinary words that merely contain a keyword survive; an innocent pair does not swallow a sensitive one inside its value; a sensitive name whose value is an object loses the whole object; and redaction is idempotent, which matters because Nova redacts before posting and the host redacts again on export, so two passes over the same bytes is the normal path.

**The parity tests deliberately reuse the host suite's cases.** Two implementations in two languages will drift, and the only thing that makes that survivable is holding both to one set of cases rather than each to its own.

One cross-language trap worth recording: Java reads an unescaped `[` inside a character class as the start of a nested class where JavaScript reads it as a literal, so an identical pattern compiles in JS and throws at class-init in Kotlin.

## Sharing

Through the system share sheet, so the user picks the destination every time. Nova never chooses a recipient, which is what keeps this a handoff rather than telemetry, and the report says so in its own first line.

The report also tells the user to attach the Polaris bundle, because a client-only report is the shape that earns a follow-up question instead of a fix.

## Reporting without waiting to crash

The post-crash prompt only fires after a crash, which is the narrower half of what needs reporting. The failure that actually costs a user an evening is usually one where **nothing crashed**: the stream came up and looked wrong, or a setting did not apply.

Settings now carries a **Report a problem** entry, reachable at any time, building the same redacted report and handing it to the share sheet. Wired on both settings paths: the Compose screen dispatches it directly rather than falling through to its legacy fallback, and the legacy fragment gets its own click listener, so it behaves the same whichever screen the device shows.

A report with no crash and no log is still worth sending, since it carries the Nova version, device, Android release and whatever the user typed. Refusing to build one because nothing crashed would block exactly the case the entry exists for.

## Known gap

The **host** submission path has tested plumbing and no UI trigger yet. The crash prompt fires in `PcView.onResume`, before computer polling starts, and `ComputerManagerBinder` exposes `getComputer(uuid)` but no synchronous list, so there is no host reliably in hand at that moment.

The share sheet covers every case today and is the documented fallback for an unpaired client. Adding the host trigger belongs where a host is unambiguously in hand, which is the per-computer screen, and is a follow-up rather than a guess made here.

## Also

`HelpLauncher.launchTroubleshooting` pointed at the Moonlight wiki, which cannot describe a Polaris host. It now points at the Polaris troubleshooting guide.

## Verification

- [x] **1359 unit tests, 0 failures, 0 skipped**, counted from the XML results rather than trusting an exit code, since a `--tests` filter that matches nothing exits 0 here.
- [x] Both `assembleNonRoot_gameDebug` and `assembleNonRoot_gameDebugAndroidTest` build, the latter because CI never compiles it and a green check proves nothing about it.
- [x] Crash handler tested three ways: marker written and platform still delegated to, delegation still happening when the marker cannot be written, and survival with no previous handler.
- [x] Redaction parity tested against the host's own case list, including idempotence, structured values, quoted JSON keys, and the diagnostics that must survive byte for byte.

## Notes

No pairing, certificate, permission, or manifest-capability changes. The new log and crash marker live in app-private storage; nothing added is world readable. The share sheet is the only outbound path Nova chooses on its own, and the user picks its destination.
