### PR TITLE
ci(security): disable vulnerable Kotlin cache paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
@@ -37,10 +36,10 @@ jobs:
         run: sdkmanager "ndk;27.0.12077973"
 
       - name: Lint debug build
-        run: ./gradlew -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug
+        run: ./gradlew --no-build-cache -PnovaAbis=x86_64 -PlintFailOnError=true lintNonRoot_gameDebug
 
       - name: Run JVM tests
-        run: ./gradlew -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest
+        run: ./gradlew --no-build-cache -PnovaAbis=x86_64 testNonRoot_gameDebugUnitTest
 
       - name: Run helper and onboarding tests
         run: python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight
@@ -62,7 +61,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
@@ -87,7 +85,7 @@ jobs:
           disk-size: 1024M
           emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot -no-metrics
-          script: ./gradlew -PnovaAbis=x86_64 connectedNonRoot_gameDebugAndroidTest --stacktrace
+          script: ./gradlew --no-build-cache -PnovaAbis=x86_64 connectedNonRoot_gameDebugAndroidTest --stacktrace
 
   build:
     name: Assemble release APK
@@ -109,7 +107,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
@@ -125,7 +122,7 @@ jobs:
         run: sdkmanager "ndk;27.0.12077973"
 
       - name: Build release APK
-        run: ./gradlew assembleNonRoot_gameRelease
+        run: ./gradlew --no-build-cache assembleNonRoot_gameRelease
 
       - name: Sign APKs
         if: github.event_name != 'pull_request' && env.HAS_KEYSTORE_BASE64 == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6
         with:
-          additional-arguments: -PnovaAbis=x86_64 --no-configuration-cache
-          cache-provider: basic
+          additional-arguments: -PnovaAbis=x86_64 --no-build-cache --no-configuration-cache
+          cache-disabled: true
           dependency-graph: generate-and-submit

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeBuildConfigurationTest.kt
@@ -1,13 +1,96 @@
 package com.papi.nova.ui
 
+import java.io.StringReader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.Properties
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NovaComposeBuildConfigurationTest {
+    @Test
+    fun vulnerableKotlinCachesRemainDisabledAcrossCi() {
+        val repositoryRoot = Paths.get("..").toAbsolutePath().normalize()
+        val gradleProperties = readText(repositoryRoot.resolve("gradle.properties"))
+        val workflows = Files.list(repositoryRoot.resolve(".github/workflows")).use { paths ->
+            paths.iterator().asSequence()
+                .filter { path ->
+                    Files.isRegularFile(path) &&
+                        (path.fileName.toString().endsWith(".yml") || path.fileName.toString().endsWith(".yaml"))
+                }
+                .associate { it.fileName.toString() to readText(it) }
+        }
+
+        assertPropertyDisabled(
+            gradleProperties,
+            "org.gradle.caching",
+            "Kotlin 2.3.21 must keep the Gradle build cache disabled"
+        )
+        assertPropertyDisabled(
+            gradleProperties,
+            "kapt.incremental.apt",
+            "Kotlin 2.3.21 must keep KAPT incremental local-state deserialization disabled"
+        )
+
+        workflows.forEach { (name, workflow) ->
+            assertFalse(
+                "$name must not restore or save the Gradle User Home cache",
+                Regex("(?m)^\\s*cache:\\s*['\"]?gradle['\"]?\\s*(?:#.*)?$").containsMatchIn(workflow)
+            )
+            assertFalse(
+                "$name must not enable Gradle's build cache on the command line",
+                Regex("(?:^|\\s)--build-cache(?=\\s|$)").containsMatchIn(workflow)
+            )
+            assertFalse(
+                "$name must not override the fail-closed Gradle cache properties",
+                workflow.contains("org.gradle.caching") || workflow.contains("kapt.incremental.apt")
+            )
+            assertFalse(
+                "$name must not add a Gradle cache action without extending this fail-closed contract",
+                Regex(
+                    "(?i)(?:gradle/actions/setup-gradle|gradle/gradle-build-action|" +
+                        "actions/cache(?:/restore|/save)?)@"
+                ).containsMatchIn(workflow)
+            )
+            workflow.lineSequence()
+                .filter { Regex("(?:^|\\s)(?:\\./)?gradle(?:w)?(?:\\s|$)").containsMatchIn(it) }
+                .forEach { invocation ->
+                    assertTrue(
+                        "$name Gradle invocations must fail closed with --no-build-cache: $invocation",
+                        invocation.contains("--no-build-cache")
+                    )
+                }
+        }
+
+        val dependencySubmissionSteps = workflows.flatMap { (name, workflow) ->
+            actionSteps(workflow, "gradle/actions/dependency-submission").map { name to it }
+        }
+        val dependencySubmissionReferences = workflows.values.sumOf { workflow ->
+            Regex("(?i)gradle/actions/dependency-submission@").findAll(workflow).count()
+        }
+        assertTrue("CI must retain dependency graph submission", dependencySubmissionSteps.isNotEmpty())
+        assertEquals(
+            "every dependency-submission reference must be a directly inspectable action step",
+            dependencySubmissionReferences,
+            dependencySubmissionSteps.size
+        )
+        dependencySubmissionSteps.forEach { (name, step) ->
+            assertTrue(
+                "$name dependency submission must disable its Gradle User Home cache",
+                Regex("(?m)^\\s*cache-disabled:\\s*true\\s*$").containsMatchIn(step)
+            )
+            assertTrue(
+                "$name dependency submission must pass --no-build-cache to its Gradle invocation",
+                Regex("(?m)^\\s*additional-arguments:.*(?:^|\\s)--no-build-cache(?:\\s|$)")
+                    .containsMatchIn(step)
+            )
+        }
+    }
+
     @Test
     fun gradleEnablesComposeWithKotlinCompilerPluginAndBom() {
         val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
@@ -68,16 +151,65 @@ class NovaComposeBuildConfigurationTest {
 
     @Test
     fun buildDoesNotUseKaptForNewKotlinProcessing() {
-        val rootBuild = String(Files.readAllBytes(Paths.get("../build.gradle")), StandardCharsets.UTF_8)
-        val appBuild = String(Files.readAllBytes(Paths.get("build.gradle")), StandardCharsets.UTF_8)
-        val settings = String(Files.readAllBytes(Paths.get("../settings.gradle")), StandardCharsets.UTF_8)
-        val combinedBuildConfig = listOf(rootBuild, appBuild, settings).joinToString("\n")
+        val repositoryRoot = Paths.get("..").toAbsolutePath().normalize()
+        val buildFiles = Files.walk(repositoryRoot).use { paths ->
+            paths.iterator().asSequence()
+                .filter { path ->
+                    Files.isRegularFile(path) &&
+                        (path.fileName.toString().endsWith(".gradle") || path.fileName.toString().endsWith(".gradle.kts")) &&
+                        repositoryRoot.relativize(path).none { segment ->
+                            segment.toString() == ".git" ||
+                                segment.toString() == ".gradle" ||
+                                segment.toString() == "build"
+                        }
+                }
+                .toList()
+        }
 
-        assertFalse(
-            "Prefer KSP over kapt for future Kotlin annotation processors",
-            combinedBuildConfig.contains("kapt")
-        )
+        buildFiles.forEach { buildFile ->
+            assertFalse(
+                "Prefer KSP over kapt for future Kotlin annotation processors: ${repositoryRoot.relativize(buildFile)}",
+                readText(buildFile).contains("kapt", ignoreCase = true)
+            )
+        }
     }
+
+    private fun readText(path: Path): String =
+        String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+
+    private fun assertPropertyDisabled(propertiesText: String, key: String, message: String) {
+        val definitionCount = Regex(
+            "(?m)^[ \\t\\f]*${Regex.escape(key)}(?=[ \\t\\f:=])"
+        ).findAll(propertiesText).count()
+        assertEquals("$message with one unambiguous definition", 1, definitionCount)
+
+        val effectiveProperties = Properties().apply {
+            load(StringReader(propertiesText))
+        }
+        assertEquals("$message as its effective Java Properties value", "false", effectiveProperties.getProperty(key))
+    }
+
+    private fun actionSteps(workflow: String, action: String): List<String> {
+        val lines = workflow.lines()
+        return lines.indices
+            .filter {
+                Regex("(?i)^uses:\\s*['\"]?${Regex.escape(action)}@")
+                    .containsMatchIn(lines[it].trimStart().removePrefix("- "))
+            }
+            .map { usesIndex ->
+                val usesLine = lines[usesIndex]
+                val usesIndent = usesLine.indexOfFirst { !it.isWhitespace() }.coerceAtLeast(0)
+                val stepIndent = if (usesLine.trimStart().startsWith("- uses:")) usesIndent else (usesIndent - 2).coerceAtLeast(0)
+                var start = usesIndex
+                while (start > 0 && !isYamlListItem(lines[start], stepIndent)) start--
+                var end = usesIndex + 1
+                while (end < lines.size && !isYamlListItem(lines[end], stepIndent)) end++
+                lines.subList(start, end).joinToString("\n")
+            }
+    }
+
+    private fun isYamlListItem(line: String, indent: Int): Boolean =
+        line.indexOfFirst { !it.isWhitespace() } == indent && line.trimStart().startsWith("- ")
 
     @Test
     fun rootTestAggregationUsesLazyTaskRegistration() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,10 @@ android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
 
 android.builtInKotlin=true
-org.gradle.caching=true
+# CVE-2026-53914: Kotlin 2.3.21 can unsafely deserialize KAPT incremental cache
+# metadata. This cache is Gradle local state, separate from the build cache.
+# Keep both paths off until a stable Kotlin 2.4.20+ toolchain is qualified.
+org.gradle.caching=false
+kapt.incremental.apt=false
 org.gradle.configuration-cache=true
 # android.newDsl=true
-


### PR DESCRIPTION
## Summary

- disable KAPT incremental annotation-processing cache deserialization with `kapt.incremental.apt=false` while Nova remains on vulnerable Kotlin 2.3.21
- keep Gradle task-output caching disabled project-wide as defense in depth
- remove GitHub Actions Gradle User Home cache restore/save from build and CodeQL jobs
- disable caching inside the Gradle dependency-submission action while retaining dependency graph generation
- pass `--no-build-cache` explicitly to every CI Gradle invocation
- pin those boundaries with an executable contract that discovers every workflow and Gradle module, rejects command-line property overrides, and blocks unreviewed cache actions

Mitigates Dependabot alert #42 / [CVE-2026-53914](https://github.com/advisories/GHSA-r937-wjx7-w2jp). The [upstream fix](https://github.com/JetBrains/kotlin/commit/bf51df665b458fda7c3eaf436c4d88dc119d7ec6) hardens deserialization of KAPT's incremental `java-cache.bin` and `apt-cache.bin`.

## Scope

This is a temporary pre-release containment, not a claim that the vulnerable Kotlin plugin has been upgraded. Nova does not currently apply KAPT, so the known vulnerable path is not reachable in the present build; the explicit property keeps it fail-closed if KAPT is introduced before the toolchain upgrade.

Maven Central currently has patched `2.4.20` builds only through `2.4.20-RC`. Nova stays on stable `2.3.21` until the Kotlin/Compose/AGP combination can be upgraded and qualified together.

The Dependabot alert should remain open until a stable patched Kotlin release replaces this mitigation.

## Verification

Exact head: `9d021fc2e4833f3287a89365a9b81927bea14129`, based on master `befb1f4824eb2b2c6be6bff2de9cc509f46d0132`.

Fedora verifier with an initialized native submodule and the Android SDK:

- RED on untouched master with the original contract: failed because `org.gradle.caching=true`
- RED on the first mitigation with the corrected KAPT contract: failed because `kapt.incremental.apt=false` was absent
- GREEN after the corrected mitigation: focused cache contract 1/1
- full JVM suite: 1360 tests, 0 failures/errors/skips
- helper/onboarding Python suite: 51/51
- Android lint: successful with the repository's existing baseline
- all edited workflow YAML parses successfully
- actionlint clean except for the repository's pre-existing SC2012 finding
- `git diff --check` clean

Protected exact-head CI passed: Build Nova APK (lint, JVM tests, helper tests, and release assembly), CodeQL, and Public Hygiene.