### PR TITLE
feat(ui): add subtle sponsor link

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -311,6 +311,7 @@ class NovaLibraryActivity : NovaActivity() {
                         onOpenPolarisSync = ::openPolarisSync,
                         onOpenHelpDiagnostics = ::openHelpDiagnostics,
                         onOpenAbout = ::showAboutNova,
+                        onOpenSponsor = ::openSponsor,
                         onSortMode = { sortMode ->
                             updateLibraryOptions { it.copy(sortMode = sortMode) }
                         },
@@ -1080,6 +1081,10 @@ class NovaLibraryActivity : NovaActivity() {
         ).show()
     }
 
+    private fun openSponsor() {
+        HelpLauncher.launchSponsor(this)
+    }
+
     private fun finishWithTransition() {
         finish()
         NovaThemeManager.applyBackTransition(this)
@@ -1172,6 +1177,7 @@ class NovaLibraryActivity : NovaActivity() {
         onOpenPolarisSync: () -> Unit,
         onOpenHelpDiagnostics: () -> Unit,
         onOpenAbout: () -> Unit,
+        onOpenSponsor: () -> Unit,
         onSortMode: (NovaLibrarySortMode) -> Unit,
         onLayoutMode: (NovaLibraryLayoutMode) -> Unit,
         onPosterTitlesVisible: (Boolean) -> Unit,
@@ -1463,7 +1469,8 @@ class NovaLibraryActivity : NovaActivity() {
                         onOpenPolarisSync = onOpenPolarisSync,
                         onManageServer = onManageServer,
                         onOpenHelpDiagnostics = onOpenHelpDiagnostics,
-                        onOpenAbout = onOpenAbout
+                        onOpenAbout = onOpenAbout,
+                        onOpenSponsor = onOpenSponsor
                     )
                 }
                 activeOptionsSheet -> {
@@ -2738,7 +2745,8 @@ class NovaLibraryActivity : NovaActivity() {
         onOpenPolarisSync: () -> Unit,
         onManageServer: () -> Unit,
         onOpenHelpDiagnostics: () -> Unit,
-        onOpenAbout: () -> Unit
+        onOpenAbout: () -> Unit,
+        onOpenSponsor: () -> Unit
     ) {
         val colors = LocalNovaComposeColors.current
         val surfaces = LocalNovaLibrarySurfaces.current
@@ -2933,6 +2941,20 @@ class NovaLibraryActivity : NovaActivity() {
                             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 5.dp)
                         )
                     }
+                    NovaActionButton(
+                        text = stringResource(R.string.nova_system_menu_sponsor),
+                        contentDescription = stringResource(R.string.nova_system_menu_sponsor_hint),
+                        onClick = {
+                            onDismiss()
+                            onOpenSponsor()
+                        },
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .widthIn(min = 120.dp),
+                        minHeight = 28.dp,
+                        fontSize = 9.sp,
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)
+                    )
                     Spacer(modifier = Modifier.height(4.dp))
                 }
             }

--- a/app/src/main/java/com/papi/nova/utils/HelpLauncher.kt
+++ b/app/src/main/java/com/papi/nova/utils/HelpLauncher.kt
@@ -51,6 +51,11 @@ object HelpLauncher {
     }
 
     @JvmStatic
+    fun launchSponsor(context: Context) {
+        launchUrl(context, "https://github.com/sponsors/papi-ux")
+    }
+
+    @JvmStatic
     fun launchGameStreamEolFaq(context: Context) {
         launchUrl(
             context,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,6 +261,8 @@
     <string name="nova_system_menu_about">About Nova</string>
     <string name="nova_system_menu_about_hint">Version and client identity.</string>
     <string name="nova_system_menu_about_toast">%1$s</string>
+    <string name="nova_system_menu_sponsor">♥ Sponsor</string>
+    <string name="nova_system_menu_sponsor_hint">Support Polaris and Nova on GitHub Sponsors.</string>
     <string name="nova_controller_hint_system">System</string>
     <string name="nova_game_detail_resume">Resume</string>
     <string name="nova_game_detail_watch">Watch</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
@@ -129,5 +129,14 @@ class NovaLibraryActivitySourceTest {
         assertTrue(systemMenu.contains("onManageServer: () -> Unit"))
         assertTrue(systemMenu.contains("onOpenHelpDiagnostics: () -> Unit"))
         assertTrue(systemMenu.contains("onOpenAbout: () -> Unit"))
+        assertTrue(systemMenu.contains("onOpenSponsor: () -> Unit"))
+        assertTrue(systemMenu.contains("R.string.nova_system_menu_sponsor"))
+        assertTrue(systemMenu.contains("R.string.nova_system_menu_sponsor_hint"))
+        assertTrue(systemMenu.contains("onOpenSponsor()"))
+        assertTrue(systemMenu.contains("minHeight = 28.dp"))
+        assertTrue(systemMenu.contains("fontSize = 9.sp"))
+        assertTrue(source.contains("onOpenSponsor = ::openSponsor"))
+        assertTrue(source.contains("private fun openSponsor()"))
+        assertTrue(source.contains("HelpLauncher.launchSponsor(this)"))
     }
 }

--- a/app/src/test/java/com/papi/nova/utils/HelpLauncherUrlTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/HelpLauncherUrlTest.kt
@@ -28,4 +28,21 @@ class HelpLauncherUrlTest {
             setupGuide.contains("moonlight-stream/moonlight-docs")
         )
     }
+
+    @Test
+    fun sponsorLaunchesThePapiUxGithubSponsorsPage() {
+        val source = String(
+            Files.readAllBytes(Path.of("src/main/java/com/papi/nova/utils/HelpLauncher.kt")),
+            StandardCharsets.UTF_8
+        )
+        val sponsor = source.substring(
+            source.indexOf("fun launchSponsor"),
+            source.indexOf("fun launchGameStreamEolFaq")
+        )
+
+        assertTrue(
+            "Sponsor should open the papi-ux GitHub Sponsors page",
+            sponsor.contains("https://github.com/sponsors/papi-ux")
+        )
+    }
 }

--- a/app/src/test/java/com/papi/nova/utils/KotlinUtilsCoreMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/KotlinUtilsCoreMigrationTest.kt
@@ -30,6 +30,7 @@ class KotlinUtilsCoreMigrationTest {
         HelpLauncher::class.java.getMethod("launchUrl", Context::class.java, String::class.java)
         HelpLauncher::class.java.getMethod("launchSetupGuide", Context::class.java)
         HelpLauncher::class.java.getMethod("launchTroubleshooting", Context::class.java)
+        HelpLauncher::class.java.getMethod("launchSponsor", Context::class.java)
         HelpLauncher::class.java.getMethod("launchGameStreamEolFaq", Context::class.java)
 
         assertTrue(Runnable::class.java.isAssignableFrom(Dialog::class.java))


### PR DESCRIPTION
## What changed

- adds a compact `♥ Sponsor` action beneath Help and About in Nova's System drawer
- routes it through the existing browser and in-app WebView launcher to `https://github.com/sponsors/papi-ux`
- keeps the control controller-focusable and gives it a descriptive accessibility label
- pins the exact destination, callback wiring, compact presentation, and Java-compatible launcher API in tests

## Why

GitHub Sponsors should be discoverable in Nova without becoming a primary navigation action or competing with host controls.

## User impact

Users can open the papi-ux GitHub Sponsors page from a quiet footer action in System. Existing Help, About, host, and streaming controls are unchanged.

## Validation

- RED: both new sponsor contracts failed before implementation
- GREEN: 10 focused launcher, API, and System drawer tests
- GREEN: Android lint with `lintFailOnError=true`
- GREEN: public surface and public docs checks
- GREEN: `git diff --check`
- full local unit run reached 1,306 tests with all affected tests passing; 7 unrelated failures remained: 3 existing artwork-cache eviction assertions and 4 Android 36 Robolectric classes that require Java 21 while the local runner has Java 17

No streaming, pairing, or host-management behavior changes.