### PR TITLE
fix(settings): stop presets rewriting fps and share panel culling

### DIFF
--- a/app/src/main/java/com/papi/nova/preferences/NovaDisplayFpsCapability.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaDisplayFpsCapability.kt
@@ -1,0 +1,62 @@
+package com.papi.nova.preferences
+
+import android.os.Build
+import android.view.Display
+
+/**
+ * Panel-capability rules for the standard stream FPS options.
+ *
+ * Extracted from the legacy settings fragment so every surface that offers an FPS
+ * choice (legacy PreferenceFragment, Compose settings, Play Setup) culls with the
+ * same thresholds instead of each growing its own.
+ */
+object NovaDisplayFpsCapability {
+    /** Minimum panel refresh rate required to offer the 120 FPS option. */
+    const val FPS_120_MIN_PANEL_HZ = 118f
+
+    /** Minimum panel refresh rate required to offer the 90 FPS option. */
+    const val FPS_90_MIN_PANEL_HZ = 88f
+
+    private val STANDARD_FPS_VALUES = listOf(30, 60, 90, 120)
+
+    /** The panel's fastest refresh rate across all supported display modes. */
+    @JvmStatic
+    fun maxSupportedFps(display: Display): Float {
+        var maxSupportedFps = display.refreshRate
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            for (candidate in display.supportedModes) {
+                if (candidate.refreshRate > maxSupportedFps) {
+                    maxSupportedFps = candidate.refreshRate
+                }
+            }
+        }
+        return maxSupportedFps
+    }
+
+    /** The standard FPS options this panel can actually present, ascending. */
+    @JvmStatic
+    fun allowedFpsValues(maxSupportedFps: Float): List<Int> {
+        val values = mutableListOf(30, 60)
+        if (maxSupportedFps >= FPS_90_MIN_PANEL_HZ) {
+            values += 90
+        }
+        if (maxSupportedFps >= FPS_120_MIN_PANEL_HZ) {
+            values += 120
+        }
+        return values
+    }
+
+    /**
+     * Coerces a stored standard FPS value down to the fastest option the panel allows.
+     * Non-standard values (native/custom rates) pass through untouched, matching the
+     * legacy culling which only ever rewrote the standard entries it removed.
+     */
+    @JvmStatic
+    fun coerce(requestedFps: Int, maxSupportedFps: Float): Int {
+        val allowed = allowedFpsValues(maxSupportedFps)
+        if (requestedFps in allowed || requestedFps !in STANDARD_FPS_VALUES) {
+            return requestedFps
+        }
+        return allowed.last { it <= requestedFps }
+    }
+}

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
@@ -31,6 +31,14 @@ internal val NOVA_STREAM_UI_RESET_REMOVALS = setOf(
     "nova_polaris_hud_y"
 )
 
+// A preset never writes the fps preference: the user's frame-rate choice is
+// orthogonal and must survive preset switches.
+internal fun novaPresetSettingUpdates(preset: StreamPreset): Map<String, NovaSettingValue> = mapOf(
+    PreferenceConfiguration.RESOLUTION_PREF_STRING to NovaSettingValue.StringValue(preset.resolution),
+    PreferenceConfiguration.BITRATE_PREF_STRING to NovaSettingValue.IntValue(preset.bitrateKbps),
+    "video_format" to NovaSettingValue.StringValue(preset.codec)
+)
+
 internal suspend fun persistNovaStreamUiDefaults(
     store: NovaSettingsStore,
     definitions: NovaSettingsDefinitionSet
@@ -131,12 +139,7 @@ class NovaSettingsViewModel(
         if (definition.key != "nova_stream_preset" || value !is NovaSettingValue.StringValue) return
 
         val preset = StreamPreset.fromKey(value.value) ?: return
-        val updates = mapOf(
-            PreferenceConfiguration.RESOLUTION_PREF_STRING to NovaSettingValue.StringValue(preset.resolution),
-            PreferenceConfiguration.FPS_PREF_STRING to NovaSettingValue.StringValue(preset.fps),
-            PreferenceConfiguration.BITRATE_PREF_STRING to NovaSettingValue.IntValue(preset.bitrateKbps),
-            "video_format" to NovaSettingValue.StringValue(preset.codec)
-        )
+        val updates = novaPresetSettingUpdates(preset)
         for ((key, settingValue) in updates) {
             val presetDefinition = definitions.find(key) ?: continue
             store.set(presetDefinition, settingValue)

--- a/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
@@ -668,7 +668,7 @@ class PreferenceConfiguration {
                 prefs.getString(RESOLUTION_PREF_STRING, DEFAULT_RESOLUTION) ?: DEFAULT_RESOLUTION
             }
             val fps = if (legacyResFps == "720p60") {
-                StreamPreset.BALANCED.fps
+                DEFAULT_FPS
             } else {
                 prefs.getString(FPS_PREF_STRING, DEFAULT_FPS) ?: DEFAULT_FPS
             }
@@ -684,7 +684,7 @@ class PreferenceConfiguration {
             val shouldMigrate =
                 preset == StreamPreset.BALANCED.key &&
                     resolution == LEGACY_DEFAULT_RESOLUTION &&
-                    fps == StreamPreset.BALANCED.fps &&
+                    fps == DEFAULT_FPS &&
                     isBalancedDefaultBitrate &&
                     codec == StreamPreset.BALANCED.codec
 
@@ -692,7 +692,7 @@ class PreferenceConfiguration {
                 .putBoolean(LEGACY_BALANCED_RESOLUTION_MIGRATION, true)
             if (shouldMigrate) {
                 editor.putString(RESOLUTION_PREF_STRING, StreamPreset.BALANCED.resolution)
-                editor.putString(FPS_PREF_STRING, StreamPreset.BALANCED.fps)
+                editor.putString(FPS_PREF_STRING, DEFAULT_FPS)
                 editor.remove(LEGACY_RES_FPS_PREF_STRING)
             }
             editor.apply()

--- a/app/src/main/java/com/papi/nova/preferences/StreamPreset.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamPreset.kt
@@ -1,14 +1,15 @@
 package com.papi.nova.preferences
 
 /**
- * Streaming quality presets — quick-switch between resolution+bitrate+codec+FPS combos.
+ * Streaming quality presets — quick-switch between resolution+bitrate+codec combos.
  * Inspired by Steam Link's Fast/Balanced/Beautiful and GeForce NOW's mode system.
+ * Frame rate is deliberately not part of a preset: the user's fps choice is
+ * orthogonal and must survive preset switches.
  */
 data class StreamPreset(
     val key: String,
     val label: String,
     val resolution: String,    // e.g. "1280x720"
-    val fps: String,           // e.g. "60"
     val bitrateKbps: Int,      // e.g. 20000
     val codec: String          // e.g. "auto", "forceh265", "neverh265"
 ) {
@@ -17,7 +18,6 @@ data class StreamPreset(
             key = "performance",
             label = "Performance",
             resolution = "1280x720",
-            fps = "60",
             bitrateKbps = 10000,
             codec = "auto"
         )
@@ -26,7 +26,6 @@ data class StreamPreset(
             key = "balanced",
             label = "Balanced",
             resolution = "1920x1080",
-            fps = "60",
             bitrateKbps = 20000,
             codec = "auto"
         )
@@ -35,7 +34,6 @@ data class StreamPreset(
             key = "quality",
             label = "Quality",
             resolution = "1920x1080",
-            fps = "60",
             bitrateKbps = 50000,
             codec = "forceh265"
         )

--- a/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
+++ b/app/src/main/java/com/papi/nova/preferences/StreamSettings.kt
@@ -125,10 +125,14 @@ class StreamSettings : NovaActivity() {
 
     private fun showComposeSettings() {
         legacyMode = false
+        val maxPanelFps = NovaDisplayFpsCapability.maxSupportedFps(windowManager.defaultDisplay)
+        coerceStoredFpsToPanel(maxPanelFps)
         val canonicalDefinitions = NovaSettingDefinitions.load(this)
         val definitions = NovaSettingsAvailability.filter(this, canonicalDefinitions).let { filtered ->
             filtered.copy(
-                settings = filtered.settings.filterNot { it.key == NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY }
+                settings = filtered.settings
+                    .filterNot { it.key == NovaSettingsFeatureFlags.COMPOSE_SETTINGS_KEY }
+                    .map { definition -> cullFpsOptionsToPanel(definition, maxPanelFps) }
             )
         }
         val store = NovaSettingsRepository.create(this)
@@ -162,6 +166,30 @@ class StreamSettings : NovaActivity() {
         }
         setContentView(content)
         UiHelper.notifyNewRootView(this)
+    }
+
+    // The legacy fragment culls the fps ListPreference to what the panel can present
+    // (removeEntryFromListAndSetValue below); the Compose screen reads the raw XML
+    // definitions, so it applies the same panel rules here or 90/120 get offered on
+    // panels that cannot show them.
+    private fun cullFpsOptionsToPanel(
+        definition: NovaSettingDefinition,
+        maxPanelFps: Float
+    ): NovaSettingDefinition {
+        if (definition.key != PreferenceConfiguration.FPS_PREF_STRING) {
+            return definition
+        }
+        val allowed = NovaDisplayFpsCapability.allowedFpsValues(maxPanelFps).map(Int::toString)
+        return definition.copy(options = definition.options.filter { it.value in allowed })
+    }
+
+    private fun coerceStoredFpsToPanel(maxPanelFps: Float) {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val stored = prefs.getString(PreferenceConfiguration.FPS_PREF_STRING, null)?.toIntOrNull() ?: return
+        val coerced = NovaDisplayFpsCapability.coerce(stored, maxPanelFps)
+        if (coerced != stored) {
+            prefs.edit().putString(PreferenceConfiguration.FPS_PREF_STRING, coerced.toString()).apply()
+        }
     }
 
     private fun showLegacySettings() {
@@ -628,7 +656,6 @@ class StreamSettings : NovaActivity() {
                 if (preset != null) {
                     getPrefs().edit()
                         .putString("list_resolution", preset.resolution)
-                        .putString("list_fps", preset.fps)
                         .putInt("seekbar_bitrate_kbps", preset.bitrateKbps)
                         .putString("video_format", preset.codec)
                         .apply()
@@ -754,7 +781,7 @@ class StreamSettings : NovaActivity() {
             }
 
             val display = activity.windowManager.defaultDisplay
-            var maxSupportedFps = display.refreshRate
+            val maxSupportedFps = NovaDisplayFpsCapability.maxSupportedFps(display)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 var maxSupportedResW = 0
@@ -802,10 +829,6 @@ class StreamSettings : NovaActivity() {
                         maxSupportedResW = 2560
                     } else if ((width >= 1920 || height >= 1080) && maxSupportedResW < 1920) {
                         maxSupportedResW = 1920
-                    }
-
-                    if (candidate.refreshRate > maxSupportedFps) {
-                        maxSupportedFps = candidate.refreshRate
                     }
                 }
 
@@ -886,16 +909,17 @@ class StreamSettings : NovaActivity() {
                 addNativeResolutionEntries(width, height, false, false)
             }
 
-            if (maxSupportedFps < 118) {
+            val allowedFpsValues = NovaDisplayFpsCapability.allowedFpsValues(maxSupportedFps)
+            if (120 !in allowedFpsValues) {
                 removeEntryFromListAndSetValue(PreferenceConfiguration.FPS_PREF_STRING, "120", "90")
             }
-            if (maxSupportedFps < 88) {
+            if (90 !in allowedFpsValues) {
                 removeEntryFromListAndSetValue(PreferenceConfiguration.FPS_PREF_STRING, "90", "60")
             }
             addNativeFrameRateEntry(maxSupportedFps, false)
 
             findPreference<CheckBoxPreference>(PreferenceConfiguration.UNLOCK_FPS_STRING)?.let { unlockFpsPref ->
-                if (maxSupportedFps < 88) {
+                if (90 !in allowedFpsValues) {
                     unlockFpsPref.isEnabled = false
                     unlockFpsPref.summary = getString(
                         R.string.summary_unlock_fps_display_cap,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -543,7 +543,7 @@ private const val NOVA_DETAIL_SCENERY_CHROME_ALPHA = 0.16f
 internal fun novaProfilePreferenceConsequenceRes(value: String): Int =
     when (value.trim().lowercase()) {
         "quality" -> R.string.nova_play_setup_pref_quality
-        "balanced" -> R.string.nova_play_setup_pref_balanced
+        "stability" -> R.string.nova_play_setup_pref_stability
         "high_fps" -> R.string.nova_play_setup_pref_high_fps
         else -> R.string.nova_play_setup_pref_auto
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,7 +293,7 @@
     <string name="nova_play_setup_every_game">Every Game</string>
     <string name="nova_play_setup_pref_auto">Polaris decides from how each session went.</string>
     <string name="nova_play_setup_pref_quality">Holds resolution and bitrate. Drops frames before it drops sharpness.</string>
-    <string name="nova_play_setup_pref_balanced">Gives up a little of each to keep the stream steady.</string>
+    <string name="nova_play_setup_pref_stability">Plays it safe. Holds a steadier, lower target instead of chasing peaks.</string>
     <string name="nova_play_setup_pref_high_fps">Chases frame rate. Softens the picture when the host cannot hold both.</string>
     <string name="nova_play_setup_steam_direct">Launches the game itself. Nothing else opens.</string>
     <string name="nova_play_setup_steam_big_picture">Opens Big Picture first, which takes the controller until the game starts.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,7 +18,7 @@
         <ListPreference
             android:key="nova_stream_preset"
             android:title="Quality Preset"
-            android:summary="Performance (720p 10Mbps) · Balanced (1080p 20Mbps) · Quality (1080p HEVC 50Mbps)"
+            android:summary="Performance (720p 10Mbps) · Balanced (1080p 20Mbps) · Quality (1080p HEVC 50Mbps). Frame rate is set separately below."
             android:entries="@array/nova_preset_names"
             android:entryValues="@array/nova_preset_values"
             android:defaultValue="balanced"

--- a/app/src/test/java/com/papi/nova/preferences/NovaDisplayFpsCapabilityTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaDisplayFpsCapabilityTest.kt
@@ -1,0 +1,53 @@
+package com.papi.nova.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NovaDisplayFpsCapabilityTest {
+    @Test
+    fun panelBelow90ThresholdOffersOnly30And60() {
+        assertEquals(listOf(30, 60), NovaDisplayFpsCapability.allowedFpsValues(59.9f))
+        assertEquals(listOf(30, 60), NovaDisplayFpsCapability.allowedFpsValues(60f))
+        assertEquals(listOf(30, 60), NovaDisplayFpsCapability.allowedFpsValues(87.9f))
+    }
+
+    @Test
+    fun panelAt90ThresholdAdds90ButNot120() {
+        assertEquals(listOf(30, 60, 90), NovaDisplayFpsCapability.allowedFpsValues(88f))
+        assertEquals(listOf(30, 60, 90), NovaDisplayFpsCapability.allowedFpsValues(90f))
+        assertEquals(listOf(30, 60, 90), NovaDisplayFpsCapability.allowedFpsValues(117.9f))
+    }
+
+    @Test
+    fun panelAt120ThresholdOffersEverything() {
+        assertEquals(listOf(30, 60, 90, 120), NovaDisplayFpsCapability.allowedFpsValues(118f))
+        assertEquals(listOf(30, 60, 90, 120), NovaDisplayFpsCapability.allowedFpsValues(120f))
+        assertEquals(listOf(30, 60, 90, 120), NovaDisplayFpsCapability.allowedFpsValues(144f))
+    }
+
+    @Test
+    fun coerceFollowsTheLegacyFallbackChain() {
+        // 120 on a panel that can only offer 90 falls to 90, exactly like the
+        // legacy removeEntryFromListAndSetValue(FPS, "120", "90") rewrite.
+        assertEquals(90, NovaDisplayFpsCapability.coerce(120, 100f))
+        // 120 on a 60Hz panel cascades all the way down, like the legacy
+        // double rewrite 120 -> 90 -> 60.
+        assertEquals(60, NovaDisplayFpsCapability.coerce(120, 60f))
+        assertEquals(60, NovaDisplayFpsCapability.coerce(90, 60f))
+    }
+
+    @Test
+    fun coerceLeavesAllowedValuesAlone() {
+        assertEquals(120, NovaDisplayFpsCapability.coerce(120, 120f))
+        assertEquals(90, NovaDisplayFpsCapability.coerce(90, 90f))
+        assertEquals(30, NovaDisplayFpsCapability.coerce(30, 60f))
+    }
+
+    @Test
+    fun coerceLeavesNonStandardValuesAlone() {
+        // The legacy culling only ever rewrote the standard entries it removed;
+        // a native or custom rate must pass through untouched.
+        assertEquals(144, NovaDisplayFpsCapability.coerce(144, 60f))
+        assertEquals(59, NovaDisplayFpsCapability.coerce(59, 60f))
+    }
+}

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -174,7 +174,7 @@ class NovaSettingsDefinitionsTest {
         prefs.edit()
             .putString("nova_stream_preset", StreamPreset.BALANCED.key)
             .putString(PreferenceConfiguration.RESOLUTION_PREF_STRING, "1280x720")
-            .putString(PreferenceConfiguration.FPS_PREF_STRING, StreamPreset.BALANCED.fps)
+            .putString(PreferenceConfiguration.FPS_PREF_STRING, PreferenceConfiguration.DEFAULT_FPS)
             .putInt(PreferenceConfiguration.BITRATE_PREF_STRING, 15000)
             .putString("video_format", StreamPreset.BALANCED.codec)
             .commit()
@@ -202,7 +202,7 @@ class NovaSettingsDefinitionsTest {
             prefs.getString(PreferenceConfiguration.RESOLUTION_PREF_STRING, null)
         )
         assertEquals(
-            StreamPreset.BALANCED.fps,
+            PreferenceConfiguration.DEFAULT_FPS,
             prefs.getString(PreferenceConfiguration.FPS_PREF_STRING, null)
         )
         assertFalse(prefs.contains("list_resolution_fps"))
@@ -214,7 +214,7 @@ class NovaSettingsDefinitionsTest {
         prefs.edit()
             .putString("nova_stream_preset", StreamPreset.PERFORMANCE.key)
             .putString(PreferenceConfiguration.RESOLUTION_PREF_STRING, StreamPreset.PERFORMANCE.resolution)
-            .putString(PreferenceConfiguration.FPS_PREF_STRING, StreamPreset.PERFORMANCE.fps)
+            .putString(PreferenceConfiguration.FPS_PREF_STRING, PreferenceConfiguration.DEFAULT_FPS)
             .putInt(PreferenceConfiguration.BITRATE_PREF_STRING, StreamPreset.PERFORMANCE.bitrateKbps)
             .putString("video_format", StreamPreset.PERFORMANCE.codec)
             .commit()

--- a/app/src/test/java/com/papi/nova/preferences/NovaStreamPresetUpdatesTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaStreamPresetUpdatesTest.kt
@@ -1,0 +1,44 @@
+package com.papi.nova.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class NovaStreamPresetUpdatesTest {
+    @Test
+    fun presetsWriteResolutionBitrateAndCodecOnly() {
+        for (preset in StreamPreset.PRESETS) {
+            assertEquals(
+                setOf(
+                    PreferenceConfiguration.RESOLUTION_PREF_STRING,
+                    PreferenceConfiguration.BITRATE_PREF_STRING,
+                    "video_format"
+                ),
+                novaPresetSettingUpdates(preset).keys
+            )
+        }
+    }
+
+    @Test
+    fun presetsNeverTouchTheFpsPreference() {
+        // The user's frame-rate choice is orthogonal to the quality preset and
+        // must survive a preset switch; presets used to silently reset it to 60.
+        for (preset in StreamPreset.PRESETS) {
+            assertFalse(
+                "preset ${preset.key} must not write ${PreferenceConfiguration.FPS_PREF_STRING}",
+                PreferenceConfiguration.FPS_PREF_STRING in novaPresetSettingUpdates(preset)
+            )
+        }
+    }
+
+    @Test
+    fun presetValuesStayPinned() {
+        assertEquals("1280x720", StreamPreset.PERFORMANCE.resolution)
+        assertEquals(10000, StreamPreset.PERFORMANCE.bitrateKbps)
+        assertEquals("1920x1080", StreamPreset.BALANCED.resolution)
+        assertEquals(20000, StreamPreset.BALANCED.bitrateKbps)
+        assertEquals("1920x1080", StreamPreset.QUALITY.resolution)
+        assertEquals(50000, StreamPreset.QUALITY.bitrateKbps)
+        assertEquals("forceh265", StreamPreset.QUALITY.codec)
+    }
+}


### PR DESCRIPTION
## Summary

- Quality presets no longer rewrite the saved video frame rate: applying Performance/Balanced/Quality used to silently reset a 120 FPS choice back to 60. Presets now set resolution, bitrate, and codec only, in both the legacy fragment and the Compose settings screen, and `StreamPreset` loses its `fps` field. The one legacy migration that read `StreamPreset.BALANCED.fps` now uses the `DEFAULT_FPS` constant it always equalled, so migration behavior is unchanged.
- The Compose settings screen (the default UI) offered 90/120 FPS on panels that cannot present them; only the legacy fragment culled the list. The panel thresholds now live in a shared `NovaDisplayFpsCapability` (max panel rate, allowed standard values, coerce-down chain), used by both UIs. A stored standard value above the panel ceiling is coerced down once on open, matching the legacy `removeEntryFromListAndSetValue` semantics; native/custom rates pass through untouched.
- The Play Setup tuning consequence copy had a dead `"balanced"` branch while the real `"stability"` preference fell through to the Auto description. Replaced with a proper `stability` description; the unused `nova_play_setup_pref_balanced` string is removed.
- Preset summary in Settings now states that frame rate is set separately.

## Exact candidate

- `Commit:` `460f69e837851b4609f2253698acb80c9581a7c3`
- `Tree:` `49fe729e4485cb65ceebfbf0193fe1bad45dd3ca`
- `Parent:` `ef4e8edbbabeb049eaa3e541a3208d02c0fa51fd`
- `Base:` `ef4e8edbbabeb049eaa3e541a3208d02c0fa51fd` (origin/master, v1.3.7)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` — 1372 tests, 0 failures, 0 errors, 0 skipped (counted from the JUnit XML, including the new `NovaDisplayFpsCapabilityTest` and `NovaStreamPresetUpdatesTest` classes)
- [x] `:app:lintNonRoot_gameDebug -PlintFailOnError=true` — 0 new errors (baseline noise only)
- [x] `:app:assembleNonRoot_gameDebugAndroidTest` — compiles (run because the `StreamPreset` constructor signature changed; CI never builds this variant)
- [ ] Device QA on the RP6 (deferred to the arc's end-to-end pass: preset switch preserves FPS, Compose and legacy offer the same culled list)
