### PR TITLE
test(doctor): retain Undo when verify omits metadata

### DIFF
--- a/app/src/test/java/com/papi/nova/ui/DoctorActionReceiptStoreTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/DoctorActionReceiptStoreTest.kt
@@ -106,6 +106,27 @@ class DoctorActionReceiptStoreTest {
     }
 
     @Test
+    fun resolvedVerificationWithoutUndoMetadataKeepsPreviousUndoReceipt() {
+        val resolved = DoctorActionReceiptStore.applyResult(
+            previous = watchingReceipt(),
+            scopeId = scopeA,
+            result = PolarisDoctorActionResult(
+                status = true,
+                state = "resolved",
+                message = "Doctor verified that network pressure cleared.",
+                runId = "doctor-run-1"
+            ),
+            nowEpochMs = 10_000L
+        )
+
+        assertTrue(resolved.isTerminal)
+        assertEquals("", resolved.verificationActionId)
+        assertEquals(0L, resolved.verificationDueAtEpochMs)
+        assertTrue(resolved.undoAvailable)
+        assertEquals("restore_quality", resolved.undoActionId)
+    }
+
+    @Test
     fun explicitHostUndoRevocationOverridesPreviousAvailability() {
         val revoked = DoctorActionReceiptStore.applyResult(
             previous = watchingReceipt(),


### PR DESCRIPTION
## what changed

- cover a terminal Doctor verification response that omits optional `undo_available` and `undo_action_id` metadata
- prove verification polling stops while the previous authenticated Undo receipt stays actionable
- keep production behavior unchanged

## why

the existing terminal-verification test supplied explicit Undo metadata, so it could still pass if the omitted-field fallback regressed. this locks down the fallback used when the host resolves verification without repeating optional Undo fields.

## verification

- focused Doctor, API, and UI tests - 90/90
- full unit suite - 1,389/1,389
- `:app:lintNonRoot_gameDebug`
- `:app:assembleNonRoot_gameDebug` for `armeabi-v7a`, `arm64-v8a`, and `x86_64`
- sabotage RED confirmed for omitted Undo metadata retention
- separate sabotage RED confirmed for exact authenticated session-scope validation
- independent review - approve, high confidence, zero blockers

## scope

this changes one test file and no production source. physical Doctor verify/Undo evidence remains a separate gate. no APK was installed and no device, tag, release, or publication action was performed.
