### PR TITLE
fix(controls): keep touch overlay inside viewport

### DIFF
--- a/app/src/main/java/com/papi/nova/binding/input/virtual_controller/VirtualController.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/virtual_controller/VirtualController.kt
@@ -50,8 +50,21 @@ class VirtualController(
         } else {
             null
         }
+    private var layoutRefreshPending = false
+    private var appliedViewportWidth = 0
+    private var appliedViewportHeight = 0
+    private val layoutChangeListener = View.OnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+        val width = right - left
+        val height = bottom - top
+        if (width > 0 && height > 0 &&
+            (width != appliedViewportWidth || height != appliedViewportHeight)
+        ) {
+            scheduleLayoutRefresh()
+        }
+    }
 
     init {
+        frame_layout?.addOnLayoutChangeListener(layoutChangeListener)
         buttonConfigure.alpha = 0.25f
         buttonConfigure.isFocusable = false
         buttonConfigure.setBackgroundResource(R.drawable.ic_settings)
@@ -145,17 +158,68 @@ class VirtualController(
     fun getElements(): List<VirtualControllerElement> = elements
 
     fun refreshLayout() {
+        val layout = frame_layout ?: return
+        val width = layout.width
+        val height = layout.height
+        if (width <= 0 || height <= 0) {
+            scheduleLayoutRefresh()
+            return
+        }
+
+        refreshLayout(width, height)
+    }
+
+    private fun refreshLayout(viewportWidth: Int, viewportHeight: Int) {
+        val wasShown = buttonConfigure.visibility == View.VISIBLE
         removeElements()
 
-        val screen = context.resources.displayMetrics
-        val buttonSize = (screen.heightPixels * 0.06f).toInt()
+        val viewport = VirtualControllerConfigurationLoader.resolveLayoutViewport(
+            viewportWidth,
+            viewportHeight,
+        )
+        val buttonSize = (viewport.height * 0.06f).toInt().coerceAtLeast(1)
         val params = FrameLayout.LayoutParams(buttonSize, buttonSize)
         params.leftMargin = 15
         params.topMargin = 15
         frame_layout?.addView(buttonConfigure, params)
 
-        VirtualControllerConfigurationLoader.createDefaultLayout(this, context)
-        VirtualControllerConfigurationLoader.loadFromPreferences(this, context)
+        VirtualControllerConfigurationLoader.createDefaultLayout(
+            this,
+            context,
+            viewportWidth,
+            viewportHeight,
+        )
+        VirtualControllerConfigurationLoader.loadFromPreferences(
+            this,
+            context,
+            viewportWidth,
+            viewportHeight,
+        )
+        if (!wasShown) {
+            hide()
+        } else if (currentMode == ControllerMode.DisableEnableButtons) {
+            showElements()
+        } else {
+            showEnabledElements()
+        }
+        appliedViewportWidth = viewportWidth
+        appliedViewportHeight = viewportHeight
+    }
+
+    private fun scheduleLayoutRefresh() {
+        if (layoutRefreshPending) return
+        layoutRefreshPending = true
+        handler.post {
+            layoutRefreshPending = false
+            val layout = frame_layout ?: return@post
+            val width = layout.width
+            val height = layout.height
+            if (width > 0 && height > 0 &&
+                (width != appliedViewportWidth || height != appliedViewportHeight)
+            ) {
+                refreshLayout(width, height)
+            }
+        }
     }
 
     fun getControllerMode(): ControllerMode = currentMode

--- a/app/src/main/java/com/papi/nova/binding/input/virtual_controller/VirtualControllerConfigurationLoader.kt
+++ b/app/src/main/java/com/papi/nova/binding/input/virtual_controller/VirtualControllerConfigurationLoader.kt
@@ -2,6 +2,7 @@ package com.papi.nova.binding.input.virtual_controller
 
 import android.app.Activity
 import android.content.Context
+import android.widget.FrameLayout
 import com.papi.nova.R
 import com.papi.nova.nvstream.input.ControllerPacket
 import com.papi.nova.preferences.PreferenceConfiguration
@@ -11,6 +12,25 @@ import org.json.JSONObject
 object VirtualControllerConfigurationLoader {
     const val OSC_PREFERENCE = "OSC"
     private const val OSC_PREFERENCE_COMPACT_HANDHELD = "OSC_compact_handheld"
+    private const val MIN_ELEMENT_SIZE_PX = 20
+
+    internal data class LayoutViewport(
+        val width: Int,
+        val height: Int,
+        val rightDisplacement: Int,
+    )
+
+    internal fun resolveLayoutViewport(width: Int, height: Int): LayoutViewport {
+        val safeWidth = width.coerceAtLeast(1)
+        val safeHeight = height.coerceAtLeast(1)
+        val fittedHeight = minOf(safeHeight, safeWidth * 9 / 16).coerceAtLeast(1)
+        val baseWidth = fittedHeight * 16 / 9
+        return LayoutViewport(
+            width = safeWidth,
+            height = fittedHeight,
+            rightDisplacement = (safeWidth - baseWidth).coerceAtLeast(0),
+        )
+    }
 
     private fun screenScale(units: Int, height: Int): Int = (height.toFloat() / 72f * units).toInt()
 
@@ -301,9 +321,20 @@ object VirtualControllerConfigurationLoader {
     @JvmStatic
     fun createDefaultLayout(controller: VirtualController, context: Context) {
         val screen = context.resources.displayMetrics
+        createDefaultLayout(controller, context, screen.widthPixels, screen.heightPixels)
+    }
+
+    @JvmStatic
+    fun createDefaultLayout(
+        controller: VirtualController,
+        context: Context,
+        viewportWidth: Int,
+        viewportHeight: Int,
+    ) {
+        val viewport = resolveLayoutViewport(viewportWidth, viewportHeight)
         val config = PreferenceConfiguration.readPreferences(context)
-        val rightDisplacement = screen.widthPixels - screen.heightPixels * 16 / 9
-        val height = screen.heightPixels
+        val height = viewport.height
+        val rightDisplacement = viewport.rightDisplacement
 
         if (!config.onlyL3R3) {
             if (PreferenceConfiguration.ONSCREEN_CONTROLLER_LAYOUT_PRESET_COMPACT_HANDHELD == config.onscreenControllerLayoutPreset) {
@@ -337,7 +368,20 @@ object VirtualControllerConfigurationLoader {
 
     @JvmStatic
     fun loadFromPreferences(controller: VirtualController, context: Context) {
+        val screen = context.resources.displayMetrics
+        loadFromPreferences(controller, context, screen.widthPixels, screen.heightPixels)
+    }
+
+    @JvmStatic
+    fun loadFromPreferences(
+        controller: VirtualController,
+        context: Context,
+        viewportWidth: Int,
+        viewportHeight: Int,
+    ) {
         val pref = context.getSharedPreferences(getOscPreferenceName(context), Activity.MODE_PRIVATE)
+        val safeWidth = viewportWidth.coerceAtLeast(1)
+        val safeHeight = viewportHeight.coerceAtLeast(1)
 
         for (element in controller.getElements()) {
             val prefKey = element.elementId.toString()
@@ -345,11 +389,29 @@ object VirtualControllerConfigurationLoader {
             if (jsonConfig != null) {
                 try {
                     element.loadConfiguration(JSONObject(jsonConfig))
+                    clampElementToViewport(element, safeWidth, safeHeight)
                 } catch (e: JSONException) {
                     e.printStackTrace()
                     pref.edit().remove(prefKey).apply()
                 }
             }
         }
+    }
+
+    private fun clampElementToViewport(
+        element: VirtualControllerElement,
+        viewportWidth: Int,
+        viewportHeight: Int,
+    ) {
+        val params = element.layoutParams as? FrameLayout.LayoutParams ?: return
+        val minimumWidth = minOf(MIN_ELEMENT_SIZE_PX, viewportWidth)
+        val minimumHeight = minOf(MIN_ELEMENT_SIZE_PX, viewportHeight)
+        params.width = params.width.coerceIn(minimumWidth, viewportWidth)
+        params.height = params.height.coerceIn(minimumHeight, viewportHeight)
+        params.leftMargin = params.leftMargin.coerceIn(0, viewportWidth - params.width)
+        params.topMargin = params.topMargin.coerceIn(0, viewportHeight - params.height)
+        params.rightMargin = 0
+        params.bottomMargin = 0
+        element.layoutParams = params
     }
 }

--- a/app/src/test/java/com/papi/nova/binding/input/virtual_controller/VirtualControllerViewportTest.kt
+++ b/app/src/test/java/com/papi/nova/binding/input/virtual_controller/VirtualControllerViewportTest.kt
@@ -1,0 +1,200 @@
+package com.papi.nova.binding.input.virtual_controller
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import com.papi.nova.preferences.PreferenceConfiguration
+import com.papi.nova.shadows.ShadowMoonBridge
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33], shadows = [ShadowMoonBridge::class])
+@RunWith(RobolectricTestRunner::class)
+class VirtualControllerViewportTest {
+    private lateinit var context: Context
+    private var originalMetricsWidth = 0
+    private var originalMetricsHeight = 0
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        originalMetricsWidth = context.resources.displayMetrics.widthPixels
+        originalMetricsHeight = context.resources.displayMetrics.heightPixels
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .putString(
+                PreferenceConfiguration.ONSCREEN_CONTROLLER_LAYOUT_PRESET_PREF_STRING,
+                PreferenceConfiguration.ONSCREEN_CONTROLLER_LAYOUT_PRESET_COMPACT_HANDHELD,
+            )
+            .putBoolean("checkbox_only_show_L3R3", false)
+            .commit()
+        compactProfile().edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        context.resources.displayMetrics.widthPixels = originalMetricsWidth
+        context.resources.displayMetrics.heightPixels = originalMetricsHeight
+        compactProfile().edit().clear().commit()
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .remove(PreferenceConfiguration.ONSCREEN_CONTROLLER_LAYOUT_PRESET_PREF_STRING)
+            .remove("checkbox_only_show_L3R3")
+            .commit()
+    }
+
+    @Test
+    fun measuredLandscapeViewportWinsWhileResourceMetricsAreStillPortrait() {
+        setResourceMetrics(width = 1080, height = 2400)
+        val fixture = fixture(width = 2400, height = 1080)
+
+        fixture.controller.refreshLayout()
+
+        assertElementsInside(fixture.controller, width = 2400, height = 1080)
+        assertFaceClusterAnchoredRight(fixture.controller, width = 2400)
+    }
+
+    @Test
+    fun tallViewportFitsControlsWithoutNegativeRightAnchoring() {
+        setResourceMetrics(width = 1080, height = 2400)
+        val fixture = fixture(width = 1080, height = 2400)
+
+        fixture.controller.refreshLayout()
+
+        assertElementsInside(fixture.controller, width = 1080, height = 2400)
+        assertFaceClusterAnchoredRight(fixture.controller, width = 1080)
+    }
+
+    @Test
+    fun savedCoordinatesAreClampedInsideMeasuredViewport() {
+        compactProfile().edit()
+            .putString(
+                VirtualControllerElement.EID_A.toString(),
+                JSONObject()
+                    .put("LEFT", 2600)
+                    .put("TOP", 1200)
+                    .put("WIDTH", 700)
+                    .put("HEIGHT", 500)
+                    .put("ENABLED", true)
+                    .toString(),
+            )
+            .commit()
+        val fixture = fixture(width = 2400, height = 1080)
+
+        fixture.controller.refreshLayout()
+
+        assertElementsInside(fixture.controller, width = 2400, height = 1080)
+        assertFaceClusterAnchoredRight(fixture.controller, width = 2400)
+    }
+
+    @Test
+    fun controllerRelayoutsWhenMeasuredViewportChanges() {
+        setResourceMetrics(width = 1080, height = 2400)
+        val fixture = fixture(width = 1080, height = 2400)
+        fixture.controller.refreshLayout()
+        val portraitLeft = elementParams(fixture.controller, VirtualControllerElement.EID_A).leftMargin
+
+        fixture.parent.layout(0, 0, 2400, 1080)
+        shadowOf(fixture.activity.mainLooper).idle()
+
+        assertElementsInside(fixture.controller, width = 2400, height = 1080)
+        val landscapeLeft = elementParams(fixture.controller, VirtualControllerElement.EID_A).leftMargin
+        assertTrue(
+            "A should move with the right edge after relayout: before=$portraitLeft after=$landscapeLeft parent=${fixture.parent.width}x${fixture.parent.height}",
+            landscapeLeft > portraitLeft,
+        )
+        assertTrue("A should land in the landscape viewport's right half", landscapeLeft > 1200)
+    }
+
+    @Test
+    fun hiddenControllerStaysHiddenAcrossViewportRelayout() {
+        val fixture = fixture(width = 2400, height = 1080)
+        fixture.controller.refreshLayout()
+        fixture.controller.hide()
+
+        fixture.parent.layout(0, 0, 2160, 1080)
+        shadowOf(fixture.activity.mainLooper).idle()
+
+        assertTrue("controller should retain its elements after relayout", fixture.controller.getElements().isNotEmpty())
+        fixture.controller.getElements().forEach { element ->
+            assertEquals(
+                "hidden controller element ${element.elementId} became visible after relayout",
+                View.GONE,
+                element.visibility,
+            )
+        }
+        assertEquals(
+            "hidden configuration control should show, not hide, on the next toggle",
+            1,
+            fixture.controller.switchShowHide(),
+        )
+    }
+
+    private fun fixture(width: Int, height: Int): Fixture {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val parent = FrameLayout(activity)
+        parent.layout(0, 0, width, height)
+        return Fixture(
+            activity = activity,
+            parent = parent,
+            controller = VirtualController(null, parent, activity),
+        )
+    }
+
+    private fun compactProfile() =
+        context.getSharedPreferences("OSC_compact_handheld", Context.MODE_PRIVATE)
+
+    private fun setResourceMetrics(width: Int, height: Int) {
+        context.resources.displayMetrics.widthPixels = width
+        context.resources.displayMetrics.heightPixels = height
+    }
+
+    private fun assertElementsInside(controller: VirtualController, width: Int, height: Int) {
+        assertTrue("controller should create touch elements", controller.getElements().isNotEmpty())
+        controller.getElements().forEach { element ->
+            val params = element.layoutParams as FrameLayout.LayoutParams
+            assertTrue("element ${element.elementId} width must be positive", params.width > 0)
+            assertTrue("element ${element.elementId} height must be positive", params.height > 0)
+            assertTrue("element ${element.elementId} starts left of viewport", params.leftMargin >= 0)
+            assertTrue("element ${element.elementId} starts above viewport", params.topMargin >= 0)
+            assertTrue(
+                "element ${element.elementId} exceeds viewport width: ${params.leftMargin}+${params.width}>$width",
+                params.leftMargin + params.width <= width,
+            )
+            assertTrue(
+                "element ${element.elementId} exceeds viewport height: ${params.topMargin}+${params.height}>$height",
+                params.topMargin + params.height <= height,
+            )
+        }
+    }
+
+    private fun assertFaceClusterAnchoredRight(controller: VirtualController, width: Int) {
+        val params = elementParams(controller, VirtualControllerElement.EID_A)
+        assertTrue("A should remain in the viewport's right half", params.leftMargin >= width / 2)
+    }
+
+    private fun elementParams(controller: VirtualController, elementId: Int): FrameLayout.LayoutParams {
+        val element = controller.getElements().firstOrNull { it.elementId == elementId }
+        assertNotNull("missing controller element $elementId", element)
+        return element!!.layoutParams as FrameLayout.LayoutParams
+    }
+
+    private data class Fixture(
+        val activity: Activity,
+        val parent: FrameLayout,
+        val controller: VirtualController,
+    )
+}


### PR DESCRIPTION
## what changed

- derive touch-controller geometry from the measured stream container instead of potentially stale resource metrics
- fit the legacy 16:9 controller canvas inside tall or narrow viewports without negative right anchoring
- relayout when the container size changes
- keep restored custom controls inside the active viewport
- preserve hidden overlay state across relayouts

## why

#248 shows Nova 1.3.7 rendering oversized controls with the right-side cluster shifted, overlapping, or missing on a 2400×1080 phone. the layout could initialize while Android still exposed portrait-shaped resource metrics, which scaled every control from the tall dimension and made the right-edge displacement negative.

this keeps the existing layouts and customization model, but binds them to the viewport they are actually drawn into.

## existing controls

opacity and touch-press vibration are already available in Nova settings, so this does not add duplicate controls or change their defaults.

## verification

- untouched focused baseline - 5/5
- intended viewport RED - 0/4
- hidden-state lifecycle RED - 0/1
- focused final suite - 10/10
- full unit suite - 1,394/1,394
- `:app:lintNonRoot_gameDebug`
- `:app:assembleNonRoot_gameDebug` for `armeabi-v7a`, `arm64-v8a`, and `x86_64`
- sabotage REDs confirmed independently for measured-container precedence, fitted tall-window geometry, and saved-profile containment
- independent review and narrow follow-up - approve, high confidence, zero blockers

physical verification is intentionally after merge so the smoke can use the exact CI-signed production-package artifact and retain the paired host state.

Fixes #248
