### PR TITLE
fix(doctor): enable confirmed Steam Input recovery

### DIFF
--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -900,6 +900,7 @@ class PolarisApiClient @JvmOverloads constructor(
                 targetBitrateKbps = actionPayload?.optInt("target_bitrate_kbps", 0) ?: 0,
                 verificationDelaySeconds = actionVerification?.optInt("delay_seconds", 0) ?: 0,
                 undoSupported = actionUndo?.optBoolean("supported", false) ?: false,
+                requiresConfirmation = safeAction?.opt("requires_confirmation") == true,
                 packetLossPct = parseDoctorEvidenceNumber(doctor, "packet_loss"),
                 latencyMs = parseDoctorEvidenceNumber(doctor, "latency"),
                 destructiveActionAllowed = false

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -269,6 +269,7 @@ data class PolarisSessionStatus(
         val targetBitrateKbps: Int = 0,
         val verificationDelaySeconds: Int = 0,
         val undoSupported: Boolean = false,
+        val requiresConfirmation: Boolean = false,
         val packetLossPct: Double? = null,
         val latencyMs: Double? = null,
         val destructiveActionAllowed: Boolean = false
@@ -280,8 +281,25 @@ data class PolarisSessionStatus(
             "recheck_network" -> version >= 2
             "lower_bitrate" -> version >= 2 && primaryIssue == "network_jitter" && networkPressureConfirmed
             "restore_quality" -> version >= 2 && primaryIssue == "quality_capped_by_history" && targetBitrateKbps > 0
+            "disable_steam_input_xbox" -> version >= 2 &&
+                primaryIssue == "steam_input_conflict" &&
+                actionKind == "host_setting" &&
+                resultId.isNotBlank() &&
+                requiresConfirmation &&
+                undoSupported
             else -> false
         }
+
+        /**
+         * True when this doctor payload is the same actionable pair the user just confirmed.
+         * Guards against a session refresh swapping the safe action out from under a confirmation
+         * dialog before the positive button is pressed.
+         */
+        fun matchesConfirmedAction(confirmed: DoctorStatus): Boolean =
+            actionId.isNotBlank() &&
+                resultId.isNotBlank() &&
+                actionId == confirmed.actionId &&
+                resultId == confirmed.resultId
     }
 
     data class HealthStatus(

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -28,6 +28,7 @@ import com.papi.nova.binding.input.GameInputDevice
 import com.papi.nova.binding.input.KeyboardTranslator
 import com.papi.nova.ui.compose.NovaComposeTheme
 import com.papi.nova.utils.DeviceUtils
+import com.papi.nova.utils.UiHelper
 
 /**
  * Stream quick menu with grouped sections for tuning, overlays, controls, and session actions.
@@ -549,16 +550,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             }
         }
 
-        fun runDoctorAction() {
-            val status = sessionStatus
-            val doctor = status?.doctor
-            val client = apiClient
-            if (client == null || status == null || doctor == null || !doctor.canExecuteAction ||
-                doctorActionPendingRegistry.isPending()
-            ) {
-                game.copyNovaHudDiagnostics()
-                return
-            }
+        fun executeConfirmedDoctorAction(doctor: PolarisSessionStatus.DoctorStatus, client: PolarisApiClient) {
             val scope = doctorReceiptScopeId ?: return
             val request = beginNewDoctorRequest(scope) ?: return
             game.launchReplacingRuntimeIo("NovaQuickMenuDoctorAction") {
@@ -599,6 +591,48 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     doctorMenuRefreshRegistry.dispatch()
                 }
             }
+        }
+
+        fun runDoctorAction() {
+            val status = sessionStatus
+            val doctor = status?.doctor
+            val client = apiClient
+            if (client == null || status == null || doctor == null || !doctor.canExecuteAction ||
+                !status.canAdjustHostTuning ||
+                doctorActionPendingRegistry.isPending()
+            ) {
+                game.copyNovaHudDiagnostics()
+                return
+            }
+            if (doctor.requiresConfirmation) {
+                val confirmed = doctor
+                UiHelper.displayConfirmationDialog(
+                    game,
+                    game.getString(R.string.nova_quick_menu_doctor_confirm_steam_input_title),
+                    game.getString(R.string.nova_quick_menu_doctor_confirm_steam_input_message),
+                    game.getString(R.string.nova_quick_menu_doctor_confirm_steam_input_proceed),
+                    game.getString(R.string.cancel),
+                    Runnable {
+                        val currentStatus = sessionStatus
+                        val currentClient = apiClient
+                        val currentDoctor = currentStatus?.doctor
+                        if (currentClient == null ||
+                            currentStatus == null ||
+                            currentDoctor == null ||
+                            !currentDoctor.canExecuteAction ||
+                            !currentStatus.canAdjustHostTuning ||
+                            !currentDoctor.matchesConfirmedAction(confirmed) ||
+                            doctorActionPendingRegistry.isPending()
+                        ) {
+                            return@Runnable
+                        }
+                        executeConfirmedDoctorAction(currentDoctor, currentClient)
+                    },
+                    null
+                )
+                return
+            }
+            executeConfirmedDoctorAction(doctor, client)
         }
 
         val callbacks = NovaQuickMenuCallbacks(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -992,6 +992,9 @@
     <string name="nova_quick_menu_doctor_receipt_verified">Verified</string>
     <string name="nova_quick_menu_doctor_receipt_attention">Needs attention</string>
     <string name="nova_quick_menu_doctor_receipt_undo_caption">Undo remains available here to restore the previous bitrate and Auto Quality state.</string>
+    <string name="nova_quick_menu_doctor_confirm_steam_input_title">Disable Xbox Steam Input?</string>
+    <string name="nova_quick_menu_doctor_confirm_steam_input_message">Desktop Steam and the current Steam game will close. Doctor will disable Xbox Steam Input, verify the fix, and keep Undo available so you can restore the previous setting.</string>
+    <string name="nova_quick_menu_doctor_confirm_steam_input_proceed">Close Steam and disable</string>
     <string name="nova_quick_menu_copy_hud_diagnostics">Copy HUD Diagnostics</string>
     <string name="nova_quick_menu_copy_hud_diagnostics_caption">Privacy-safe stream summary for bug reports.</string>
     <string name="nova_quick_menu_hud_diagnostics_copied">Nova HUD diagnostics copied</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -401,6 +401,149 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
+    fun parseSessionStatusResponse_marksDisableSteamInputXboxActionExecutable() {
+        val json = JSONObject(
+            "{\"state\":\"streaming\",\"streaming_active\":true," +
+                "\"doctor\":{\"version\":2,\"result_id\":\"doctor-v2-steam_input_conflict-xbox\"," +
+                "\"primary_issue\":\"steam_input_conflict\"," +
+                "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"label\":\"Disable Xbox Steam Input\"," +
+                "\"kind\":\"host_setting\",\"requires_confirmation\":true," +
+                "\"verification\":{\"delay_seconds\":6},\"undo\":{\"supported\":true}}}}"
+        )
+
+        val status = PolarisApiClient.parseSessionStatusResponse(json)
+
+        assertEquals("disable_steam_input_xbox", status.doctor.actionId)
+        assertEquals("steam_input_conflict", status.doctor.primaryIssue)
+        assertEquals("host_setting", status.doctor.actionKind)
+        assertEquals("doctor-v2-steam_input_conflict-xbox", status.doctor.resultId)
+        assertTrue(status.doctor.undoSupported)
+        assertTrue(status.doctor.requiresConfirmation)
+        assertTrue(status.doctor.canExecuteAction)
+    }
+
+    @Test
+    fun disableSteamInputXboxActionRefusesMalformedContract() {
+        fun status(overrides: String): PolarisSessionStatus.DoctorStatus {
+            val json = JSONObject(
+                "{\"state\":\"streaming\",\"streaming_active\":true," +
+                    "\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                    "\"primary_issue\":\"steam_input_conflict\"," +
+                    "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\"," +
+                    "\"kind\":\"host_setting\",\"requires_confirmation\":true," +
+                    "\"verification\":{\"delay_seconds\":6},\"undo\":{\"supported\":true}" +
+                    overrides + "}}}"
+            )
+            return PolarisApiClient.parseSessionStatusResponse(json).doctor
+        }
+
+        assertTrue(status("").canExecuteAction)
+        assertFalse(
+            "version below 2 must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":1,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"requires_confirmation\":true,\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "mismatched primary_issue must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"network_jitter\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"requires_confirmation\":true,\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "non host_setting kind must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"live_tuning\"," +
+                        "\"requires_confirmation\":true,\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "blank result_id must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"requires_confirmation\":true,\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "stringified requires_confirmation must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"requires_confirmation\":\"true\",\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "missing requires_confirmation must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"undo\":{\"supported\":true}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+        assertFalse(
+            "undo.supported false must reject",
+            PolarisApiClient.parseSessionStatusResponse(
+                JSONObject(
+                    "{\"state\":\"streaming\",\"doctor\":{\"version\":2,\"result_id\":\"doctor-xbox\"," +
+                        "\"primary_issue\":\"steam_input_conflict\"," +
+                        "\"safe_recovery_action\":{\"id\":\"disable_steam_input_xbox\",\"kind\":\"host_setting\"," +
+                        "\"requires_confirmation\":true,\"undo\":{\"supported\":false}}}}"
+                )
+            ).doctor.canExecuteAction
+        )
+    }
+
+    @Test
+    fun matchesConfirmedAction_requiresExactActionIdAndResultIdPair() {
+        val confirmed = PolarisSessionStatus.DoctorStatus(
+            actionId = "disable_steam_input_xbox",
+            resultId = "doctor-v2-steam_input_conflict-xbox"
+        )
+
+        assertTrue(confirmed.matchesConfirmedAction(confirmed))
+        assertFalse(
+            confirmed.copy(actionId = "lower_bitrate").matchesConfirmedAction(confirmed)
+        )
+        assertFalse(
+            confirmed.copy(resultId = "doctor-v2-steam_input_conflict-xbox-next")
+                .matchesConfirmedAction(confirmed)
+        )
+        assertFalse(
+            confirmed.copy(actionId = "").matchesConfirmedAction(confirmed)
+        )
+        assertFalse(
+            confirmed.copy(resultId = "").matchesConfirmedAction(confirmed)
+        )
+        assertFalse(
+            PolarisSessionStatus.DoctorStatus().matchesConfirmedAction(confirmed)
+        )
+    }
+
+    @Test
     fun parseSessionStatusResponse_fallsBackForOlderHostsWithoutDoctorPayload() {
         val json = JSONObject(
             "{\"state\":\"streaming\",\"streaming_active\":true," +


### PR DESCRIPTION
## summary

- enable Polaris Doctor's existing `disable_steam_input_xbox` recovery action in Nova
- require the exact v2 host-setting contract, literal confirmation, a nonblank result ID, and Undo support
- bind confirmation to the exact action ID and result ID so refreshed or stale diagnoses fail closed
- enforce owner host-tuning permission at the execution seam

## why

physical RP6 validation produced a real Steam Input conflict and Polaris advertised `Close Steam and fix`, but Nova's action whitelist silently reduced it to read-only advice.

this keeps the action one-click for normal users without making it one-tap dangerous. Nova explains that desktop Steam and the current Steam game will close, then only posts after confirmation. existing receipt, verification, and authenticated Undo handling stay unchanged.

## verification

- intended compile RED before `requiresConfirmation` existed
- focused Doctor contract tests GREEN
- three sabotage variants correctly RED: string-coerced confirmation, missing confirmation gate, and stale result-ID matching
- full unit suite: 1397 tests, 0 failures, 0 errors, 0 skipped
- lint and debug assemble GREEN
- independent review: APPROVE, zero blockers
