### PR TITLE
fix(hud): distinguish recovery from fallback

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -495,11 +495,16 @@ class NovaHudEventTrail(private val capacity: Int = 4) {
         record("Bitrate $direction: ${formatHudMbps(fromKbps)} → ${formatHudMbps(toKbps)}")
     }
 
-    fun recordRecoveryProfile(targetFps: Double) {
+    fun recordRecoveryProfile(targetFps: Double, recoveryQueued: Boolean) {
         if (targetFps <= 0.0) {
             return
         }
-        record("Next launch recovery: ${targetFps.roundToInt()} FPS")
+        val label = if (recoveryQueued) {
+            "Next launch recovery: ${targetFps.roundToInt()} FPS"
+        } else {
+            "Fallback ready: ${targetFps.roundToInt()} FPS"
+        }
+        record(label)
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -325,8 +325,9 @@ class NovaStreamHud(
                 status?.adaptiveBitrateEnabled == true
             streamPolicy = StreamPolicyUiState.from(status, lastBitrateKbps, targetFps)
             val safeTarget = status?.health?.safeTargetFps ?: 0.0
-            if (status?.health?.relaunchRecommended == true && safeTarget > 0.0) {
-                eventTrail.recordRecoveryProfile(safeTarget)
+            val recoveryQueued = status?.autoQuality?.isRecoveryQueued == true
+            if (safeTarget > 0.0 && (recoveryQueued || status?.health?.relaunchRecommended == true)) {
+                eventTrail.recordRecoveryProfile(safeTarget, recoveryQueued = recoveryQueued)
             }
             if (streamPolicy.effectiveBitrateKbps > 0) {
                 currentBitrateKbps = streamPolicy.effectiveBitrateKbps

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -536,7 +536,7 @@ class NovaHudUiStateTest {
         trail.recordBitrateChange(fromKbps = 30000, toKbps = 22000)
         assertEquals("Bitrate lowered: 30M → 22M", trail.latestLabel)
 
-        trail.recordRecoveryProfile(targetFps = 60.0)
+        trail.recordRecoveryProfile(targetFps = 60.0, recoveryQueued = true)
         val state = NovaHudUiState.from(
             mode = NovaHudMode.PERFORMANCE,
             fps = 59.0,
@@ -553,6 +553,19 @@ class NovaHudUiStateTest {
 
         assertEquals("Next launch recovery: 60 FPS", trail.latestLabel)
         assertEquals("Next launch recovery: 60 FPS", state.eventBreadcrumbLabel)
+    }
+
+    @Test
+    fun recoveryProfileHoldingWithSafeTargetReadsAsFallbackReady() {
+        // Stable 120 FPS with a held historical 60 FPS safeTarget must not read as a
+        // scheduled downgrade — only autoQuality state = recovery_queued is the queued
+        // case; anything else (holding, unknown) is a fallback that is available, not
+        // one that has been booked.
+        val trail = NovaHudEventTrail(capacity = 3)
+
+        trail.recordRecoveryProfile(targetFps = 60.0, recoveryQueued = false)
+
+        assertEquals("Fallback ready: 60 FPS", trail.latestLabel)
     }
 
     @Test
@@ -589,6 +602,23 @@ class NovaHudUiStateTest {
         assertTrue(source.contains("updateFps(sample.fps)"))
         assertTrue(source.contains("updateFromPerfText(text: String)"))
         assertTrue(source.contains("NovaHudPerfSample.fromPerfText(text)"))
+    }
+
+    @Test
+    fun streamHudDerivesRecoveryQueuedFromAutoQualityStateForBreadcrumb() {
+        // A held historical safeTarget must not read as a scheduled downgrade. The
+        // queued-vs-fallback distinction lives on Polaris' parsed autoQuality state
+        // (isRecoveryQueued), so the call site must read that field and pass it
+        // through to the trail — no local re-derivation from relaunchRecommended alone.
+        val source = String(
+            Files.readAllBytes(Path.of("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")),
+            StandardCharsets.UTF_8
+        )
+
+        assertTrue(source.contains("status?.autoQuality?.isRecoveryQueued"))
+        assertTrue(
+            source.contains("eventTrail.recordRecoveryProfile(safeTarget, recoveryQueued = recoveryQueued)")
+        )
     }
 
     private fun status(


### PR DESCRIPTION
## summary

- keep `Next launch recovery: N FPS` only for Polaris state `recovery_queued`
- show `Fallback ready: N FPS` for held or unknown historical safe targets
- leave live FPS telemetry and Polaris recovery policy untouched

## why

Nova could show `Stable • Stream 120` beside `Next launch recovery: 60 FPS`. both values came from real data, but the wording made a stored safety fallback look like Nova had already scheduled a downgrade.

older hosts also fail safely now. without an explicit queued state, Nova describes the value as a fallback instead of claiming a next-launch change.

## verification

- intended compile RED before the state-aware event API existed
- focused HUD suite: 22 tests GREEN
- sabotage RED when the call site hardcoded queued state
- sabotage RED when the helper always emitted next-launch recovery
- full unit suite: 1396 tests, 0 failures, 0 errors, 0 skipped
- lint and debug assemble GREEN
- independent review: APPROVE, zero blockers
