### PR TITLE
fix(hud): retire stale recovery breadcrumbs

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -495,6 +495,12 @@ class NovaHudEventTrail(private val capacity: Int = 4) {
         record("Bitrate $direction: ${formatHudMbps(fromKbps)} → ${formatHudMbps(toKbps)}")
     }
 
+    fun retireRecoveryProfile() {
+        labels.removeAll { label ->
+            label.startsWith("Next launch recovery:") || label.startsWith("Fallback ready:")
+        }
+    }
+
     fun recordRecoveryProfile(targetFps: Double, recoveryQueued: Boolean) {
         if (targetFps <= 0.0) {
             return

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -328,6 +328,8 @@ class NovaStreamHud(
             val recoveryQueued = status?.autoQuality?.isRecoveryQueued == true
             if (safeTarget > 0.0 && (recoveryQueued || status?.health?.relaunchRecommended == true)) {
                 eventTrail.recordRecoveryProfile(safeTarget, recoveryQueued = recoveryQueued)
+            } else {
+                eventTrail.retireRecoveryProfile()
             }
             if (streamPolicy.effectiveBitrateKbps > 0) {
                 currentBitrateKbps = streamPolicy.effectiveBitrateKbps

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -556,6 +556,57 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun retireRecoveryProfileRemovesStaleRecoveryButKeepsBitrateHistory() {
+        val trail = NovaHudEventTrail(capacity = 4)
+
+        trail.recordBitrateChange(fromKbps = 30000, toKbps = 22000)
+        trail.recordRecoveryProfile(targetFps = 60.0, recoveryQueued = true)
+        assertEquals("Next launch recovery: 60 FPS", trail.latestLabel)
+
+        trail.retireRecoveryProfile()
+
+        assertEquals("Bitrate lowered: 30M → 22M", trail.latestLabel)
+    }
+
+    @Test
+    fun retireRecoveryProfileRemovesFallbackReadyEntries() {
+        val trail = NovaHudEventTrail(capacity = 4)
+
+        trail.recordBitrateChange(fromKbps = 22000, toKbps = 30000)
+        trail.recordRecoveryProfile(targetFps = 60.0, recoveryQueued = false)
+        assertEquals("Fallback ready: 60 FPS", trail.latestLabel)
+
+        trail.retireRecoveryProfile()
+
+        assertEquals("Bitrate recovered: 22M → 30M", trail.latestLabel)
+    }
+
+    @Test
+    fun retireRecoveryProfileIsNoOpWhenTrailHoldsNoRecoveryEntries() {
+        val trail = NovaHudEventTrail(capacity = 4)
+
+        trail.recordBitrateChange(fromKbps = 30000, toKbps = 22000)
+        trail.recordBitrateChange(fromKbps = 22000, toKbps = 18000)
+
+        trail.retireRecoveryProfile()
+
+        assertEquals("Bitrate lowered: 22M → 18M", trail.latestLabel)
+    }
+
+    @Test
+    fun retireRecoveryProfileClearsEveryRecoveryFamilyEntry() {
+        val trail = NovaHudEventTrail(capacity = 4)
+
+        trail.recordRecoveryProfile(targetFps = 90.0, recoveryQueued = false)
+        trail.recordBitrateChange(fromKbps = 30000, toKbps = 22000)
+        trail.recordRecoveryProfile(targetFps = 60.0, recoveryQueued = true)
+
+        trail.retireRecoveryProfile()
+
+        assertEquals("Bitrate lowered: 30M → 22M", trail.latestLabel)
+    }
+
+    @Test
     fun recoveryProfileHoldingWithSafeTargetReadsAsFallbackReady() {
         // Stable 120 FPS with a held historical 60 FPS safeTarget must not read as a
         // scheduled downgrade — only autoQuality state = recovery_queued is the queued
@@ -619,6 +670,28 @@ class NovaHudUiStateTest {
         assertTrue(
             source.contains("eventTrail.recordRecoveryProfile(safeTarget, recoveryQueued = recoveryQueued)")
         )
+    }
+
+    @Test
+    fun streamHudRetiresRecoveryBreadcrumbWhenSafeTargetOrRecoveryStateClears() {
+        // NovaHudEventTrail is append-only, so once "Next launch recovery" or
+        // "Fallback ready" is recorded it lingers next to newer live telemetry.
+        // applySessionStatus must retire the recovery-family entry as soon as
+        // safeTarget drops to zero or neither recoveryQueued nor
+        // relaunchRecommended is true, so stale copy doesn't sit beside a
+        // healthy session.
+        val source = String(
+            Files.readAllBytes(Path.of("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")),
+            StandardCharsets.UTF_8
+        )
+
+        assertTrue(source.contains("eventTrail.retireRecoveryProfile()"))
+        assertTrue(
+            source.contains(
+                "if (safeTarget > 0.0 && (recoveryQueued || status?.health?.relaunchRecommended == true)) {"
+            )
+        )
+        assertTrue(source.contains("} else {\n                eventTrail.retireRecoveryProfile()"))
     }
 
     private fun status(


### PR DESCRIPTION
## summary

- retire `Next launch recovery` and `Fallback ready` breadcrumbs when the recovery condition clears
- preserve bitrate and unrelated HUD history
- remove every stale recovery-family entry, not just the newest one

## why

The HUD event trail was append-only. A recovery label could remain beside newer healthy live telemetry after Polaris cleared the safe target or stopped recommending a recovery launch.

## verification

- focused HUD tests: 27/27
- sabotage with old production behavior: compile RED on the missing retirement contract
- restored full Nova unit suite: 1404/1404, zero failures/errors/skips
- lint and debug assemble: green
- independent blocking review: pass, zero blockers

## limits

this changes breadcrumb lifecycle only. it does not alter Polaris recovery thresholds or current-stream FPS telemetry.
