### PR TITLE
chore(release): prepare Nova 1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 1.3.8 - 2026-08-25
+
+Nova 1.3.8 makes high-FPS launches match what Play Setup says, keeps handheld controls inside the viewport, and makes recovery status honest instead of leaving stale warnings behind.
+
+Play Setup now sends one composed launch-tuning request for High FPS, shows the difference between what Nova requested and what Polaris granted, and keeps Settings presets from silently rewriting FPS or share-panel culling choices (#245-#247). Compact Handheld touch controls stay fully inside the viewport on narrow devices (#250).
+
+Command Center and NovaHUD now distinguish active recovery from fallback, retire stale recovery breadcrumbs, and keep authenticated Doctor receipt ownership across stream resume (#249, #252-#254). Steam Input evidence remains visible as manual guidance in this release. Automatic Steam profile Fix, Apply, and Undo are not offered.
+
+Android TV banner branding is refreshed to match the current Nova identity.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.3.8 and versionCode 40.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus portable SHA-256 sidecars through the GitHub release workflow.
+
+### Validation notes
+
+- The exact release-prep candidate must pass JVM tests, strict lint, public hygiene, and three-ABI release assembly before merge.
+- Final publication remains gated on the exact signed ARM64 artifact: package/version identity, signer continuity, in-place install and launch on the Retroid Pocket 6, controller-first focus, one Control stream, Command Center Doctor read-only behavior, and clean teardown with the host restored.
+- Steam Input profile mutation and Undo remain deliberately unavailable in this release. Doctor continues to report evidence and manual guidance without changing Steam files.
+
 ## 1.3.7 - 2026-08-19
 
 Nova 1.3.7 adds a user-controlled problem-report handoff, stops offering a per-session display choice the host cannot honor, and adds the two Steam Big Picture chords that were still unreachable from many streaming controllers.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.3.7"
-        versionCode = 39
+        versionName "1.3.8"
+        versionCode = 40
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,14 +81,14 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/39.txt"
+            "fastlane/metadata/android/en-US/changelogs/40.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.3.7\""))
-        assertTrue(build.contains("versionCode = 39"))
-        assertTrue(changelog.contains("## 1.3.7 - 2026-08-19"))
-        assertTrue(changelog.contains("does not automatically upload a report"))
+        assertTrue(build.contains("versionName \"1.3.8\""))
+        assertTrue(build.contains("versionCode = 40"))
+        assertTrue(changelog.contains("## 1.3.8 - 2026-08-25"))
+        assertTrue(changelog.contains("Automatic Steam profile Fix, Apply, and Undo are not offered."))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
         assertTrue(releaseWorkflow.contains("--notes-file \"\$release_notes\""))
         assertTrue(releaseWorkflow.contains("gh release edit \"\${GITHUB_REF_NAME}\""))
@@ -107,7 +107,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.3.7"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.3.8"))
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/40.txt
+++ b/fastlane/metadata/android/en-US/changelogs/40.txt
@@ -1,0 +1,2 @@
+Nova 1.3.8
+High FPS launches now carry one binding tuning request and show what Nova asked for versus what Polaris granted. Settings no longer rewrite FPS. Compact Handheld controls stay inside the viewport. Command Center recovery and HUD status no longer leave stale breadcrumbs. Steam Input remains read-only guidance in this release, with no automatic Fix or Undo. Android TV banner branding is refreshed. Includes signed ARM64, ARMv7, and x86_64 APKs with SHA-256 checksums.

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -154,7 +154,7 @@ required_metadata=(
   "$metadata_dir/full_description.txt"
   "$metadata_dir/changelogs/16.txt"
   "$metadata_dir/changelogs/38.txt"
-  "$metadata_dir/changelogs/39.txt"
+  "$metadata_dir/changelogs/40.txt"
   "$metadata_dir/images/icon.png"
   "docs/fdroid.md"
 )


### PR DESCRIPTION
## what changed

- bumps Nova to version `1.3.8` and version code `40`
- adds curated 1.3.8 changelog and Google Play notes
- updates the release metadata and public-doc contracts to require the new version
- states the release boundary honestly: Steam Input remains read-only guidance with no automatic Fix, Apply, or Undo

## exact candidate

- head: `a54082ec5dee0fbee549de5e278cec992f4c3f3f`
- tree: `5c23368111b2598a9d2efe064bc4b4759c01a0c2`
- parent: merged Nova master `639521d4fcfd0ef86b6a11b64669cba1ea03d4e4`

## verification

- strict Android lint: successful
- JVM tests: `1412/1412`
- Retroid/helper tests: `51/51`
- release-note tests: `4/4`
- public documentation guard: successful
- ARM64, ARMv7, and x86_64 release assembly: successful
- independent exact-candidate replay: PASS
- exact package identity: `com.papi.nova` version `1.3.8/40`

RP6 Control and Command Center Doctor passed against the exact read-only Polaris candidate. Doctor rendered guidance without Fix, Apply, or Undo. Android TV launcher visual verification remains explicitly waived and is not counted as passed.

## security alert audit

GitHub reports two moderate default-branch Dependabot alerts. Exact `nonRoot_gameReleaseRuntimeClasspath` contains neither `io.netty:netty-codec-http` nor `org.jetbrains.kotlin:kotlin-gradle-plugin`. Kotlin `2.3.21` is build tooling, the first patched version is `2.4.20-Beta1`, and release CI uses `--no-build-cache` with no remote build cache. Netty is likewise absent from the packaged runtime graph. This PR does not dismiss either alert or introduce a beta compiler/transitive override during release prep; both remain visible for a separate dependency-hardening pass.

## boundaries

this PR does not tag, sign, publish, deploy, or activate Nova. merge is allowed only if the exact head remains green. final master must be rebuilt and frozen before any separate tag/sign/publish approval.
