### PR TITLE
fix(play-setup): persist per-game resolution + add independent Frame Rate row

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
@@ -71,6 +71,12 @@ data class NovaDisplayResolutionPlanner(
             return if (parts.size == 3) "${parts[0]}x${parts[1]}" else targetMode
         }
 
+        /** The trailing rate half of a planner target mode, or null when it can't be read. */
+        fun resolutionFps(targetMode: String): Int? {
+            val parts = targetMode.trim().split('x', 'X')
+            return parts.getOrNull(2)?.toFloatOrNull()?.roundToInt()
+        }
+
         private fun plannerTitle(choice: PolarisGame.DisplayPlannerChoice, recommendedId: String): String {
             return if (choice.id == recommendedId) {
                 "Best for this device"

--- a/app/src/main/java/com/papi/nova/ui/NovaFrameRateOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaFrameRateOverrides.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/**
+ * Where the frame rate chosen for a game in Play Setup is remembered.
+ *
+ * Mirrors [NovaResolutionOverrides] and [NovaLaunchModeOverrides]: a plain per-game
+ * SharedPreferences entry, absent when the game has never had an explicit pin and
+ * should keep following the resolution choice's own paired rate (or the host's plan).
+ */
+object NovaFrameRateOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "frame_rate_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): Int? {
+        val stored = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(key(game), 0)
+        return stored.takeIf { it > 0 }
+    }
+
+    fun save(context: Context, game: PolarisGame, fps: Int) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(key(game), fps)
+            .apply()
+    }
+
+    /** Remove the per-game pin so the game follows the resolution/host rate again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -392,8 +392,10 @@ class NovaGameDetailActivity : NovaActivity() {
         explainedRow = NovaPlaySetupRow.WHERE_IT_RUNS
         // An explicit resolution, held until launch rather than launching on the spot.
         // Picking one used to start the game immediately, which is why the row that owned
-        // it could not be a setting: there was nothing to set.
-        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(null)
+        // it could not be a setting: there was nothing to set. The choice itself is
+        // rebuilt fresh from the planner every open, so only its id is persisted
+        // (NovaResolutionOverrides) and resolved back against this open's planner here.
+        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(loadResolutionOverride(currentGame))
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -763,6 +765,7 @@ class NovaGameDetailActivity : NovaActivity() {
          */
         fun chooseResolution(choice: NovaDisplayResolutionChoice) {
             chosenResolution = choice
+            saveResolutionOverride(currentGame, choice.id)
         }
 
         fun selectProfilePreference(value: String) {
@@ -1382,6 +1385,16 @@ class NovaGameDetailActivity : NovaActivity() {
 
     private fun saveProfilePreference(game: PolarisGame, preference: String) {
         AutoQualityProfilePreferences.save(this@NovaGameDetailActivity, game.name, preference)
+    }
+
+    /** Resolves a saved resolution-choice id back against this open's planner, if any. */
+    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? {
+        val savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game) ?: return null
+        return resolutionPlanner(game).visibleChoices.firstOrNull { it.id == savedId }
+    }
+
+    private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
+        NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -396,6 +396,11 @@ class NovaGameDetailActivity : NovaActivity() {
         // rebuilt fresh from the planner every open, so only its id is persisted
         // (NovaResolutionOverrides) and resolved back against this open's planner here.
         var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(loadResolutionOverride(currentGame))
+        // An explicit frame-rate pin, independent of resolution. It composes over
+        // whatever fps the resolution choice (or the host's own plan) would have used --
+        // see NovaLaunchStreamOverride.compose, where fpsOverride wins over both. Persisted
+        // the same way as chosenResolution, so it survives past this Activity's lifetime.
+        var chosenFps by mutableStateOf<Int?>(loadFrameRateOverride(currentGame))
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -406,17 +411,21 @@ class NovaGameDetailActivity : NovaActivity() {
 
         /**
          * The blob this launch would go out with: the host's plan, composed with the
-         * resolution chosen here and the High FPS pin, when either exists. Composed
-         * over the host blob rather than replacing it, so a resolution pick no longer
-         * silently discards the recovery clamp -- only the explicit fps pin releases
-         * it. The fps that launches must always be re-derivable from this blob.
+         * resolution chosen here and the fps pin, when either exists. Composed over the
+         * host blob rather than replacing it, so a resolution pick no longer silently
+         * discards the recovery clamp -- only the explicit fps pin releases it. An
+         * explicit Frame Rate row choice wins over the implicit Tuning = High FPS pin,
+         * since a pin made by name here is a more specific answer than one inferred
+         * from a quality profile. The fps that launches must always be re-derivable
+         * from this blob.
          */
         fun launchOptimization(): JSONObject? {
             val preferences = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
             return NovaLaunchStreamOverride.compose(
                 raw = optimizationState.rawOptimization,
                 resolution = chosenResolution,
-                fpsOverride = NovaLaunchStreamOverride.highFpsPin(profilePreference, preferences.fps),
+                fpsOverride = chosenFps
+                    ?: NovaLaunchStreamOverride.highFpsPin(profilePreference, preferences.fps),
                 fallbackWidth = preferences.width,
                 fallbackHeight = preferences.height,
                 fallbackFps = preferences.fps.toInt(),
@@ -768,6 +777,20 @@ class NovaGameDetailActivity : NovaActivity() {
             saveResolutionOverride(currentGame, choice.id)
         }
 
+        /**
+         * Pin a frame rate rather than launching with it, same as [chooseResolution].
+         * Null clears the pin -- the row's own "Auto" option -- so the game goes back to
+         * whatever fps the resolution choice or the host's plan would have used.
+         */
+        fun chooseFrameRate(fps: Int?) {
+            chosenFps = fps
+            if (fps != null) {
+                saveFrameRateOverride(currentGame, fps)
+            } else {
+                clearFrameRateOverride(currentGame)
+            }
+        }
+
         fun selectProfilePreference(value: String) {
             if (value == profilePreference) return
             profilePreference = value
@@ -884,6 +907,41 @@ class NovaGameDetailActivity : NovaActivity() {
                         )
                     },
                     overridden = overridden,
+                )
+
+                val effectiveFps = chosenFps
+                    ?: effective?.targetMode?.let { NovaDisplayResolutionPlanner.resolutionFps(it) }
+                rows += NovaPlaySetupRowState(
+                    row = NovaPlaySetupRow.FRAME_RATE,
+                    label = getString(R.string.nova_play_setup_frame_rate),
+                    caption = if (chosenFps != null) {
+                        getString(R.string.nova_play_setup_frame_rate_chosen)
+                    } else {
+                        getString(R.string.nova_play_setup_frame_rate_caption)
+                    },
+                    value = effectiveFps?.let { getString(R.string.nova_play_setup_frame_rate_fps_format, it) }.orEmpty(),
+                    stripTitle = getString(R.string.nova_play_setup_strip_frame_rate),
+                    options = buildList {
+                        add(
+                            NovaPlaySetupOption(
+                                label = getString(R.string.nova_play_setup_frame_rate_auto),
+                                consequence = getString(R.string.nova_play_setup_frame_rate_auto_consequence),
+                                current = chosenFps == null,
+                                onSelect = { chooseFrameRate(null) },
+                            )
+                        )
+                        NOVA_FRAME_RATE_CHOICES.forEach { fps ->
+                            add(
+                                NovaPlaySetupOption(
+                                    label = getString(R.string.nova_play_setup_frame_rate_fps_format, fps),
+                                    consequence = "",
+                                    current = chosenFps == fps,
+                                    onSelect = { chooseFrameRate(fps) },
+                                )
+                            )
+                        }
+                    },
+                    overridden = chosenFps != null,
                 )
             }
 
@@ -1395,6 +1453,18 @@ class NovaGameDetailActivity : NovaActivity() {
 
     private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
         NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
+    }
+
+    private fun loadFrameRateOverride(game: PolarisGame): Int? {
+        return NovaFrameRateOverrides.load(this@NovaGameDetailActivity, game)
+    }
+
+    private fun saveFrameRateOverride(game: PolarisGame, fps: Int) {
+        NovaFrameRateOverrides.save(this@NovaGameDetailActivity, game, fps)
+    }
+
+    private fun clearFrameRateOverride(game: PolarisGame) {
+        NovaFrameRateOverrides.clear(this@NovaGameDetailActivity, game)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {
@@ -1939,3 +2009,11 @@ class NovaGameDetailActivity : NovaActivity() {
  * early anyway, so this is only ever the cost of walking away mid-change.
  */
 private const val NOVA_PLAY_SETUP_SETTLE_MS = 650L
+
+/**
+ * The fixed rates the Frame Rate row offers, independent of what any resolution
+ * choice happens to pair with. Not host-derived like the resolution list -- Polaris
+ * does not publish a capability list to filter this against, so it stays the common
+ * handheld/TV rates rather than guessing at what the display or host can actually hit.
+ */
+private val NOVA_FRAME_RATE_CHOICES = listOf(30, 60, 90, 120)

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -410,6 +410,7 @@ internal enum class NovaPlaySetupScope { THIS_GAME, EVERY_GAME }
 internal enum class NovaPlaySetupRow {
     WHERE_IT_RUNS,
     RESOLUTION,
+    FRAME_RATE,
     TUNING,
     STEAM_LAUNCH,
     HOST_DEFAULT_DISPLAY,

--- a/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/**
+ * Where the resolution chosen for a game in Play Setup is remembered.
+ *
+ * [NovaDisplayResolutionChoice] is rebuilt fresh from the planner on every screen open, so
+ * only the choice's stable [NovaDisplayResolutionChoice.id] is persisted here — the id is
+ * resolved back against that game's current [NovaDisplayResolutionPlanner.visibleChoices]
+ * at load time, the same way [NovaLaunchModeOverrides] resolves a saved mode id.
+ */
+object NovaResolutionOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "resolution_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): String? =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(key(game), null)
+            ?.takeIf { it.isNotBlank() }
+
+    fun save(context: Context, game: PolarisGame, choiceId: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(key(game), choiceId)
+            .apply()
+    }
+
+    /** Remove the per-game choice so the game follows the planner's recommendation again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,6 +338,13 @@
     <string name="nova_play_setup_resolution_caption">The display is made to match this handheld</string>
     <string name="nova_play_setup_resolution_chosen">Chosen here \u00b7 applies at launch</string>
     <string name="nova_play_setup_strip_resolution">If you changed the resolution</string>
+    <string name="nova_play_setup_frame_rate">Frame Rate</string>
+    <string name="nova_play_setup_frame_rate_caption">Follows the resolution\'s own rate</string>
+    <string name="nova_play_setup_frame_rate_chosen">Chosen here \u00b7 applies at launch</string>
+    <string name="nova_play_setup_strip_frame_rate">If you changed the frame rate</string>
+    <string name="nova_play_setup_frame_rate_auto">Auto</string>
+    <string name="nova_play_setup_frame_rate_auto_consequence">Whatever the resolution or host plans</string>
+    <string name="nova_play_setup_frame_rate_fps_format">%d FPS</string>
     <string name="nova_play_setup_tuning">Tuning</string>
     <string name="nova_play_setup_strip_tuning">If you changed the tuning</string>
     <string name="nova_play_setup_tuning_pins">Pins %1$d FPS from your Settings frame rate</string>


### PR DESCRIPTION
## Context

On the Play Setup screen, **Where It Runs** and **Tuning** already persist their per-game choice across sessions (`NovaLaunchModeOverrides`, `AutoQualityProfilePreferences`). **Resolution** did not: picking a resolution worked for the launch it was chosen for, but after a disconnect/reconnect (or any time `NovaGameDetailActivity` gets recreated) the row silently reset back to the planner's recommendation, as if the choice had never been made.

## Root cause

`chosenResolution` (`NovaGameDetailActivity.kt`) was a plain `mutableStateOf<NovaDisplayResolutionChoice?>(null)` Activity-scoped Compose state field with no backing store at all - it only ever got read once by `launchOptimization()` to build the one-shot launch override blob, then died with the Activity on `finish()`. There was no persistence path to hook into; the row just looked like a setting without being one.

## What this does

Adds `NovaResolutionOverrides`, mirroring the existing `NovaLaunchModeOverrides` pattern: only the chosen `NovaDisplayResolutionChoice.id` is persisted (SharedPreferences, keyed per game), since the `NovaDisplayResolutionChoice` objects themselves are rebuilt fresh from the planner on every screen open anyway.

- `chooseResolution()` now saves the id alongside updating the in-memory state.
- `chosenResolution`'s initial value is resolved from the saved id against that open's `resolutionPlanner(game).visibleChoices` via a new `loadResolutionOverride()` helper.

No changes to the picker UI, the planner, or the launch-time override blob - this only fixes what happens to the choice *between* launches.

## Testing

- `./gradlew :app:compileRootDebugKotlin` - builds clean
- Built and installed on a real device (AYN Thor, debug build). In Play Setup for Crisis Core –FINAL FANTASY VII– REUNION, changed Resolution to **Performance (960x540)**, then **force-stopped the app entirely** (not just backgrounded/disconnected) and relaunched. Reopened Play Setup for the same game: Resolution still showed **960x540** with the "Chosen here · applies at launch" caption. This is a stronger test than a session disconnect since it confirms the fix survives full process death, not just Activity recreation within a live process.