### PR TITLE
feat: prioritize game detail actions and track pin state

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -108,6 +108,7 @@ import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaFocusableCard
 import com.papi.nova.utils.DeviceUtils
+import com.papi.nova.utils.GameShortcutPinState
 import com.papi.nova.utils.ServerHelper
 import com.papi.nova.utils.ShortcutHelper
 import kotlinx.coroutines.CancellationException
@@ -137,6 +138,9 @@ class NovaGameDetailActivity : NovaActivity() {
     private var clientSettings: PolarisClientSettings? = null
     private var serverName: String = ""
     private var serverUuid: String? = null
+    private var shortcutGameAppId: Int? = null
+    private var shortcutPinState by mutableStateOf(GameShortcutPinState.UNSUPPORTED)
+    private var shortcutPinRequestPending by mutableStateOf(false)
 
     /**
      * The sheet took these as constructor lambdas. Keeping the names and the nullable
@@ -251,6 +255,8 @@ class NovaGameDetailActivity : NovaActivity() {
 
         apiClient = PolarisApiClient(this, host, httpsPort, serverCert)
         shortcutHelper = ShortcutHelper(this)
+        shortcutGameAppId = game.appId
+        refreshShortcutPinState()
         artworkViewModel = ViewModelProvider(
             this,
             NovaArtworkLibraryUpdateViewModel.Factory(
@@ -274,6 +280,44 @@ class NovaGameDetailActivity : NovaActivity() {
 
         setUpDetail(game, apiClient)
         refreshActiveSession(game)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshShortcutPinState()
+    }
+
+    private fun refreshShortcutPinState() {
+        if (!::shortcutHelper.isInitialized) return
+        val hostUuid = serverUuid?.takeIf { it.isNotBlank() }
+        val appId = shortcutGameAppId
+        shortcutPinState = if (hostUuid == null || appId == null) {
+            GameShortcutPinState.UNSUPPORTED
+        } else {
+            shortcutHelper.getGameShortcutPinState(hostUuid, appId)
+        }
+        if (shortcutPinState != GameShortcutPinState.AVAILABLE) {
+            shortcutPinRequestPending = false
+        }
+    }
+
+    /**
+     * requestPinShortcut() only means the launcher accepted the request. Poll briefly
+     * while its confirmation UI is up, and recheck again from onResume, so Nova never
+     * calls a request "pinned" before Android does.
+     */
+    private fun awaitShortcutPinConfirmation() {
+        shortcutPinRequestPending = true
+        lifecycleScope.launch {
+            repeat(12) {
+                delay(250)
+                refreshShortcutPinState()
+                if (shortcutPinState == GameShortcutPinState.PINNED) {
+                    return@launch
+                }
+            }
+            shortcutPinRequestPending = false
+        }
     }
 
     /**
@@ -1223,6 +1267,8 @@ class NovaGameDetailActivity : NovaActivity() {
                             resetWorking = false
                         }
                     },
+                    shortcutPinState = shortcutPinState,
+                    shortcutPinRequestPending = shortcutPinRequestPending,
                     onPinShortcut = {
                         val hostUuid = serverUuid
                         val messageRes = if (hostUuid.isNullOrEmpty()) {
@@ -1238,6 +1284,7 @@ class NovaGameDetailActivity : NovaActivity() {
                                 iconBits = null,
                             )
                             if (pinned) {
+                                awaitShortcutPinConfirmation()
                                 R.string.nova_library_pin_shortcut_success
                             } else {
                                 R.string.nova_library_pin_shortcut_unsupported

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -72,6 +72,7 @@ import com.papi.nova.ui.compose.NovaBadge
 import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaFocusableCard
 import com.papi.nova.ui.compose.NovaRadius
+import com.papi.nova.utils.GameShortcutPinState
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -233,6 +234,8 @@ internal fun NovaGameDetailContent(
     onAdvancePlaySetupRow: (NovaPlaySetupRow) -> Unit,
     onRetryHighFps: () -> Unit,
     onResetProfile: () -> Unit,
+    shortcutPinState: GameShortcutPinState,
+    shortcutPinRequestPending: Boolean,
     onPinShortcut: () -> Unit,
     artworkState: NovaArtworkStudioState,
     onRefreshArtwork: () -> Unit,
@@ -297,6 +300,8 @@ internal fun NovaGameDetailContent(
             onPrimaryLaunch = onPrimaryLaunch,
             onRetryHighFps = onRetryHighFps,
             onResetProfile = onResetProfile,
+            shortcutPinState = shortcutPinState,
+            shortcutPinRequestPending = shortcutPinRequestPending,
             onPinShortcut = onPinShortcut,
             onDestination = onDestination,
             activeSession = activeSession,

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
@@ -41,6 +42,7 @@ import androidx.compose.runtime.key
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -76,6 +78,7 @@ import com.papi.nova.ui.compose.NovaChromeType
 import com.papi.nova.ui.compose.NovaControllerHint
 import com.papi.nova.ui.compose.NovaControllerHintBar
 import com.papi.nova.ui.compose.NovaRadius
+import com.papi.nova.utils.GameShortcutPinState
 import kotlinx.coroutines.delay
 
 /** Where the detail window currently is. Back unwinds one level before leaving. */
@@ -129,6 +132,8 @@ internal fun NovaGameDetailOverview(
     onPrimaryLaunch: () -> Unit,
     onRetryHighFps: () -> Unit,
     onResetProfile: () -> Unit,
+    shortcutPinState: GameShortcutPinState,
+    shortcutPinRequestPending: Boolean,
     onPinShortcut: () -> Unit,
     onDestination: (NovaGameDetailDestination) -> Unit,
     activeSession: NovaLibraryActiveSessionUiState?,
@@ -248,6 +253,8 @@ internal fun NovaGameDetailOverview(
                 onPrimaryLaunch = onPrimaryLaunch,
                 onRetryHighFps = onRetryHighFps,
                 onResetProfile = onResetProfile,
+                shortcutPinState = shortcutPinState,
+                shortcutPinRequestPending = shortcutPinRequestPending,
                 onPinShortcut = onPinShortcut,
                 onDestination = onDestination,
                 activeSession = activeSession,
@@ -412,6 +419,8 @@ private fun NovaGameDetailActions(
     onPrimaryLaunch: () -> Unit,
     onRetryHighFps: () -> Unit,
     onResetProfile: () -> Unit,
+    shortcutPinState: GameShortcutPinState,
+    shortcutPinRequestPending: Boolean,
     onPinShortcut: () -> Unit,
     onDestination: (NovaGameDetailDestination) -> Unit,
     activeSession: NovaLibraryActiveSessionUiState?,
@@ -419,29 +428,15 @@ private fun NovaGameDetailActions(
     onEndSession: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val lane: @Composable (@Composable () -> Unit) -> Unit = { content ->
-        if (stacked) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-                modifier = modifier.fillMaxWidth(),
-                content = { content() },
-            )
-        } else {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = modifier,
-                content = { content() },
-            )
+    val playFocusable = uiState.playEnabled || activeSession != null
+    LaunchedEffect(playFocusable) {
+        if (playFocusable) {
+            delay(NOVA_FIRST_FOCUS_SETTLE_MS)
+            runCatching { playFocusRequester.requestFocus() }
         }
     }
 
-    // Stacked buttons sized to their own labels look ragged; in a column they share a width.
-    val itemWidth: Modifier = if (stacked) Modifier.fillMaxWidth() else Modifier
-
-    lane {
-        // Precedence: someone else's session, then yours, then the ordinary launch.
-        // Launching over a session another device owns would take their display.
+    val primaryAction: @Composable (Modifier) -> Unit = { actionModifier ->
         NovaGameDetailAction(
             text = when {
                 activeSession?.watchOnly == true -> stringResource(R.string.nova_game_detail_watch)
@@ -452,87 +447,125 @@ private fun NovaGameDetailActions(
             enabled = uiState.playEnabled || activeSession != null,
             primary = activeSession?.watchOnly != true,
             glyph = stringResource(R.string.nova_controller_hint_a),
-            modifier = itemWidth
+            modifier = actionModifier
                 .focusRequester(playFocusRequester)
                 .testTag("nova-game-detail-primary"),
         )
+    }
 
-        // Play holds first focus, and it has to be asked for here.
-        //
-        // The request used to live in NovaGameDetailLaunchFooter, which lost its last
-        // caller when this window replaced the bottom sheet, so nothing had requested
-        // focus since. Focus fell to whichever node happened to be focusable first, and
-        // the primary is not focusable until the launch profile arrives -- so on a slow
-        // profile the d-pad started on the destination beside Play instead of on Play.
-        //
-        // Keyed on enabled, because that is the moment the primary becomes reachable.
-        // The request is allowed to fail: while a destination is open the Overview is a
-        // focusProperties { canFocus = false } group, and asking then must not throw.
-        //
-        // Settle first, for the same reason novaHoldsFirstFocus does: when the profile
-        // is already cached, playEnabled is true on the first composition, so this
-        // effect runs before Play is placed -- the request lands on nothing, runCatching
-        // swallows it, and focus falls to the first focusable above Play (the launch-
-        // profile row). Waiting one settle lets layout happen so the request lands on
-        // Play. On the slow-profile path playEnabled flips true after layout, so the
-        // wait costs nothing there.
-        val playFocusable = uiState.playEnabled || activeSession != null
-        LaunchedEffect(playFocusable) {
-            if (playFocusable) {
-                delay(NOVA_FIRST_FOCUS_SETTLE_MS)
-                runCatching { playFocusRequester.requestFocus() }
-            }
-        }
+    val endAction: @Composable (Modifier) -> Unit = { actionModifier ->
+        NovaGameDetailAction(
+            text = stringResource(R.string.nova_game_detail_end_session),
+            onClick = onEndSession,
+            mark = "◼",
+            modifier = actionModifier,
+        )
+    }
 
-        if (activeSession != null && !activeSession.watchOnly) {
-            NovaGameDetailAction(
-                text = stringResource(R.string.nova_game_detail_end_session),
-                onClick = onEndSession,
-                mark = "◼",
-                modifier = itemWidth,
-            )
-        }
+    val retryAction: @Composable (Modifier) -> Unit = { actionModifier ->
+        NovaGameDetailAction(
+            text = stringResource(R.string.nova_library_retry_high_fps),
+            onClick = onRetryHighFps,
+            mark = "\u25B2",
+            modifier = actionModifier,
+        )
+    }
 
-        // Reset is on the rail whatever the review is doing. It used to be drawn only
-        // while a review was expanded, which made Play Setup's copy the only one anybody
-        // could reach the rest of the time -- and the copy is what a four-row Play Setup
-        // has no room for.
-        if (reviewExpanded && optimizationState.profileSummary?.showRetryHighFps == true) {
-            NovaGameDetailAction(
-                text = stringResource(R.string.nova_library_retry_high_fps),
-                onClick = onRetryHighFps,
-                mark = "\u25B2",
-                modifier = itemWidth,
-            )
-        }
+    val playSetupAction: @Composable (Modifier) -> Unit = { actionModifier ->
+        NovaGameDetailAction(
+            text = stringResource(R.string.nova_play_setup_title),
+            onClick = { onDestination(NovaGameDetailDestination.PLAY_SETUP) },
+            iconRes = R.drawable.ic_settings,
+            modifier = actionModifier.testTag("nova-game-detail-play-setup"),
+        )
+    }
+
+    val resetAction: @Composable (Modifier) -> Unit = { actionModifier ->
         NovaGameDetailAction(
             text = stringResource(R.string.nova_library_reset_game_profile),
             onClick = onResetProfile,
-            mark = "\u21BA",
-            modifier = itemWidth,
+            iconRes = R.drawable.ic_update,
+            modifier = actionModifier.testTag("nova-game-detail-reset"),
         )
+    }
+
+    val pinVisible = shortcutPinState != GameShortcutPinState.UNSUPPORTED
+    val pinLabel = when {
+        shortcutPinRequestPending -> stringResource(R.string.nova_library_pin_shortcut_pending)
+        shortcutPinState == GameShortcutPinState.PINNED ->
+            stringResource(R.string.nova_library_pin_shortcut_pinned)
+        else -> stringResource(R.string.nova_library_pin_shortcut)
+    }
+    val pinAction: @Composable (Modifier) -> Unit = { actionModifier ->
         NovaGameDetailAction(
-            text = stringResource(R.string.nova_library_pin_shortcut),
+            text = pinLabel,
             onClick = onPinShortcut,
-            mark = "\u2691",
-            modifier = itemWidth,
+            enabled = shortcutPinState == GameShortcutPinState.AVAILABLE &&
+                !shortcutPinRequestPending,
+            iconRes = if (shortcutPinState == GameShortcutPinState.PINNED) {
+                R.drawable.ic_check
+            } else {
+                R.drawable.ic_nova_pin
+            },
+            iconOnly = true,
+            modifier = actionModifier.testTag("nova-game-detail-pin-shortcut"),
         )
-        if (!reviewExpanded) {
-            // Three nodes, always. `showLaunchModeAction` used to decide whether a
-            // fourth existed, so the lane changed length depending on the game; what it
-            // gated is now a row inside Play Setup rather than an action beside it.
-            NovaGameDetailAction(
-                text = stringResource(R.string.nova_play_setup_title),
-                onClick = { onDestination(NovaGameDetailDestination.PLAY_SETUP) },
-                mark = "\u2699",
-                modifier = itemWidth,
-            )
-            NovaGameDetailAction(
-                text = stringResource(R.string.nova_artwork_studio_title),
-                onClick = { onDestination(NovaGameDetailDestination.ARTWORK) },
-                mark = "\u25C8",
-                modifier = itemWidth,
-            )
+    }
+
+    val artworkAction: @Composable (Modifier) -> Unit = { actionModifier ->
+        NovaGameDetailAction(
+            text = stringResource(R.string.nova_artwork_studio_title),
+            onClick = { onDestination(NovaGameDetailDestination.ARTWORK) },
+            iconRes = R.drawable.ic_nova_artwork,
+            iconOnly = true,
+            modifier = actionModifier.testTag("nova-game-detail-artwork"),
+        )
+    }
+
+    val showEnd = activeSession != null && !activeSession.watchOnly
+    val showRetry = reviewExpanded && optimizationState.profileSummary?.showRetryHighFps == true
+
+    if (stacked) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            primaryAction(Modifier.fillMaxWidth())
+            if (showEnd) endAction(Modifier.fillMaxWidth())
+            if (showRetry) retryAction(Modifier.fillMaxWidth())
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (!reviewExpanded) playSetupAction(Modifier.weight(1f))
+                resetAction(Modifier.weight(1f))
+            }
+
+            if (pinVisible || !reviewExpanded) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (pinVisible) pinAction(Modifier)
+                    if (!reviewExpanded) artworkAction(Modifier)
+                }
+            }
+        }
+    } else {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier,
+        ) {
+            primaryAction(Modifier)
+            if (showEnd) endAction(Modifier)
+            if (showRetry) retryAction(Modifier)
+            if (!reviewExpanded) playSetupAction(Modifier)
+            resetAction(Modifier)
+            if (pinVisible) pinAction(Modifier)
+            if (!reviewExpanded) artworkAction(Modifier)
         }
     }
 }
@@ -790,6 +823,8 @@ private fun NovaGameDetailAction(
     primary: Boolean = false,
     glyph: String? = null,
     mark: String? = null,
+    iconRes: Int? = null,
+    iconOnly: Boolean = false,
 ) {
     val colors = LocalNovaComposeColors.current
     val surfaces = LocalNovaLibrarySurfaces.current
@@ -816,9 +851,19 @@ private fun NovaGameDetailAction(
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(9.dp),
+        horizontalArrangement = if (iconOnly) {
+            Arrangement.Center
+        } else {
+            Arrangement.spacedBy(9.dp)
+        },
         modifier = modifier
-            .heightIn(min = NovaGameDetailActionHeight)
+            .then(
+                if (iconOnly) {
+                    Modifier.size(NovaGameDetailActionHeight)
+                } else {
+                    Modifier.heightIn(min = NovaGameDetailActionHeight)
+                }
+            )
             .clip(shape)
             .background(background, shape)
             .border(
@@ -834,7 +879,10 @@ private fun NovaGameDetailAction(
                 onClick = onClick,
             )
             .semantics { contentDescription = text }
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(
+                horizontal = if (iconOnly) 11.dp else 14.dp,
+                vertical = 10.dp,
+            ),
     ) {
         if (glyph != null) {
             Box(
@@ -855,14 +903,24 @@ private fun NovaGameDetailAction(
         if (mark != null) {
             Text(text = mark, color = label.copy(alpha = 0.62f), fontSize = 13.sp)
         }
-        Text(
-            text = text,
-            color = label,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (iconRes != null) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = label.copy(alpha = if (iconOnly) 0.82f else 0.72f),
+                modifier = Modifier.size(if (iconOnly) 22.dp else 18.dp),
+            )
+        }
+        if (!iconOnly) {
+            Text(
+                text = text,
+                color = label,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/papi/nova/utils/ShortcutHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ShortcutHelper.kt
@@ -22,6 +22,12 @@ import java.nio.charset.Charset
 import java.util.Collections
 import java.util.LinkedList
 
+enum class GameShortcutPinState {
+    UNSUPPORTED,
+    AVAILABLE,
+    PINNED,
+}
+
 class ShortcutHelper(private val context: Activity) {
     private val sm: ShortcutManager? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
@@ -129,8 +135,35 @@ class ShortcutHelper(private val context: Activity) {
         createAppViewShortcut(details, false, false)
     }
 
-    private fun getShortcutIdForGame(computer: ComputerDetails, app: NvApp): String {
-        return computer.uuid + app.appId
+    private fun getShortcutIdForGame(computer: ComputerDetails, app: NvApp): String =
+        getShortcutIdForGame(computer.uuid, app.appId)
+
+    private fun getShortcutIdForGame(hostUuid: String, appId: Int): String = hostUuid + appId
+
+    /**
+     * Reports the launcher's state for one exact host/game shortcut.
+     *
+     * A game appearing in Nova's own library is unrelated to Android's pinned-shortcut
+     * registry. Keeping this query next to the ID builder prevents the detail UI from
+     * guessing from either library membership or a previously accepted pin request.
+     */
+    @TargetApi(Build.VERSION_CODES.O)
+    fun getGameShortcutPinState(hostUuid: String, appId: Int): GameShortcutPinState {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return GameShortcutPinState.UNSUPPORTED
+        }
+
+        val manager = sm ?: return GameShortcutPinState.UNSUPPORTED
+        if (!manager.isRequestPinShortcutSupported) {
+            return GameShortcutPinState.UNSUPPORTED
+        }
+
+        val shortcutId = getShortcutIdForGame(hostUuid, appId)
+        return if (manager.pinnedShortcuts.any { it.id == shortcutId }) {
+            GameShortcutPinState.PINNED
+        } else {
+            GameShortcutPinState.AVAILABLE
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.O)
@@ -200,7 +233,7 @@ class ShortcutHelper(private val context: Activity) {
             action = Intent.ACTION_DEFAULT
         }
 
-        val shortcutInfo = ShortcutInfo.Builder(context, hostUuid + appId)
+        val shortcutInfo = ShortcutInfo.Builder(context, getShortcutIdForGame(hostUuid, appId))
             .setIntent(intent)
             .setShortLabel(appName + " (" + hostName + ")")
             .setIcon(appIcon)

--- a/app/src/main/res/drawable/ic_nova_artwork.xml
+++ b/app/src/main/res/drawable/ic_nova_artwork.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,4h16c1.1,0 2,0.9 2,2v12c0,1.1 -0.9,2 -2,2H4c-1.1,0 -2,-0.9 -2,-2V6c0,-1.1 0.9,-2 2,-2zM4,6v9.2l3.8,-3.8 2.7,2.7 3.7,-4.4L20,16.5V6H4zM7.5,10c-0.8,0 -1.5,-0.7 -1.5,-1.5S6.7,7 7.5,7 9,7.7 9,8.5 8.3,10 7.5,10z" />
+</vector>

--- a/app/src/main/res/drawable/ic_nova_pin.xml
+++ b/app/src/main/res/drawable/ic_nova_pin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14,4v4.5l2,2V12h-3v7l-1,2 -1,-2v-7H8v-1.5l2,-2V4H8V2h8v2z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,8 @@
     <string name="nova_library_reset_game_profile_empty">No saved game profile</string>
     <string name="nova_library_reset_game_profile_failed">Profile reset failed</string>
     <string name="nova_library_pin_shortcut">Pin to Home Screen</string>
+    <string name="nova_library_pin_shortcut_pending">Waiting for launcher</string>
+    <string name="nova_library_pin_shortcut_pinned">Pinned to Home Screen</string>
     <string name="nova_library_pin_shortcut_success">Shortcut request sent - your launcher may ask you to place it</string>
     <string name="nova_library_pin_shortcut_unsupported">Your launcher doesn\'t support pinned shortcuts</string>
     <string name="nova_library_pin_shortcut_failed">Couldn\'t create the shortcut</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1140,27 +1140,45 @@ class NovaComposeSourceGuardTest {
             detail.contains("internal fun NovaGameDetailLaunchFooter(")
         )
         assertTrue(
-            "the action lane is one row, so a D-pad walk never leaves it",
+            "landscape keeps one deterministic action row and portrait groups utilities below it",
             actions.contains("Row(") &&
+                actions.contains("if (stacked) {") &&
+                actions.contains("Column(") &&
                 actions.contains("horizontalArrangement = Arrangement.spacedBy(10.dp)")
         )
         assertTrue(
             "every focusable action clears the accessible target floor",
             detail.contains("internal val NovaGameDetailActionHeight = 48.dp") &&
-                detail.contains("heightIn(min = NovaGameDetailActionHeight)")
+                detail.contains("heightIn(min = NovaGameDetailActionHeight)") &&
+                detail.contains("Modifier.size(NovaGameDetailActionHeight)")
         )
-        // A fixed four now rather than three. Reset used to be drawn only while a review
-        // was expanded, so outside that case the only way to reach it was a copy inside
-        // Play Setup -- and a Play Setup held to four rows has no room to keep one. What
-        // the guard is really protecting is unchanged: the count must not vary by game.
         assertTrue(
-            "the rail is a fixed four, so a D-pad walk cannot find a different number of " +
-                "nodes on a different game; only an expanded review adds to it",
+            "Launch stays primary; Play Setup and Reset retain labels; Pin and Artwork are " +
+                "compact utilities rather than peers competing with launch",
             actions.contains("NovaGameDetailDestination.PLAY_SETUP") &&
                 actions.contains("NovaGameDetailDestination.ARTWORK") &&
-                actions.contains("if (!reviewExpanded) {") &&
+                actions.contains("iconRes = R.drawable.ic_settings") &&
+                actions.contains("iconRes = R.drawable.ic_update") &&
+                actions.substringAfter("val pinAction:").substringBefore("val artworkAction:")
+                    .contains("iconOnly = true") &&
+                actions.substringAfter("val artworkAction:").substringBefore("val showEnd")
+                    .contains("iconOnly = true") &&
                 actions.contains("onRetryHighFps") &&
                 actions.contains("onResetProfile")
+        )
+        assertTrue(
+            "pin visibility and enabled state come from Android's exact shortcut state",
+            actions.contains("shortcutPinState != GameShortcutPinState.UNSUPPORTED") &&
+                actions.contains("shortcutPinState == GameShortcutPinState.PINNED") &&
+                actions.contains("shortcutPinState == GameShortcutPinState.AVAILABLE") &&
+                actions.contains("!shortcutPinRequestPending")
+        )
+        assertTrue(
+            "icon-only utilities keep their full spoken label on the parent control",
+            detail.contains(".semantics { contentDescription = text }") &&
+                detail.contains("contentDescription = null") &&
+                actions.contains("nova-game-detail-pin-shortcut") &&
+                actions.contains("nova-game-detail-artwork")
         )
         assertFalse(
             "reset must not be gated on a review being open: that left it unreachable in the " +

--- a/app/src/test/java/com/papi/nova/utils/ShortcutHelperPolarisShortcutTest.kt
+++ b/app/src/test/java/com/papi/nova/utils/ShortcutHelperPolarisShortcutTest.kt
@@ -30,6 +30,11 @@ class ShortcutHelperPolarisShortcutTest {
         val appName = "Ys VIII: Lacrimosa of Dana"
         val hdrSupported = true
 
+        assertEquals(
+            GameShortcutPinState.AVAILABLE,
+            ShortcutHelper(activity).getGameShortcutPinState(hostUuid, appId),
+        )
+
         val result = ShortcutHelper(activity).createPinnedGameShortcut(
             hostUuid = hostUuid,
             hostName = hostName,
@@ -56,6 +61,32 @@ class ShortcutHelperPolarisShortcutTest {
         assertEquals(appUuid, intent.getStringExtra(Game.EXTRA_APP_UUID))
         assertEquals("" + appId, intent.getStringExtra(Game.EXTRA_APP_ID))
         assertEquals(hdrSupported, intent.getBooleanExtra(Game.EXTRA_APP_HDR, !hdrSupported))
+        assertEquals(
+            GameShortcutPinState.PINNED,
+            ShortcutHelper(activity).getGameShortcutPinState(hostUuid, appId),
+        )
+        assertEquals(
+            "pin state must be scoped to the exact host and app",
+            GameShortcutPinState.AVAILABLE,
+            ShortcutHelper(activity).getGameShortcutPinState(hostUuid, appId + 1),
+        )
+        assertEquals(
+            "a shortcut pinned for another host must not claim this game is pinned",
+            GameShortcutPinState.AVAILABLE,
+            ShortcutHelper(activity).getGameShortcutPinState("OTHER-HOST", appId),
+        )
+    }
+
+    @Test
+    fun reportsUnsupportedWhenLauncherCannotRequestPinnedShortcuts() {
+        val activity = Robolectric.buildActivity(Activity::class.java).get()
+        val shortcutManager = activity.getSystemService(ShortcutManagerClass)
+        shadowOf(shortcutManager).setIsRequestPinShortcutSupported(false)
+
+        assertEquals(
+            GameShortcutPinState.UNSUPPORTED,
+            ShortcutHelper(activity).getGameShortcutPinState("HOST", 42),
+        )
     }
 
     companion object {


### PR DESCRIPTION
## Summary

- keep Launch as the dominant game-detail action while preserving its resolved launch label
- keep Play Setup and Reset Game Profile as labeled secondary actions
- move Pin and Artwork Studio into compact 48 dp icon-only utility controls with accessible spoken labels
- derive pin availability from Android's exact host/app shortcut ID instead of Nova library membership
- hide Pin when unsupported, disable it while the launcher request is pending, and show a checked state only after Android reports the shortcut pinned
- preserve deterministic landscape D-pad order: Launch, Play Setup, Reset, Pin, Artwork

## Verification

- `./gradlew :app:testRootDebugUnitTest --tests com.papi.nova.utils.ShortcutHelperPolarisShortcutTest --tests com.papi.nova.ui.NovaComposeSourceGuardTest`
- `./gradlew :app:lintRootDebug`
- `./gradlew --no-build-cache assembleNonRoot_gameRelease`
- `./gradlew --no-build-cache assembleNonRoot_gameBenchmark`
- physical RP6 preserved-data benchmark replacement: PASS
  - production package remained unchanged
  - benchmark preferences survived replacement
  - D-pad traversal matched the intended five-action order
  - Artwork opened and controller Back returned safely
  - no launcher shortcut was created during acceptance
  - no candidate crash observed

## Broader-suite note

The full local JVM suite retains seven unrelated baseline/environment failures: four Android SDK 36 Robolectric cases require Java 21 on the local Mac, and three artwork-cache eviction failures reproduce on the untouched base commit. The focused changed-area tests, lint, and release/benchmark assemblies are green.
