### PR TITLE
fix(play-setup): persist per-game resolution choice in Play Setup

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -779,8 +779,11 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
             // A resolution was an answer to "how should this run on that display". Changing
-            // the display changes the question, so the answer does not carry over.
+            // the display changes the question, so the answer does not carry over — and
+            // must not resurface on the next open either, or the question looks answered
+            // when it was never asked for this display.
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
@@ -834,6 +837,7 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
@@ -843,6 +847,7 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.clear(this@NovaGameDetailActivity, currentGame)
             refreshUiState()
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = uiState.playUsesVirtualDisplay) }
         }
 
@@ -1475,13 +1480,19 @@ class NovaGameDetailActivity : NovaActivity() {
     }
 
     /** Resolves a saved resolution-choice id back against this open's planner, if any. */
-    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? {
-        val savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game) ?: return null
-        return resolutionPlanner(game).visibleChoices.firstOrNull { it.id == savedId }
-    }
+    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? =
+        resolveSavedResolutionChoice(
+            savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game),
+            visibleChoices = resolutionPlanner(game).visibleChoices,
+        )
 
     private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
         NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
+    }
+
+    /** Drop the durable choice, not just the in-memory state, so it does not return on reopen. */
+    private fun clearResolutionOverride(game: PolarisGame) {
+        NovaResolutionOverrides.clear(this@NovaGameDetailActivity, game)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {
@@ -2010,3 +2021,20 @@ class NovaGameDetailActivity : NovaActivity() {
  * early anyway, so this is only ever the cost of walking away mid-change.
  */
 private const val NOVA_PLAY_SETUP_SETTLE_MS = 650L
+
+/**
+ * Resolves a persisted resolution-choice id against this open's planner choices.
+ *
+ * [NovaDisplayResolutionChoice] objects are rebuilt fresh from the planner on every
+ * screen open, so a saved id can point at a choice that no longer exists — a host
+ * catalog change, a different display topology, or a stale id from before this game's
+ * choices were last rebuilt. That must read as "no override", not a crash or a stale
+ * object, so the lookup is a plain [List.firstOrNull] and a miss returns null.
+ */
+internal fun resolveSavedResolutionChoice(
+    savedId: String?,
+    visibleChoices: List<NovaDisplayResolutionChoice>,
+): NovaDisplayResolutionChoice? {
+    if (savedId.isNullOrBlank()) return null
+    return visibleChoices.firstOrNull { it.id == savedId }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -438,8 +438,10 @@ class NovaGameDetailActivity : NovaActivity() {
         explainedRow = NovaPlaySetupRow.WHERE_IT_RUNS
         // An explicit resolution, held until launch rather than launching on the spot.
         // Picking one used to start the game immediately, which is why the row that owned
-        // it could not be a setting: there was nothing to set.
-        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(null)
+        // it could not be a setting: there was nothing to set. The choice itself is
+        // rebuilt fresh from the planner every open, so only its id is persisted
+        // (NovaResolutionOverrides) and resolved back against this open's planner here.
+        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(loadResolutionOverride(currentGame))
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -854,6 +856,7 @@ class NovaGameDetailActivity : NovaActivity() {
          */
         fun chooseResolution(choice: NovaDisplayResolutionChoice) {
             chosenResolution = choice
+            saveResolutionOverride(currentGame, choice.id)
         }
 
         fun selectProfilePreference(value: String) {
@@ -1469,6 +1472,16 @@ class NovaGameDetailActivity : NovaActivity() {
 
     private fun saveProfilePreference(game: PolarisGame, preference: String) {
         AutoQualityProfilePreferences.save(this@NovaGameDetailActivity, game.id, game.name, preference)
+    }
+
+    /** Resolves a saved resolution-choice id back against this open's planner, if any. */
+    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? {
+        val savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game) ?: return null
+        return resolutionPlanner(game).visibleChoices.firstOrNull { it.id == savedId }
+    }
+
+    private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
+        NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {

--- a/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/**
+ * Where the resolution chosen for a game in Play Setup is remembered.
+ *
+ * [NovaDisplayResolutionChoice] is rebuilt fresh from the planner on every screen open, so
+ * only the choice's stable [NovaDisplayResolutionChoice.id] is persisted here — the id is
+ * resolved back against that game's current [NovaDisplayResolutionPlanner.visibleChoices]
+ * at load time, the same way [NovaLaunchModeOverrides] resolves a saved mode id.
+ */
+object NovaResolutionOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "resolution_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): String? =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(key(game), null)
+            ?.takeIf { it.isNotBlank() }
+
+    fun save(context: Context, game: PolarisGame, choiceId: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(key(game), choiceId)
+            .apply()
+    }
+
+    /** Remove the per-game choice so the game follows the planner's recommendation again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest.kt
@@ -1,0 +1,56 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * A resolution choice answers "how should this run on that display". Changing which
+ * display a game runs on — a new launch mode, a full-panel mode pick, or dropping back
+ * to the host default — changes the question, so the answer must not carry over.
+ *
+ * Each of those three entry points already cleared the in-memory chosenResolution, but
+ * left the durable NovaResolutionOverrides entry untouched: the next screen open re-read
+ * the stale saved id and the cleared choice silently came back, as if it had never been
+ * cleared. Every entry point that resets chosenResolution to null must also clear the
+ * durable override in the same breath. Guarded at the source since these are private
+ * closures inside NovaGameDetailActivity.onCreate, not reachable from a JVM unit test.
+ */
+class NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest {
+    private val source =
+        File("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt").readText()
+
+    private fun assertClearsDurableOverrideAlongsideInMemoryState(functionSignature: String) {
+        val functionStart = source.indexOf(functionSignature)
+        assertTrue("$functionSignature must exist in NovaGameDetailActivity.kt", functionStart >= 0)
+
+        val nullAssignment = source.indexOf("chosenResolution = null", functionStart)
+        assertTrue(
+            "$functionSignature must reset chosenResolution to null.",
+            nullAssignment in functionStart until (functionStart + 2000),
+        )
+
+        val clearCall = source.indexOf("clearResolutionOverride(currentGame)", functionStart)
+        assertTrue(
+            "$functionSignature clears chosenResolution in memory but must also call " +
+                "clearResolutionOverride(currentGame) — otherwise the saved choice id survives and " +
+                "silently reapplies the next time this screen opens.",
+            clearCall in functionStart until (functionStart + 2000),
+        )
+    }
+
+    @Test
+    fun selectLaunchModeClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun selectLaunchMode(mode: String)")
+    }
+
+    @Test
+    fun pickPlayModeClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun pickPlayMode(mode: String)")
+    }
+
+    @Test
+    fun pickHostDefaultClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun pickHostDefault()")
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaResolutionOverridesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaResolutionOverridesTest.kt
@@ -1,0 +1,116 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaResolutionOverridesTest {
+    private val context: Context
+        get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun clearPreferences() {
+        context.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    private fun game(id: String, appId: Int = 0) = PolarisGame(id = id, appId = appId, name = "Game")
+
+    @Test
+    fun savedChoiceIdIsRestoredForTheSameGame() {
+        val target = game(id = "uuid-a")
+
+        NovaResolutionOverrides.save(context, target, "performance-960x540")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, target))
+    }
+
+    @Test
+    fun differentGamesKeepIndependentCanonicalChoices() {
+        val gameA = game(id = "uuid-a")
+        val gameB = game(id = "uuid-b")
+
+        NovaResolutionOverrides.save(context, gameA, "performance-960x540")
+        NovaResolutionOverrides.save(context, gameB, "quality-1920x1080")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, gameA))
+        assertEquals("quality-1920x1080", NovaResolutionOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun gamesWithBlankIdFallBackToAppIdAndStayIndependent() {
+        val gameA = game(id = "", appId = 111)
+        val gameB = game(id = "", appId = 222)
+
+        NovaResolutionOverrides.save(context, gameA, "performance-960x540")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, gameA))
+        assertNull(NovaResolutionOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun clearRemovesTheSavedChoiceSoTheGameFollowsThePlannerAgain() {
+        val target = game(id = "uuid-a")
+        NovaResolutionOverrides.save(context, target, "performance-960x540")
+
+        NovaResolutionOverrides.clear(context, target)
+
+        assertNull(NovaResolutionOverrides.load(context, target))
+    }
+
+    @Test
+    fun loadWithNoSavedChoiceReturnsNull() {
+        assertNull(NovaResolutionOverrides.load(context, game(id = "uuid-never-chosen")))
+    }
+
+    // --- resolveSavedResolutionChoice: the saved id resolved against a live planner ---
+
+    private fun choice(id: String, recommended: Boolean = false) = NovaDisplayResolutionChoice(
+        id = id,
+        title = id,
+        targetMode = "1920x1080x60",
+        badge = "",
+        reason = "",
+        advanced = false,
+        custom = false,
+        safe = true,
+        recommended = recommended,
+    )
+
+    @Test
+    fun savedIdPresentInThePlannerResolvesToThatChoice() {
+        val choices = listOf(choice("balanced", recommended = true), choice("performance"))
+
+        val resolved = resolveSavedResolutionChoice(savedId = "performance", visibleChoices = choices)
+
+        assertEquals("performance", resolved?.id)
+    }
+
+    @Test
+    fun savedIdNoLongerInThePlannerResolvesToNoOverrideRatherThanCrashing() {
+        val choices = listOf(choice("balanced", recommended = true))
+
+        val resolved = resolveSavedResolutionChoice(savedId = "performance-removed", visibleChoices = choices)
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun blankOrNullSavedIdResolvesToNoOverride() {
+        val choices = listOf(choice("balanced", recommended = true))
+
+        assertNull(resolveSavedResolutionChoice(savedId = null, visibleChoices = choices))
+        assertNull(resolveSavedResolutionChoice(savedId = "", visibleChoices = choices))
+    }
+}


### PR DESCRIPTION
## Context

Split out of #261 per review. This is just the resolution persistence bug fix; the independent Frame Rate feature is in #266, stacked on top of this branch.

On the Play Setup screen, **Where It Runs** and **Tuning** already persist their per-game choice across sessions (`NovaLaunchModeOverrides`, `AutoQualityProfilePreferences`). **Resolution** did not: picking a resolution worked for the launch it was chosen for, but after a disconnect/reconnect (or any time `NovaGameDetailActivity` gets recreated) the row silently reset back to the planner's recommendation, as if the choice had never been made.

## Root cause

`chosenResolution` was a plain Activity-scoped Compose state field with no backing store. There was no persistence path to hook into; the row just looked like a setting without being one.

## What this does

- Adds `NovaResolutionOverrides`, mirroring `NovaLaunchModeOverrides`: only the chosen `NovaDisplayResolutionChoice.id` is persisted (SharedPreferences, keyed per game).
- `chooseResolution()` saves the id alongside updating the in-memory state; `chosenResolution`'s initial value resolves the saved id against that open's `resolutionPlanner(game).visibleChoices`.
- **Review fix:** `selectLaunchMode()`, `pickPlayMode()`, and `pickHostDefault()` cleared only the in-memory `chosenResolution`, so the persisted value came back on the next open even though the code already said changing the display changes the question. All three now also call the new `clearResolutionOverride(game)`.
- Extracts the saved-id-against-planner resolution into a top-level `resolveSavedResolutionChoice()` so it's reachable from a JVM test instead of only exercisable on a real device.

## Testing

- `NovaResolutionOverridesTest`: canonical per-app separation (including the blank-id-falls-back-to-appId case), saved-id restoration, `clear()`, and `resolveSavedResolutionChoice()` returning null both for a saved id the current planner no longer contains and for a blank/null saved id.
- `NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest`: guards at the source (these are private closures inside `NovaGameDetailActivity.onCreate`, not reachable directly from a JVM test) that `selectLaunchMode()`, `pickPlayMode()`, and `pickHostDefault()` each call `clearResolutionOverride(currentGame)` alongside resetting `chosenResolution`.
- `./gradlew :app:compileRootDebugKotlin` — builds clean.
- Full `ui` package test suite green (3 pre-existing unrelated failures in this sandbox are a local JDK/SDK toolchain mismatch, not caused by this change — confirmed they fail identically on `upstream/master` before this branch).