### PR TITLE
feat(play-setup): add an independent Frame Rate row

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
@@ -71,6 +71,12 @@ data class NovaDisplayResolutionPlanner(
             return if (parts.size == 3) "${parts[0]}x${parts[1]}" else targetMode
         }
 
+        /** The trailing rate half of a planner target mode, or null when it can't be read. */
+        fun resolutionFps(targetMode: String): Int? {
+            val parts = targetMode.trim().split('x', 'X')
+            return parts.getOrNull(2)?.toFloatOrNull()?.roundToInt()
+        }
+
         private fun plannerTitle(choice: PolarisGame.DisplayPlannerChoice, recommendedId: String): String {
             return if (choice.id == recommendedId) {
                 "Best for this device"

--- a/app/src/main/java/com/papi/nova/ui/NovaFrameRateOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaFrameRateOverrides.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/**
+ * Where the frame rate chosen for a game in Play Setup is remembered.
+ *
+ * Mirrors [NovaResolutionOverrides] and [NovaLaunchModeOverrides]: a plain per-game
+ * SharedPreferences entry, absent when the game has never had an explicit pin and
+ * should keep following the resolution choice's own paired rate (or the host's plan).
+ */
+object NovaFrameRateOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "frame_rate_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): Int? {
+        val stored = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(key(game), 0)
+        return stored.takeIf { it > 0 }
+    }
+
+    fun save(context: Context, game: PolarisGame, fps: Int) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(key(game), fps)
+            .apply()
+    }
+
+    /** Remove the per-game pin so the game follows the resolution/host rate again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -779,8 +779,11 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
             // A resolution was an answer to "how should this run on that display". Changing
-            // the display changes the question, so the answer does not carry over.
+            // the display changes the question, so the answer does not carry over — and
+            // must not resurface on the next open either, or the question looks answered
+            // when it was never asked for this display.
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
@@ -834,6 +837,7 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.save(this@NovaGameDetailActivity, currentGame, mode)
             refreshUiState()
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = PolarisGame.normalizeLaunchMode(mode) == PolarisGame.MODE_HOST_VIRTUAL_DISPLAY) }
         }
 
@@ -843,6 +847,7 @@ class NovaGameDetailActivity : NovaActivity() {
             NovaLaunchModeOverrides.clear(this@NovaGameDetailActivity, currentGame)
             refreshUiState()
             chosenResolution = null
+            clearResolutionOverride(currentGame)
             settleThen { loadOptimization(profilePreference, usesVirtualDisplay = uiState.playUsesVirtualDisplay) }
         }
 
@@ -1475,13 +1480,19 @@ class NovaGameDetailActivity : NovaActivity() {
     }
 
     /** Resolves a saved resolution-choice id back against this open's planner, if any. */
-    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? {
-        val savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game) ?: return null
-        return resolutionPlanner(game).visibleChoices.firstOrNull { it.id == savedId }
-    }
+    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? =
+        resolveSavedResolutionChoice(
+            savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game),
+            visibleChoices = resolutionPlanner(game).visibleChoices,
+        )
 
     private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
         NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
+    }
+
+    /** Drop the durable choice, not just the in-memory state, so it does not return on reopen. */
+    private fun clearResolutionOverride(game: PolarisGame) {
+        NovaResolutionOverrides.clear(this@NovaGameDetailActivity, game)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {
@@ -2010,3 +2021,20 @@ class NovaGameDetailActivity : NovaActivity() {
  * early anyway, so this is only ever the cost of walking away mid-change.
  */
 private const val NOVA_PLAY_SETUP_SETTLE_MS = 650L
+
+/**
+ * Resolves a persisted resolution-choice id against this open's planner choices.
+ *
+ * [NovaDisplayResolutionChoice] objects are rebuilt fresh from the planner on every
+ * screen open, so a saved id can point at a choice that no longer exists — a host
+ * catalog change, a different display topology, or a stale id from before this game's
+ * choices were last rebuilt. That must read as "no override", not a crash or a stale
+ * object, so the lookup is a plain [List.firstOrNull] and a miss returns null.
+ */
+internal fun resolveSavedResolutionChoice(
+    savedId: String?,
+    visibleChoices: List<NovaDisplayResolutionChoice>,
+): NovaDisplayResolutionChoice? {
+    if (savedId.isNullOrBlank()) return null
+    return visibleChoices.firstOrNull { it.id == savedId }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -442,6 +442,11 @@ class NovaGameDetailActivity : NovaActivity() {
         // rebuilt fresh from the planner every open, so only its id is persisted
         // (NovaResolutionOverrides) and resolved back against this open's planner here.
         var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(loadResolutionOverride(currentGame))
+        // An explicit frame-rate pin, independent of resolution. It composes over
+        // whatever fps the resolution choice (or the host's own plan) would have used --
+        // see NovaLaunchStreamOverride.compose, where fpsOverride wins over both. Persisted
+        // the same way as chosenResolution, so it survives past this Activity's lifetime.
+        var chosenFps by mutableStateOf<Int?>(loadFrameRateOverride(currentGame))
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -452,17 +457,21 @@ class NovaGameDetailActivity : NovaActivity() {
 
         /**
          * The blob this launch would go out with: the host's plan, composed with the
-         * resolution chosen here and the High FPS pin, when either exists. Composed
-         * over the host blob rather than replacing it, so a resolution pick no longer
-         * silently discards the recovery clamp -- only the explicit fps pin releases
-         * it. The fps that launches must always be re-derivable from this blob.
+         * resolution chosen here and the fps pin, when either exists. Composed over the
+         * host blob rather than replacing it, so a resolution pick no longer silently
+         * discards the recovery clamp -- only the explicit fps pin releases it. An
+         * explicit Frame Rate row choice wins over the implicit Tuning = High FPS pin,
+         * since a pin made by name here is a more specific answer than one inferred
+         * from a quality profile. The fps that launches must always be re-derivable
+         * from this blob.
          */
         fun launchOptimization(): JSONObject? {
             val preferences = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
             return NovaLaunchStreamOverride.compose(
                 raw = optimizationState.rawOptimization,
                 resolution = chosenResolution,
-                fpsOverride = NovaLaunchStreamOverride.highFpsPin(profilePreference, preferences.fps),
+                fpsOverride = chosenFps
+                    ?: NovaLaunchStreamOverride.highFpsPin(profilePreference, preferences.fps),
                 fallbackWidth = preferences.width,
                 fallbackHeight = preferences.height,
                 fallbackFps = preferences.fps.toInt(),
@@ -864,6 +873,20 @@ class NovaGameDetailActivity : NovaActivity() {
             saveResolutionOverride(currentGame, choice.id)
         }
 
+        /**
+         * Pin a frame rate rather than launching with it, same as [chooseResolution].
+         * Null clears the pin -- the row's own "Auto" option -- so the game goes back to
+         * whatever fps the resolution choice or the host's plan would have used.
+         */
+        fun chooseFrameRate(fps: Int?) {
+            chosenFps = fps
+            if (fps != null) {
+                saveFrameRateOverride(currentGame, fps)
+            } else {
+                clearFrameRateOverride(currentGame)
+            }
+        }
+
         fun selectProfilePreference(value: String) {
             if (value == profilePreference) return
             profilePreference = value
@@ -977,6 +1000,41 @@ class NovaGameDetailActivity : NovaActivity() {
                         )
                     },
                     overridden = overridden,
+                )
+
+                val effectiveFps = chosenFps
+                    ?: effective?.targetMode?.let { NovaDisplayResolutionPlanner.resolutionFps(it) }
+                rows += NovaPlaySetupRowState(
+                    row = NovaPlaySetupRow.FRAME_RATE,
+                    label = getString(R.string.nova_play_setup_frame_rate),
+                    caption = if (chosenFps != null) {
+                        getString(R.string.nova_play_setup_frame_rate_chosen)
+                    } else {
+                        getString(R.string.nova_play_setup_frame_rate_caption)
+                    },
+                    value = effectiveFps?.let { getString(R.string.nova_play_setup_frame_rate_fps_format, it) }.orEmpty(),
+                    stripTitle = getString(R.string.nova_play_setup_strip_frame_rate),
+                    options = buildList {
+                        add(
+                            NovaPlaySetupOption(
+                                label = getString(R.string.nova_play_setup_frame_rate_auto),
+                                consequence = getString(R.string.nova_play_setup_frame_rate_auto_consequence),
+                                current = chosenFps == null,
+                                onSelect = { chooseFrameRate(null) },
+                            )
+                        )
+                        NOVA_FRAME_RATE_CHOICES.forEach { fps ->
+                            add(
+                                NovaPlaySetupOption(
+                                    label = getString(R.string.nova_play_setup_frame_rate_fps_format, fps),
+                                    consequence = "",
+                                    current = chosenFps == fps,
+                                    onSelect = { chooseFrameRate(fps) },
+                                )
+                            )
+                        }
+                    },
+                    overridden = chosenFps != null,
                 )
             }
 
@@ -1493,6 +1551,18 @@ class NovaGameDetailActivity : NovaActivity() {
     /** Drop the durable choice, not just the in-memory state, so it does not return on reopen. */
     private fun clearResolutionOverride(game: PolarisGame) {
         NovaResolutionOverrides.clear(this@NovaGameDetailActivity, game)
+    }
+
+    private fun loadFrameRateOverride(game: PolarisGame): Int? {
+        return NovaFrameRateOverrides.load(this@NovaGameDetailActivity, game)
+    }
+
+    private fun saveFrameRateOverride(game: PolarisGame, fps: Int) {
+        NovaFrameRateOverrides.save(this@NovaGameDetailActivity, game, fps)
+    }
+
+    private fun clearFrameRateOverride(game: PolarisGame) {
+        NovaFrameRateOverrides.clear(this@NovaGameDetailActivity, game)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {
@@ -2038,3 +2108,12 @@ internal fun resolveSavedResolutionChoice(
     if (savedId.isNullOrBlank()) return null
     return visibleChoices.firstOrNull { it.id == savedId }
 }
+
+/**
+ * The fixed rates the Frame Rate row could offer, independent of what any resolution
+ * choice happens to pair with. Not host-derived like the resolution list -- Polaris does
+ * not publish a capability list to filter this against -- but it must still be culled to
+ * what this panel can actually present: see [NovaDisplayFpsCapability.allowedFpsValues],
+ * the same threshold every other FPS-offering surface in the app uses.
+ */
+private val NOVA_FRAME_RATE_CHOICES = listOf(30, 60, 90, 120)

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -97,6 +97,7 @@ import com.papi.nova.api.PolarisStreamDisplayMode
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.manager.PolarisProfileSync
 import com.papi.nova.manager.StreamSyncManager
+import com.papi.nova.preferences.NovaDisplayFpsCapability
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.ui.compose.LocalNovaComposeColors
 import com.papi.nova.ui.compose.LocalNovaLibrarySurfaces
@@ -470,8 +471,7 @@ class NovaGameDetailActivity : NovaActivity() {
             return NovaLaunchStreamOverride.compose(
                 raw = optimizationState.rawOptimization,
                 resolution = chosenResolution,
-                fpsOverride = chosenFps
-                    ?: NovaLaunchStreamOverride.highFpsPin(profilePreference, preferences.fps),
+                fpsOverride = effectiveFpsPin(chosenFps, profilePreference, preferences.fps),
                 fallbackWidth = preferences.width,
                 fallbackHeight = preferences.height,
                 fallbackFps = preferences.fps.toInt(),
@@ -1023,7 +1023,13 @@ class NovaGameDetailActivity : NovaActivity() {
                                 onSelect = { chooseFrameRate(null) },
                             )
                         )
-                        NOVA_FRAME_RATE_CHOICES.forEach { fps ->
+                        // Culled to what this panel can actually present -- offering 120
+                        // on a 60Hz panel would let a player lock in a launch the display
+                        // cannot honor, turning a simple choice into a fail-closed error.
+                        val panelAllowedFps = NovaDisplayFpsCapability.allowedFpsValues(
+                            NovaDisplayFpsCapability.maxSupportedFps(windowManager.defaultDisplay)
+                        )
+                        NOVA_FRAME_RATE_CHOICES.filter { it in panelAllowedFps }.forEach { fps ->
                             add(
                                 NovaPlaySetupOption(
                                     label = getString(R.string.nova_play_setup_frame_rate_fps_format, fps),
@@ -1036,15 +1042,28 @@ class NovaGameDetailActivity : NovaActivity() {
                     },
                     overridden = chosenFps != null,
                 )
+            } else if (chosenFps != null) {
+                // The Frame Rate row only exists alongside the display planner above. A
+                // pin saved during an earlier session with a planner could otherwise keep
+                // steering launchOptimization()'s fpsOverride from here on while having no
+                // visible, clearable control on this screen -- a durable lock nobody can
+                // see or undo. Retire it instead of leaving it stuck.
+                chooseFrameRate(null)
             }
 
             rows += NovaPlaySetupRowState(
                 row = NovaPlaySetupRow.TUNING,
                 label = getString(R.string.nova_play_setup_tuning),
-                // High FPS is binding, so the caption states the explicit pin.
-                // Historical Doctor guidance never participates in this launch.
+                // High FPS is binding, so the caption states the explicit pin -- but only
+                // when Tuning's own High FPS preference is what is actually pinning it. An
+                // explicit Frame Rate row choice wins over that pin in launchOptimization()
+                // (see the fpsOverride comment there), and the row above already says so;
+                // Tuning claiming credit for a number the Frame Rate row is really the one
+                // launching with would put a wrong number in front of the player -- not
+                // just an inconsistent one. Historical Doctor guidance never participates
+                // in this launch either way.
                 caption = when {
-                    fpsPin != null -> getString(R.string.nova_play_setup_tuning_pins, fpsPin)
+                    chosenFps == null && fpsPin != null -> getString(R.string.nova_play_setup_tuning_pins, fpsPin)
                     // The row used to show only the saved ask; for the asks the host
                     // owns, the outcome is the half that was never said anywhere.
                     else -> when (
@@ -1071,7 +1090,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         onSelect = { selectProfilePreference(value) },
                     )
                 },
-                overridden = fpsPin != null,
+                overridden = chosenFps == null && fpsPin != null,
             )
 
             if (uiState.showSteamLaunchMode) {
@@ -1553,8 +1572,22 @@ class NovaGameDetailActivity : NovaActivity() {
         NovaResolutionOverrides.clear(this@NovaGameDetailActivity, game)
     }
 
+    /**
+     * A saved pin from a previous open, coerced down to what this panel can present.
+     *
+     * The pin can outlive the panel it was chosen on -- a different physical display, or
+     * the same one after a refresh-rate change. An impossible value here would not just
+     * look wrong: launchOptimization() feeds it straight into fpsOverride, so it would
+     * fail the launch outright rather than merely being an odd choice on screen.
+     */
     private fun loadFrameRateOverride(game: PolarisGame): Int? {
-        return NovaFrameRateOverrides.load(this@NovaGameDetailActivity, game)
+        val saved = NovaFrameRateOverrides.load(this@NovaGameDetailActivity, game) ?: return null
+        val maxSupportedFps = NovaDisplayFpsCapability.maxSupportedFps(windowManager.defaultDisplay)
+        val coerced = NovaDisplayFpsCapability.coerce(saved, maxSupportedFps)
+        if (coerced != saved) {
+            NovaFrameRateOverrides.save(this@NovaGameDetailActivity, game, coerced)
+        }
+        return coerced
     }
 
     private fun saveFrameRateOverride(game: PolarisGame, fps: Int) {
@@ -2117,3 +2150,16 @@ internal fun resolveSavedResolutionChoice(
  * the same threshold every other FPS-offering surface in the app uses.
  */
 private val NOVA_FRAME_RATE_CHOICES = listOf(30, 60, 90, 120)
+
+/**
+ * The fps that actually launches: an explicit Frame Rate row pin, or -- only when there
+ * is none -- the fps Tuning = High FPS would pin instead.
+ *
+ * The single place this precedence is decided. [NovaGameDetailActivity]'s
+ * launchOptimization() feeds this straight into the launch envelope's fpsOverride; the
+ * Play Setup Tuning row caption must never name a different winner than this, which is
+ * why the row suppresses its own "Pins N FPS" claim whenever chosenFps is non-null
+ * instead of recomputing this precedence a second time.
+ */
+internal fun effectiveFpsPin(chosenFps: Int?, profilePreference: String, settingsFps: Float): Int? =
+    chosenFps ?: NovaLaunchStreamOverride.highFpsPin(profilePreference, settingsFps)

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -438,8 +438,10 @@ class NovaGameDetailActivity : NovaActivity() {
         explainedRow = NovaPlaySetupRow.WHERE_IT_RUNS
         // An explicit resolution, held until launch rather than launching on the spot.
         // Picking one used to start the game immediately, which is why the row that owned
-        // it could not be a setting: there was nothing to set.
-        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(null)
+        // it could not be a setting: there was nothing to set. The choice itself is
+        // rebuilt fresh from the planner every open, so only its id is persisted
+        // (NovaResolutionOverrides) and resolved back against this open's planner here.
+        var chosenResolution by mutableStateOf<NovaDisplayResolutionChoice?>(loadResolutionOverride(currentGame))
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -854,6 +856,7 @@ class NovaGameDetailActivity : NovaActivity() {
          */
         fun chooseResolution(choice: NovaDisplayResolutionChoice) {
             chosenResolution = choice
+            saveResolutionOverride(currentGame, choice.id)
         }
 
         fun selectProfilePreference(value: String) {
@@ -1469,6 +1472,16 @@ class NovaGameDetailActivity : NovaActivity() {
 
     private fun saveProfilePreference(game: PolarisGame, preference: String) {
         AutoQualityProfilePreferences.save(this@NovaGameDetailActivity, game.id, game.name, preference)
+    }
+
+    /** Resolves a saved resolution-choice id back against this open's planner, if any. */
+    private fun loadResolutionOverride(game: PolarisGame): NovaDisplayResolutionChoice? {
+        val savedId = NovaResolutionOverrides.load(this@NovaGameDetailActivity, game) ?: return null
+        return resolutionPlanner(game).visibleChoices.firstOrNull { it.id == savedId }
+    }
+
+    private fun saveResolutionOverride(game: PolarisGame, choiceId: String) {
+        NovaResolutionOverrides.save(this@NovaGameDetailActivity, game, choiceId)
     }
 
     private fun loadArtworkState(game: PolarisGame): NovaArtworkStudioState {

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -410,6 +410,7 @@ internal enum class NovaPlaySetupScope { THIS_GAME, EVERY_GAME }
 internal enum class NovaPlaySetupRow {
     WHERE_IT_RUNS,
     RESOLUTION,
+    FRAME_RATE,
     TUNING,
     STEAM_LAUNCH,
     HOST_DEFAULT_DISPLAY,

--- a/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaResolutionOverrides.kt
@@ -1,0 +1,41 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/**
+ * Where the resolution chosen for a game in Play Setup is remembered.
+ *
+ * [NovaDisplayResolutionChoice] is rebuilt fresh from the planner on every screen open, so
+ * only the choice's stable [NovaDisplayResolutionChoice.id] is persisted here — the id is
+ * resolved back against that game's current [NovaDisplayResolutionPlanner.visibleChoices]
+ * at load time, the same way [NovaLaunchModeOverrides] resolves a saved mode id.
+ */
+object NovaResolutionOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "resolution_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): String? =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(key(game), null)
+            ?.takeIf { it.isNotBlank() }
+
+    fun save(context: Context, game: PolarisGame, choiceId: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(key(game), choiceId)
+            .apply()
+    }
+
+    /** Remove the per-game choice so the game follows the planner's recommendation again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,6 +338,13 @@
     <string name="nova_play_setup_resolution_caption">The display is made to match this handheld</string>
     <string name="nova_play_setup_resolution_chosen">Chosen here \u00b7 applies at launch</string>
     <string name="nova_play_setup_strip_resolution">If you changed the resolution</string>
+    <string name="nova_play_setup_frame_rate">Frame Rate</string>
+    <string name="nova_play_setup_frame_rate_caption">Follows the resolution\'s own rate</string>
+    <string name="nova_play_setup_frame_rate_chosen">Chosen here \u00b7 applies at launch</string>
+    <string name="nova_play_setup_strip_frame_rate">If you changed the frame rate</string>
+    <string name="nova_play_setup_frame_rate_auto">Auto</string>
+    <string name="nova_play_setup_frame_rate_auto_consequence">Whatever the resolution or host plans</string>
+    <string name="nova_play_setup_frame_rate_fps_format">%d FPS</string>
     <string name="nova_play_setup_tuning">Launch preset</string>
     <string name="nova_play_setup_strip_tuning">If you changed the tuning</string>
     <string name="nova_play_setup_tuning_pins">Pins %1$d FPS from your Settings frame rate</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaFrameRateOverridesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaFrameRateOverridesTest.kt
@@ -1,0 +1,128 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaFrameRateOverridesTest {
+    private val context: Context
+        get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun clearPreferences() {
+        context.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    private fun game(id: String, appId: Int = 0) = PolarisGame(id = id, appId = appId, name = "Game")
+
+    // --- store: save/load/clear, canonical per-app isolation ---
+
+    @Test
+    fun savedFpsIsRestoredForTheSameGame() {
+        val target = game(id = "uuid-a")
+
+        NovaFrameRateOverrides.save(context, target, 90)
+
+        assertEquals(90, NovaFrameRateOverrides.load(context, target))
+    }
+
+    @Test
+    fun differentGamesKeepIndependentCanonicalPins() {
+        val gameA = game(id = "uuid-a")
+        val gameB = game(id = "uuid-b")
+
+        NovaFrameRateOverrides.save(context, gameA, 90)
+        NovaFrameRateOverrides.save(context, gameB, 120)
+
+        assertEquals(90, NovaFrameRateOverrides.load(context, gameA))
+        assertEquals(120, NovaFrameRateOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun gamesWithBlankIdFallBackToAppIdAndStayIndependent() {
+        val gameA = game(id = "", appId = 111)
+        val gameB = game(id = "", appId = 222)
+
+        NovaFrameRateOverrides.save(context, gameA, 90)
+
+        assertEquals(90, NovaFrameRateOverrides.load(context, gameA))
+        assertNull(NovaFrameRateOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun clearRemovesThePinSoTheGameFollowsTheResolutionOrHostAgain() {
+        val target = game(id = "uuid-a")
+        NovaFrameRateOverrides.save(context, target, 90)
+
+        NovaFrameRateOverrides.clear(context, target)
+
+        assertNull(NovaFrameRateOverrides.load(context, target))
+    }
+
+    @Test
+    fun loadWithNoSavedPinReturnsNull() {
+        assertNull(NovaFrameRateOverrides.load(context, game(id = "uuid-never-pinned")))
+    }
+
+    // --- effectiveFpsPin: explicit Frame Rate row wins over Tuning = High FPS ---
+
+    @Test
+    fun explicitChosenFpsWinsOverHighFpsPreference() {
+        val winner = effectiveFpsPin(chosenFps = 60, profilePreference = "high_fps", settingsFps = 120f)
+
+        assertEquals(60, winner)
+    }
+
+    @Test
+    fun highFpsPreferenceAppliesOnlyWhenNoExplicitChoiceExists() {
+        val winner = effectiveFpsPin(chosenFps = null, profilePreference = "high_fps", settingsFps = 120f)
+
+        assertEquals(120, winner)
+    }
+
+    @Test
+    fun neitherAnExplicitChoiceNorHighFpsMeansNoPin() {
+        val winner = effectiveFpsPin(chosenFps = null, profilePreference = "quality", settingsFps = 120f)
+
+        assertNull(winner)
+    }
+
+    // --- end to end: the precedence winner is what the resolver actually receives ---
+
+    @Test
+    fun theExplicitWinnerNotTheHighFpsPreferenceReachesTheComposedTargetFps() {
+        // The review's exact failure case: Tuning = High FPS would pin 120, but the
+        // player explicitly chose 60 on the Frame Rate row. The composed envelope --
+        // what the deterministic resolver and the game actually launch with -- must
+        // carry 60, locked, with explicit provenance, not 120.
+        val winner = effectiveFpsPin(chosenFps = 60, profilePreference = "high_fps", settingsFps = 120f)
+        val composed = NovaLaunchStreamOverride.compose(
+            raw = JSONObject(),
+            resolution = null,
+            fpsOverride = winner,
+            fallbackWidth = 1920,
+            fallbackHeight = 1080,
+            fallbackFps = 60,
+        )!!
+
+        val targetFps = composed.getJSONObject("resolved_profile").getJSONObject("fields").getJSONObject("target_fps")
+        assertEquals(60.0, targetFps.getDouble("value"), 0.001)
+        assertEquals("explicit_launch_request", targetFps.getString("source"))
+        assertTrue(targetFps.getBoolean("locked"))
+        assertEquals("1920x1080x60", composed.getString("display_mode"))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaFrameRateRowSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaFrameRateRowSourceGuardTest.kt
@@ -1,0 +1,112 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards Frame Rate row behavior that lives inside private closures in
+ * NovaGameDetailActivity.onCreate and is therefore not reachable directly from a JVM
+ * unit test.
+ */
+class NovaFrameRateRowSourceGuardTest {
+    private val source =
+        File("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt").readText()
+
+    /**
+     * The Frame Rate row only exists alongside the display planner. Without this, a pin
+     * saved during an earlier session with a planner would keep steering
+     * launchOptimization()'s fpsOverride while having no visible, clearable control on
+     * this screen -- a durable lock nobody can see or undo.
+     */
+    @Test
+    fun aPinIsRetiredWhenThePlannerThatWouldShowItsRowIsUnavailable() {
+        val plannerGate = source.indexOf("if (planner.available && planner.visibleChoices.isNotEmpty())")
+        assertTrue("buildPlaySetupRows must gate the Resolution/Frame Rate rows on planner availability.", plannerGate >= 0)
+
+        val elseBranch = source.indexOf("} else if (chosenFps != null) {", plannerGate)
+        assertTrue(
+            "When the planner is unavailable, the else branch must check chosenFps != null so a " +
+                "pin from an earlier session with a planner is not left stuck.",
+            elseBranch in plannerGate until (plannerGate + 6000),
+        )
+
+        val retireCall = source.indexOf("chooseFrameRate(null)", elseBranch)
+        assertTrue(
+            "The unavailable-planner branch must call chooseFrameRate(null) to retire the pin " +
+                "(clearing both the in-memory state and the durable NovaFrameRateOverrides entry) " +
+                "instead of leaving it invisible but still affecting the launch.",
+            retireCall in elseBranch until (elseBranch + 500),
+        )
+    }
+
+    /** Offering 120 FPS on a panel that cannot present it turns a choice into a launch error. */
+    @Test
+    fun theRowOffersOnlyFpsValuesThisPanelCanActuallyPresent() {
+        val rowStart = source.indexOf("row = NovaPlaySetupRow.FRAME_RATE")
+        assertTrue("The Frame Rate row must exist.", rowStart >= 0)
+
+        val optionsStart = source.indexOf("options = buildList {", rowStart)
+        assertTrue(optionsStart in rowStart until (rowStart + 2000))
+
+        val capabilityCall = source.indexOf("NovaDisplayFpsCapability.allowedFpsValues(", optionsStart)
+        assertTrue(
+            "The Frame Rate row's option list must filter NOVA_FRAME_RATE_CHOICES through " +
+                "NovaDisplayFpsCapability.allowedFpsValues(...) -- the same panel-capability " +
+                "threshold every other FPS-offering surface in the app uses -- instead of always " +
+                "offering all four fixed values regardless of what the display can present.",
+            capabilityCall in optionsStart until (optionsStart + 2000),
+        )
+
+        val filterCall = source.indexOf("NOVA_FRAME_RATE_CHOICES.filter", optionsStart)
+        assertTrue(filterCall in optionsStart until (optionsStart + 2000))
+        assertTrue(
+            "NOVA_FRAME_RATE_CHOICES must be filtered before the capability check is defined uselessly.",
+            capabilityCall < filterCall,
+        )
+    }
+
+    /**
+     * The Tuning row's "Pins N FPS" caption must never name a different fps than what
+     * actually launches. An explicit Frame Rate row choice wins over Tuning = High FPS in
+     * launchOptimization(), so Tuning claiming a pin it does not control (its own
+     * highFpsPin(...) value) whenever chosenFps is also set would show a number the
+     * launch does not use -- the review's exact "Tuning says 120, launch is 60" case.
+     */
+    @Test
+    fun tuningRowSuppressesItsOwnPinClaimWheneverTheFrameRateRowChoiceWins() {
+        val tuningRowStart = source.indexOf("row = NovaPlaySetupRow.TUNING")
+        assertTrue("The Tuning row must exist.", tuningRowStart >= 0)
+
+        val captionCondition = source.indexOf("chosenFps == null && fpsPin != null ->", tuningRowStart)
+        assertTrue(
+            "The Tuning row's \"Pins N FPS\" caption must only fire when chosenFps is null -- " +
+                "otherwise it can name Tuning's own highFpsPin(...) value while the Frame Rate " +
+                "row's explicit choice is what actually launches.",
+            captionCondition in tuningRowStart until (tuningRowStart + 1500),
+        )
+
+        val overriddenField = source.indexOf("overridden = chosenFps == null && fpsPin != null,", tuningRowStart)
+        assertTrue(
+            "The Tuning row's overridden flag must use the same chosenFps == null && fpsPin != " +
+                "null condition as its caption -- the visible explanation and the badge must agree.",
+            overriddenField in tuningRowStart until (tuningRowStart + 3500),
+        )
+    }
+
+    /** A pin saved on one panel (or refresh-rate setting) must not survive as an impossible one on another. */
+    @Test
+    fun loadingASavedPinCoercesItToWhatThisPanelCanPresent() {
+        val loadStart = source.indexOf("private fun loadFrameRateOverride(game: PolarisGame): Int?")
+        assertTrue("loadFrameRateOverride must exist.", loadStart >= 0)
+
+        val coerceCall = source.indexOf("NovaDisplayFpsCapability.coerce(", loadStart)
+        assertTrue(
+            "loadFrameRateOverride must coerce the saved value through " +
+                "NovaDisplayFpsCapability.coerce(...) -- otherwise a pin saved on a faster panel (or " +
+                "before a refresh-rate change) would keep reaching launchOptimization()'s fpsOverride " +
+                "unfiltered, turning a stale choice into a fail-closed launch error.",
+            coerceCall in loadStart until (loadStart + 800),
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest.kt
@@ -1,0 +1,56 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * A resolution choice answers "how should this run on that display". Changing which
+ * display a game runs on — a new launch mode, a full-panel mode pick, or dropping back
+ * to the host default — changes the question, so the answer must not carry over.
+ *
+ * Each of those three entry points already cleared the in-memory chosenResolution, but
+ * left the durable NovaResolutionOverrides entry untouched: the next screen open re-read
+ * the stale saved id and the cleared choice silently came back, as if it had never been
+ * cleared. Every entry point that resets chosenResolution to null must also clear the
+ * durable override in the same breath. Guarded at the source since these are private
+ * closures inside NovaGameDetailActivity.onCreate, not reachable from a JVM unit test.
+ */
+class NovaResolutionOverrideClearedOnDisplayChangeSourceGuardTest {
+    private val source =
+        File("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt").readText()
+
+    private fun assertClearsDurableOverrideAlongsideInMemoryState(functionSignature: String) {
+        val functionStart = source.indexOf(functionSignature)
+        assertTrue("$functionSignature must exist in NovaGameDetailActivity.kt", functionStart >= 0)
+
+        val nullAssignment = source.indexOf("chosenResolution = null", functionStart)
+        assertTrue(
+            "$functionSignature must reset chosenResolution to null.",
+            nullAssignment in functionStart until (functionStart + 2000),
+        )
+
+        val clearCall = source.indexOf("clearResolutionOverride(currentGame)", functionStart)
+        assertTrue(
+            "$functionSignature clears chosenResolution in memory but must also call " +
+                "clearResolutionOverride(currentGame) — otherwise the saved choice id survives and " +
+                "silently reapplies the next time this screen opens.",
+            clearCall in functionStart until (functionStart + 2000),
+        )
+    }
+
+    @Test
+    fun selectLaunchModeClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun selectLaunchMode(mode: String)")
+    }
+
+    @Test
+    fun pickPlayModeClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun pickPlayMode(mode: String)")
+    }
+
+    @Test
+    fun pickHostDefaultClearsTheDurableResolutionOverride() {
+        assertClearsDurableOverrideAlongsideInMemoryState("fun pickHostDefault()")
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaResolutionOverridesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaResolutionOverridesTest.kt
@@ -1,0 +1,116 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaResolutionOverridesTest {
+    private val context: Context
+        get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun clearPreferences() {
+        context.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    private fun game(id: String, appId: Int = 0) = PolarisGame(id = id, appId = appId, name = "Game")
+
+    @Test
+    fun savedChoiceIdIsRestoredForTheSameGame() {
+        val target = game(id = "uuid-a")
+
+        NovaResolutionOverrides.save(context, target, "performance-960x540")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, target))
+    }
+
+    @Test
+    fun differentGamesKeepIndependentCanonicalChoices() {
+        val gameA = game(id = "uuid-a")
+        val gameB = game(id = "uuid-b")
+
+        NovaResolutionOverrides.save(context, gameA, "performance-960x540")
+        NovaResolutionOverrides.save(context, gameB, "quality-1920x1080")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, gameA))
+        assertEquals("quality-1920x1080", NovaResolutionOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun gamesWithBlankIdFallBackToAppIdAndStayIndependent() {
+        val gameA = game(id = "", appId = 111)
+        val gameB = game(id = "", appId = 222)
+
+        NovaResolutionOverrides.save(context, gameA, "performance-960x540")
+
+        assertEquals("performance-960x540", NovaResolutionOverrides.load(context, gameA))
+        assertNull(NovaResolutionOverrides.load(context, gameB))
+    }
+
+    @Test
+    fun clearRemovesTheSavedChoiceSoTheGameFollowsThePlannerAgain() {
+        val target = game(id = "uuid-a")
+        NovaResolutionOverrides.save(context, target, "performance-960x540")
+
+        NovaResolutionOverrides.clear(context, target)
+
+        assertNull(NovaResolutionOverrides.load(context, target))
+    }
+
+    @Test
+    fun loadWithNoSavedChoiceReturnsNull() {
+        assertNull(NovaResolutionOverrides.load(context, game(id = "uuid-never-chosen")))
+    }
+
+    // --- resolveSavedResolutionChoice: the saved id resolved against a live planner ---
+
+    private fun choice(id: String, recommended: Boolean = false) = NovaDisplayResolutionChoice(
+        id = id,
+        title = id,
+        targetMode = "1920x1080x60",
+        badge = "",
+        reason = "",
+        advanced = false,
+        custom = false,
+        safe = true,
+        recommended = recommended,
+    )
+
+    @Test
+    fun savedIdPresentInThePlannerResolvesToThatChoice() {
+        val choices = listOf(choice("balanced", recommended = true), choice("performance"))
+
+        val resolved = resolveSavedResolutionChoice(savedId = "performance", visibleChoices = choices)
+
+        assertEquals("performance", resolved?.id)
+    }
+
+    @Test
+    fun savedIdNoLongerInThePlannerResolvesToNoOverrideRatherThanCrashing() {
+        val choices = listOf(choice("balanced", recommended = true))
+
+        val resolved = resolveSavedResolutionChoice(savedId = "performance-removed", visibleChoices = choices)
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun blankOrNullSavedIdResolvesToNoOverride() {
+        val choices = listOf(choice("balanced", recommended = true))
+
+        assertNull(resolveSavedResolutionChoice(savedId = null, visibleChoices = choices))
+        assertNull(resolveSavedResolutionChoice(savedId = "", visibleChoices = choices))
+    }
+}


### PR DESCRIPTION
## Context

Split out of #261 per review, stacked on #265 (the resolution persistence fix). GitHub does not let a cross-fork PR base off a branch that only exists on the fork, so this is opened against `master` like #265 — until #265 merges, "Files changed" here shows both PRs' diffs combined; please review by commit (2 commits: the resolution fix from #265, then this PR's own commit) rather than by the combined file diff. Rebase/retarget once #265 merges.

Resolution and frame rate were coupled: each resolution choice from the planner carries its own paired rate (e.g. "1440x810x60"), and the only way to pin an fps independently of that was the global Tuning = High FPS profile plus the app-wide Settings frame rate — there was no per-game way to say "this resolution, but 90fps".

## What this does

Adds a Frame Rate row between Resolution and Tuning, offering Auto plus 30/60/90/120 fps. An explicit pick composes over whichever fps the resolution choice (or the host's plan) would have used, via the existing `NovaLaunchStreamOverride.compose` `fpsOverride` parameter. Persists per-game via `NovaFrameRateOverrides`, mirroring the resolution override.

## Review fixes

1. **One winner for the caption and the envelope.** `launchOptimization()` already let an explicit Frame Rate row pin win over the implicit Tuning = High FPS pin, but the Tuning row's caption and `overridden` flag derived `fpsPin` from `highFpsPin()` alone — Tuning could say "Pins 120 FPS" while the explicit row's 60 FPS was what actually launched. Fixed by having the Tuning row suppress its own "Pins N FPS" claim whenever `chosenFps` is set, since a different row's explicit choice already explains what's happening and Tuning doesn't control it in that case. `effectiveFpsPin()` is now the single place the `chosenFps`-vs-`highFpsPin` precedence is decided; `launchOptimization()` calls it instead of re-deriving the same expression inline.
2. **Retire a pin the UI can no longer represent.** The Frame Rate row only renders alongside the display planner. A pin saved during an earlier session with a planner kept steering `launchOptimization()`'s `fpsOverride` even after the planner became unavailable, with no visible or clearable control left on screen. The planner-unavailable branch now calls `chooseFrameRate(null)` to retire it.
3. **Respect panel capability.** The row offered a fixed 30/60/90/120 list regardless of what the device's display could present, and a saved pin from a faster panel (or before a refresh-rate change) was never re-checked. Both the offered options and `loadFrameRateOverride()` now go through `NovaDisplayFpsCapability` (`allowedFpsValues` / `coerce`) — the same panel-capability threshold every other FPS-offering surface in the app already uses.

## Testing

- `NovaFrameRateOverridesTest`: canonical per-app isolation (including the blank-id-falls-back-to-appId case), saved-value restoration, `clear()`; `effectiveFpsPin()` precedence (explicit wins, High FPS applies only with no explicit choice, neither means no pin); an end-to-end case reproducing the review's exact example — Tuning = High FPS pinning 120 with an explicit 60 FPS choice present — asserting the composed `target_fps` field is 60, locked, with explicit provenance.
- `NovaFrameRateRowSourceGuardTest`: guards the parts of this fix living in private `NovaGameDetailActivity.onCreate` closures (not reachable from a JVM test directly) — the pin-retirement branch calls `chooseFrameRate(null)`, the row's options are filtered through `NovaDisplayFpsCapability.allowedFpsValues(...)`, `loadFrameRateOverride` coerces through `NovaDisplayFpsCapability.coerce(...)`, and the Tuning row's caption and `overridden` flag share the same condition.
- `./gradlew :app:compileRootDebugKotlin` — builds clean.
- Full `ui` package test suite green (3 pre-existing unrelated failures in this sandbox are a local JDK/SDK toolchain mismatch, not caused by this change).