### PR TITLE
copy: lead with what Nova does instead of where it runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Nova
 
-**Your PC games, wherever you want to play on Android.**
+**The streaming client that speaks host.**
 
 Nova turns Android TVs, handhelds, tablets, and phones into a polished home for
 PC game streaming. Pair it with Polaris for a controller-first Library, clear

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Handheld-first game streaming for Polaris and Moonlight hosts
+The streaming client that speaks host: Polaris and Moonlight, every screen


### PR DESCRIPTION
## Summary

The README headline and the Play listing both described Nova by the hardware it
runs on. That was already inaccurate on an Android TV, and it gets worse as Nova
moves past Android.

Both now lead with "The streaming client that speaks host", which is the thing
no other Moonlight client does: Nova reads launch modes, session state, and
stream health from the host instead of treating it as a black box. The claim is
about behaviour, so it stays true on every screen Nova reaches later.

The store listing keeps Polaris, Moonlight, and the multi-screen coverage in the
same line, at 74 of the 80 characters the listing allows, so store search still
has something to match on.

## Exact candidate

Branch `copy/product-headline`, one commit on master `4787454d`. The same line
is going out on papi-ux.com and the GitHub About blurb, so the wording matches
everywhere Nova is introduced.

## Verification

Text-only change to a README headline and a store listing file. No source, test,
or resource string is touched, and nothing in the test tree pins either string.
The listing stays inside the 80-character Play limit.
