### PR TITLE
feat(play-setup): add per-game encoder selection and truthful HUD health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+NovaHUD now treats SHM/CPU capture as stream topology rather than a health failure. Healthy standard streams stay green while the capture path remains visible; Doctor, sync, HDR, decoder, and pacing evidence still raise attention when action is actually needed.
+
 ## 1.4.1 - 2026-09-03
 
 Nova 1.4.1 is the matched client for Polaris 1.4.1. It makes the selected host encoder understandable in Play Setup, keeps capability-only Doctor evidence informational, adds the typed Hyprland Desktop Takeover choice, and tightens controller focus on Android TV.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 NovaHUD now treats SHM/CPU capture as stream topology rather than a health failure. Healthy standard streams stay green while the capture path remains visible; Doctor, sync, HDR, decoder, and pacing evidence still raise attention when action is actually needed.
 
+Play Setup can now keep the host encoder policy or select one of the backends Polaris advertises for a single game. Auto is the only choice allowed to fall back after a live launch probe; an explicit NVENC, VA-API, Vulkan, VideoToolbox, or software choice fails closed if that backend cannot initialize. The selection is remembered per game, carried through pinned shortcuts, and bound to Polaris' exact launch contract without rewriting the host-wide setting.
+
 ## 1.4.1 - 2026-09-03
 
 Nova 1.4.1 is the matched client for Polaris 1.4.1. It makes the selected host encoder understandable in Play Setup, keeps capability-only Doctor evidence informational, adds the typed Hyprland Desktop Takeover choice, and tightens controller focus on Android TV.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Moonlight-compatible hosts remain supported too.
 Nova is matched to Polaris while retaining the standard Moonlight-compatible
 path:
 
-- **Play Setup says what will launch.** Resolution and frame rate are independent
-  per-game choices, host-wide modes remain visibly host-wide, and Auto, Quality,
-  High FPS, and Stability show the resolved host plan before play.
+- **Play Setup says what will launch.** Resolution, frame rate, and encoder are
+  independent per-game choices, host-wide modes remain visibly host-wide, and
+  Auto, Quality, High FPS, and Stability show the resolved host plan before play.
 - **Doctor stays evidence-first.** Command Center refreshes current host evidence,
   separates network, host, and client findings, and presents Auto Fix only for a
   reversible same-stream action the paired host can verify or roll back.
@@ -90,9 +90,10 @@ in Portable Chrome, Console OLED, Miami Nebula, High Contrast, and Material You.
 ### Decide
 
 Play Setup describes what will happen for this title: where it runs, the client
-resolution, frame rate, tuning policy, and Steam launch behavior. Resolution and
-FPS stay independent, a host-only mode links back to Polaris instead of posing as
-a per-game choice, and a session-scoped choice does not silently rewrite the host
+resolution, frame rate, encoder policy, tuning policy, and Steam launch behavior.
+Resolution and FPS stay independent, a named encoder is strict while encoder Auto
+may fall back, a host-only mode links back to Polaris instead of posing as a
+per-game choice, and a session-scoped choice does not silently rewrite the host
 default.
 
 ![Nova Polaris Aurora Play Setup for Control Ultimate Edition, showing Private Stream and session choices](docs/screenshots/nova-play-setup-control-aurora-v1.3.6.webp)

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -282,6 +282,7 @@ val policyMessage:String = ""
 private var resumeExistingRequested:Boolean = false
 private var mirrorDesktop:Boolean = false
 private var streamMode:String = ""
+private var encoderBackend:String = ""
 private var forcePrivateAfterSteamClose:Boolean = false
 private var clientPresentationReportInFlight:AtomicBoolean = AtomicBoolean(false)
 private var cursorVisibilitySyncLock:Any = Any()
@@ -1064,6 +1065,9 @@ vDisplay = this@Game.getIntent().getBooleanExtra(EXTRA_VDISPLAY, false)
 var displayModeExplicit:Boolean = this@Game.getIntent().getBooleanExtra(EXTRA_DISPLAY_MODE_EXPLICIT, false)
 mirrorDesktop = this@Game.getIntent().getBooleanExtra(EXTRA_MIRROR_DESKTOP, false)
 streamMode = this@Game.getIntent().getStringExtra(EXTRA_STREAM_MODE) ?: ""
+encoderBackend = com.papi.nova.api.PolarisClientSettings.normalizeEncoderBackend(
+this@Game.getIntent().getStringExtra(EXTRA_ENCODER_BACKEND)
+).orEmpty()
 forcePrivateAfterSteamClose = this@Game.getIntent().getBooleanExtra(EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, false)
 launchProfilePreference = this@Game.getIntent().getStringExtra(EXTRA_AI_PROFILE_PREFERENCE) ?: ""
 launchOptimizationJson = this@Game.getIntent().getStringExtra(EXTRA_LAUNCH_OPTIMIZATION)
@@ -1620,6 +1624,8 @@ displayHeight
 .setDisplayModeExplicit(displayModeExplicit)
 .setMirrorDesktop(mirrorDesktop)
 .setStreamMode(streamMode)
+.setEncoderBackend(encoderBackend)
+.setExpectedEncoder(if (launchResolvedProfileTrusted) encoderBackend else "")
 .setExpectedTopology(expectedLaunchTopology)
 .setForcePrivateAfterSteamClose(forcePrivateAfterSteamClose)
 .setResolutionScaleFactor(prefConfig!!.resolutionScaleFactor)
@@ -2578,6 +2584,7 @@ com.papi.nova.utils.DeviceUtils.getModel(),
 launchProfilePreference,
 launchOptimizationJson.orEmpty(),
 streamMode,
+encoderBackend,
 mirrorDesktop.toString(),
 vDisplay.toString(),
 bitrateLocked.toString(),
@@ -2625,7 +2632,8 @@ fpsLocked:Boolean,
 requestedTopology:String,
 topologyLocked:Boolean,
 mirrorDesktopRequested:Boolean,
-forcePrivateRequested:Boolean
+forcePrivateRequested:Boolean,
+requestedEncoderBackend:String
 ):Boolean {
 if (!com.papi.nova.manager.StreamSyncManager.hasTrustedResolvedProfile(optimization)) return false
 val topologyEnvelopeHonored = com.papi.nova.manager.LaunchTopologyEnvelope.matches(
@@ -2684,6 +2692,10 @@ optimization,
 ) == true))
 return hdrWithinEnvelope &&
 topologyEnvelopeHonored &&
+com.papi.nova.manager.NovaEncoderLaunchContract.honors(
+optimization,
+requestedEncoderBackend
+) &&
 resolvedFps > 0f &&
 (clientMaximumFps <= 0f || resolvedFps <= clientMaximumFps + 0.5f) &&
 displayLockHonored &&
@@ -2764,7 +2776,8 @@ preference.equals("high_fps", ignoreCase = true),
 requestedTopology,
 exactTopologyLocked,
 mirrorDesktop,
-forcePrivateAfterSteamClose
+forcePrivateAfterSteamClose,
+encoderBackend
 ) && !containsNovaLaunchOverride)
 {
 // Play Setup already resolved the exact per-launch locks. Its HDR value is
@@ -2842,7 +2855,8 @@ bitrateKbps = resolverRequest.bitrateKbps,
 bitrateLocked = resolverRequest.bitrateLocked,
 hdr = requestedHdr,
 clientMaxFps = getMaxSupportedRefreshRate(getWindowManager().getDefaultDisplay()),
-launchBounded = true)
+launchBounded = true,
+encoderBackend = encoderBackend)
 }
 catch (e:com.papi.nova.api.PolarisApiRejectedException)
 {
@@ -2875,10 +2889,11 @@ preference.equals("high_fps", ignoreCase = true),
 requestedTopology,
 exactTopologyLocked,
 mirrorDesktop,
-forcePrivateAfterSteamClose
+forcePrivateAfterSteamClose,
+encoderBackend
 ))
 {
-LimeLog.severe("Nova: Rejecting resolved profile outside the current HDR, FPS, or bitrate-lock envelope")
+LimeLog.severe("Nova: Rejecting resolved profile outside the current HDR, FPS, bitrate-lock, or encoder envelope")
 return blocked()
 }
 }
@@ -7291,6 +7306,7 @@ companion object {
  const val EXTRA_SERVER_CERT:String = "ServerCert"
  const val EXTRA_VDISPLAY:String = "VirtualDisplay"
  const val EXTRA_STREAM_MODE:String = "StreamMode"
+ const val EXTRA_ENCODER_BACKEND:String = "EncoderBackend"
  const val EXTRA_DISPLAY_MODE_EXPLICIT:String = "DisplayModeExplicit"
  const val EXTRA_MIRROR_DESKTOP:String = "MirrorDesktop"
 const val EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE:String = "ForcePrivateAfterSteamClose"

--- a/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
+++ b/app/src/main/java/com/papi/nova/ShortcutTrampoline.kt
@@ -24,6 +24,7 @@ import com.papi.nova.nvstream.wol.WakeOnLanSender
 import com.papi.nova.preferences.PreferenceConfiguration
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.ui.AutoQualityProfilePreferences
+import com.papi.nova.ui.NovaEncoderBackendOverrides
 import com.papi.nova.ui.NovaLaunchPreflight
 import com.papi.nova.ui.NovaLaunchStreamOverride
 import com.papi.nova.ui.NovaThemeManager
@@ -68,6 +69,7 @@ class ShortcutTrampoline : NovaActivity() {
         val usesVirtualDisplay: Boolean? = null,
         val mirrorDesktop: Boolean = false,
         val streamMode: String = "",
+        val encoderBackend: String = "",
         val streamWidth: Int = 0,
         val streamHeight: Int = 0,
         val streamFps: Float = 0f,
@@ -185,6 +187,7 @@ class ShortcutTrampoline : NovaActivity() {
                                                         streamHeight = readyLaunchPlan.streamHeight,
                                                         streamFps = readyLaunchPlan.streamFps,
                                                         streamMode = readyLaunchPlan.streamMode,
+                                                        encoderBackend = readyLaunchPlan.encoderBackend,
                                                     ),
                                                 )
 
@@ -667,6 +670,10 @@ class ShortcutTrampoline : NovaActivity() {
             ShortcutLaunchPlan(
                 app = launchApp,
                 polarisGame = polarisGame,
+                encoderBackend = NovaEncoderBackendOverrides.load(
+                    this,
+                    polarisGame,
+                ).orEmpty(),
             )
         } catch (e: Exception) {
             LimeLog.warning("Nova: Shortcut launch Polaris metadata lookup failed: ${e.message}")
@@ -696,6 +703,14 @@ class ShortcutTrampoline : NovaActivity() {
             }
 
             val clientSettings = apiClient.getClientSettings()
+            val encoderBackend = if (clientSettings != null) {
+                NovaEncoderBackendOverrides.loadAvailable(this, polarisGame, clientSettings).orEmpty()
+            } else {
+                // Preserve the explicit choice when settings could not be fetched. Game's
+                // fresh resolver will either prove it or fail closed; a successful typed
+                // catalog lookup above is allowed to retire an unavailable stale choice.
+                launchPlan.encoderBackend
+            }
             // The per-game Tuning choice, not a fixed "auto": a game pinned to High FPS
             // in Play Setup must launch pinned from a home-screen shortcut too.
             val profilePreference = AutoQualityProfilePreferences.load(this, polarisGame.id, polarisGame.name)
@@ -716,6 +731,7 @@ class ShortcutTrampoline : NovaActivity() {
                 clientMaxFps = StreamSyncManager.maxSupportedRefreshRate(
                     ServerHelper.getActiveDisplay(this, preferences)
                 ),
+                encoderBackend = encoderBackend,
             )
             val composed = NovaLaunchStreamOverride.compose(
                 optimization,
@@ -756,6 +772,7 @@ class ShortcutTrampoline : NovaActivity() {
                 usesVirtualDisplay = launchUsesVirtualDisplay,
                 mirrorDesktop = launchMirrorDesktop,
                 streamMode = launchMode,
+                encoderBackend = encoderBackend,
                 streamWidth = launchResolution.width,
                 streamHeight = launchResolution.height,
                 streamFps = launchFps,
@@ -789,6 +806,7 @@ class ShortcutTrampoline : NovaActivity() {
                 streamHeight = readyLaunchPlan.streamHeight,
                 streamFps = readyLaunchPlan.streamFps,
                 streamMode = readyLaunchPlan.streamMode,
+                encoderBackend = readyLaunchPlan.encoderBackend,
             )
 
             runOnUiThread {

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -533,7 +533,8 @@ class PolarisApiClient @JvmOverloads constructor(
             bitrateKbps: Int = 0,
             bitrateLocked: Boolean = false,
             hdr: Boolean? = null,
-            clientMaxFps: Float = 0f
+            clientMaxFps: Float = 0f,
+            encoderBackend: String = ""
         ): String {
             val preferenceParam = preference
                 .takeIf { it.isNotBlank() }
@@ -564,6 +565,9 @@ class PolarisApiClient @JvmOverloads constructor(
                 .takeIf { it > 0f && it.isFinite() }
                 ?.let { "&client_max_fps=$it" }
                 ?: ""
+            val encoderParam = PolarisClientSettings.normalizeEncoderBackend(encoderBackend)
+                ?.let { "&encoder=${java.net.URLEncoder.encode(it, "UTF-8")}" }
+                ?: ""
             return "/optimize?device=${java.net.URLEncoder.encode(device, "UTF-8")}" +
                 "&game=${java.net.URLEncoder.encode(game, "UTF-8")}" +
                 preferenceParam +
@@ -576,7 +580,8 @@ class PolarisApiClient @JvmOverloads constructor(
                 bitrateParam +
                 bitrateLockParam +
                 hdrParam +
-                clientMaxFpsParam
+                clientMaxFpsParam +
+                encoderParam
         }
 
         private fun parseStringArray(array: org.json.JSONArray?): List<String> {
@@ -668,6 +673,27 @@ class PolarisApiClient @JvmOverloads constructor(
                         sessionOverridable = mode.optBoolean("session_overridable", true)
                     )
                 }
+            }
+        }
+
+        private fun parseEncoderOptions(array: org.json.JSONArray?): List<PolarisClientSettings.EncoderOption> {
+            if (array == null) return emptyList()
+            val seen = linkedSetOf<String>()
+            return (0 until array.length()).mapNotNull { index ->
+                val encoder = array.optJSONObject(index) ?: return@mapNotNull null
+                val value = PolarisClientSettings.normalizeEncoderBackend(
+                    encoder.opt("value") as? String,
+                ) ?: return@mapNotNull null
+                if (!seen.add(value)) return@mapNotNull null
+                PolarisClientSettings.EncoderOption(
+                    value = value,
+                    label = (encoder.opt("label") as? String).orEmpty(),
+                    available = encoder.opt("available") as? Boolean ?: false,
+                    experimental = encoder.opt("experimental") as? Boolean ?: false,
+                    fallbackAllowed = encoder.opt("fallback_allowed") as? Boolean ?: false,
+                    runtimeValidation = (encoder.opt("runtime_validation") as? String).orEmpty(),
+                    reason = (encoder.opt("reason") as? String).orEmpty(),
+                )
             }
         }
 
@@ -768,6 +794,8 @@ class PolarisApiClient @JvmOverloads constructor(
                 ),
                 capabilities = PolarisClientSettings.Capabilities(
                     modes = parseModeOptions(capabilities?.optJSONArray("modes")),
+                    encoders = parseEncoderOptions(capabilities?.optJSONArray("encoders")),
+                    sessionEncoderOverride = strictBoolean(capabilities, "session_encoder_override"),
                     displayModeOverride = capabilities?.optBoolean("display_mode_override", false) ?: false,
                     targetBitrateOverride = capabilities?.optBoolean("target_bitrate_override", false) ?: false,
                     aiAutoQualityControl = capabilities?.let {
@@ -1030,6 +1058,7 @@ class PolarisApiClient @JvmOverloads constructor(
                     optimizerSync = features?.optBoolean("optimizer_sync_v1") ?: false,
                     resolvedProfileProvenance = strictBoolean(features, "resolved_profile_provenance_v1"),
                     expectedTopologyAssertion = strictBoolean(features, "expected_topology_assertion_v1"),
+                    encoderBackendSelection = strictBoolean(features, "encoder_backend_selection_v1"),
                     lockScreenControl = features?.optBoolean("lock_screen_control") ?: false,
                     cursorVisibilityControl = features?.optBoolean("cursor_visibility_control") ?: false,
                     liveMediaTelemetry = strictBoolean(features, "live_media_telemetry_v1"),
@@ -3070,7 +3099,8 @@ class PolarisApiClient @JvmOverloads constructor(
         bitrateLocked: Boolean = false,
         hdr: Boolean? = null,
         clientMaxFps: Float = 0f,
-        launchBounded: Boolean = false
+        launchBounded: Boolean = false,
+        encoderBackend: String = ""
     ): org.json.JSONObject? {
         return try {
             val url = "$baseUrl${buildOptimizationPath(
@@ -3088,7 +3118,8 @@ class PolarisApiClient @JvmOverloads constructor(
                 bitrateKbps = bitrateKbps,
                 bitrateLocked = bitrateLocked,
                 hdr = hdr,
-                clientMaxFps = clientMaxFps
+                clientMaxFps = clientMaxFps,
+                encoderBackend = encoderBackend
             )}"
             val request = Request.Builder().url(url).get().build()
             LimeLog.info("Nova: Optimization query start for $url")

--- a/app/src/main/java/com/papi/nova/api/PolarisCapabilities.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisCapabilities.kt
@@ -20,6 +20,7 @@ data class PolarisCapabilities(
         val optimizerSync: Boolean = false,
         val resolvedProfileProvenance: Boolean = false,
         val expectedTopologyAssertion: Boolean = false,
+        val encoderBackendSelection: Boolean = false,
         val lockScreenControl: Boolean = false,
         val cursorVisibilityControl: Boolean = false,
         val liveMediaTelemetry: Boolean = false,

--- a/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt
@@ -37,6 +37,8 @@ data class PolarisClientSettings(
 
     data class Capabilities(
         val modes: List<ModeOption> = emptyList(),
+        val encoders: List<EncoderOption> = emptyList(),
+        val sessionEncoderOverride: Boolean = false,
         val displayModeOverride: Boolean = false,
         val targetBitrateOverride: Boolean = false,
         val aiAutoQualityControl: Boolean = false,
@@ -63,6 +65,20 @@ data class PolarisClientSettings(
          */
         val sessionOverridable: Boolean = true
     )
+
+    /** A backend this Polaris build accepts for one launch, pending its live GPU probe. */
+    data class EncoderOption(
+        val value: String = "",
+        val label: String = "",
+        val available: Boolean = false,
+        val experimental: Boolean = false,
+        val fallbackAllowed: Boolean = false,
+        val runtimeValidation: String = "",
+        val reason: String = ""
+    ) {
+        val displayLabel: String
+            get() = label.ifBlank { labelForEncoder(value) }
+    }
 
     val desiredModeLabel: String
         get() = desired.streamDisplayModeLabel.ifBlank { labelForMode(desired.streamDisplayMode) }
@@ -93,6 +109,25 @@ data class PolarisClientSettings(
             "desktop_display", "host_display" -> "Mirror Desktop"
             "windowed_stream", "gpu_native", "gpu-native" -> "Private Stream (GPU-native)"
             else -> ""
+        }
+
+        @JvmStatic
+        fun normalizeEncoderBackend(value: String?): String? = value
+            ?.trim()
+            ?.lowercase()
+            ?.takeIf { it.matches(Regex("[a-z0-9][a-z0-9_-]{0,63}")) }
+
+        @JvmStatic
+        fun labelForEncoder(backend: String): String = when (normalizeEncoderBackend(backend)) {
+            "auto" -> "Auto"
+            "nvenc" -> "NVIDIA NVENC"
+            "vaapi" -> "VA-API"
+            "vulkan" -> "Vulkan Video"
+            "quicksync" -> "Intel Quick Sync"
+            "amdvce" -> "AMD AMF/VCE"
+            "videotoolbox" -> "VideoToolbox"
+            "software" -> "Software"
+            else -> backend.trim()
         }
     }
 }

--- a/app/src/main/java/com/papi/nova/manager/NovaEncoderLaunchContract.kt
+++ b/app/src/main/java/com/papi/nova/manager/NovaEncoderLaunchContract.kt
@@ -1,0 +1,33 @@
+package com.papi.nova.manager
+
+import com.papi.nova.api.PolarisClientSettings
+import org.json.JSONObject
+
+/** Validates the encoder portion of Polaris' deterministic per-launch profile. */
+object NovaEncoderLaunchContract {
+
+    fun honors(optimization: JSONObject, requestedBackend: String): Boolean {
+        val requested = PolarisClientSettings.normalizeEncoderBackend(requestedBackend)
+            ?: return requestedBackend.isBlank()
+        val field = optimization.optJSONObject("resolved_profile")
+            ?.optJSONObject("fields")
+            ?.optJSONObject("encoder_backend")
+            ?: return false
+        val resolution = optimization.optJSONObject("encoder_resolution") ?: return false
+        val fieldValue = PolarisClientSettings.normalizeEncoderBackend(
+            field.opt("value") as? String,
+        )
+        val resolutionRequested = PolarisClientSettings.normalizeEncoderBackend(
+            resolution.opt("requested") as? String,
+        )
+        val resolutionResolved = PolarisClientSettings.normalizeEncoderBackend(
+            resolution.opt("resolved") as? String,
+        )
+        return fieldValue == requested &&
+            resolutionRequested == requested &&
+            resolutionResolved == requested &&
+            field.opt("locked") == true &&
+            resolution.opt("locked") == true &&
+            (resolution.opt("fallback_allowed") == (requested == "auto"))
+    }
+}

--- a/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/StreamConfiguration.kt
@@ -32,6 +32,8 @@ class StreamConfiguration private constructor() {
     private var resolvedProfile = false
     private var mirrorDesktop = false
     private var streamMode = ""
+    private var encoderBackend = ""
+    private var expectedEncoder = ""
     private var expectedTopology = ""
     private var forcePrivateAfterSteamClose = false
 
@@ -185,6 +187,17 @@ class StreamConfiguration private constructor() {
             return this
         }
 
+        fun setEncoderBackend(encoderBackend: String?): Builder {
+            // Blank preserves the host default; "auto" is an explicit session policy.
+            config.encoderBackend = encoderBackend?.trim()?.lowercase().orEmpty()
+            return this
+        }
+
+        fun setExpectedEncoder(expectedEncoder: String?): Builder {
+            config.expectedEncoder = expectedEncoder?.trim()?.lowercase().orEmpty()
+            return this
+        }
+
         fun setExpectedTopology(expectedTopology: String?): Builder {
             config.expectedTopology = expectedTopology?.trim()?.lowercase().orEmpty()
             return this
@@ -265,6 +278,10 @@ class StreamConfiguration private constructor() {
     fun getMirrorDesktop(): Boolean = mirrorDesktop
 
     fun getStreamMode(): String = streamMode
+
+    fun getEncoderBackend(): String = encoderBackend
+
+    fun getExpectedEncoder(): String = expectedEncoder
 
     fun getExpectedTopology(): String = expectedTopology
 

--- a/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
+++ b/app/src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt
@@ -670,14 +670,31 @@ class NvHTTP @Throws(IOException::class) constructor(
             .takeIf { it.isNotBlank() }
             ?.let { "&streamMode=" + URLEncoder.encode(it, "UTF-8") }
             ?: ""
+        val encoderBackendParam = streamConfig.getEncoderBackend()
+            .takeIf { it.isNotBlank() }
+            ?.let { "&encoderBackend=" + URLEncoder.encode(it, "UTF-8") }
+            ?: ""
         val resolvedProfileParam = if (streamConfig.getResolvedProfile()) {
             val expectedTopology = streamConfig.getExpectedTopology()
             require(expectedTopology.isNotBlank()) {
                 "A deterministic resolved profile requires an expected topology assertion"
             }
+            val expectedEncoder = streamConfig.getExpectedEncoder()
+            if (streamConfig.getEncoderBackend().isNotBlank()) {
+                require(expectedEncoder == streamConfig.getEncoderBackend()) {
+                    "A deterministic encoder override requires a matching expected encoder assertion"
+                }
+            } else {
+                require(expectedEncoder.isBlank()) {
+                    "An expected encoder assertion requires an explicit encoder override"
+                }
+            }
             "&resolvedProfile=1&bitrateKbps=" + streamConfig.getBitrate() +
                 "&resolvedHdr=" + (if (enableHdr) 1 else 0) +
-                "&expectedTopology=" + URLEncoder.encode(expectedTopology, "UTF-8")
+                "&expectedTopology=" + URLEncoder.encode(expectedTopology, "UTF-8") +
+                expectedEncoder.takeIf { it.isNotBlank() }
+                    ?.let { "&expectedEncoder=" + URLEncoder.encode(it, "UTF-8") }
+                    .orEmpty()
         } else {
             ""
         }
@@ -702,6 +719,7 @@ class NvHTTP @Throws(IOException::class) constructor(
                 (if (mirrorDesktop) "&launchMode=mirror_desktop" else "") +
                 (if (forcePrivateAfterSteamClose) "&closeDesktopSteamForPrivate=1&launchMode=force_private_stream" else "") +
                 streamModeParam +
+                encoderBackendParam +
                 profilePreference +
                 resolvedProfileParam +
                 "&localAudioPlayMode=" + (if (streamConfig.getPlayLocalAudio()) 1 else 0) +

--- a/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
@@ -105,9 +105,6 @@ data class AutoQualityUiState(
                 safeBitrateApplied ||
                 (!authoritativeDoctor && healthSuggestsRecovery && status.health.safeDisplayMode.isNotBlank()) ||
                 (!authoritativeDoctor && status.health.recoveryProfile.isNotBlank())
-            val cpuCapture = status.capture.transport.equals("shm", ignoreCase = true) ||
-                status.capture.residency.equals("cpu", ignoreCase = true) ||
-                status.encoder.targetResidency.equals("cpu", ignoreCase = true)
             val syncFailed = status.syncStatus.isFailed ||
                 presentationStatus == "blocked"
             val severeHealth = healthGrade == "degraded" ||
@@ -140,8 +137,7 @@ data class AutoQualityUiState(
 
             val manualNeedsAttention = manualOverride && (
                 syncFailed ||
-                    severeHealth ||
-                    cpuCapture
+                    severeHealth
                 )
 
             if (manualOverride && manualNeedsAttention) {
@@ -230,9 +226,8 @@ data class AutoQualityUiState(
                 )
             }
 
-            if (syncFailed || severeHealth || cpuCapture) {
+            if (syncFailed || severeHealth) {
                 val label = when {
-                    cpuCapture -> "Needs Attention"
                     status.health.decoderRisk.equals("elevated", ignoreCase = true) -> "Decoder pressure"
                     syncFailed -> "Sync attention"
                     else -> "Needs Attention"

--- a/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
@@ -111,6 +111,9 @@ data class AutoQualityUiState(
                 (!authoritativeDoctor && status.health.decoderRisk.equals("elevated", ignoreCase = true))
             val manualOverride = status.syncStatus.isManualOverride ||
                 syncState == "manual_override"
+            val cleanAdaptiveRecovery = authoritativeDoctor &&
+                adaptiveLowered &&
+                !status.hasHealthConcerns
 
             if (status.isHdrDowngraded) {
                 return AutoQualityUiState(
@@ -245,7 +248,7 @@ data class AutoQualityUiState(
                 )
             }
 
-            if (autoPolicy.isRecoveringBitrate) {
+            if (autoPolicy.isRecoveringBitrate || cleanAdaptiveRecovery) {
                 return AutoQualityUiState(
                     state = State.RECOVERING,
                     label = "Recovering Bitrate",
@@ -254,7 +257,11 @@ data class AutoQualityUiState(
                         ?.replace(" Mbps", "M")
                         ?: "REC",
                     detail = autoPolicy.summary.takeIf { it.isNotBlank() }
-                        ?: streamPolicy.statusCaption,
+                        ?: if (status.tuning.adaptiveBitrateState.equals("recovering", ignoreCase = true)) {
+                            "Auto Safe is recovering toward the launch quality ceiling"
+                        } else {
+                            "Auto Safe is holding a lower live target while the stream remains healthy"
+                        },
                     targetSummary = streamPolicy.targetSummary,
                     tone = Tone.INFO,
                     enabled = true,

--- a/app/src/main/java/com/papi/nova/ui/NovaEncoderBackendOverrides.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaEncoderBackendOverrides.kt
@@ -1,0 +1,72 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.api.PolarisClientSettings
+import com.papi.nova.shared.polaris.model.PolarisGame
+
+/** Remembers an explicit per-game encoder choice without changing Polaris' host setting. */
+object NovaEncoderBackendOverrides {
+
+    private const val PREFS_NAME = "nova_prefs"
+    private const val KEY_PREFIX = "encoder_backend_override_"
+
+    private fun key(game: PolarisGame): String =
+        KEY_PREFIX + game.id.ifBlank { game.appId.toString() }
+
+    fun load(context: Context, game: PolarisGame): String? {
+        val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = preferences.getString(key(game), null) ?: return null
+        val normalized = PolarisClientSettings.normalizeEncoderBackend(raw)
+        if (normalized == null) {
+            preferences.edit().remove(key(game)).apply()
+            return null
+        }
+        if (normalized != raw) {
+            preferences.edit().putString(key(game), normalized).apply()
+        }
+        return normalized
+    }
+
+    /**
+     * Resolve the saved choice against this host's typed, build-specific catalog.
+     * A choice the current host can no longer select is retired so it cannot return
+     * later as invisible launch authority.
+     */
+    fun loadAvailable(
+        context: Context,
+        game: PolarisGame,
+        settings: PolarisClientSettings,
+    ): String? {
+        val saved = load(context, game) ?: return null
+        val supported = settings.capabilities.sessionEncoderOverride &&
+            settings.capabilities.encoders.any { option ->
+                option.available &&
+                    PolarisClientSettings.normalizeEncoderBackend(option.value) == saved
+            }
+        if (!supported) {
+            clear(context, game)
+            return null
+        }
+        return saved
+    }
+
+    fun save(context: Context, game: PolarisGame, backend: String) {
+        val normalized = PolarisClientSettings.normalizeEncoderBackend(backend)
+        if (normalized == null) {
+            clear(context, game)
+            return
+        }
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(key(game), normalized)
+            .apply()
+    }
+
+    /** Remove the explicit choice so this game follows Polaris' configured encoder again. */
+    fun clear(context: Context, game: PolarisGame) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(key(game))
+            .apply()
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -151,8 +151,8 @@ class NovaGameDetailActivity : NovaActivity() {
      * shape lets the body below stay the code that was reviewed as a bottom sheet,
      * rather than a rewrite that happens to compile.
      */
-    private val onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, String, String, JSONObject?) -> Unit)? =
-        { game, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, streamMode, presentationMode, preflight ->
+    private val onLaunch: ((PolarisGame, Boolean, Boolean, Boolean, String, String, String, String, JSONObject?) -> Unit)? =
+        { game, withVirtualDisplay, mirrorDesktop, forcePrivateAfterSteamClose, profilePreference, streamMode, encoderBackend, presentationMode, preflight ->
             setResult(
                 RESULT_OK,
                 Intent().putExtra(
@@ -163,6 +163,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         .put(RESULT_KEY_FORCE_PRIVATE, forcePrivateAfterSteamClose)
                         .put(RESULT_KEY_PROFILE_PREFERENCE, profilePreference)
                         .put(RESULT_KEY_STREAM_MODE, streamMode)
+                        .put(RESULT_KEY_ENCODER_BACKEND, encoderBackend)
                         // Presentation only: the library can name an unpinned host
                         // default without turning it into streamMode authority.
                         .put(RESULT_KEY_PRESENTATION_MODE, presentationMode)
@@ -486,6 +487,11 @@ class NovaGameDetailActivity : NovaActivity() {
         // resolution row changes dimensions while fpsOverride alone changes cadence. Persisted
         // the same way as chosenResolution, so it survives past this Activity's lifetime.
         var chosenFps by mutableStateOf<Int?>(loadFrameRateOverride(currentGame))
+        // Null keeps Polaris' configured host policy. "auto" is deliberately not
+        // null: it asks Polaris to choose and permits fallback for this launch.
+        var chosenEncoderBackend by mutableStateOf<String?>(
+            NovaEncoderBackendOverrides.load(this@NovaGameDetailActivity, currentGame),
+        )
         // Changing a row is cheap; telling the host about it is not. Presses settle first
         // so that cycling past three values costs one round-trip rather than three.
         var settleJob: Job? = null
@@ -530,6 +536,28 @@ class NovaGameDetailActivity : NovaActivity() {
             uiState = buildUiState(currentGame, preference)
         }
 
+        fun reconcileEncoderBackend(settings: PolarisClientSettings): Boolean {
+            val available = NovaEncoderBackendOverrides.loadAvailable(
+                this@NovaGameDetailActivity,
+                currentGame,
+                settings,
+            )
+            val changed = chosenEncoderBackend != available
+            chosenEncoderBackend = available
+            return changed
+        }
+
+        fun selectedEncoderBackend(): String {
+            val selected = chosenEncoderBackend ?: return ""
+            val settings = clientSettings ?: return ""
+            return selected.takeIf { candidate ->
+                settings.capabilities.sessionEncoderOverride &&
+                    settings.capabilities.encoders.any { option ->
+                        option.available && option.value == candidate
+                    }
+            }.orEmpty()
+        }
+
         /**
          * Publish the settings learned by launch preflight before resolving its mode.
          *
@@ -554,6 +582,7 @@ class NovaGameDetailActivity : NovaActivity() {
             if (!preflightRequestFence.owns(requestGeneration)) {
                 throw CancellationException("launch preflight superseded")
             }
+            reconcileEncoderBackend(updated)
             clientSettings = updated
             refreshUiState()
             return true
@@ -579,6 +608,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     .getOrNull()
             }
             if (settings != null) {
+                reconcileEncoderBackend(settings)
                 clientSettings = settings
                 refreshUiState()
             }
@@ -590,6 +620,7 @@ class NovaGameDetailActivity : NovaActivity() {
             serverUuid = serverUuid,
             scope = lifecycleScope,
             onSettingsChanged = { settings ->
+                reconcileEncoderBackend(settings)
                 clientSettings = settings
                 refreshUiState()
             },
@@ -674,6 +705,7 @@ class NovaGameDetailActivity : NovaActivity() {
                 // choice, or the safe replacement for a host default that is no
                 // longer launch-ready, travels for this session only.
                 uiState.launchStreamMode,
+                selectedEncoderBackend(),
                 // A normal host default intentionally stays out of streamMode. Carry
                 // its resolved name separately so the library can describe it truthfully.
                 uiState.playMode,
@@ -781,6 +813,7 @@ class NovaGameDetailActivity : NovaActivity() {
                         "launch preflight settings unavailable"
                     }
                     val optimizationMode = uiState.playMode
+                    val optimizationEncoder = selectedEncoderBackend()
                     val opt = withContext(Dispatchers.IO) {
                         val launchPrefs = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
                         val metered = StreamSyncManager.isMeteredNetwork(this@NovaGameDetailActivity)
@@ -797,6 +830,7 @@ class NovaGameDetailActivity : NovaActivity() {
                             clientMaxFps = StreamSyncManager.maxSupportedRefreshRate(
                                 ServerHelper.getActiveDisplay(this@NovaGameDetailActivity, launchPrefs)
                             ),
+                            encoderBackend = optimizationEncoder,
                         )
                     }
                     check(StreamSyncManager.hasTrustedResolvedProfile(opt)) {
@@ -1013,6 +1047,29 @@ class NovaGameDetailActivity : NovaActivity() {
             }
         }
 
+        /** Select a backend for this game only; null returns to Polaris' host setting. */
+        fun chooseEncoderBackend(backend: String?) {
+            val normalized = PolarisClientSettings.normalizeEncoderBackend(backend)
+            if (backend != null && normalized == null) return
+            val allowed = backend == null || clientSettings?.capabilities?.let { capabilities ->
+                capabilities.sessionEncoderOverride && capabilities.encoders.any { option ->
+                    option.available && option.value == normalized
+                }
+            } == true
+            if (!allowed || normalized == chosenEncoderBackend) return
+            chosenEncoderBackend = normalized
+            if (normalized == null) {
+                NovaEncoderBackendOverrides.clear(this@NovaGameDetailActivity, currentGame)
+            } else {
+                NovaEncoderBackendOverrides.save(
+                    this@NovaGameDetailActivity,
+                    currentGame,
+                    normalized,
+                )
+            }
+            settleThen { loadOptimization(profilePreference) }
+        }
+
         fun selectProfilePreference(value: String) {
             if (value == profilePreference) return
             profilePreference = value
@@ -1058,9 +1115,8 @@ class NovaGameDetailActivity : NovaActivity() {
         }
 
         /**
-         * The act column, resolved. Four rows at most, and fewer when a row has nothing to
-         * offer -- a host with one launch mode, or no display planner, drops the row rather
-         * than drawing a control with a single value in it.
+         * The act column, resolved. Rows appear only when the current host has a real choice
+         * to offer; richer catalogs use the panel's measured scrolling fallback.
          */
         fun buildPlaySetupRows(): List<NovaPlaySetupRowState> {
             val rows = mutableListOf<NovaPlaySetupRowState>()
@@ -1182,6 +1238,59 @@ class NovaGameDetailActivity : NovaActivity() {
                 // visible, clearable control on this screen -- a durable lock nobody can
                 // see or undo. Retire it instead of leaving it stuck.
                 chooseFrameRate(null)
+            }
+
+            val encoderCatalog = clientSettings?.capabilities?.takeIf {
+                it.sessionEncoderOverride
+            }?.encoders.orEmpty().filter { it.available }.distinctBy { it.value }
+            if (encoderCatalog.isNotEmpty()) {
+                val selectedEncoder = selectedEncoderBackend()
+                val selectedOption = encoderCatalog.firstOrNull { it.value == selectedEncoder }
+                rows += NovaPlaySetupRowState(
+                    row = NovaPlaySetupRow.ENCODER,
+                    label = getString(R.string.nova_play_setup_encoder),
+                    caption = when {
+                        selectedEncoder.isBlank() -> getString(
+                            R.string.nova_play_setup_encoder_host_default_caption,
+                        )
+                        selectedOption?.fallbackAllowed == true -> getString(
+                            R.string.nova_play_setup_encoder_auto_caption,
+                        )
+                        else -> getString(R.string.nova_play_setup_encoder_exact_caption)
+                    },
+                    value = selectedOption?.displayLabel
+                        ?: getString(R.string.nova_play_setup_encoder_host_default),
+                    stripTitle = getString(R.string.nova_play_setup_strip_encoder),
+                    options = buildList {
+                        add(
+                            NovaPlaySetupOption(
+                                label = getString(R.string.nova_play_setup_encoder_host_default),
+                                consequence = getString(
+                                    R.string.nova_play_setup_encoder_host_default_consequence,
+                                ),
+                                current = selectedEncoder.isBlank(),
+                                onSelect = { chooseEncoderBackend(null) },
+                            ),
+                        )
+                        encoderCatalog.forEach { option ->
+                            add(
+                                NovaPlaySetupOption(
+                                    label = option.displayLabel,
+                                    consequence = option.reason.ifBlank {
+                                        if (option.fallbackAllowed) {
+                                            getString(R.string.nova_play_setup_encoder_auto_consequence)
+                                        } else {
+                                            getString(R.string.nova_play_setup_encoder_exact_consequence)
+                                        }
+                                    },
+                                    current = option.value == selectedEncoder,
+                                    onSelect = { chooseEncoderBackend(option.value) },
+                                ),
+                            )
+                        }
+                    },
+                    overridden = selectedEncoder.isNotBlank(),
+                )
             }
 
             rows += NovaPlaySetupRowState(
@@ -2282,6 +2391,7 @@ class NovaGameDetailActivity : NovaActivity() {
         const val RESULT_KEY_FORCE_PRIVATE = "forcePrivateAfterSteamClose"
         const val RESULT_KEY_PROFILE_PREFERENCE = "profilePreference"
         const val RESULT_KEY_STREAM_MODE = "streamDisplayMode"
+        const val RESULT_KEY_ENCODER_BACKEND = "encoderBackend"
         const val RESULT_KEY_PRESENTATION_MODE = "presentationDisplayMode"
         const val RESULT_KEY_PREFLIGHT = "preflightOptimization"
 

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailContent.kt
@@ -223,7 +223,7 @@ internal fun NovaGameDetailContent(
     steamLaunchModeLabel: String,
     steamLaunchCaption: String,
     optimizationState: NovaGameDetailOptimizationState,
-    /** The four rows of the act column, already resolved, in draw order. */
+    /** The act-column rows already resolved from the current host catalog, in draw order. */
     playSetupRows: List<NovaPlaySetupRowState>,
     /** Which row the comparison strip is currently explaining. */
     explainedPlaySetupRow: NovaPlaySetupRow,
@@ -409,7 +409,7 @@ internal fun NovaGameDetailContent(
                 } else {
                     val summary = optimizationState.profileSummary
                     // Spend the room that is there rather than a number picked in advance:
-                    // a host with a display planner has a fourth row and so less of it.
+                    // each advertised launch control leaves less room for the legend.
                     val consequenceLines =
                         novaPlaySetupConsequenceLines(bodyHeight, playSetupRows.size)
                     NovaPlaySetupBody(
@@ -491,7 +491,7 @@ internal fun NovaGameDetailContent(
                             factCount = summary?.let { 4 } ?: 2,
                         ),
                         rows = {
-                            // Four rows, drawn in a fixed order. Each advances its own value
+                            // Host-backed rows, drawn in a fixed order. Each advances its own value
                             // on A or a tap, and points the strip at itself on focus, so the
                             // explanation follows the cursor without being a stop on it.
                             playSetupRows.forEachIndexed { index, rowState ->

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -843,6 +843,7 @@ class NovaLibraryActivity : NovaActivity() {
             forcePrivateAfterSteamClose = request.optBoolean(NovaGameDetailActivity.RESULT_KEY_FORCE_PRIVATE),
             profilePreference = request.optString(NovaGameDetailActivity.RESULT_KEY_PROFILE_PREFERENCE, "auto"),
             resolvedMode = request.optString(NovaGameDetailActivity.RESULT_KEY_STREAM_MODE, ""),
+            encoderBackend = request.optString(NovaGameDetailActivity.RESULT_KEY_ENCODER_BACKEND, ""),
             presentationMode = request.optString(NovaGameDetailActivity.RESULT_KEY_PRESENTATION_MODE, ""),
             preflightOptimization = request.optJSONObject(NovaGameDetailActivity.RESULT_KEY_PREFLIGHT),
         )
@@ -856,6 +857,7 @@ class NovaLibraryActivity : NovaActivity() {
         presentationMode: String = "",
         forcePrivateAfterSteamClose: Boolean = false,
         profilePreference: String = "auto",
+        encoderBackend: String = "",
         preflightOptimization: org.json.JSONObject? = null
     ) {
         if (game.appId <= 0) {
@@ -979,7 +981,8 @@ class NovaLibraryActivity : NovaActivity() {
                     launchOptimizationJson = preflightOptimization?.toString(),
                     mirrorDesktop = launchMirrorsDesktop,
                     forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
-                    streamMode = launchMode
+                    streamMode = launchMode,
+                    encoderBackend = encoderBackend,
                 )
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaPlaySetup.kt
@@ -233,9 +233,10 @@ internal fun NovaPlaySetupColumnHead(text: String) {
  *
  * This is a legend, not a picker. It describes whichever row currently holds focus, so it
  * is deliberately **not** a focus target: making it one would mean stopping on a thing
- * that exists only to explain the thing you just stopped on, and it would put a fifth and
- * sixth stop in the path of every visit down the column. Left and right do nothing in this
- * panel, which is the point -- four rows, no scrolling, nothing to hunt for.
+ * that exists only to explain the thing you just stopped on, and it would add another
+ * stop in the path of every visit down the column. Left and right do nothing in this
+ * panel, which is the point -- a short bounded list, with scrolling only when the
+ * host advertises enough session choices to need it.
  *
  * It stays tappable, because touch has no cursor for it to follow. A finger can take the
  * card it wants directly instead of pressing a row until the right value comes round.
@@ -251,13 +252,12 @@ internal fun NovaPlaySetupComparison(
     title: String,
     options: List<NovaPlaySetupOption>,
     /**
-     * One line rather than two once the column carries a fourth row.
+     * One line rather than two once the column grows beyond its compact shape.
      *
      * The panel has to fit a ~325dp landscape viewport without scrolling. Four rows at the
-     * 48dp accessible floor plus their gaps is 212dp of it, and the legend has to live in
-     * what is left. A host advertising a display planner is exactly the case that adds that
-     * fourth row, so the legend gives up its second line rather than the panel giving up
-     * fitting.
+     * 48dp accessible floor plus their gaps consume most of it, and the legend has to live
+     * in what is left. The legend gives up extra lines before the panel uses its scrolling
+     * fallback.
      */
     consequenceMaxLines: Int = 2,
     /**
@@ -393,11 +393,8 @@ internal enum class NovaPlaySetupScope { THIS_GAME, EVERY_GAME }
 /**
  * The things Play Setup can change, in the order they are drawn.
  *
- * Four per scope, and fixed at four. The act column has to fit a landscape viewport that is
- * roughly 230-275dp once the panel's chrome and the bottom fade are taken out, and the strip
- * below the rows used to start at 272dp in the lightest case and 332dp for a Steam game -- so
- * the strip every control on this screen wrote to was off the bottom of the window at the
- * moment it was written, with nothing scrolling to it. A fifth row would put it back there.
+ * Kept in one stable order. Compact hosts still fit without scrolling; richer host catalogs
+ * can add rows and use the wide panel's measured scroll fallback rather than hiding a choice.
  *
  * More Launch Settings is not among them. It held resolution, and behind it codec and
  * bitrate -- which are consequences of a resolution, not choices anyone makes separately.
@@ -411,6 +408,7 @@ internal enum class NovaPlaySetupRow {
     WHERE_IT_RUNS,
     RESOLUTION,
     FRAME_RATE,
+    ENCODER,
     TUNING,
     STEAM_LAUNCH,
     HOST_DEFAULT_DISPLAY,

--- a/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
+++ b/app/src/main/java/com/papi/nova/utils/ServerHelper.kt
@@ -173,6 +173,7 @@ object ServerHelper {
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
         streamMode: String = "",
+        encoderBackend: String = "",
     ): Intent {
         val prefConfig = PreferenceConfiguration.readPreferences(parent)
         val selectedAndroidDisplay = if (prefConfig.enableFullExDisplay) {
@@ -215,6 +216,9 @@ object ServerHelper {
         gameIntent.putExtra(Game.EXTRA_MIRROR_DESKTOP, mirrorDesktop)
         if (streamMode.isNotBlank()) {
             gameIntent.putExtra(Game.EXTRA_STREAM_MODE, streamMode)
+        }
+        if (encoderBackend.isNotBlank()) {
+            gameIntent.putExtra(Game.EXTRA_ENCODER_BACKEND, encoderBackend)
         }
         gameIntent.putExtra(Game.EXTRA_FORCE_PRIVATE_AFTER_STEAM_CLOSE, forcePrivateAfterSteamClose)
         gameIntent.putExtra(Game.EXTRA_WATCH_ONLY, watchOnly)
@@ -301,6 +305,7 @@ object ServerHelper {
         streamHeight: Int = 0,
         streamFps: Float = 0f,
         streamMode: String = "",
+        encoderBackend: String = "",
     ): Intent {
         var serverCert: ByteArray? = null
         try {
@@ -337,6 +342,7 @@ object ServerHelper {
             mirrorDesktop = mirrorDesktop,
             forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
             streamMode = streamMode,
+            encoderBackend = encoderBackend,
         )
     }
 
@@ -406,6 +412,7 @@ object ServerHelper {
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
         streamMode: String = "",
+        encoderBackend: String = "",
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -433,6 +440,7 @@ object ServerHelper {
             mirrorDesktop,
             forcePrivateAfterSteamClose,
             streamMode = streamMode,
+            encoderBackend = encoderBackend,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)
@@ -499,6 +507,7 @@ object ServerHelper {
         mirrorDesktop: Boolean = false,
         forcePrivateAfterSteamClose: Boolean = false,
         streamMode: String = "",
+        encoderBackend: String = "",
     ) {
         parent.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE).edit()
             .putInt("last_played_$pcUuid", app.appId)
@@ -523,6 +532,7 @@ object ServerHelper {
             mirrorDesktop = mirrorDesktop,
             forcePrivateAfterSteamClose = forcePrivateAfterSteamClose,
             streamMode = streamMode,
+            encoderBackend = encoderBackend,
         )
         parent.startActivity(intent)
         NovaThemeManager.applyFadeTransition(parent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,7 +341,7 @@
     <string name="nova_play_setup_consequence_keep_off">The host keeps whatever was last sent.</string>
     <string name="nova_play_setup_on">On</string>
     <string name="nova_play_setup_off">Off</string>
-    <!-- Play Setup's four rows. The strip titles are conditional sentences rather than
+    <!-- Play Setup's rows. The strip titles are conditional sentences rather than
          nouns, because the strip explains a change not yet made. -->
     <string name="nova_play_setup_where_caption">Which display Polaris makes for this session</string>
     <string name="nova_play_setup_strip_where">If you changed where it runs</string>
@@ -356,6 +356,15 @@
     <string name="nova_play_setup_frame_rate_auto">Auto</string>
     <string name="nova_play_setup_frame_rate_auto_consequence">Keeps the host-resolved or Settings frame rate</string>
     <string name="nova_play_setup_frame_rate_fps_format">%d FPS</string>
+    <string name="nova_play_setup_encoder">Encoder</string>
+    <string name="nova_play_setup_encoder_host_default">Host default</string>
+    <string name="nova_play_setup_encoder_host_default_caption">Uses Polaris\' configured encoder policy</string>
+    <string name="nova_play_setup_encoder_auto_caption">Polaris chooses for this launch · fallback allowed</string>
+    <string name="nova_play_setup_encoder_exact_caption">Required for this launch · no silent fallback</string>
+    <string name="nova_play_setup_strip_encoder">If you changed the encoder</string>
+    <string name="nova_play_setup_encoder_host_default_consequence">Keeps the encoder configured on this host</string>
+    <string name="nova_play_setup_encoder_auto_consequence">Lets Polaris live-test and choose a working encoder</string>
+    <string name="nova_play_setup_encoder_exact_consequence">Fails the launch if this backend cannot initialize</string>
     <string name="nova_play_setup_tuning">Launch preset</string>
     <string name="nova_play_setup_strip_tuning">If you changed the tuning</string>
     <string name="nova_play_setup_tuning_pins">Pins %1$d FPS from your Settings frame rate</string>

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -776,6 +776,7 @@ class PolarisApiClientParsingTest {
                 "\"features\":{\"ai_optimizer\":true,\"ai_optimizer_control\":true,\"cursor_visibility_control\":true," +
                 "\"stream_policy_v1\":true,\"client_settings_v1\":true,\"optimizer_sync_v1\":true," +
                 "\"resolved_profile_provenance_v1\":true,\"expected_topology_assertion_v1\":true," +
+                "\"encoder_backend_selection_v1\":true," +
                 "\"live_media_telemetry_v1\":true}," +
                 "\"capture\":{\"backend\":\"wayland\",\"codecs\":[\"hevc\"]}}"
         )
@@ -792,8 +793,33 @@ class PolarisApiClientParsingTest {
         assertTrue(capabilities.features.optimizerSync)
         assertTrue(capabilities.features.resolvedProfileProvenance)
         assertTrue(capabilities.features.expectedTopologyAssertion)
+        assertTrue(capabilities.features.encoderBackendSelection)
         assertTrue(capabilities.features.liveMediaTelemetry)
         assertTrue(PolarisApiClient.supportsDeterministicLaunchContract(capabilities))
+    }
+
+    @Test
+    fun parseClientSettingsResponseCarriesTypedSessionEncoderCatalog() {
+        val settings = PolarisApiClient.parseClientSettingsResponse(
+            JSONObject(
+                "{\"version\":1,\"desired\":{},\"effective\":{},\"capabilities\":{" +
+                    "\"session_encoder_override\":true,\"encoders\":[" +
+                    "{\"value\":\"AUTO\",\"label\":\"Automatic\",\"available\":true," +
+                    "\"fallback_allowed\":true,\"runtime_validation\":\"launch\"}," +
+                    "{\"value\":\"vulkan\",\"label\":\"Vulkan Video\",\"available\":true," +
+                    "\"experimental\":true,\"fallback_allowed\":false," +
+                    "\"runtime_validation\":\"launch\",\"reason\":\"Require Vulkan.\"}," +
+                    "{\"value\":\"vulkan\",\"available\":true}," +
+                    "{\"value\":\"bad/backend\",\"available\":true}]}}",
+            ),
+        )
+
+        assertTrue(settings.capabilities.sessionEncoderOverride)
+        assertEquals(listOf("auto", "vulkan"), settings.capabilities.encoders.map { it.value })
+        assertTrue(settings.capabilities.encoders.first().fallbackAllowed)
+        assertTrue(settings.capabilities.encoders.last().experimental)
+        assertEquals("launch", settings.capabilities.encoders.last().runtimeValidation)
+        assertEquals("Require Vulkan.", settings.capabilities.encoders.last().reason)
     }
 
     @Test
@@ -2341,6 +2367,28 @@ class PolarisApiClientParsingTest {
             path
         )
         assertFalse(path.contains("trial="))
+    }
+
+    @Test
+    fun buildOptimizationPathCarriesOnlyCanonicalExplicitEncoderChoice() {
+        val explicit = PolarisApiClient.buildOptimizationPath(
+            device = "Retroid Pocket 6",
+            game = "game-1",
+            encoderBackend = " VULKAN ",
+        )
+        val hostDefault = PolarisApiClient.buildOptimizationPath(
+            device = "Retroid Pocket 6",
+            game = "game-1",
+        )
+        val malformed = PolarisApiClient.buildOptimizationPath(
+            device = "Retroid Pocket 6",
+            game = "game-1",
+            encoderBackend = "not/a/backend",
+        )
+
+        assertTrue(explicit.contains("&encoder=vulkan"))
+        assertFalse(hostDefault.contains("&encoder="))
+        assertFalse(malformed.contains("&encoder="))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/manager/NovaEncoderLaunchContractTest.kt
+++ b/app/src/test/java/com/papi/nova/manager/NovaEncoderLaunchContractTest.kt
@@ -1,0 +1,71 @@
+package com.papi.nova.manager
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaEncoderLaunchContractTest {
+
+    private fun optimization(
+        requested: String = "vulkan",
+        resolved: String = requested,
+        locked: Boolean = true,
+        fallbackAllowed: Boolean = requested == "auto",
+    ) = JSONObject()
+        .put(
+            "resolved_profile",
+            JSONObject().put(
+                "fields",
+                JSONObject().put(
+                    "encoder_backend",
+                    JSONObject()
+                        .put("value", resolved)
+                        .put("locked", locked),
+                ),
+            ),
+        )
+        .put(
+            "encoder_resolution",
+            JSONObject()
+                .put("requested", requested)
+                .put("resolved", resolved)
+                .put("locked", locked)
+                .put("fallback_allowed", fallbackAllowed),
+        )
+
+    @Test
+    fun blankHostDefaultNeedsNoEncoderAssertion() {
+        assertTrue(NovaEncoderLaunchContract.honors(JSONObject(), ""))
+    }
+
+    @Test
+    fun exactBackendRequiresMatchingLockedTypedProvenance() {
+        assertTrue(NovaEncoderLaunchContract.honors(optimization(), "VULKAN"))
+        assertFalse(NovaEncoderLaunchContract.honors(optimization(resolved = "vaapi"), "vulkan"))
+        assertFalse(NovaEncoderLaunchContract.honors(optimization(locked = false), "vulkan"))
+        assertFalse(NovaEncoderLaunchContract.honors(JSONObject(), "vulkan"))
+    }
+
+    @Test
+    fun autoRequiresTheHostToDeclareFallbackWhileExactBackendsForbidIt() {
+        assertTrue(NovaEncoderLaunchContract.honors(optimization(requested = "auto"), "auto"))
+        assertFalse(
+            NovaEncoderLaunchContract.honors(
+                optimization(requested = "auto", fallbackAllowed = false),
+                "auto",
+            ),
+        )
+        assertFalse(
+            NovaEncoderLaunchContract.honors(
+                optimization(requested = "vulkan", fallbackAllowed = true),
+                "vulkan",
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/nvstream/KotlinNvstreamContractsMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/nvstream/KotlinNvstreamContractsMigrationTest.kt
@@ -266,6 +266,8 @@ class KotlinNvstreamContractsMigrationTest {
         assertFalse(defaults.getEnableUltraLowLatency())
         assertFalse(defaults.getForceFreshLaunch())
         assertFalse(defaults.getResumeExistingOnly())
+        assertEquals("", defaults.getEncoderBackend())
+        assertEquals("", defaults.getExpectedEncoder())
         assertEquals("", defaults.getExpectedTopology())
 
         val customApp = NvApp("Custom")
@@ -296,10 +298,14 @@ class KotlinNvstreamContractsMigrationTest {
             .setEnableUltraLowLatency(true)
             .setForceFreshLaunch(true)
             .setResumeExistingOnly(true)
+            .setEncoderBackend(" VULKAN ")
+            .setExpectedEncoder(" VULKAN ")
             .setExpectedTopology(" Gamescope_Stream ")
             .build()
 
         assertSame(customApp, config.getApp())
+        assertEquals("vulkan", config.getEncoderBackend())
+        assertEquals("vulkan", config.getExpectedEncoder())
         assertEquals(StreamConfiguration.STREAM_CFG_REMOTE, config.getRemote())
         assertEquals(1920, config.getWidth())
         assertEquals(1080, config.getHeight())

--- a/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
@@ -331,13 +331,15 @@ class AutoQualityUiStateTest {
     }
 
     @Test
-    fun cpuCaptureNeedsAttention() {
+    fun healthyCpuCaptureStaysStable() {
         val state = AutoQualityUiState.from(
             status = status(capture = capture(transport = "shm", residency = "cpu"))
         )
 
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals("Needs Attention", state.label)
+        assertEquals(AutoQualityUiState.State.STABLE, state.state)
+        assertEquals(AutoQualityUiState.Tone.STABLE, state.tone)
+        assertEquals("Stream Ready", state.label)
+        assertEquals("OK", state.compactLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
@@ -154,6 +154,45 @@ class AutoQualityUiStateTest {
     }
 
     @Test
+    fun greenDoctorMakesCleanAutoSafeRecoveryInformational() {
+        val state = AutoQualityUiState.from(
+            status = status(
+                tuning = PolarisSessionStatus.TuningStatus(
+                    adaptiveBitrateEnabled = true,
+                    adaptiveTargetBitrateKbps = 12000,
+                    adaptiveBaseBitrateKbps = 30000,
+                    adaptiveBitrateState = "recovering",
+                    adaptiveBitrateReason = "healthy_window",
+                    aiOptimizerEnabled = false
+                ),
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    version = 2,
+                    resultId = "doctor-clean-auto-safe-recovery",
+                    status = "ok",
+                    severity = "info",
+                    trafficLight = "green",
+                    primaryIssue = "none",
+                    evidenceItems = listOf(
+                        PolarisSessionStatus.DoctorStatus.EvidenceItem(
+                            id = "effective_quality_ceiling",
+                            status = "watch",
+                            source = "launch_policy",
+                            value = 30000.0
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(AutoQualityUiState.State.RECOVERING, state.state)
+        assertEquals(AutoQualityUiState.Tone.INFO, state.tone)
+        assertEquals("Recovering Bitrate", state.label)
+        assertEquals("12M", state.compactLabel)
+        assertTrue(state.recovering)
+    }
+
+    @Test
     fun hostRenderRecoveryHistoryShowsObservationalPacingWatch() {
         val state = AutoQualityUiState.from(
             status = status(

--- a/app/src/test/java/com/papi/nova/ui/NovaEncoderBackendOverridesTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaEncoderBackendOverridesTest.kt
@@ -1,0 +1,97 @@
+package com.papi.nova.ui
+
+import android.content.Context
+import com.papi.nova.api.PolarisClientSettings
+import com.papi.nova.shared.polaris.model.PolarisGame
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class NovaEncoderBackendOverridesTest {
+    private val context: Context
+        get() = RuntimeEnvironment.getApplication()
+    private val preferences
+        get() = context.getSharedPreferences("nova_prefs", Context.MODE_PRIVATE)
+    private val game = PolarisGame(id = "encoder-game", appId = 42, name = "Game")
+    private val key = "encoder_backend_override_encoder-game"
+
+    @Before
+    @After
+    fun clearPreferences() {
+        preferences.edit().clear().commit()
+    }
+
+    private fun settings(vararg backends: String) = PolarisClientSettings(
+        capabilities = PolarisClientSettings.Capabilities(
+            sessionEncoderOverride = true,
+            encoders = backends.map { backend ->
+                PolarisClientSettings.EncoderOption(value = backend, available = true)
+            },
+        ),
+    )
+
+    @Test
+    fun savedChoiceIsCanonicalAndScopedToTheGame() {
+        NovaEncoderBackendOverrides.save(context, game, " VULKAN ")
+
+        assertEquals("vulkan", NovaEncoderBackendOverrides.load(context, game))
+        assertNull(
+            NovaEncoderBackendOverrides.load(
+                context,
+                PolarisGame(id = "other-game", appId = 43, name = "Other"),
+            ),
+        )
+    }
+
+    @Test
+    fun autoRemainsAnExplicitChoiceDistinctFromHostDefault() {
+        NovaEncoderBackendOverrides.save(context, game, "auto")
+
+        assertEquals(
+            "auto",
+            NovaEncoderBackendOverrides.loadAvailable(context, game, settings("auto", "vulkan")),
+        )
+        NovaEncoderBackendOverrides.clear(context, game)
+        assertNull(NovaEncoderBackendOverrides.load(context, game))
+    }
+
+    @Test
+    fun choiceMissingFromTheCurrentHostCatalogIsRetired() {
+        NovaEncoderBackendOverrides.save(context, game, "vulkan")
+
+        assertNull(
+            NovaEncoderBackendOverrides.loadAvailable(context, game, settings("auto", "vaapi")),
+        )
+        assertFalse(preferences.contains(key))
+    }
+
+    @Test
+    fun disabledSessionOverrideCannotLeaveInvisibleLaunchAuthority() {
+        NovaEncoderBackendOverrides.save(context, game, "vulkan")
+        val disabled = settings("auto", "vulkan").copy(
+            capabilities = settings("auto", "vulkan").capabilities.copy(
+                sessionEncoderOverride = false,
+            ),
+        )
+
+        assertNull(NovaEncoderBackendOverrides.loadAvailable(context, game, disabled))
+        assertFalse(preferences.contains(key))
+    }
+
+    @Test
+    fun malformedPersistedValueIsRemoved() {
+        preferences.edit().putString(key, "not/a/backend").commit()
+
+        assertNull(NovaEncoderBackendOverrides.load(context, game))
+        assertFalse(preferences.contains(key))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaEncoderLaunchSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaEncoderLaunchSourceGuardTest.kt
@@ -1,0 +1,51 @@
+package com.papi.nova.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+class NovaEncoderLaunchSourceGuardTest {
+
+    @Test
+    fun playSetupChoiceTravelsOnlyAsSessionScopedExactLaunchAuthority() {
+        val detail = source("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt")
+        val library = source("src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt")
+        val helper = source("src/main/java/com/papi/nova/utils/ServerHelper.kt")
+        val game = source("src/main/java/com/papi/nova/Game.kt")
+        val nvhttp = source("src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt")
+        val shortcut = source("src/main/java/com/papi/nova/ShortcutTrampoline.kt")
+
+        assertTrue(detail.contains("row = NovaPlaySetupRow.ENCODER,"))
+        assertTrue(detail.contains("encoderBackend = optimizationEncoder"))
+        assertTrue(detail.contains(".put(RESULT_KEY_ENCODER_BACKEND, encoderBackend)"))
+        assertTrue(library.contains("encoderBackend = request.optString("))
+        assertTrue(library.contains("encoderBackend = encoderBackend,"))
+        assertTrue(helper.contains("gameIntent.putExtra(Game.EXTRA_ENCODER_BACKEND, encoderBackend)"))
+        assertTrue(game.contains("NovaEncoderLaunchContract.honors("))
+        assertTrue(game.contains("encoderBackend = encoderBackend)"))
+        assertTrue(game.contains(".setExpectedEncoder(if (launchResolvedProfileTrusted) encoderBackend else \"\")"))
+        assertTrue(nvhttp.contains("&encoderBackend="))
+        assertTrue(nvhttp.contains("&expectedEncoder="))
+        assertTrue(shortcut.contains("NovaEncoderBackendOverrides.loadAvailable("))
+        assertTrue(shortcut.contains("if (clientSettings != null)"))
+        assertTrue(shortcut.contains("loadAvailable(this, polarisGame, clientSettings).orEmpty()"))
+        assertTrue(shortcut.contains("encoderBackend = readyLaunchPlan.encoderBackend"))
+    }
+
+    @Test
+    fun hostDefaultAndAutoRemainDifferentChoices() {
+        val detail = source("src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt")
+        val override = source("src/main/java/com/papi/nova/ui/NovaEncoderBackendOverrides.kt")
+        val nvhttp = source("src/main/java/com/papi/nova/nvstream/http/NvHTTP.kt")
+
+        assertTrue(detail.contains("onSelect = { chooseEncoderBackend(null) }"))
+        assertTrue(detail.contains("overridden = selectedEncoder.isNotBlank()"))
+        assertTrue(override.contains("fun clear(context: Context, game: PolarisGame)"))
+        assertTrue(nvhttp.contains("streamConfig.getEncoderBackend().isNotBlank()"))
+    }
+
+    private fun source(path: String): String =
+        String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -340,7 +340,10 @@ class NovaHudUiStateTest {
             width = 1920,
             height = 1080,
             status = status(
-                encoder = PolarisSessionStatus.EncoderStatus(targetResidency = "cpu")
+                health = PolarisSessionStatus.HealthStatus(
+                    grade = "degraded",
+                    summary = "Decoder timing needs attention"
+                )
             ),
             sparklineSamples = emptyList()
         )
@@ -843,6 +846,55 @@ class NovaHudUiStateTest {
         assertEquals("Needs attention", state.healthReasonLabel)
         assertEquals(NovaHudTone.WARNING, state.healthReasonTone)
         assertEquals(NovaHudTone.WARNING, state.layerHealth[1].tone)
+    }
+
+    @Test
+    fun healthyStandardShmCaptureDoesNotShowAttention() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 117.0,
+            targetFps = 120.0,
+            latencyMs = 5,
+            codec = "hevc_vulkan",
+            bitrateKbps = 20_000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                encoder = PolarisSessionStatus.EncoderStatus(
+                    codec = "hevc_vulkan",
+                    bitrateKbps = 20_000,
+                    fps = 120.0,
+                    requestedClientFps = 120.0,
+                    sessionTargetFps = 120.0,
+                    encodeTargetFps = 120.0,
+                    targetDevice = "vulkan",
+                    targetResidency = "gpu"
+                ),
+                capture = PolarisSessionStatus.CaptureStatus(
+                    transport = "shm",
+                    residency = "cpu"
+                ),
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    version = 2,
+                    resultId = "doctor-current-control-observation",
+                    status = "ok",
+                    severity = "info",
+                    trafficLight = "green",
+                    primaryIssue = "control_channel_observation",
+                    likelyCause = "Control retries were observed without confirmed video loss."
+                )
+            ),
+            sparklineSamples = listOf(116f, 117f, 118f)
+        )
+
+        assertEquals("OK", state.autopilotCompactLabel)
+        assertEquals("Stream Ready", state.autopilotHudLabel)
+        assertEquals(NovaHudTone.STABLE, state.statusTone)
+        assertEquals("Control retries observed", state.healthReasonLabel)
+        assertEquals(NovaHudTone.MUTED, state.healthReasonTone)
+        assertTrue(state.streamModeLabel.contains("SHM/CPU capture"))
+        assertEquals(NovaHudLayerHealth("HOST", NovaHudTone.STABLE), state.layerHealth.first())
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -301,6 +301,61 @@ class NovaHudUiStateTest {
     }
 
     @Test
+    fun cleanAutoSafeRecoveryDoesNotRaiseAttention() {
+        val state = NovaHudUiState.from(
+            mode = NovaHudMode.MINIMAL,
+            fps = 120.0,
+            targetFps = 120.0,
+            latencyMs = 3,
+            codec = "hevc",
+            bitrateKbps = 12000,
+            width = 1920,
+            height = 1080,
+            status = status(
+                encoder = PolarisSessionStatus.EncoderStatus(
+                    codec = "hevc_nvenc",
+                    bitrateKbps = 12000,
+                    fps = 120.0,
+                    requestedClientFps = 120.0,
+                    sessionTargetFps = 120.0,
+                    encodeTargetFps = 120.0,
+                    targetResidency = "gpu"
+                ),
+                tuning = PolarisSessionStatus.TuningStatus(
+                    adaptiveBitrateEnabled = true,
+                    adaptiveTargetBitrateKbps = 12000,
+                    adaptiveBaseBitrateKbps = 20000,
+                    adaptiveBitrateState = "recovering",
+                    adaptiveBitrateReason = "healthy_window",
+                    aiOptimizerEnabled = false
+                ),
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    version = 2,
+                    resultId = "doctor-clean-auto-safe-recovery",
+                    status = "ok",
+                    severity = "info",
+                    trafficLight = "green",
+                    primaryIssue = "none",
+                    evidenceItems = listOf(
+                        PolarisSessionStatus.DoctorStatus.EvidenceItem(
+                            id = "effective_quality_ceiling",
+                            status = "watch",
+                            source = "launch_policy",
+                            value = 20000.0
+                        )
+                    )
+                )
+            ),
+            sparklineSamples = listOf(120f)
+        )
+
+        assertEquals("Stable", state.healthReasonLabel)
+        assertEquals("Recovering Bitrate", state.autopilotLabel)
+        assertEquals(NovaHudTone.INFO, state.statusTone)
+    }
+
+    @Test
     fun hudLabelsStayCompactForSpaceConstrainedOverlay() {
         val stable = NovaHudUiState.from(
             mode = NovaHudMode.DEBUG,


### PR DESCRIPTION
## Summary

- add a per-game encoder selector to Play Setup with Host default, Auto, and host-advertised named backends
- persist the choice through normal launches and pinned shortcuts
- carry the encoder request and launch assertions through the host contract
- keep healthy SHM sessions and clean Auto Safe bitrate recovery out of `ATTN`
- retain actionable warnings for confirmed media loss and authoritative amber/red Doctor findings

## Behavior

- Host default preserves the host configuration
- Auto allows a live per-session probe and fallback
- named encoders are required for that launch and never silently fall back
- older hosts remain compatible when the new capability fields are absent
- healthy recovery is displayed as muted context rather than a warning

End-to-end encoder selection depends on papi-ux/polaris#598.

## Verification

- full `testNonRoot_gameDebugUnitTest` suite passes
- `assembleNonRoot_gameBenchmark` passes
- cross-repository contract audit reports no new drift
- signed benchmark APK installed over the existing RP6 app with application data, pairing, and the 24-game library preserved
- Play Setup persisted strict NVIDIA NVENC for a real title
- the launch reached 1920x1080 at 120 FPS over HEVC with CUDA selected and no fallback
- healthy control retries remained green; confirmed media loss still raised a critical state and cleared when the evidence cleared
- abrupt disconnect caused no host restart or coredump
