### PR TITLE
release: prepare Nova 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## Unreleased
 
+## 1.4.2 - 2026-09-04
+
+Nova 1.4.2 is the matched client for Polaris 1.4.2. It adds per-game encoder selection to Play Setup and stops treating a healthy SHM capture path as a stream health failure.
+
 NovaHUD now treats SHM/CPU capture as stream topology rather than a health failure. Healthy standard streams stay green while the capture path remains visible; Doctor, sync, HDR, decoder, and pacing evidence still raise attention when action is actually needed.
 
 Play Setup can now keep the host encoder policy or select one of the backends Polaris advertises for a single game. Auto is the only choice allowed to fall back after a live launch probe; an explicit NVENC, VA-API, Vulkan, VideoToolbox, or software choice fails closed if that backend cannot initialize. The selection is remembered per game, carried through pinned shortcuts, and bound to Polaris' exact launch contract without rewriting the host-wide setting.
+
+Polaris owns encoder probing, fallback, and launch policy; Nova only carries the per-game request and shows what the host decided. Older hosts without the capability fields keep their configured default. Steam Input remains manual and read-only.
+
+### Release packaging
+
+- Bumps the Android app to versionName 1.4.2 and versionCode 44 so it installs cleanly over Nova 1.4.1/43.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus portable SHA-256 sidecars through the GitHub release workflow.
+
+### Validation notes
+
+- The exact release-prep candidate must pass JVM tests, strict lint, public hygiene, and three-ABI release assembly before merge.
+- The per-game encoder path was exercised on the Retroid Pocket 6 with strict NVIDIA NVENC at 1920x1080, 120 FPS, HEVC, with no fallback and a clean abrupt-disconnect teardown; final publication remains gated on exact signed-artifact identity and signer continuity.
 
 ## 1.4.1 - 2026-09-03
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.4.1"
-        versionCode = 43
+        versionName "1.4.2"
+        versionCode = 44
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,14 +81,15 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/43.txt"
+            "fastlane/metadata/android/en-US/changelogs/44.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.4.1\""))
-        assertTrue(build.contains("versionCode = 43"))
-        assertTrue(changelog.contains("## 1.4.1 - 2026-09-03"))
+        assertTrue(build.contains("versionName \"1.4.2\""))
+        assertTrue(build.contains("versionCode = 44"))
+        assertTrue(changelog.contains("## 1.4.2 - 2026-09-04"))
         assertTrue(changelog.contains("Steam Input remains manual and read-only."))
+        assertTrue(changelog.contains("Polaris owns encoder probing, fallback, and launch policy"))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
         assertTrue(releaseWorkflow.contains("--notes-file \"\$release_notes\""))
         assertTrue(releaseWorkflow.contains("gh release edit \"\${GITHUB_REF_NAME}\""))
@@ -107,7 +108,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.4.1"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.4.2"))
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/44.txt
+++ b/fastlane/metadata/android/en-US/changelogs/44.txt
@@ -1,0 +1,2 @@
+Nova 1.4.2
+Play Setup can now keep the host encoder policy or pick one of the backends Polaris advertises for a single game. Auto may fall back after its live probe; an explicit choice fails closed instead of switching silently. NovaHUD treats SHM/CPU capture as stream topology rather than a health failure, so healthy streams stay green while Doctor, sync, HDR, decoder, and pacing evidence still raise attention when needed. Matched client for Polaris 1.4.2.


### PR DESCRIPTION
## Summary

Prepares Nova 1.4.2, the matched client for Polaris 1.4.2. No client code changes beyond #274, which is already on master; this is the release identity, the changelog, the store notes, and the test that pins them.

- `app/build.gradle`: versionName 1.4.2, versionCode 44, so it installs cleanly over 1.4.1/43.
- `CHANGELOG.md`: the Unreleased entries (per-game encoder selection in Play Setup; SHM capture as topology rather than a health failure) become `## 1.4.2 - 2026-09-04` with the release packaging and validation notes in the house format; `## Unreleased` stays as an empty heading. `scripts/extract_release_notes.py v1.4.2` extracts it cleanly.
- `fastlane/metadata/android/en-US/changelogs/44.txt`: Google Play notes, 461 code points.
- `NovaReleaseMetadataTest`: pins moved to 1.4.2/44 and the new changelog heading, plus the 1.4.2 host/client boundary sentence.

Tagging follows through `bin/release.sh` on the merged master head; the tag build signs and publishes the three ABIs with their SHA-256 sidecars.

## Exact candidate

`Commit:` `d3de90d635926aebb8c40e298ba7b836587561ce`
`Tree:` `540cb533431798feeeeac2d1598502afe6ab30d2`
`Parent:` `20488d88f00aff0dc78c7a15cc677093758a496d`
`Base:` `20488d88f00aff0dc78c7a15cc677093758a496d`

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest --tests com.papi.nova.NovaReleaseMetadataTest`: 3/3 (JUnit report on disk, not a silently filtered run)
- [x] `bash scripts/check-public-docs.sh`: clean
- [x] `bash scripts/check-public-surface.sh`: clean
- [x] `python3 scripts/extract_release_notes.py v1.4.2`: extracts the section
- [x] `git diff --check`: clean

Not covered here: the full JVM suite, strict lint, and three-ABI release assembly run in CI on this PR; `bin/release.sh` runs them again locally before it tags. The Retroid Pocket 6 smoke of the published APK follows the tag build.
