### PR TITLE
fix(game): tolerate a configuration change before the controller exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Starting a stream with the device held in portrait no longer crashes Nova. The rotation to landscape used to reach the controller handler before the connection had created it; the sensor toggles in that path now tolerate a missing handler.
+
 ## 1.4.2 - 2026-09-04
 
 Nova 1.4.2 is the matched client for Polaris 1.4.2. It adds per-game encoder selection to Play Setup and stops treating a healthy SHM capture path as a stream health failure.

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -2263,7 +2263,7 @@ performanceOverlayView!!.setVisibility(View.GONE)
 notificationOverlayView!!.setVisibility(View.GONE)
 
  // Disable sensors while in PiP mode
-                controllerHandler!!.disableSensors()
+                controllerHandler?.disableSensors()
 
  // Update GameManager state to indicate we're in PiP (still gaming, but interruptible)
                 UiHelper.notifyStreamEnteringPiP(this)
@@ -2307,7 +2307,7 @@ performanceOverlayView!!.setVisibility(View.VISIBLE)
 notificationOverlayView!!.setVisibility(requestedNotificationOverlayVisibility)
 
  // Enable sensors again after exiting PiP
-                controllerHandler!!.enableSensors()
+                controllerHandler?.enableSensors()
 
  // Update GameManager state to indicate we're out of PiP (gaming, non-interruptible)
                 UiHelper.notifyStreamExitingPiP(this)

--- a/app/src/test/java/com/papi/nova/GameConfigurationChangeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/GameConfigurationChangeSourceGuardTest.kt
@@ -1,0 +1,46 @@
+package com.papi.nova
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GameConfigurationChangeSourceGuardTest {
+
+    @Test
+    fun configurationChangesBeforeTheControllerExistsDoNotCrashTheStream() {
+        // A rotation (portrait to landscape at stream start) delivers
+        // onConfigurationChanged before the connection has created the
+        // ControllerHandler, so the sensor toggles must tolerate a null handler.
+        val game = readSource("src/main/java/com/papi/nova/Game.kt")
+        val onConfigurationChanged = game.section(
+            "override fun onConfigurationChanged(newConfig:Configuration)",
+            "private fun getPictureInPictureParams("
+        )
+
+        assertTrue(
+            "PiP entry must disable sensors through a safe call",
+            onConfigurationChanged.contains("controllerHandler?.disableSensors()")
+        )
+        assertTrue(
+            "PiP exit must enable sensors through a safe call",
+            onConfigurationChanged.contains("controllerHandler?.enableSensors()")
+        )
+        assertTrue(
+            "onConfigurationChanged must never force-unwrap the controller handler",
+            !onConfigurationChanged.contains("controllerHandler!!")
+        )
+    }
+
+    private fun readSource(path: String): String =
+        String(Files.readAllBytes(Path.of(path)), StandardCharsets.UTF_8)
+
+    private fun String.section(startMarker: String, endMarker: String): String {
+        val start = indexOf(startMarker)
+        require(start >= 0) { "Missing start marker: $startMarker" }
+        val end = indexOf(endMarker, start)
+        require(end >= 0) { "Missing end marker: $endMarker" }
+        return substring(start, end)
+    }
+}


### PR DESCRIPTION
## Summary

Nova crashes on the main thread when a stream is started with the device held in portrait. The Game activity rotates to landscape while the connection is still being established, and `onConfigurationChanged` force-unwrapped `controllerHandler` (`Game.kt:2310`, `controllerHandler!!.enableSensors()` in the not-in-PiP branch) before the connection had created it. Found on the Retroid Pocket 6 while smoking the published 1.4.2 APK; the code dates from the July import, so 1.4.1 has it too and it is not a regression. Held sideways, the same launch streams normally.

- Both sensor toggles in `onConfigurationChanged` (PiP entry and exit) use safe calls. The handler enables its own sensors when it is created, so nothing is lost when it does not exist yet.
- `GameConfigurationChangeSourceGuardTest` pins the two safe calls and forbids any `controllerHandler!!` in that function.
- CHANGELOG Unreleased entry.

## Exact candidate

`Commit:` `cdfda3a137f80fc8cad8227e3635fbb0f2dbb1b6`
`Tree:` `210ed4fcb8342d974f22856ab6e1f184eb5f2c1c`
`Parent:` `4f50967a281385a0366650e76b0a5f528b85efcd`
`Base:` `4f50967a281385a0366650e76b0a5f528b85efcd`

## Verification

- [x] `GameConfigurationChangeSourceGuardTest`: fails against master's `Game.kt` (force-unwrap present), passes with this change (JUnit report on disk)
- [x] `bash scripts/check-public-docs.sh`, `bash scripts/check-public-surface.sh`, `git diff --check`: clean
- [x] Crash reproduced on the RP6 with the 1.4.2 release APK from portrait (`FATAL EXCEPTION: main ... Game.onConfigurationChanged`), and the same launch streams at 120 FPS in landscape

Not covered: a device run of this exact build from portrait; the full JVM suite and lint run in CI.
