### PR TITLE
fix(artwork): say why an artwork search failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Artwork search failures now say what is wrong. When Polaris has no SteamGridDB key, when SteamGridDB rejects the key, or when the host is being rate limited, Nova shows that specific message instead of a generic "search unavailable", using the failure code Polaris 1.4.3 and newer send.
+
 Starting a stream with the device held in portrait no longer crashes Nova. The rotation to landscape used to reach the controller handler before the connection had created it; the sensor toggles in that path now tolerate a missing handler.
 
 ## 1.4.2 - 2026-09-04

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -99,6 +99,16 @@ data class PolarisArtworkUpdateResult(
     val remainingKinds: List<String>,
 )
 
+/**
+ * Polaris refused an artwork search and said why. [code] is the host's stable
+ * failure word (for example `steamgriddb_unauthorized`); an older host that sent
+ * no body leaves it null.
+ */
+class PolarisArtworkSearchUnavailableException(
+    val code: String?,
+    val httpStatus: Int,
+) : IOException("artwork candidate search HTTP $httpStatus${code?.let { " ($it)" } ?: ""}")
+
 class PolarisArtworkLibraryUpdateUnavailableException :
     IOException("Polaris artwork library update API unavailable")
 
@@ -2415,7 +2425,13 @@ class PolarisApiClient @JvmOverloads constructor(
                 .addQueryParameter("query", sanitizedQuery)
                 .build()
             executeArtwork(Request.Builder().url(url).build()).use { response ->
-                if (!response.isSuccessful) throw IOException("artwork candidate search HTTP ${response.code}")
+                if (!response.isSuccessful) {
+                    val failure = runCatching { parseBoundedArtworkJson(response.body) }.getOrNull()
+                    throw PolarisArtworkSearchUnavailableException(
+                        com.papi.nova.ui.NovaArtworkSearchFailure.codeFrom(failure),
+                        response.code,
+                    )
+                }
                 val json = parseBoundedArtworkJson(response.body)
                     ?: throw IOException("artwork candidate search returned an invalid response")
                 parseArtworkCandidates(json, gameId, serverAddress, resolvedHttpsPort)

--- a/app/src/main/java/com/papi/nova/ui/NovaArtworkSearchFailure.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaArtworkSearchFailure.kt
@@ -1,0 +1,28 @@
+package com.papi.nova.ui
+
+import com.papi.nova.R
+import org.json.JSONObject
+
+/**
+ * Maps the coded failure Polaris returns for an artwork search onto the message
+ * Nova shows. Polaris answers a failed search with `{"status": false, "code":
+ * "...", "error": "..."}`; the code is the contract, the English is the host's.
+ */
+object NovaArtworkSearchFailure {
+    const val CODE_KEY_MISSING = "steamgriddb_key_missing"
+    const val CODE_UNAUTHORIZED = "steamgriddb_unauthorized"
+    const val CODE_RATE_LIMITED = "steamgriddb_rate_limited"
+
+    /** The failure code from a non-2xx search body, or null when the host sent none. */
+    fun codeFrom(body: JSONObject?): String? = normalizeCode(body?.optString("code"))
+
+    /** Trim and lowercase a code; blank means the host sent none. */
+    fun normalizeCode(raw: String?): String? = raw?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
+
+    fun messageRes(code: String?): Int = when (normalizeCode(code)) {
+        CODE_KEY_MISSING -> R.string.nova_artwork_search_no_key
+        CODE_UNAUTHORIZED -> R.string.nova_artwork_search_key_rejected
+        CODE_RATE_LIMITED -> R.string.nova_artwork_search_rate_limited
+        else -> R.string.nova_artwork_search_failed
+    }
+}

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -1697,6 +1697,10 @@ class NovaGameDetailActivity : NovaActivity() {
                                 )
                             } catch (e: CancellationException) {
                                 throw e
+                            } catch (e: com.papi.nova.api.PolarisArtworkSearchUnavailableException) {
+                                artworkState = artworkState.reduce(
+                                    NovaArtworkStudioAction.Failed(getString(NovaArtworkSearchFailure.messageRes(e.code))),
+                                )
                             } catch (_: Exception) {
                                 artworkState = artworkState.reduce(
                                     NovaArtworkStudioAction.Failed(getString(R.string.nova_artwork_search_failed)),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1569,6 +1569,9 @@
     <string name="nova_artwork_apply_match">Apply Match</string>
     <string name="nova_artwork_no_matches">No matches found</string>
     <string name="nova_artwork_search_failed">Artwork search unavailable. Check SteamGridDB in Polaris and try again.</string>
+    <string name="nova_artwork_search_no_key">Polaris has no SteamGridDB API key. Add one in Polaris settings, then search again.</string>
+    <string name="nova_artwork_search_key_rejected">SteamGridDB rejected the Polaris API key. Update it in Polaris settings, then search again.</string>
+    <string name="nova_artwork_search_rate_limited">SteamGridDB is rate limiting the host. Wait a minute and search again.</string>
     <string name="nova_artwork_refresh_failed">Artwork refresh failed</string>
     <string name="nova_artwork_apply_failed">Custom match failed</string>
     <string name="nova_artwork_clear_failed">Clear custom match failed</string>

--- a/app/src/test/java/com/papi/nova/ui/NovaArtworkSearchFailureTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaArtworkSearchFailureTest.kt
@@ -1,0 +1,33 @@
+package com.papi.nova.ui
+
+import com.papi.nova.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NovaArtworkSearchFailureTest {
+
+    @Test
+    fun codedHostFailuresGetTheirOwnMessage() {
+        assertEquals(R.string.nova_artwork_search_no_key, NovaArtworkSearchFailure.messageRes("steamgriddb_key_missing"))
+        assertEquals(R.string.nova_artwork_search_key_rejected, NovaArtworkSearchFailure.messageRes("steamgriddb_unauthorized"))
+        assertEquals(R.string.nova_artwork_search_rate_limited, NovaArtworkSearchFailure.messageRes(" STEAMGRIDDB_RATE_LIMITED "))
+    }
+
+    @Test
+    fun unknownOrMissingCodesKeepTheGenericMessage() {
+        assertEquals(R.string.nova_artwork_search_failed, NovaArtworkSearchFailure.messageRes(null))
+        assertEquals(R.string.nova_artwork_search_failed, NovaArtworkSearchFailure.messageRes(""))
+        assertEquals(R.string.nova_artwork_search_failed, NovaArtworkSearchFailure.messageRes("steamgriddb_unavailable"))
+        assertEquals(R.string.nova_artwork_search_failed, NovaArtworkSearchFailure.messageRes("something-else"))
+    }
+
+    @Test
+    fun codesAreNormalizedAndBlankMeansNone() {
+        assertEquals("steamgriddb_unauthorized", NovaArtworkSearchFailure.normalizeCode(" STEAMGRIDDB_Unauthorized "))
+        assertNull(NovaArtworkSearchFailure.normalizeCode("   "))
+        assertNull(NovaArtworkSearchFailure.normalizeCode(""))
+        assertNull(NovaArtworkSearchFailure.normalizeCode(null))
+        assertNull(NovaArtworkSearchFailure.codeFrom(null))
+    }
+}

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -1412,7 +1412,13 @@ class NovaComposeSourceGuardTest {
 
         assertTrue(
             "candidate search should surface HTTP, envelope, and malformed-body failures without retaining provider response content",
-            api.contains("throw IOException(\"artwork candidate search HTTP \${response.code}\")") &&
+            api.contains("throw PolarisArtworkSearchUnavailableException(") &&
+                api.contains("NovaArtworkSearchFailure.codeFrom(failure)") &&
+                api.contains("class PolarisArtworkSearchUnavailableException(") &&
+                api.contains("val code: String?,") &&
+                api.contains("val httpStatus: Int,") &&
+                !api.contains("class PolarisArtworkSearchUnavailableException(\n    val body") &&
+                api.contains("IOException(\"artwork candidate search HTTP \$httpStatus") &&
                 api.contains("throw IOException(\"invalid artwork candidate search response\")") &&
                 api.contains("catch (_: JSONException)") &&
                 api.contains("throw IOException(\"invalid artwork JSON\")") &&
@@ -1424,6 +1430,8 @@ class NovaComposeSourceGuardTest {
                 searchHandler.contains("catch (e: CancellationException)") &&
                 searchHandler.contains("throw e") &&
                 searchHandler.contains("catch (_: Exception)") &&
+                searchHandler.contains("catch (e: com.papi.nova.api.PolarisArtworkSearchUnavailableException)") &&
+                searchHandler.contains("NovaArtworkSearchFailure.messageRes(e.code)") &&
                 !searchHandler.contains("runCatching") &&
                 searchHandler.contains("R.string.nova_artwork_search_failed") &&
                 searchHandler.contains("R.string.nova_artwork_no_matches")


### PR DESCRIPTION
## Summary

Companion to papi-ux/polaris#607. Every failed artwork search read "Artwork search unavailable. Check SteamGridDB in Polaris and try again", whether the host had no SteamGridDB key, SteamGridDB rejected the key, or the host was rate limited. That is what happened on 2026-09-04 with a key that a pre-1.4.1 settings save had blanked.

- `PolarisApiClient.searchArtworkCandidates` raises a typed `PolarisArtworkSearchUnavailableException(code, httpStatus)` on a non-2xx answer, reading only the `code` field of the host's JSON body; nothing from the provider is retained.
- `NovaArtworkSearchFailure` maps `steamgriddb_key_missing`, `steamgriddb_unauthorized`, and `steamgriddb_rate_limited` to three new strings that name the fix; unknown codes and older hosts that send no body keep the existing generic message. "No matches" stays reserved for a successful empty search.
- `NovaComposeSourceGuardTest.artworkProviderFailuresAreNotReportedAsNoMatches` is re-pinned to the new form with the same intent (HTTP, envelope, and malformed-body failures surface without retaining provider content; the sheet maps the typed failure separately from the generic catch).
- CHANGELOG Unreleased entry.

## Exact candidate

`Commit:` `252f243e1c1204fc84e7f8cd555a47ad30f38442`
`Tree:` `9170e36a13e17532e8cca117247dd2f1b23b4d3b`
`Parent:` `bdee2642bf27d8d9a9a90043d695409cb29ae1cf`
`Base:` `bdee2642bf27d8d9a9a90043d695409cb29ae1cf`

## Verification

- [x] `NovaArtworkSearchFailureTest` 3/3, `NovaArtworkStudioSourceGuardTest` 13/13, `NovaComposeSourceGuardTest` 82/82, `PolarisApiClientParsingTest` 79/79 (JUnit reports on disk)
- [x] `bash scripts/check-public-docs.sh`, `bash scripts/check-public-surface.sh`, `git diff --check`: clean

Not covered: a device run against a host with a rejected key; the full JVM suite and lint run in CI.
