### PR TITLE
fix(settings): offer native and custom resolutions and FPS in the modern lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The modern Settings resolution and FPS lists now offer the device's native modes and your custom resolution or refresh rate, the way the legacy view always did.
 - Starting a stream with the device held in portrait no longer crashes Nova.
 - Artwork search failures say what is wrong: no SteamGridDB key, a rejected key, or rate limiting, using the codes Polaris 1.4.3 and newer send.
 

--- a/app/src/main/java/com/papi/nova/preferences/NovaDeviceListOptions.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaDeviceListOptions.kt
@@ -1,0 +1,177 @@
+package com.papi.nova.preferences
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.Display
+import androidx.preference.PreferenceManager
+import com.papi.nova.R
+
+/**
+ * The entries the legacy settings fragment appends to the resolution and FPS
+ * lists at runtime: the device's native modes and the custom values the player
+ * typed under Advanced. The modern settings read their lists from the XML
+ * arrays alone, so a custom resolution set there was only ever offered in the
+ * legacy view (nova#275). The option maths is pure so it is testable without a
+ * display; [forDevice] reads the device once and [augment] applies it.
+ */
+object NovaDeviceListOptions {
+    data class Labels(
+        val native: String,
+        val nativeFullscreen: String,
+        val portrait: String,
+        val landscape: String,
+        val custom: String,
+        val fpsSuffix: String,
+    )
+
+    /** A landscape-normalized native size; [insetsRemoved] marks a mode reported beside a notch-adjusted one. */
+    data class NativeSize(val width: Int, val height: Int, val insetsRemoved: Boolean = false)
+
+    class DeviceLists internal constructor(
+        private val nativeSizes: List<NativeSize>,
+        private val nativeMaxFps: Float?,
+        private val customResolution: String?,
+        private val customRefreshRate: String?,
+        private val labels: Labels,
+    ) {
+        fun augment(definition: NovaSettingDefinition): NovaSettingDefinition = when (definition.key) {
+            PreferenceConfiguration.RESOLUTION_PREF_STRING ->
+                definition.copy(options = resolutionOptions(definition.options, nativeSizes, customResolution, labels))
+            PreferenceConfiguration.FPS_PREF_STRING ->
+                definition.copy(options = fpsOptions(definition.options, nativeMaxFps, customRefreshRate, labels))
+            else -> definition
+        }
+    }
+
+    /** "1920x1080" to (1920, 1080); null for anything else. */
+    fun parseResolution(value: String?): Pair<Int, Int>? {
+        val segments = value?.trim()?.split("x") ?: return null
+        if (segments.size != 2) return null
+        val width = segments[0].trim().toIntOrNull() ?: return null
+        val height = segments[1].trim().toIntOrNull() ?: return null
+        if (width <= 0 || height <= 0) return null
+        return width to height
+    }
+
+    fun resolutionOptions(
+        base: List<NovaSettingOption>,
+        nativeSizes: List<NativeSize>,
+        customResolution: String?,
+        labels: Labels,
+    ): List<NovaSettingOption> {
+        val options = base.toMutableList()
+        val known = base.mapTo(mutableSetOf()) { it.value }
+        fun add(width: Int, height: Int, prefix: String, orientation: String?) {
+            val value = "${width}x$height"
+            if (!known.add(value)) return
+            val label = buildString {
+                append(prefix)
+                if (orientation != null) {
+                    append(' ')
+                    append(orientation)
+                }
+                append(" ($value)")
+            }
+            options += NovaSettingOption(label = label, value = value)
+        }
+        // The legacy fragment lists a squarish screen both ways, portrait first.
+        fun addPair(width: Int, height: Int, prefix: String) {
+            if (PreferenceConfiguration.isSquarishScreen(width, height)) {
+                add(height, width, prefix, labels.portrait)
+                add(width, height, prefix, labels.landscape)
+            } else {
+                add(width, height, prefix, null)
+            }
+        }
+        parseResolution(customResolution)?.let { (width, height) -> addPair(width, height, labels.custom) }
+        for (size in nativeSizes) {
+            addPair(size.width, size.height, if (size.insetsRemoved) labels.nativeFullscreen else labels.native)
+        }
+        return options
+    }
+
+    fun fpsOptions(
+        base: List<NovaSettingOption>,
+        nativeMaxFps: Float?,
+        customRefreshRate: String?,
+        labels: Labels,
+    ): List<NovaSettingOption> {
+        val options = base.toMutableList()
+        val known = base.mapTo(mutableSetOf()) { it.value }
+        fun add(value: String, prefix: String) {
+            if (!known.add(value)) return
+            options += NovaSettingOption(label = "$prefix ($value ${labels.fpsSuffix})", value = value)
+        }
+        // Same string forms the legacy fragment stores: a custom rate keeps its
+        // decimal ("90.0"), the native rate is rounded ("120").
+        customRefreshRate?.trim()?.toFloatOrNull()?.takeIf { it > 0f }?.let { add(it.toString(), labels.custom) }
+        nativeMaxFps?.let { fps ->
+            val rounded = Math.round(fps)
+            if (rounded > 0) add(rounded.toString(), labels.native)
+        }
+        return options
+    }
+
+    fun forDevice(context: Context): DeviceLists {
+        val labels = Labels(
+            native = context.getString(R.string.resolution_prefix_native),
+            nativeFullscreen = context.getString(R.string.resolution_prefix_native_fullscreen),
+            portrait = context.getString(R.string.resolution_prefix_native_portrait),
+            landscape = context.getString(R.string.resolution_prefix_native_landscape),
+            custom = context.getString(R.string.resolution_prefix_custom),
+            fpsSuffix = context.getString(R.string.fps_suffix_fps),
+        )
+        val prefs = runCatching { PreferenceManager.getDefaultSharedPreferences(context) }.getOrNull()
+        val display = runCatching {
+            (context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager)?.getDisplay(Display.DEFAULT_DISPLAY)
+        }.getOrNull()
+        return DeviceLists(
+            nativeSizes = display?.let { runCatching { nativeSizes(it, context.packageManager) }.getOrNull() }.orEmpty(),
+            nativeMaxFps = display?.let { runCatching { NovaDisplayFpsCapability.maxSupportedFps(it) }.getOrNull() },
+            customResolution = prefs?.getString(PreferenceConfiguration.CUSTOM_RESOLUTION_PREF_STRING, null),
+            customRefreshRate = prefs?.getString(PreferenceConfiguration.CUSTOM_REFRESH_RATE_PREF_STRING, null),
+            labels = labels,
+        )
+    }
+
+    /** Mirrors the legacy fragment: notch-adjusted real size first, then every supported mode. */
+    @Suppress("DEPRECATION")
+    internal fun nativeSizes(display: Display, packageManager: PackageManager): List<NativeSize> {
+        val sizes = mutableListOf<NativeSize>()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            val metrics = DisplayMetrics()
+            display.getRealMetrics(metrics)
+            sizes += NativeSize(maxOf(metrics.widthPixels, metrics.heightPixels), minOf(metrics.widthPixels, metrics.heightPixels))
+            return sizes
+        }
+        var hasInsets = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val cutout = display.cutout
+            if (cutout != null) {
+                val widthInsets = cutout.safeInsetLeft + cutout.safeInsetRight
+                val heightInsets = cutout.safeInsetBottom + cutout.safeInsetTop
+                if (widthInsets != 0 || heightInsets != 0) {
+                    val metrics = DisplayMetrics()
+                    display.getRealMetrics(metrics)
+                    sizes += NativeSize(
+                        maxOf(metrics.widthPixels - widthInsets, metrics.heightPixels - heightInsets),
+                        minOf(metrics.widthPixels - widthInsets, metrics.heightPixels - heightInsets),
+                    )
+                    hasInsets = true
+                }
+            }
+        }
+        val television = packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
+        for (mode in display.supportedModes) {
+            val width = maxOf(mode.physicalWidth, mode.physicalHeight)
+            val height = minOf(mode.physicalWidth, mode.physicalHeight)
+            if (!television || width > 3840 || height > 2160) {
+                sizes += NativeSize(width, height, insetsRemoved = hasInsets)
+            }
+        }
+        return sizes
+    }
+}

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingDefinitions.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingDefinitions.kt
@@ -103,7 +103,10 @@ object NovaSettingDefinitions {
             }
         }
 
-        return NovaSettingsDefinitionSet(categories = categories, settings = settings)
+        // The resolution and FPS lists also carry what the legacy fragment appends at
+        // runtime: the device's native modes and the custom values typed under Advanced.
+        val deviceLists = NovaDeviceListOptions.forDevice(context)
+        return NovaSettingsDefinitionSet(categories = categories, settings = settings.map(deviceLists::augment))
     }
 
     private fun AttributeSet.toDefinition(

--- a/app/src/test/java/com/papi/nova/preferences/NovaDeviceListOptionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaDeviceListOptionsTest.kt
@@ -1,0 +1,79 @@
+package com.papi.nova.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NovaDeviceListOptionsTest {
+    private val labels = NovaDeviceListOptions.Labels(
+        native = "Native",
+        nativeFullscreen = "Native Full-Screen",
+        portrait = "(Portrait)",
+        landscape = "(Landscape)",
+        custom = "Custom",
+        fpsSuffix = "FPS",
+    )
+    private val base = listOf(
+        NovaSettingOption("720p", "1280x720"),
+        NovaSettingOption("1080p", "1920x1080"),
+    )
+
+    @Test
+    fun customResolutionIsOfferedAfterThePresets() {
+        // nova#275: a custom resolution typed under Advanced never showed up
+        // in the modern resolution list, only in the legacy view.
+        val options = NovaDeviceListOptions.resolutionOptions(base, emptyList(), "2560x1600", labels)
+        assertEquals(base + NovaSettingOption("Custom (2560x1600)", "2560x1600"), options)
+    }
+
+    @Test
+    fun valuesAlreadyInTheListAreNotDuplicatedAndBadInputIsIgnored() {
+        assertEquals(base, NovaDeviceListOptions.resolutionOptions(base, emptyList(), "1920x1080", labels))
+        assertEquals(base, NovaDeviceListOptions.resolutionOptions(base, emptyList(), "abc", labels))
+        assertEquals(base, NovaDeviceListOptions.resolutionOptions(base, emptyList(), "1920x", labels))
+        assertEquals(base, NovaDeviceListOptions.resolutionOptions(base, emptyList(), null, labels))
+        assertNull(NovaDeviceListOptions.parseResolution("0x1080"))
+    }
+
+    @Test
+    fun squarishScreensAreListedBothWaysPortraitFirst() {
+        val options = NovaDeviceListOptions.resolutionOptions(base, emptyList(), "1200x1000", labels)
+        assertEquals(
+            base + listOf(
+                NovaSettingOption("Custom (Portrait) (1000x1200)", "1000x1200"),
+                NovaSettingOption("Custom (Landscape) (1200x1000)", "1200x1000"),
+            ),
+            options,
+        )
+    }
+
+    @Test
+    fun nativeModesFollowTheCustomEntryAndNameTheNotchAdjustedOne() {
+        val native = listOf(
+            NovaDeviceListOptions.NativeSize(2340, 1080),
+            NovaDeviceListOptions.NativeSize(2400, 1080, insetsRemoved = true),
+            NovaDeviceListOptions.NativeSize(1920, 1080, insetsRemoved = true),
+        )
+        val options = NovaDeviceListOptions.resolutionOptions(base, native, "3840x2160", labels)
+        assertEquals(
+            base + listOf(
+                NovaSettingOption("Custom (3840x2160)", "3840x2160"),
+                NovaSettingOption("Native (2340x1080)", "2340x1080"),
+                NovaSettingOption("Native Full-Screen (2400x1080)", "2400x1080"),
+            ),
+            options,
+        )
+    }
+
+    @Test
+    fun fpsListGetsTheCustomRateThenTheNativeRateInLegacyStringForms() {
+        val fpsBase = listOf(NovaSettingOption("60", "60"), NovaSettingOption("120", "120"))
+        val options = NovaDeviceListOptions.fpsOptions(fpsBase, 120f, "90", labels)
+        assertEquals(fpsBase + NovaSettingOption("Custom (90.0 FPS)", "90.0"), options)
+        assertEquals(
+            fpsBase + NovaSettingOption("Native (144 FPS)", "144"),
+            NovaDeviceListOptions.fpsOptions(fpsBase, 144.2f, "not-a-number", labels),
+        )
+        assertEquals(fpsBase, NovaDeviceListOptions.fpsOptions(fpsBase, null, "0", labels))
+    }
+}

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -59,6 +59,23 @@ class NovaSettingsDefinitionsTest {
     }
 
     @Test
+    fun resolutionAndFpsListsOfferTheCustomValuesTypedUnderAdvanced() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putString(PreferenceConfiguration.CUSTOM_RESOLUTION_PREF_STRING, "2560x1600")
+            .putString(PreferenceConfiguration.CUSTOM_REFRESH_RATE_PREF_STRING, "90")
+            .commit()
+
+        val definitions = NovaSettingDefinitions.load(context)
+        val resolution = definitions.require("list_resolution").options
+        val fps = definitions.require("list_fps").options
+
+        val custom = resolution.single { it.value == "2560x1600" }
+        assertTrue(custom.label, custom.label.startsWith(context.getString(R.string.resolution_prefix_custom)))
+        assertEquals(resolution.size, resolution.map { it.value }.toSet().size)
+        assertTrue(fps.any { it.value == "90.0" && it.label.startsWith(context.getString(R.string.resolution_prefix_custom)) })
+    }
+
+    @Test
     fun definitionsClassifyCoreControlTypes() {
         val definitions = NovaSettingDefinitions.load(context)
 


### PR DESCRIPTION
## Summary

From nova#275 (second report in the thread): a custom resolution set under **Settings > Advanced** never appeared in the modern **Client stream defaults > Resolution** list, only in the legacy view. The modern settings read every list from the XML arrays alone; the legacy fragment appends the device's native modes and the custom values at runtime. So the modern list was missing both.

- `NovaDeviceListOptions` mirrors the legacy additions as pure functions: the custom resolution first, then the notch-adjusted real size and every supported display mode (TV hosts keep the same 4K gate), with the portrait/landscape pair for squarish screens and the same labels (`Custom (2560x1600)`, `Native (Portrait) (…)`, `Native Full-Screen (…)`); on the FPS list, the custom refresh rate (`90.0`, the string form the legacy fragment stores) and the rounded native rate. Existing values are never duplicated; bad input is ignored.
- `NovaSettingDefinitions.load` reads the device once (`forDevice`) and applies it to `list_resolution` and `list_fps`; every device read is wrapped so a missing display or preferences can never break settings load.
- CHANGELOG Unreleased entry.

Not changed: the legacy fragment (it keeps its own code path), and the legacy behaviour that a custom value appears after the settings screen is reopened.

## Exact candidate

`Commit:` `8dce261ec708241b18f8cb64c1c123d0d4336ae0`
`Tree:` `46660f56799fb411a9709ccffe8555e30ea92f7b`
`Parent:` `224693913dfe45e2b29d796021ae5ab361bfe0ee`
`Base:` `224693913dfe45e2b29d796021ae5ab361bfe0ee`

## Verification

- [x] `NovaDeviceListOptionsTest` 5/5 (custom appended, dedupe and bad input, squarish pair, native and notch labels, FPS forms)
- [x] `NovaSettingsDefinitionsTest` 19/19 including the new Robolectric case, which fails against master's loader (RED) and passes here
- [x] `KotlinPreferenceScreensMigrationTest` 13/13, `NovaSettingsUiStateTest` 7/7
- [x] `bash scripts/check-public-docs.sh`, `bash scripts/check-public-surface.sh`, `git diff --check`: clean

Not covered: a device run of the modern settings screen; the full JVM suite and lint run in CI.
