### PR TITLE
feat(command-center): put daily controls first and tidy Doctor, Stream, and HUD copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - The modern Settings resolution and FPS lists now offer the device's native modes and your custom resolution or refresh rate, the way the legacy view always did.
 - Starting a stream with the device held in portrait no longer crashes Nova.
 - Artwork search failures say what is wrong: no SteamGridDB key, a rejected key, or rate limiting, using the codes Polaris 1.4.3 and newer send.
+- Command Center puts Quick Keys, Controls, and Session first; Doctor, Stream, Sync, and Advanced follow. The session strip still carries the health verdict at the top.
+- Close is the primary Command Center button. Disconnect stays quiet and End Session reads as destructive.
+- The Doctor card leads with the finding, keeps one action, and shows evidence only when Doctor graded something as actionable. It no longer repeats under Overlays.
+- The Stream card (formerly Launch preset) drops the sentence the strip and Doctor already show. The session pill names the mode and encoder; capture path, mode source, and role move to the detail line.
+- Overlays gain a HUD Mode row that cycles Minimal, Performance, and Debug, and Stats Overlay says it is the legacy Moonlight text.
+- The host safe profile card moves under Advanced and says it is observational.
+- NovaHUD: recovery reads SAFE instead of REC, the 1% low tile shows the number once, control channel retries read Link retries, bitrate and codec drop the accent color, and the Debug header shows the short mode name.
 
 ## 1.4.2 - 2026-09-04
 

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -6792,6 +6792,14 @@ showNovaHud()
 }
 }
 
+fun cycleNovaHudMode() {
+if (!isNovaHudShowing())
+{
+return
+}
+novaHud?.cycleMode()
+}
+
 private fun setNovaHudPreference(enabled:Boolean) {
 PreferenceManager.getDefaultSharedPreferences(this)
 .edit()

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -796,7 +796,7 @@ data class PolarisSessionStatus(
         authoritativeDoctorVerdictNeedsAttention -> "Needs attention"
         doctorPrimaryIsObservation && hasActionableDoctorEvidence -> "Needs attention"
         doctor.primaryIssue.equals("network_observation", ignoreCase = true) -> "Network recheck"
-        doctor.primaryIssue.equals("control_channel_observation", ignoreCase = true) -> "Control retries"
+        doctor.primaryIssue.equals("control_channel_observation", ignoreCase = true) -> "Link retries"
         doctor.primaryIssue.equals("network_jitter", ignoreCase = true) -> "Network"
         doctor.primaryIssue.contains("decoder", ignoreCase = true) -> "Decoder"
         !hasAuthoritativeDoctorResult && health.grade.equals("degraded", ignoreCase = true) -> "Stream degraded"

--- a/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
@@ -255,7 +255,7 @@ data class AutoQualityUiState(
                     compactLabel = streamPolicy.adaptiveTargetLabel
                         .takeIf { it.isNotBlank() }
                         ?.replace(" Mbps", "M")
-                        ?: "REC",
+                        ?: "SAFE",
                     detail = autoPolicy.summary.takeIf { it.isNotBlank() }
                         ?: if (status.tuning.adaptiveBitrateState.equals("recovering", ignoreCase = true)) {
                             "Auto Safe is recovering toward the launch quality ceiling"
@@ -345,7 +345,7 @@ data class AutoQualityUiState(
                     compactLabel = when {
                         hostRenderLimited -> "HOST"
                         adaptiveLowered -> streamPolicy.adaptiveTargetLabel.replace(" Mbps", "M")
-                        else -> "REC"
+                        else -> "SAFE"
                     },
                     detail = detail,
                     targetSummary = streamPolicy.targetSummary,

--- a/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaDisplayResolutionPlanner.kt
@@ -128,13 +128,19 @@ data class NovaPostSessionReportUiState(
                 if (health.safeBitrateKbps > 0) add("${health.safeBitrateKbps / 1000} Mbps")
                 health.safeCodec.ifBlank { null }?.let { add(it.uppercase(Locale.US)) }
             }
-            val qualityLine = "Quality: ${grade.replaceFirstChar { it.titlecase(Locale.US) }}"
+            val qualityLine = "Grade: ${grade.replaceFirstChar { it.titlecase(Locale.US) }}"
             val issueLine = "Main issue: ${issue.ifBlank { "none" }.replace('_', ' ')}"
-            val nextLaunchLine = "Next launch: ${nextLaunchParts.joinToString(" · ").ifBlank { "keep current settings" }}"
-            val recoveryLine = "Recovery: ${health.recoveryProfile.ifBlank { "none" }.replace('_', ' ')}"
-            val summary = health.summary.ifBlank { "Post-session report unavailable on this Polaris host." }
+            val nextLaunchLine = "Safe profile: ${nextLaunchParts.joinToString(" · ").ifBlank { "keep current settings" }}"
+            val recoveryLine = "Recovery record: ${health.recoveryProfile.ifBlank { "none" }.replace('_', ' ')}"
+            val summary = health.summary.ifBlank { "Host safe profile unavailable on this Polaris host." }
+            val gradeNeedsAttention = grade.lowercase(Locale.US) in setOf("watch", "degraded")
             return NovaPostSessionReportUiState(
-                visible = summary.isNotBlank() || grade != "unknown" || issue.isNotBlank(),
+                // A steady health block has nothing to report. The card earns its space only
+                // when the host carries a safe profile, a recovery record, or an issue.
+                visible = nextLaunchParts.isNotEmpty() ||
+                    health.recoveryProfile.isNotBlank() ||
+                    issue.isNotBlank() ||
+                    gradeNeedsAttention,
                 qualityLine = qualityLine,
                 issueLine = issueLine,
                 nextLaunchLine = nextLaunchLine,

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -114,6 +114,7 @@ data class NovaHudUiState(
     val codecLabel: String,
     val lowOnePercentLabel: String,
     val streamModeLabel: String,
+    val streamModeShortLabel: String,
     val autopilotLabel: String,
     val autopilotHudLabel: String,
     val autopilotCompactLabel: String,
@@ -205,8 +206,9 @@ data class NovaHudUiState(
                 bitrateLabel = formatBitrate(mode, bitrateKbps),
                 resolutionLabel = formatResolution(mode, width, height),
                 codecLabel = normalizeCodecLabel(codec),
-                lowOnePercentLabel = lowOnePercentFps.takeIf { it > 0.0 }?.roundToInt()?.let { "1%: $it" } ?: "--",
+                lowOnePercentLabel = lowOnePercentFps.takeIf { it > 0.0 }?.roundToInt()?.toString() ?: "--",
                 streamModeLabel = status?.let(::buildSessionModeLabel).orEmpty(),
+                streamModeShortLabel = status?.let(::buildSessionModeShortLabel).orEmpty(),
                 autopilotLabel = autoQuality.label,
                 autopilotHudLabel = autoQuality.hudLabel(),
                 autopilotCompactLabel = autoQuality.compactLabel,
@@ -359,7 +361,7 @@ data class NovaHudUiState(
                 normalizedPrimaryIssue == "network_observation" ->
                     "Network recheck" to NovaHudTone.MUTED
                 normalizedPrimaryIssue == "control_channel_observation" ->
-                    "Control retries observed" to NovaHudTone.MUTED
+                    "Link retries" to NovaHudTone.MUTED
                 normalizedPrimaryIssue == "network_jitter" ||
                     (status?.hasAuthoritativeDoctorResult != true && riskElevated(status?.health?.networkRisk)) ->
                     "Network jitter" to NovaHudTone.WARNING
@@ -498,6 +500,10 @@ data class NovaHudUiState(
                 .filter { it.isNotBlank() }
                 .joinToString(" ")
         }
+
+        // The Debug header has 96dp; the full mode label stays in the diagnostics copy.
+        private fun buildSessionModeShortLabel(status: PolarisSessionStatus): String =
+            status.sessionModeLabel.substringBefore(" (").trim()
 
         private fun AutoQualityUiState.hudLabel(): String = when (state) {
             AutoQualityUiState.State.OFF -> "Live Tune Off"

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -460,6 +460,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 currentGameUuid = currentGameUuid(),
                 profilePreference = currentProfilePreference(gameName),
                 hudShowing = game.isNovaHudShowing(),
+                hudMode = NovaHudMode.fromPreference(prefs.getString("nova_polaris_hud_mode", "minimal")),
                 hudOpacityPercent = NovaHudPreferences.readOpacityPercent(prefs),
                 menuOpacityPercent = NovaMenuPreferences.readOpacityPercent(prefs),
                 perfOverlayEnabled = game.prefConfig.enablePerfOverlay,
@@ -950,6 +951,9 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     when (actionId) {
                         NovaQuickMenuActionId.NOVA_HUD -> {
                             game.toggleNovaHud()
+                        }
+                        NovaQuickMenuActionId.NOVA_HUD_MODE -> {
+                            game.cycleNovaHudMode()
                         }
                         NovaQuickMenuActionId.PERF_STATS -> {
                             if (!game.prefConfig.enablePerfOverlay && game.isNovaHudShowing()) {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -113,6 +113,7 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_CTRL_1,
             NovaQuickMenuActionId.QUICK_CTRL_2 -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,
+            NovaQuickMenuActionId.NOVA_HUD_MODE,
             NovaQuickMenuActionId.PERF_STATS,
             NovaQuickMenuActionId.DIAGNOSE_STREAM,
             NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> onOverlayAction(action.id)
@@ -309,26 +310,24 @@ fun NovaQuickMenuContent(
         NovaQuickMenuHeader(state, callbacks)
         Spacer(Modifier.height(8.dp))
         NovaQuickMenuSessionStrip(state, initialFocusRequester)
+        // Daily use first: the strip above already carries the health verdict, so keys,
+        // input, and overlays come before the Doctor and stream cards that explain it.
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
-        if (state.doctorReceiptAction.visible) {
-            Spacer(Modifier.height(10.dp))
-            NovaQuickMenuInfoCard(
-                action = state.doctorReceiptAction,
-                callbacks = callbacks
-            )
+        NovaQuickMenuPanel(title = quickKeysTitle) {
+            NovaQuickKeys(state.quickKeys, callbacks)
         }
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuStabilityCard(state.stability, callbacks)
-        if (state.postSessionReport.visible) {
-            Spacer(Modifier.height(10.dp))
-            NovaQuickMenuPostSessionReportCard(state.postSessionReport)
+        NovaQuickMenuPanel(title = controlsTitle) {
+            state.controlRows.forEach { row ->
+                NovaQuickMenuRow(action = row, callbacks = callbacks)
+            }
         }
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuInfoCard(
-            action = state.sync,
-            callbacks = callbacks
-        )
+        NovaQuickMenuPanel(title = sessionTitle) {
+            state.sessionRows.filter { it.visible }.forEach { row ->
+                NovaQuickMenuRow(action = row, callbacks = callbacks)
+            }
+        }
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuPanel(title = overlaysTitle) {
             state.overlayRows.forEach { row ->
@@ -344,9 +343,21 @@ fun NovaQuickMenuContent(
             )
         }
         Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = quickKeysTitle) {
-            NovaQuickKeys(state.quickKeys, callbacks)
+        NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
+        if (state.doctorReceiptAction.visible) {
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuInfoCard(
+                action = state.doctorReceiptAction,
+                callbacks = callbacks
+            )
         }
+        Spacer(Modifier.height(10.dp))
+        NovaQuickMenuStabilityCard(state.stability, callbacks)
+        Spacer(Modifier.height(10.dp))
+        NovaQuickMenuInfoCard(
+            action = state.sync,
+            callbacks = callbacks
+        )
         Spacer(Modifier.height(10.dp))
         NovaQuickMenuInfoCard(
             action = state.advancedToggle,
@@ -359,17 +370,11 @@ fun NovaQuickMenuContent(
                     NovaQuickMenuRow(action = row, callbacks = callbacks)
                 }
             }
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = controlsTitle) {
-            state.controlRows.forEach { row ->
-                NovaQuickMenuRow(action = row, callbacks = callbacks)
-            }
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = sessionTitle) {
-            state.sessionRows.filter { it.visible }.forEach { row ->
-                NovaQuickMenuRow(action = row, callbacks = callbacks)
+            // Observational history from the host; it explains Auto's fallbacks but never
+            // changes a launch, so it lives with the other diagnostics.
+            if (state.postSessionReport.visible) {
+                Spacer(Modifier.height(10.dp))
+                NovaQuickMenuPostSessionReportCard(state.postSessionReport)
             }
         }
     }
@@ -435,6 +440,8 @@ private fun NovaQuickMenuTitleBlock(state: NovaQuickMenuUiState, modifier: Modif
     }
 }
 
+// Close is the primary: this menu opens on every Back press, so the safe action wears the
+// accent. Disconnect stays quiet and End Session reads as destructive.
 @Composable
 private fun NovaQuickMenuHeaderButton(
     action: NovaQuickMenuAction,
@@ -446,7 +453,8 @@ private fun NovaQuickMenuHeaderButton(
         onClick = { callbacks.perform(action) },
         modifier = modifier.widthIn(min = 84.dp),
         enabled = action.enabled,
-        primary = !action.destructive,
+        primary = false,
+        destructive = action.destructive,
         cornerRadius = NovaRadius.hero,
         minHeight = 34.dp,
         fontSize = 12.sp,
@@ -466,7 +474,7 @@ private fun NovaQuickMenuCloseButton(
         modifier = modifier
             .widthIn(min = 72.dp)
             .semantics { contentDescription = closeCommandCenter },
-        primary = false,
+        primary = true,
         cornerRadius = NovaRadius.hero,
         minHeight = 34.dp,
         fontSize = 12.sp,
@@ -485,11 +493,17 @@ private fun NovaQuickMenuDiagnosisCard(
         NovaQuickMenuDoctorCapability.RECHECK -> stringResource(R.string.nova_quick_menu_doctor_capability_recheck)
         NovaQuickMenuDoctorCapability.MANUAL -> stringResource(R.string.nova_quick_menu_doctor_capability_manual)
     }
+    val classification = diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") }
     val detail = buildList {
+        classification?.let(::add)
         diagnosis.tryFirst.takeIf { it.isNotBlank() }?.let { add("Try first: $it") }
-        diagnosis.evidence.firstOrNull()?.takeIf { it.isNotBlank() }?.let { add("Evidence: $it") }
-        diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
+        // Confidence only means something next to the evidence it grades.
+        diagnosis.evidenceHighlight.takeIf { it.isNotBlank() }?.let { evidence ->
+            add("Evidence: $evidence")
+            diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
+        }
     }.joinToString(" · ")
+    val diagnoseTitle = stringResource(R.string.nova_quick_menu_diagnose_stream)
     val aiSupportingLine = diagnosis.aiExplanation.takeIf { it.isNotBlank() }?.let {
         stringResource(R.string.nova_quick_menu_doctor_ai_explanation, it)
     }
@@ -498,21 +512,22 @@ private fun NovaQuickMenuDiagnosisCard(
         ?.let { "Source: $it" }
     val supportingLine = listOfNotNull(aiSupportingLine, sourceSupportingLine).joinToString("\n")
     NovaQuickMenuInfoCard(
+        // The finding is the title and the action lives in the chip, so "Recheck" no longer
+        // shows up as title, chip, and button at once.
         action = NovaQuickMenuAction(
             id = NovaQuickMenuActionId.DIAGNOSE_STREAM,
-            label = diagnosis.actionLabel.takeIf { diagnosis.actionExecutable && it.isNotBlank() }
-                ?: "${diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") } ?: "DIAG"}: ${diagnosis.likelyCause}",
-            caption = buildList {
-                diagnosis.likelyCause.takeIf { diagnosis.actionExecutable && it.isNotBlank() }?.let { add(it) }
-                detail.takeIf { it.isNotBlank() }?.let { add(it) }
-            }.joinToString(" · ").ifBlank { "HOST / NET / CLIENT self-service diagnostics" },
+            label = diagnosis.likelyCause.trim().trimEnd('.').ifBlank { diagnoseTitle },
+            caption = detail,
             chip = NovaQuickMenuChip(
-                label = capabilityLabel,
+                label = diagnosis.actionLabel.takeIf { diagnosis.actionExecutable && it.isNotBlank() }
+                    ?: capabilityLabel,
                 tone = if (diagnosis.available) NovaQuickMenuTone.INFO else NovaQuickMenuTone.MUTED
             ),
             enabled = diagnosis.available
         ),
         supportingLine = supportingLine,
+        // Doctor findings are whole sentences; give them a second line before ellipsis.
+        labelMaxLines = 2,
         // The real callbacks. This used to construct a fresh default instance, whose
         // every member is a no-op, so the card rendered enabled and did nothing when
         // pressed -- and looked no different from one that worked. The guard forbids the
@@ -556,6 +571,7 @@ private fun NovaQuickMenuSessionStrip(
             .semantics {
                 contentDescription = listOf(
                     state.sessionMode.label,
+                    state.sessionDetail,
                     state.healthSummary,
                     state.healthDetail,
                 ).filter { it.isNotBlank() }.joinToString(". ")
@@ -580,6 +596,17 @@ private fun NovaQuickMenuSessionStrip(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            if (state.sessionDetail.isNotBlank()) {
+                Text(
+                    text = state.sessionDetail,
+                    color = colors.textMuted,
+                    fontSize = 9.sp,
+                    lineHeight = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
             if (state.healthDetail.isNotBlank()) {
                 Text(
                     text = state.healthDetail,
@@ -617,6 +644,13 @@ private fun NovaQuickMenuPostSessionReportCard(report: NovaPostSessionReportUiSt
                 color = colors.textPrimary,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = stringResource(R.string.nova_quick_menu_post_session_report_caption),
+                color = colors.textMuted,
+                fontSize = 10.sp,
+                lineHeight = 13.sp,
+                modifier = Modifier.padding(top = 4.dp)
             )
             listOf(report.qualityLine, report.issueLine, report.nextLaunchLine, report.recoveryLine).forEach { line ->
                 Text(
@@ -665,15 +699,17 @@ private fun NovaQuickMenuStabilityCard(
                 )
                 NovaQuickMenuChipView(stability.chip)
             }
-            Text(
-                text = stability.caption,
-                color = colors.textPrimary,
-                fontSize = 12.sp,
-                lineHeight = 15.sp,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = 8.dp)
-            )
+            if (stability.caption.isNotBlank()) {
+                Text(
+                    text = stability.caption,
+                    color = colors.textPrimary,
+                    fontSize = 12.sp,
+                    lineHeight = 15.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
             Text(
                 text = stability.targetSummary,
                 color = colors.textMuted,
@@ -743,7 +779,8 @@ private fun NovaQuickMenuInfoCard(
     action: NovaQuickMenuAction,
     callbacks: NovaQuickMenuCallbacks,
     modifier: Modifier = Modifier,
-    supportingLine: String = ""
+    supportingLine: String = "",
+    labelMaxLines: Int = 1
 ) {
     NovaQuickMenuClickableSurface(
         enabled = action.enabled,
@@ -761,7 +798,7 @@ private fun NovaQuickMenuInfoCard(
                     color = LocalNovaComposeColors.current.textPrimary,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
+                    maxLines = labelMaxLines,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -32,6 +32,7 @@ enum class NovaQuickMenuActionId {
     QUICK_CTRL_1,
     QUICK_CTRL_2,
     NOVA_HUD,
+    NOVA_HUD_MODE,
     PERF_STATS,
     DIAGNOSE_STREAM,
     DOCTOR_UNDO,
@@ -99,6 +100,7 @@ data class NovaQuickMenuDiagnosisState(
     val classification: String,
     val likelyCause: String,
     val evidence: List<String>,
+    val evidenceHighlight: String,
     val tryFirst: String,
     val confidence: String,
     val available: Boolean,
@@ -117,6 +119,7 @@ data class NovaQuickMenuUiState(
     val title: String,
     val subtitle: String,
     val sessionMode: NovaQuickMenuChip,
+    val sessionDetail: String,
     val healthSummary: String,
     val healthDetail: String,
     val healthTone: NovaQuickMenuTone,
@@ -129,6 +132,7 @@ data class NovaQuickMenuUiState(
     val advancedRows: List<NovaQuickMenuAction>,
     val quickKeys: List<NovaQuickMenuAction>,
     val diagnosis: NovaQuickMenuDiagnosisState,
+    val diagnosisAction: NovaQuickMenuAction,
     val doctorReceiptAction: NovaQuickMenuAction,
     val postSessionReport: NovaPostSessionReportUiState,
     val hudOpacity: NovaQuickMenuHudOpacityState,
@@ -161,6 +165,7 @@ data class NovaQuickMenuUiState(
             currentGameUuid: String?,
             profilePreference: String,
             hudShowing: Boolean,
+            hudMode: NovaHudMode = NovaHudMode.MINIMAL,
             hudOpacityPercent: Int = NovaHudPreferences.DEFAULT_OPACITY_PERCENT,
             menuOpacityPercent: Int = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT,
             perfOverlayEnabled: Boolean,
@@ -221,6 +226,7 @@ data class NovaQuickMenuUiState(
                 else -> NovaQuickMenuTone.MUTED
             }
 
+            val sessionDetail = resolveSessionDetail(context, status)
             val sessionMode = NovaQuickMenuChip(
                 label = resolveSessionModeLabel(context, status),
                 tone = when {
@@ -278,12 +284,17 @@ data class NovaQuickMenuUiState(
                 )
             }
 
+            val diagnosis = diagnosisState(status)
             val stability = NovaQuickMenuStabilityState(
-                title = context.getString(R.string.nova_quick_menu_ai_auto_quality),
+                title = context.getString(R.string.nova_quick_menu_stream_card),
                 caption = when {
                     hostStateUnavailable -> context.getString(R.string.nova_quick_menu_host_state_unavailable)
                     !apiAvailable && status == null -> context.getString(R.string.nova_quick_menu_not_polaris_session)
                     status == null -> context.getString(R.string.nova_quick_menu_health_checking)
+                    // The session strip and the Doctor card already say this sentence; the
+                    // Stream card repeats it only when it adds something.
+                    autoQuality.detail.sameSentenceAs(healthSummary) ||
+                        autoQuality.detail.sameSentenceAs(diagnosis.likelyCause) -> ""
                     else -> autoQuality.detail
                 },
                 targetSummary = streamPolicy.targetSummary.takeIf { it.isNotBlank() }
@@ -347,15 +358,14 @@ data class NovaQuickMenuUiState(
                 percent = NovaMenuPreferences.coerceOpacityPercent(menuOpacityPercent),
                 presets = NovaMenuPreferences.OPACITY_PRESETS
             )
-            val diagnosis = diagnosisState(status)
             val doctorReceiptAction = doctorReceiptAction(
                 context = context,
                 receipt = doctorReceipt,
                 canAdjustHostTuning = canAdjustHostTuning
             )
 
+            // Doctor's verdict is a card of its own, so the Overlays panel holds overlays only.
             val overlays = listOf(
-                diagnoseAction(context, status, diagnosis),
                 NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.NOVA_HUD,
                     label = context.getString(R.string.nova_quick_menu_nova_hud),
@@ -364,8 +374,19 @@ data class NovaQuickMenuUiState(
                     enabled = true
                 ),
                 NovaQuickMenuAction(
+                    id = NovaQuickMenuActionId.NOVA_HUD_MODE,
+                    label = context.getString(R.string.nova_quick_menu_hud_mode),
+                    caption = context.getString(R.string.nova_quick_menu_hud_mode_caption),
+                    chip = chip(
+                        hudModeLabel(context, hudMode),
+                        if (hudShowing) NovaQuickMenuTone.INFO else NovaQuickMenuTone.MUTED
+                    ),
+                    enabled = hudShowing
+                ),
+                NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.PERF_STATS,
                     label = context.getString(R.string.nova_quick_menu_perf_stats),
+                    caption = context.getString(R.string.nova_quick_menu_perf_stats_caption),
                     chip = onOffChip(context, perfOverlayEnabled),
                     enabled = true
                 ),
@@ -424,6 +445,7 @@ data class NovaQuickMenuUiState(
                 title = context.getString(R.string.nova_quick_menu_command_center_title),
                 subtitle = subtitle,
                 sessionMode = sessionMode,
+                sessionDetail = sessionDetail,
                 healthSummary = healthSummary,
                 healthDetail = healthDetail,
                 healthTone = healthTone,
@@ -450,6 +472,7 @@ data class NovaQuickMenuUiState(
                 advancedRows = listOf(clearRow, mangoRow),
                 quickKeys = quickKeyActions(context),
                 diagnosis = diagnosis,
+                diagnosisAction = diagnoseAction(context, status, diagnosis),
                 doctorReceiptAction = doctorReceiptAction,
                 postSessionReport = postSessionReport,
                 hudOpacity = hudOpacity,
@@ -611,6 +634,7 @@ data class NovaQuickMenuUiState(
                 classification = doctor?.classification?.takeIf { it.isNotBlank() } ?: "UNKNOWN",
                 likelyCause = doctor?.likelyCause?.takeIf { it.isNotBlank() } ?: "Connect to Polaris for HOST / NET / CLIENT diagnostics.",
                 evidence = doctor?.evidence ?: emptyList(),
+                evidenceHighlight = doctorEvidenceHighlight(status),
                 tryFirst = doctor?.firstTry.orEmpty(),
                 confidence = doctor?.confidence.orEmpty(),
                 available = available,
@@ -644,6 +668,27 @@ data class NovaQuickMenuUiState(
                     else -> ""
                 }
             )
+        }
+
+        // The host lists a passing "a stream is active" check first, so the first evidence
+        // string is never the interesting one. Show the first item Doctor itself grades as
+        // actionable, or nothing at all.
+        private fun doctorEvidenceHighlight(status: PolarisSessionStatus?): String {
+            val doctor = status?.doctor ?: return ""
+            if (doctor.evidenceItems.isEmpty()) {
+                return doctor.evidence.firstOrNull().orEmpty()
+            }
+            val index = doctor.evidenceItems.indexOfFirst { status.doctorEvidenceIsActionable(it) }
+            if (index < 0) {
+                return ""
+            }
+            val item = doctor.evidenceItems[index]
+            item.detail.takeIf { it.isNotBlank() }?.let { return it }
+            if (doctor.evidence.size == doctor.evidenceItems.size) {
+                doctor.evidence[index].takeIf { it.isNotBlank() }?.let { return it }
+            }
+            return listOfNotNull(item.id.replace('_', ' '), item.value?.toString())
+                .joinToString(" ")
         }
 
         private fun diagnoseAction(
@@ -873,27 +918,54 @@ data class NovaQuickMenuUiState(
             )
         }
 
+        // The pill names the mode and the encoder. Capture path, mode source, and role go on
+        // the detail line so the health summary beside the pill keeps its room.
         private fun resolveSessionModeLabel(context: Context, status: PolarisSessionStatus?): String {
-            val mode = when {
-                status == null -> context.getString(R.string.nova_quick_menu_mode_unknown)
-                else -> status.sessionModeWithCaptureLabel.ifBlank { status.sessionModeLabel }
-            }
             if (status == null) {
-                return mode
+                return context.getString(R.string.nova_quick_menu_mode_unknown)
             }
-            val source = when (status.displayMode.requested) {
-                "auto" -> "Auto"
-                "headless", "headless_stream", "virtual_display", "host_virtual_display", "windowed_stream", "desktop_display", "desktop_takeover" -> "Explicit"
-                else -> ""
-            }
-            val base = listOf(mode, status.encoderSelectionLabel, source)
+            val base = listOf(status.sessionModeLabel, status.encoderSelectionLabel)
                 .filter { it.isNotBlank() }
                 .joinToString(" · ")
-            return when {
-                status.isViewer -> context.getString(R.string.nova_session_mode_watch_format, base)
-                status.ownedByClient -> context.getString(R.string.nova_session_mode_owner_format, base)
-                else -> context.getString(R.string.nova_quick_menu_mode_format, base)
+            return if (status.isViewer) {
+                context.getString(R.string.nova_session_mode_watch_format, base)
+            } else {
+                base
             }
+        }
+
+        private fun resolveSessionDetail(context: Context, status: PolarisSessionStatus?): String {
+            if (status == null) {
+                return ""
+            }
+            val source = when (status.displayMode.requested) {
+                "auto" -> context.getString(R.string.nova_quick_menu_mode_source_auto)
+                "headless", "headless_stream", "virtual_display", "host_virtual_display", "windowed_stream", "desktop_display", "desktop_takeover" ->
+                    context.getString(R.string.nova_quick_menu_mode_source_explicit)
+                else -> ""
+            }
+            val role = if (!status.isViewer && status.ownedByClient) {
+                context.getString(R.string.nova_quick_menu_mode_role_owner)
+            } else {
+                ""
+            }
+            return listOf(status.capturePathLabel, source, role)
+                .filter { it.isNotBlank() }
+                .joinToString(" · ")
+        }
+
+        private fun hudModeLabel(context: Context, mode: NovaHudMode): String = context.getString(
+            when (mode) {
+                NovaHudMode.MINIMAL -> R.string.nova_quick_menu_hud_mode_minimal
+                NovaHudMode.PERFORMANCE -> R.string.nova_quick_menu_hud_mode_performance
+                NovaHudMode.DEBUG -> R.string.nova_quick_menu_hud_mode_debug
+            }
+        )
+
+        private fun String.sameSentenceAs(other: String): Boolean {
+            val mine = trim().trimEnd('.', '!')
+            val theirs = other.trim().trimEnd('.', '!')
+            return mine.isNotBlank() && mine.equals(theirs, ignoreCase = true)
         }
 
         private fun PolarisSessionStatus.hdrDowngradeDetail(context: Context): String? {

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -123,7 +123,7 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
                 )
                 if (state.streamModeLabel.isNotBlank()) {
                     Text(
-                        text = state.streamModeLabel,
+                        text = state.streamModeShortLabel,
                         color = LocalNovaComposeColors.current.textMuted,
                         fontSize = 9.sp,
                         lineHeight = 11.sp,
@@ -155,7 +155,7 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
         ) {
             HudMetric("1% LOW", state.lowOnePercentLabel, Modifier.weight(1f))
             HudMetric("RTT", state.latencyLabel, Modifier.weight(1f), valueTone = state.latencyTone)
-            HudMetric("BIT", state.bitrateLabel, Modifier.weight(1f), valueTone = NovaHudTone.INFO)
+            HudMetric("BIT", state.bitrateLabel, Modifier.weight(1f))
         }
         Row(
             modifier = Modifier
@@ -163,7 +163,7 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
                 .padding(top = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            HudMetric("CODEC", state.codecLabel.ifBlank { "--" }, Modifier.weight(1f), valueTone = NovaHudTone.INFO)
+            HudMetric("CODEC", state.codecLabel.ifBlank { "--" }, Modifier.weight(1f))
             HudMetric("RES", state.resolutionLabel, Modifier.weight(1f))
         }
     }
@@ -252,7 +252,7 @@ private fun HudPerformanceDetailRow(state: NovaHudUiState) {
         )
         HudCompactText(
             state.bitrateLabel,
-            NovaHudTone.INFO,
+            NovaHudTone.MUTED,
             modifier = Modifier.weight(1f),
             startPadding = 0.dp
         )

--- a/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
+++ b/app/src/main/java/com/papi/nova/ui/compose/NovaFocusComponents.kt
@@ -278,6 +278,10 @@ fun HapticFeedback.novaConfirm() {
     performHapticFeedback(HapticFeedbackType.Confirm)
 }
 
+// Destructive actions keep the quiet ghost shape and only tint their text, matching the
+// End Session confirm sheet.
+private val NovaDestructiveContent = Color(0xFFF87171)
+
 @Composable
 fun NovaActionButton(
     text: String,
@@ -285,6 +289,7 @@ fun NovaActionButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     primary: Boolean = false,
+    destructive: Boolean = false,
     contentDescription: String = text,
     selected: Boolean = false,
     stateDescription: String? = null,
@@ -319,6 +324,7 @@ fun NovaActionButton(
     )
     val contentColor = when {
         primary && enabled -> colors.onAccent
+        destructive && enabled -> NovaDestructiveContent
         enabled -> colors.textPrimary
         else -> colors.textMuted
     }
@@ -326,6 +332,7 @@ fun NovaActionButton(
         targetValue = when {
             focused && primary -> colors.onAccent
             focused -> surfaces.focusRing
+            destructive && !primary -> NovaDestructiveContent.copy(alpha = 0.45f)
             !primary -> surfaces.tileBorder
             else -> surfaces.tileBorder
         },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,7 +966,9 @@
     <string name="nova_quick_menu_host_controls_unavailable_caption">host controls unavailable</string>
     <string name="nova_quick_menu_session_ending_caption">session ending</string>
     <string name="nova_quick_menu_mode_unknown">Checking stream mode</string>
-    <string name="nova_quick_menu_mode_format">%1$s session</string>
+    <string name="nova_quick_menu_mode_source_auto">Auto choice</string>
+    <string name="nova_quick_menu_mode_source_explicit">Explicit choice</string>
+    <string name="nova_quick_menu_mode_role_owner">Owner</string>
     <string name="nova_quick_menu_command_center_title">Command Center</string>
     <string name="nova_quick_menu_command_center_subtitle">Quick keys, stream tuning, and session controls</string>
     <string name="nova_quick_menu_headless_subtitle">Quick keys and controls for Private Stream</string>
@@ -982,6 +984,7 @@
     <string name="nova_quick_menu_health_attention">Session needs attention.</string>
     <string name="nova_quick_menu_health_steady">Session looks steady.</string>
     <string name="nova_quick_menu_ai_auto_quality">Launch preset</string>
+    <string name="nova_quick_menu_stream_card">Stream</string>
     <string name="nova_quick_menu_auto_quality_caption_default">Watching stream quality</string>
     <string name="nova_quick_menu_ai_caption_default">balancing FPS, bitrate, and smoothness</string>
     <string name="nova_quick_menu_target_checking">Waiting for stream target</string>
@@ -1004,7 +1007,12 @@
     <string name="nova_quick_menu_controls">Controls</string>
     <string name="nova_quick_menu_session">Session</string>
     <string name="nova_quick_menu_nova_hud">Nova HUD</string>
-    <string name="nova_quick_menu_nova_hud_caption">Long-press the HUD for Command Center; hold Guide and press Y to cycle HUD modes.</string>
+    <string name="nova_quick_menu_nova_hud_caption">Long press the HUD to open Command Center.</string>
+    <string name="nova_quick_menu_hud_mode">HUD Mode</string>
+    <string name="nova_quick_menu_hud_mode_caption">Tap to cycle. Guide + Y does the same on a controller.</string>
+    <string name="nova_quick_menu_hud_mode_minimal">Minimal</string>
+    <string name="nova_quick_menu_hud_mode_performance">Performance</string>
+    <string name="nova_quick_menu_hud_mode_debug">Debug</string>
     <string name="nova_quick_menu_menu_opacity">Menu Opacity</string>
     <string name="nova_quick_menu_menu_opacity_caption">Adjust Nova menus, drawers, options, and session glass without dimming text or focus cues.</string>
     <string name="nova_quick_menu_menu_opacity_preset_cd">Set menu opacity to %1$d percent</string>
@@ -1015,6 +1023,7 @@
     <string name="nova_quick_menu_hud_opacity_selected">Selected</string>
     <string name="nova_quick_menu_hud_opacity_not_selected">Not selected</string>
     <string name="nova_quick_menu_perf_stats">Stats Overlay</string>
+    <string name="nova_quick_menu_perf_stats_caption">Legacy Moonlight stats text, separate from Nova HUD.</string>
     <string name="nova_quick_menu_diagnose_stream">Diagnose This Stream</string>
     <string name="nova_quick_menu_doctor_capability_auto_fix">Auto Fix</string>
     <string name="nova_quick_menu_doctor_capability_run_trial">Run a trial</string>
@@ -1056,7 +1065,8 @@
     <string name="nova_conn_reconnect">Reconnect</string>
     <string name="nova_quick_menu_close">Close</string>
     <string name="nova_quick_menu_close_command_center">Close Command Center</string>
-    <string name="nova_quick_menu_post_session_report">Post-session recovery report</string>
+    <string name="nova_quick_menu_post_session_report">Host safe profile</string>
+    <string name="nova_quick_menu_post_session_report_caption">Observational history from earlier sessions. Launch settings are unchanged.</string>
     <string name="nova_settings_back">Back</string>
     <string name="nova_settings_legacy">Legacy</string>
     <string name="nova_settings_search_results">%1$d results</string>
@@ -1117,7 +1127,6 @@
     <string name="nova_session_mode_virtual_display">Host Virtual Display</string>
     <string name="nova_session_mode_host_display">Mirror Desktop</string>
     <string name="nova_session_mode_watch_format">Watching · %1$s</string>
-    <string name="nova_session_mode_owner_format">%1$s · owner</string>
     <string name="nova_mangohud_warning_big_picture">Avoid on Steam Big Picture on this host.</string>
     <string name="nova_mangohud_warning_steam">Risky on Steam and Proton on this host.</string>
 

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -1664,7 +1664,7 @@ class PolarisApiClientParsingTest {
 
         assertEquals("UNKNOWN", status.doctor.classification)
         assertFalse(status.hasHealthConcerns)
-        assertEquals("Control retries", status.healthToneLabel)
+        assertEquals("Link retries", status.healthToneLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
@@ -95,7 +95,8 @@ class AutoQualityUiStateTest {
         assertTrue(status.hasHealthConcerns)
         assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
         assertEquals(AutoQualityUiState.Tone.WARNING, state.tone)
-        assertEquals("REC", state.compactLabel)
+        // "REC" read as recording on the HUD; the compact recovery label says what it does.
+        assertEquals("SAFE", state.compactLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2215,7 +2215,7 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
-    fun commandCenterFirstPaintPrioritizesSessionQualityAndHudBeforeQuickKeys() {
+    fun commandCenterFirstPaintPutsSessionHealthThenDailyControlsBeforeDiagnostics() {
         val content = readNovaQuickMenuContent()
         val body = content.section(
             "fun NovaQuickMenuContent(",
@@ -2225,31 +2225,47 @@ class NovaComposeSourceGuardTest {
             "private fun NovaQuickMenuHeader(",
             "@Composable\nprivate fun NovaQuickMenuTitleBlock("
         )
+        val headerButton = content.section(
+            "private fun NovaQuickMenuHeaderButton(",
+            "@Composable\nprivate fun NovaQuickMenuCloseButton("
+        )
+        val closeButton = content.section(
+            "private fun NovaQuickMenuCloseButton(",
+            "@Composable\nprivate fun NovaQuickMenuDiagnosisCard("
+        )
 
         val sessionStrip = body.indexOf("NovaQuickMenuSessionStrip(state, initialFocusRequester)")
-        val stabilityCard = body.indexOf("NovaQuickMenuStabilityCard(state.stability, callbacks)")
-        val syncCard = body.indexOf("action = state.sync")
-        val overlaysPanel = body.indexOf("title = overlaysTitle")
         val quickKeysPanel = body.indexOf("NovaQuickMenuPanel(title = quickKeysTitle)")
-        val advancedToggleCard = body.indexOf("action = state.advancedToggle")
         val controlsPanel = body.indexOf("title = controlsTitle")
         val sessionPanel = body.indexOf("NovaQuickMenuPanel(title = sessionTitle)")
+        val overlaysPanel = body.indexOf("title = overlaysTitle")
+        val diagnosisCard = body.indexOf("NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)")
+        val stabilityCard = body.indexOf("NovaQuickMenuStabilityCard(state.stability, callbacks)")
+        val syncCard = body.indexOf("action = state.sync")
+        val advancedToggleCard = body.indexOf("action = state.advancedToggle")
+        val reportCard = body.indexOf("NovaQuickMenuPostSessionReportCard(state.postSessionReport)")
 
         assertTrue(
-            "Command Center first paint should keep the session strip immediately after the header",
-            sessionStrip >= 0 && stabilityCard > sessionStrip
+            "Command Center first paint should keep the session strip, which carries the health verdict, immediately after the header",
+            sessionStrip >= 0 && quickKeysPanel > sessionStrip
         )
         assertTrue(
-            "stream quality/recovery state should be above overlay/HUD controls so gameplay health is understood before shortcuts",
-            stabilityCard in 0 until syncCard &&
-                syncCard in 0 until overlaysPanel
+            "the controls a player touches every session (Quick Keys, Controls, Session, Overlays) come before the Doctor and stream cards that explain the strip's verdict; on a Retroid those cards used to push the keys two pages down",
+            quickKeysPanel in 0 until controlsPanel &&
+                controlsPanel in 0 until sessionPanel &&
+                sessionPanel in 0 until overlaysPanel &&
+                overlaysPanel in 0 until diagnosisCard
         )
         assertTrue(
-            "NovaHUD/overlay controls should be promoted above Quick Keys and lower utilities in the polished Command Center hierarchy",
-            overlaysPanel in 0 until quickKeysPanel &&
-                quickKeysPanel in 0 until advancedToggleCard &&
-                advancedToggleCard in 0 until controlsPanel &&
-                controlsPanel in 0 until sessionPanel
+            "Doctor, stream target, sync, and Advanced keep their explanatory order below the controls",
+            diagnosisCard in 0 until stabilityCard &&
+                stabilityCard in 0 until syncCard &&
+                syncCard in 0 until advancedToggleCard
+        )
+        assertTrue(
+            "the host safe profile is observational history and lives inside the expanded Advanced section, not in the first paint",
+            reportCard > advancedToggleCard &&
+                body.substring(advancedToggleCard, reportCard).contains("if (state.advancedExpanded) {")
         )
         assertTrue(
             "Command Center header should expose an explicit close affordance that invokes the same dismiss callback as scrim/back",
@@ -2257,6 +2273,13 @@ class NovaComposeSourceGuardTest {
                 content.contains("stringResource(R.string.nova_quick_menu_close_command_center)") &&
                 content.contains("contentDescription = closeCommandCenter") &&
                 content.contains("onClick = callbacks.onDismiss")
+        )
+        assertTrue(
+            "Close is the primary header button: the menu opens on every Back press, so the safe action wears the accent while Disconnect stays quiet and End Session reads destructive",
+            closeButton.contains("primary = true") &&
+                headerButton.contains("primary = false") &&
+                headerButton.contains("destructive = action.destructive") &&
+                !content.contains("primary = !action.destructive")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaDisplayResolutionPlannerTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaDisplayResolutionPlannerTest.kt
@@ -75,10 +75,10 @@ class NovaDisplayResolutionPlannerTest {
             )
         )
 
-        assertEquals("Quality: Watch", report.qualityLine)
+        assertEquals("Grade: Watch", report.qualityLine)
         assertEquals("Main issue: network jitter", report.issueLine)
-        assertEquals("Next launch: headless · 60fps · 16 Mbps", report.nextLaunchLine)
-        assertEquals("Recovery: network jitter", report.recoveryLine)
+        assertEquals("Safe profile: headless · 60fps · 16 Mbps", report.nextLaunchLine)
+        assertEquals("Recovery record: network jitter", report.recoveryLine)
         assertTrue(report.copyDiagnostics.contains("Network jitter"))
         assertTrue(report.visible)
     }
@@ -89,10 +89,12 @@ class NovaDisplayResolutionPlannerTest {
             health = com.papi.nova.api.PolarisSessionStatus.HealthStatus(summary = "Session looks steady.")
         )
 
-        assertEquals("Quality: Unknown", report.qualityLine)
+        assertEquals("Grade: Unknown", report.qualityLine)
         assertEquals("Main issue: none", report.issueLine)
-        assertEquals("Next launch: keep current settings", report.nextLaunchLine)
-        assertEquals("Recovery: none", report.recoveryLine)
-        assertTrue(report.visible)
+        assertEquals("Safe profile: keep current settings", report.nextLaunchLine)
+        assertEquals("Recovery record: none", report.recoveryLine)
+        // A steady health block has nothing to report, so the Command Center card stays
+        // hidden instead of listing four "none" lines.
+        assertFalse(report.visible)
     }
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -82,6 +82,10 @@ class NovaHudUiStateTest {
         assertTrue(state.streamModeLabel.contains("Private Stream"))
         assertTrue(state.streamModeLabel.contains("GPU-native DMA-BUF"))
         assertFalse(state.streamModeLabel.contains("Headless"))
+        // The Debug header has 96dp: the short label is the mode alone, the full label
+        // stays for the diagnostics copy.
+        assertEquals("Private Stream", state.streamModeShortLabel)
+        assertEquals("55", state.lowOnePercentLabel)
         assertEquals(listOf(55f, 58f, 60f), state.sparklineSamples)
     }
 
@@ -775,8 +779,8 @@ class NovaHudUiStateTest {
         )
 
         assertFalse(status.hasHealthConcerns)
-        assertEquals("Control retries", status.healthToneLabel)
-        assertEquals("Control retries observed", state.healthReasonLabel)
+        assertEquals("Link retries", status.healthToneLabel)
+        assertEquals("Link retries", state.healthReasonLabel)
         assertEquals(NovaHudTone.MUTED, state.healthReasonTone)
         assertEquals(NovaHudTone.STABLE, state.layerHealth[1].tone)
     }
@@ -946,7 +950,7 @@ class NovaHudUiStateTest {
         assertEquals("OK", state.autopilotCompactLabel)
         assertEquals("Stream Ready", state.autopilotHudLabel)
         assertEquals(NovaHudTone.STABLE, state.statusTone)
-        assertEquals("Control retries observed", state.healthReasonLabel)
+        assertEquals("Link retries", state.healthReasonLabel)
         assertEquals(NovaHudTone.MUTED, state.healthReasonTone)
         assertTrue(state.streamModeLabel.contains("SHM/CPU capture"))
         assertEquals(NovaHudLayerHealth("HOST", NovaHudTone.STABLE), state.layerHealth.first())

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -241,9 +241,15 @@ class NovaQuickMenuUiStateTest {
         )
 
         assertTrue(state.sessionMode.label.contains("Private Stream"))
-        assertTrue(state.sessionMode.label.contains("GPU-native DMA-BUF"))
         assertTrue(state.sessionMode.label.contains("Auto → Vulkan"))
         assertFalse(state.sessionMode.label.contains("Headless"))
+        // The capture path belongs to the detail line, not the pill, so the health summary
+        // beside the pill keeps its room.
+        assertFalse(state.sessionMode.label.contains("GPU-native DMA-BUF"))
+        assertFalse(state.sessionMode.label.contains("owner"))
+        assertTrue(state.sessionDetail.contains("GPU-native DMA-BUF"))
+        assertTrue(state.sessionDetail.contains("Explicit choice"))
+        assertTrue(state.sessionDetail.contains("Owner"))
     }
 
     @Test
@@ -305,7 +311,7 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
-    fun commandCenterExposesDiagnoseThisStreamAsPrimaryOverlayAction() {
+    fun commandCenterExposesDiagnoseThisStreamAsTheDoctorCardAction() {
         val state = quickState(
             status = status(
                 doctor = PolarisSessionStatus.DoctorStatus(
@@ -350,14 +356,17 @@ class NovaQuickMenuUiStateTest {
             )
         )
 
-        val diagnose = state.overlayRows.first()
+        val diagnose = state.diagnosisAction
         assertEquals(NovaQuickMenuActionId.DIAGNOSE_STREAM, diagnose.id)
+        // Doctor's verdict is its own card; the Overlays panel holds overlays only.
+        assertFalse(state.overlayRows.any { it.id == NovaQuickMenuActionId.DIAGNOSE_STREAM })
         assertEquals("Auto Fix", diagnose.label)
         assertEquals("Wi-Fi jitter is the likely bottleneck.", diagnose.caption)
         assertEquals("NET", diagnose.chip!!.label)
         assertEquals(NovaQuickMenuTone.WARNING, diagnose.chip.tone)
         assertEquals("Lower bitrate", state.diagnosis.tryFirst)
         assertEquals("3.4% packet loss", state.diagnosis.evidence.first())
+        assertEquals("3.4% packet loss", state.diagnosis.evidenceHighlight)
         assertEquals("high", state.diagnosis.confidence)
         assertTrue(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.AUTO_FIX, state.diagnosis.capability)
@@ -436,7 +445,7 @@ class NovaQuickMenuUiStateTest {
         )
 
         assertEquals("Confirmed media loss is limiting the stream.", state.diagnosis.likelyCause)
-        assertEquals("Auto Fix", state.overlayRows.first().label)
+        assertEquals("Auto Fix", state.diagnosisAction.label)
         assertEquals(NovaQuickMenuDoctorCapability.AUTO_FIX, state.diagnosis.capability)
         assertTrue(state.diagnosis.aiExplanation.contains("Wi-Fi interference"))
         assertTrue(state.diagnosis.aiExplanation.contains("Move closer"))
@@ -446,7 +455,7 @@ class NovaQuickMenuUiStateTest {
     @Test
     fun commandCenterDisablesDiagnoseThisStreamForMoonlightFallbackSession() {
         val state = quickState(status = null, apiAvailable = false)
-        val diagnose = state.overlayRows.first { it.id == NovaQuickMenuActionId.DIAGNOSE_STREAM }
+        val diagnose = state.diagnosisAction
 
         assertFalse(diagnose.enabled)
         assertEquals("N/A", diagnose.chip!!.label)
@@ -484,7 +493,7 @@ class NovaQuickMenuUiStateTest {
             )
         )
 
-        assertEquals("Recheck network", state.overlayRows.first().label)
+        assertEquals("Recheck network", state.diagnosisAction.label)
         assertTrue(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.RECHECK, state.diagnosis.capability)
         assertEquals(0, state.diagnosis.targetBitrateKbps)
@@ -513,7 +522,7 @@ class NovaQuickMenuUiStateTest {
 
         assertFalse(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.MANUAL, state.diagnosis.capability)
-        assertEquals("Diagnose This Stream", state.overlayRows.first().label)
+        assertEquals("Diagnose This Stream", state.diagnosisAction.label)
     }
 
     @Test
@@ -537,7 +546,7 @@ class NovaQuickMenuUiStateTest {
 
         assertFalse(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.MANUAL, state.diagnosis.capability)
-        assertEquals("Diagnose This Stream", state.overlayRows.first().label)
+        assertEquals("Diagnose This Stream", state.diagnosisAction.label)
     }
 
     @Test
@@ -595,7 +604,7 @@ class NovaQuickMenuUiStateTest {
             )
         )
 
-        assertEquals("Auto Fix", state.overlayRows.first().label)
+        assertEquals("Auto Fix", state.diagnosisAction.label)
         assertTrue(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.AUTO_FIX, state.diagnosis.capability)
         assertEquals(15000, state.diagnosis.targetBitrateKbps)
@@ -628,7 +637,67 @@ class NovaQuickMenuUiStateTest {
 
         assertFalse(state.diagnosis.actionExecutable)
         assertEquals(NovaQuickMenuDoctorCapability.MANUAL, state.diagnosis.capability)
-        assertEquals("Diagnose This Stream", state.overlayRows.first().label)
+        assertEquals("Diagnose This Stream", state.diagnosisAction.label)
+    }
+
+    @Test
+    fun doctorCardHidesThePassingStreamCheckAndTheStreamCardDoesNotRepeatTheVerdict() {
+        val state = quickState(
+            status = status(
+                aiOptimizerEnabled = true,
+                tuning = PolarisSessionStatus.TuningStatus(aiOptimizerEnabled = true),
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    version = 2,
+                    resultId = "doctor-current-frame-pacing",
+                    classification = "HOST",
+                    likelyCause = "Frame pacing telemetry needs attention.",
+                    evidence = listOf("A stream is active."),
+                    confidence = "high",
+                    primaryIssue = "frame_pacing",
+                    evidenceItems = listOf(
+                        PolarisSessionStatus.DoctorStatus.EvidenceItem(
+                            id = "streaming",
+                            status = "pass",
+                            source = "stream_stats"
+                        )
+                    )
+                )
+            )
+        )
+
+        // The host lists its passing "a stream is active" check first; that is not evidence
+        // of anything, so the card shows no evidence line rather than a vacuous one.
+        assertEquals("", state.diagnosis.evidenceHighlight)
+        assertEquals("Frame pacing telemetry needs attention.", state.diagnosis.likelyCause)
+        assertEquals("Frame pacing", state.healthSummary)
+        // The strip and the Doctor card already carry the sentence; the Stream card keeps
+        // its chip and target line and drops the duplicate.
+        assertEquals("Stream", state.stability.title)
+        assertEquals("", state.stability.caption)
+        assertEquals("Launch preset", state.stability.profileTitle)
+    }
+
+    @Test
+    fun overlaysCarryAHudModeRowThatOnlyCyclesWhileTheHudIsShowing() {
+        val showing = quickState(status = status(), hudShowing = true, hudMode = NovaHudMode.DEBUG)
+        val hidden = quickState(status = status(), hudShowing = false, hudMode = NovaHudMode.PERFORMANCE)
+
+        val showingRow = showing.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD_MODE }
+        assertEquals("HUD Mode", showingRow.label)
+        assertEquals("Debug", showingRow.chip!!.label)
+        assertEquals(NovaQuickMenuTone.INFO, showingRow.chip.tone)
+        assertTrue(showingRow.enabled)
+
+        val hiddenRow = hidden.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD_MODE }
+        assertEquals("Performance", hiddenRow.chip!!.label)
+        assertEquals(NovaQuickMenuTone.MUTED, hiddenRow.chip.tone)
+        assertFalse(hiddenRow.enabled)
+
+        val hudRow = showing.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD }
+        assertEquals("Long press the HUD to open Command Center.", hudRow.caption)
+        val statsRow = showing.overlayRows.first { it.id == NovaQuickMenuActionId.PERF_STATS }
+        assertTrue(statsRow.caption.contains("Legacy Moonlight"))
     }
 
     @Test
@@ -825,6 +894,7 @@ class NovaQuickMenuUiStateTest {
         currentGameName: String? = "Portal",
         currentGameUuid: String? = "game-1",
         hudShowing: Boolean = false,
+        hudMode: NovaHudMode = NovaHudMode.MINIMAL,
         hudOpacityPercent: Int = 90,
         menuOpacityPercent: Int = NovaMenuPreferences.DEFAULT_OPACITY_PERCENT,
         fallbackTargetFps: Double = 60.0,
@@ -845,6 +915,7 @@ class NovaQuickMenuUiStateTest {
         currentGameUuid = currentGameUuid,
         profilePreference = "quality",
         hudShowing = hudShowing,
+        hudMode = hudMode,
         hudOpacityPercent = hudOpacityPercent,
         menuOpacityPercent = menuOpacityPercent,
         perfOverlayEnabled = false,


### PR DESCRIPTION
## Summary

- Command Center order: Quick Keys, Controls, Session, and Overlays come first; the Doctor, Stream, Sync, and Advanced cards follow. The session strip still carries the health verdict right under the header, so the health-first intent of the old guard survives in the strip, and the guard is re-pinned with the new order.
- Header emphasis: Close is the primary button; Disconnect is a quiet ghost; End Session gets a destructive text tint through a new `destructive` flag on `NovaActionButton`.
- Doctor card: the finding is the title (two lines allowed), the action lives in the chip, and the evidence line comes from the first item Doctor grades as actionable, so the host's passing "a stream is active" check no longer shows as evidence with "Confidence: high". The diagnose row is gone from the Overlays panel; the action is exposed as `diagnosisAction` for callers and tests.
- Stream card (formerly "Launch preset", which also named the row beneath it): keeps the chip and the target line, drops the sentence the strip and the Doctor card already show.
- Session strip: the pill is mode plus encoder ("Private Stream · NVENC"); capture path, mode source, and role move to a new `sessionDetail` line so the health summary keeps its room.
- Overlays: new HUD Mode row (chip shows Minimal / Performance / Debug, tap cycles, disabled while the HUD is off) via `Game.cycleNovaHudMode()`; the Nova HUD caption is one sentence; Stats Overlay says it is the legacy Moonlight text.
- Host safe profile (formerly "Post-session recovery report"): lives inside the expanded Advanced section, says it is observational, and is hidden when the host has nothing to report.
- NovaHUD: `REC` reads `SAFE`; the 1% low tile shows the number once; `Control retries observed` and the status label `Control retries` become `Link retries`; bitrate and codec no longer use the accent tone; the Debug header uses a new `streamModeShortLabel`.
- Changelog Unreleased bullets for all of the above.

## Exact candidate

- `Commit:` adea5b81588de301cfb7716f67909ee30dcc7ad6
- `Tree:` 29638b39d43f80377ca5440c0641ff188cd5ec8a
- `Parent:` e8b35eacf3639428efc1094a9ed1c9c5d0317660
- `Base:` master at e8b35eacf3639428efc1094a9ed1c9c5d0317660

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest`: 1602 tests, 0 failures (re-pinned `NovaComposeSourceGuardTest`, `NovaQuickMenuUiStateTest` +2 tests, `NovaHudUiStateTest`, `AutoQualityUiStateTest`, `NovaDisplayResolutionPlannerTest`, `PolarisApiClientParsingTest`)
- [x] `:app:lintNonRoot_gameRelease`: clean
- [x] `:app:assembleNonRoot_gameDebug`: three ABIs built
- [x] Device QA on the Retroid Pocket 6 (`com.papi.nova.debug`, live Control stream on pc-papi): header emphasis, strip pill and detail line, Quick Keys first, HUD Mode row cycling Minimal to Performance from the menu, Performance HUD showing `Link retries` with neutral bitrate, Doctor and Stream cards, Host safe profile inside Advanced, End Session flow.

Not covered: `:app:assembleNonRoot_gameDebugAndroidTest` fails on master already (`NovaGameDetailComposeTest` and `NovaPolarisSyncSheetComposeTest` reference parameters that no longer exist); nothing in this change touches those files. The two-line Doctor title landed after the device pass and is covered by the guard suite only.
