### PR TITLE
chore(release): prepare Nova 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.4.3 - 2026-09-05
+
+Matched client for Polaris 1.4.3: a launch crash fix, honest artwork search errors, complete resolution lists, and a tidier Command Center and NovaHUD.
+
 - The modern Settings resolution and FPS lists now offer the device's native modes and your custom resolution or refresh rate, the way the legacy view always did.
 - Starting a stream with the device held in portrait no longer crashes Nova.
 - Artwork search failures say what is wrong: no SteamGridDB key, a rejected key, or rate limiting, using the codes Polaris 1.4.3 and newer send.
@@ -12,6 +16,8 @@
 - Overlays gain a HUD Mode row that cycles Minimal, Performance, and Debug, and Stats Overlay says it is the legacy Moonlight text.
 - The host safe profile card moves under Advanced and says it is observational.
 - NovaHUD: recovery reads SAFE instead of REC, the 1% low tile shows the number once, control channel retries read Link retries, bitrate and codec drop the accent color, and the Debug header shows the short mode name.
+- versionName 1.4.3, versionCode 45; installs cleanly over 1.4.2.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 sidecars.
 
 ## 1.4.2 - 2026-09-04
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.4.2"
-        versionCode = 44
+        versionName "1.4.3"
+        versionCode = 45
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,13 +81,13 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/44.txt"
+            "fastlane/metadata/android/en-US/changelogs/45.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.4.2\""))
-        assertTrue(build.contains("versionCode = 44"))
-        assertTrue(changelog.contains("## 1.4.2 - 2026-09-04"))
+        assertTrue(build.contains("versionName \"1.4.3\""))
+        assertTrue(build.contains("versionCode = 45"))
+        assertTrue(changelog.contains("## 1.4.3 - 2026-09-05"))
         assertTrue(changelog.contains("Steam Input remains manual and read-only."))
         assertTrue(changelog.contains("Polaris owns encoder probing, fallback, and launch policy"))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
@@ -108,7 +108,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.4.2"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.4.3"))
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/45.txt
+++ b/fastlane/metadata/android/en-US/changelogs/45.txt
@@ -1,0 +1,2 @@
+Nova 1.4.3
+Starting a stream with the device held in portrait no longer crashes. Artwork search says what is wrong (missing, rejected, or rate limited SteamGridDB key). The modern Settings lists carry your custom resolution and the device's native modes. Command Center puts Quick Keys and Controls first, Close is the primary button, the Doctor card leads with the finding, and NovaHUD gains a mode row and clearer labels. Matched client for Polaris 1.4.3.


### PR DESCRIPTION
## Summary

- versionName 1.4.3, versionCode 45 (installs over 1.4.2).
- `CHANGELOG.md`: the Unreleased bullets become `## 1.4.3 - 2026-09-05` with a one line summary; the section names the matched Polaris 1.4.3, the portrait launch crash fix (#277), the coded artwork search failures (#278), the complete resolution and FPS lists (#280), and the Command Center and NovaHUD polish (#281).
- `fastlane/metadata/android/en-US/changelogs/45.txt`: Google Play notes, 457 characters.
- `NovaReleaseMetadataTest` pins the new identity, heading, and store notes.

## Exact candidate

- `Commit:` 7540c87ffbb2852762df65fb9963abf3069b9b7a
- `Tree:` 74792f726a09f073b51432421e7280a1d5c352cd
- `Parent:` d361eb6eea4e0e351cbc3b87ddf47c1f21118d8b
- `Base:` master at d361eb6eea4e0e351cbc3b87ddf47c1f21118d8b

## Verification

- [x] `python3 scripts/extract_release_notes.py v1.4.3` extracts the 1.4.3 section; `scripts/test_extract_release_notes.py` OK
- [x] `bash scripts/check-public-docs.sh` and `bash scripts/check-public-surface.sh`: clean
- [x] `:app:testNonRoot_gameDebugUnitTest --tests "*NovaReleaseMetadataTest"`: green
- [ ] `bin/release.sh` on master after merge runs both check scripts and the three ABI release assembly, then tags `v1.4.3`; the tag build signs and publishes the six assets.

Matched with papi-ux/polaris#612 (Polaris 1.4.3).
