### PR TITLE
feat(hud): decode time in Debug, a Slim layout, and a Command Center that stays out of the way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- NovaHUD gains a Slim layout: one pill with the health bar, the frame rate, and the round trip. Guide + Y now cycles Minimal, Performance, Debug, Slim.
+- NovaHUD Debug shows decode time (DEC), graded against the frame budget at the target rate, plus host processing latency (HOST) and incoming against rendered frame rate (IN / OUT). That is the rest of what the legacy stats text knew, inside the HUD.
+- Command Center picks the HUD layout with four buttons instead of cycling blind, keeps Close, Disconnect, and End Session fixed above the scrolling sections, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag.
+- Stats Overlay toggled from Command Center works on a stream that started with it off, and the toggle is remembered in Settings. Turning it on turns Nova HUD off for the next stream too, and the reverse.
+- NovaHUD reads the decoder's structured sample only. The decoder no longer builds the legacy overlay text while just the HUD is showing, and the HUD updates once per sample instead of twice.
+- The HUD Position setting is gone. It never did anything; drag the HUD to place it.
+
 ## 1.4.3 - 2026-09-05
 
 Matched client for Polaris 1.4.3: a launch crash fix, honest artwork search errors, complete resolution lists, and a tidier Command Center and NovaHUD.

--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -329,8 +329,6 @@ private var notificationOverlayView:TextView? = null
 private var requestedNotificationOverlayVisibility:Int = View.GONE
 private var performanceOverlayView:View? = null
 
-private var performanceOverlayLite:TextView? = null
-
 private var performanceOverlayBig:TextView? = null
 
 private var decoderRenderer:MediaCodecDecoderRenderer? = null
@@ -1006,8 +1004,6 @@ notificationOverlayView = findViewById(R.id.notificationOverlay)
 
 performanceOverlayView = findViewById(R.id.performanceOverlay)
 
-performanceOverlayLite = findViewById(R.id.performanceOverlayLite)
-
 performanceOverlayBig = findViewById(R.id.performanceOverlayBig)
 
 inputCaptureProvider = InputCaptureManager.getInputCaptureProvider(this, this)
@@ -1157,25 +1153,7 @@ NovaSnackbar.show(this, getString(R.string.nova_hdr_requires_android_n), Snackba
         if (prefConfig!!.enablePerfOverlay)
 {
 performanceOverlayView!!.setVisibility(View.VISIBLE)
-if (prefConfig!!.enablePerfOverlayLite)
-{
-performanceOverlayLite!!.setVisibility(View.VISIBLE)
-if (prefConfig!!.enablePerfOverlayLiteDialog)
-{
-performanceOverlayLite!!.setOnClickListener({ v-> showGameMenu(null) })
-}
-}
-else
-{
 performanceOverlayBig!!.setVisibility(View.VISIBLE)
-}
-if (prefConfig!!.enablePerfOverlayBottom)
-{
- //performanceOverlayView.getLayoutParams().layout_gravity = Gravity.BOTTOM;
-                var params:FrameLayout.LayoutParams? = performanceOverlayView!!.getLayoutParams() as FrameLayout.LayoutParams
-params!!.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
-performanceOverlayView!!.setLayoutParams(params)
-}
 }
 
 decoderRenderer = MediaCodecDecoderRenderer(
@@ -5985,23 +5963,11 @@ doctorTelemetryUploadGate.release(uploadToken)
 override fun onPerfUpdate(text:String) {
 runOnUiThread(object : Runnable {
 override fun run() {
- // Legacy perf overlay (only if enabled)
+ // Legacy perf overlay only. Nova HUD reads the structured sample in onPerfSample,
+                // so the decoder is asked for this text only while this overlay is on.
                 if (prefConfig!!.enablePerfOverlay)
 {
-if (prefConfig!!.enablePerfOverlayLite)
-{
-performanceOverlayLite!!.setText(text)
-}
-else
-{
 performanceOverlayBig!!.setText(text)
-}
-}
-
- // Feed Nova HUD (works independently of legacy overlay)
-                if (novaHud != null && novaHud!!.isShowing)
-{
-novaHud!!.updateFromPerfText(text)
 }
 }
 })
@@ -6792,12 +6758,12 @@ showNovaHud()
 }
 }
 
-fun cycleNovaHudMode() {
+fun setNovaHudMode(mode:com.papi.nova.ui.NovaHudMode) {
 if (!isNovaHudShowing())
 {
 return
 }
-novaHud?.cycleMode()
+novaHud?.setMode(mode)
 }
 
 private fun setNovaHudPreference(enabled:Boolean) {
@@ -6813,10 +6779,10 @@ novaHud = null
 syncPerfTextWanted()
 }
 
+ // Only the legacy text overlay needs the decoder to build its string on the decode
+ // thread. Nova HUD reads the structured PerfOverlaySample, which is emitted regardless.
 private fun syncPerfTextWanted() {
-decoderRenderer?.setPerfTextWanted(
-(::prefConfig.isInitialized && prefConfig!!.enablePerfOverlay) || novaHud?.isShowing == true
-)
+decoderRenderer?.setPerfTextWanted(::prefConfig.isInitialized && prefConfig!!.enablePerfOverlay)
 }
 
 fun copyNovaHudDiagnostics() {
@@ -6876,24 +6842,22 @@ hud.cycleMode()
 }
 }
 
+ /**
+  * Toggle the legacy Moonlight stats text. The choice is persisted and the decoder's text
+  * builder is re-armed in the same step. This used to flip an in-memory flag and a View,
+  * so a stream that started with the setting off showed an empty overlay when toggled from
+  * Command Center, and Settings never learned about the toggle at all.
+  */
  fun toggleHUD() {
-prefConfig!!.enablePerfOverlay = !prefConfig!!.enablePerfOverlay
-if (prefConfig!!.enablePerfOverlay)
-{
-performanceOverlayView!!.setVisibility(View.VISIBLE)
-if (prefConfig!!.enablePerfOverlayLite)
-{
-performanceOverlayLite!!.setVisibility(View.VISIBLE)
-}
-else
-{
-performanceOverlayBig!!.setVisibility(View.VISIBLE)
-}
-}
-else
-{
-performanceOverlayView!!.setVisibility(View.GONE)
-}
+val enabled:Boolean = !prefConfig!!.enablePerfOverlay
+prefConfig!!.enablePerfOverlay = enabled
+PreferenceManager.getDefaultSharedPreferences(this)
+.edit()
+.putBoolean(PreferenceConfiguration.ENABLE_PERF_OVERLAY_STRING, enabled)
+.apply()
+performanceOverlayView!!.setVisibility(if (enabled) View.VISIBLE else View.GONE)
+performanceOverlayBig!!.setVisibility(if (enabled) View.VISIBLE else View.GONE)
+syncPerfTextWanted()
 }
 
  //切换触控灵敏度开关

--- a/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
+++ b/app/src/main/java/com/papi/nova/binding/video/MediaCodecDecoderRenderer.kt
@@ -728,76 +728,47 @@ class MediaCodecDecoderRenderer(
         decodeTimeMs: Float,
         rttInfo: Long,
     ): String {
+        // One shape only. The one-line "lite" variant was gated on preferences no settings
+        // surface has offered in years; it was unreachable code with its own strings.
         val sb = StringBuilder()
-        if (prefs.enablePerfOverlayLite) {
-            if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
-                val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
-                    TrafficStatsHelper.getPackageTxBytes(Process.myUid())
-                if (lastNetDataNum != 0L) {
-                    sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
-                    val realtimeNetData = (netData - lastNetDataNum) / 1024f
-                    if (realtimeNetData >= 1000) {
-                        sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\t ")
-                    } else {
-                        sb.append(String.format("%.2f", realtimeNetData) + "K/s\t ")
-                    }
+        sb.append(context.getString(R.string.perf_overlay_streamdetails, "${initialWidth}x$initialHeight", fps.totalFps))
+        sb.append('\n')
+        sb.append(context.getString(R.string.perf_overlay_decoder, decoder)).append('\n')
+        sb.append(context.getString(R.string.perf_overlay_incomingfps, fps.receivedFps)).append('\n')
+        sb.append(context.getString(R.string.perf_overlay_renderingfps, fps.renderedFps)).append('\n')
+        sb.append(
+            context.getString(
+                R.string.perf_overlay_netdrops,
+                lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
+            ),
+        ).append('\n')
+        if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
+            val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
+                TrafficStatsHelper.getPackageTxBytes(Process.myUid())
+            if (lastNetDataNum != 0L) {
+                sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
+                val realtimeNetData = (netData - lastNetDataNum) / 1024f
+                if (realtimeNetData >= 1000) {
+                    sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\n")
+                } else {
+                    sb.append(String.format("%.2f", realtimeNetData) + "K/s\n")
                 }
-                lastNetDataNum = netData
             }
-            sb.append(context.getString(R.string.perf_overlay_lite_network_decoding_delay) + ": ")
-            sb.append(context.getString(R.string.perf_overlay_lite_net, (rttInfo shr 32).toInt()))
-            sb.append(" / ")
-            sb.append(context.getString(R.string.perf_overlay_lite_dectime, decodeTimeMs))
-            sb.append("\t")
-            sb.append(context.getString(R.string.perf_overlay_lite_packet_loss) + ": ")
+            lastNetDataNum = netData
+        }
+        sb.append(context.getString(R.string.perf_overlay_netlatency, (rttInfo shr 32).toInt(), rttInfo.toInt()))
+            .append('\n')
+        if (lastTwo.framesWithHostProcessingLatency > 0) {
             sb.append(
                 context.getString(
-                    R.string.perf_overlay_lite_netdrops,
-                    lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
-                ),
-            )
-            sb.append("\t FPS：")
-            sb.append(context.getString(R.string.perf_overlay_lite_fps, fps.totalFps))
-        } else {
-            sb.append(context.getString(R.string.perf_overlay_streamdetails, "${initialWidth}x$initialHeight", fps.totalFps))
-            sb.append('\n')
-            sb.append(context.getString(R.string.perf_overlay_decoder, decoder)).append('\n')
-            sb.append(context.getString(R.string.perf_overlay_incomingfps, fps.receivedFps)).append('\n')
-            sb.append(context.getString(R.string.perf_overlay_renderingfps, fps.renderedFps)).append('\n')
-            sb.append(
-                context.getString(
-                    R.string.perf_overlay_netdrops,
-                    lastTwo.framesLost.toFloat() / lastTwo.totalFrames * 100,
+                    R.string.perf_overlay_hostprocessinglatency,
+                    lastTwo.minHostProcessingLatency.code.toFloat() / 10,
+                    lastTwo.maxHostProcessingLatency.code.toFloat() / 10,
+                    lastTwo.totalHostProcessingLatency.toFloat() / 10 / lastTwo.framesWithHostProcessingLatency,
                 ),
             ).append('\n')
-            if (TrafficStatsHelper.getPackageRxBytes(Process.myUid()) != TrafficStats.UNSUPPORTED.toLong()) {
-                val netData = TrafficStatsHelper.getPackageRxBytes(Process.myUid()) +
-                    TrafficStatsHelper.getPackageTxBytes(Process.myUid())
-                if (lastNetDataNum != 0L) {
-                    sb.append(context.getString(R.string.perf_overlay_lite_bandwidth) + ": ")
-                    val realtimeNetData = (netData - lastNetDataNum) / 1024f
-                    if (realtimeNetData >= 1000) {
-                        sb.append(String.format("%.2f", realtimeNetData / 1024f) + "M/s\n")
-                    } else {
-                        sb.append(String.format("%.2f", realtimeNetData) + "K/s\n")
-                    }
-                }
-                lastNetDataNum = netData
-            }
-            sb.append(context.getString(R.string.perf_overlay_netlatency, (rttInfo shr 32).toInt(), rttInfo.toInt()))
-                .append('\n')
-            if (lastTwo.framesWithHostProcessingLatency > 0) {
-                sb.append(
-                    context.getString(
-                        R.string.perf_overlay_hostprocessinglatency,
-                        lastTwo.minHostProcessingLatency.code.toFloat() / 10,
-                        lastTwo.maxHostProcessingLatency.code.toFloat() / 10,
-                        lastTwo.totalHostProcessingLatency.toFloat() / 10 / lastTwo.framesWithHostProcessingLatency,
-                    ),
-                ).append('\n')
-            }
-            sb.append(context.getString(R.string.perf_overlay_dectime, decodeTimeMs))
         }
+        sb.append(context.getString(R.string.perf_overlay_dectime, decodeTimeMs))
         return sb.toString()
     }
 

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsUiState.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsUiState.kt
@@ -36,6 +36,7 @@ object NovaSettingsUiStateFactory {
         "video_format" to listOf("codec", "h264", "h265", "hevc", "av1"),
         "frame_pacing" to listOf("latency", "smoothness", "frame pacing"),
         "nova_polaris_hud" to listOf("hud", "overlay", "stats"),
+        "checkbox_enable_perf_overlay" to listOf("stats", "fps", "overlay", "perf", "moonlight", "decode"),
         "checkbox_enable_rumble" to listOf("rumble", "vibration", "haptics"),
         "nova_app_version" to listOf("build", "about", "version code", "version name")
     )

--- a/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
+++ b/app/src/main/java/com/papi/nova/preferences/NovaSettingsViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.launch
 internal val NOVA_STREAM_UI_DEFAULT_UPDATES = listOf(
     "nova_polaris_hud" to NovaSettingValue.BooleanValue(false),
     "nova_polaris_hud_mode" to NovaSettingValue.StringValue("minimal"),
-    "nova_polaris_hud_position" to NovaSettingValue.StringValue("top_left"),
     NovaHudPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaHudPreferences.DEFAULT_OPACITY_PERCENT),
     NovaMenuPreferences.KEY_OPACITY to NovaSettingValue.IntValue(NovaMenuPreferences.DEFAULT_OPACITY_PERCENT),
     "checkbox_enable_perf_overlay" to NovaSettingValue.BooleanValue(false),

--- a/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
+++ b/app/src/main/java/com/papi/nova/preferences/PreferenceConfiguration.kt
@@ -85,9 +85,6 @@ class PreferenceConfiguration {
     @JvmField var enablePip = false
     @JvmField var enablePerfOverlay = false
     @JvmField var enablePerfLogging = false
-    @JvmField var enablePerfOverlayLite = false
-    @JvmField var enablePerfOverlayLiteDialog = false
-    @JvmField var enablePerfOverlayBottom = false
     @JvmField var enableLatencyToast = false
     @JvmField var enableBackMenu = false
     @JvmField var enableFloatingButton = false
@@ -203,7 +200,8 @@ class PreferenceConfiguration {
         private const val LEGACY_DISABLE_FRAME_DROP_PREF_STRING = "checkbox_disable_frame_drop"
         private const val ENABLE_HDR_PREF_STRING = "checkbox_enable_hdr"
         private const val ENABLE_PIP_PREF_STRING = "checkbox_enable_pip"
-        private const val ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay"
+        // Public: Game persists the in-stream Stats Overlay toggle under this key.
+        const val ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay"
         private const val ENABLE_PERF_LOGGING = "checkbox_enable_perf_logging"
         private const val BIND_ALL_USB_STRING = "checkbox_usb_bind_all"
         private const val MOUSE_EMULATION_STRING = "checkbox_mouse_emulation"
@@ -290,7 +288,6 @@ class PreferenceConfiguration {
         private const val DEFAULT_ENABLE_HDR = false
         private const val DEFAULT_ENABLE_PIP = false
         private const val DEFAULT_ENABLE_PERF_OVERLAY = false
-        private const val DEFAULT_PERF_OVERLAY_BOTTOM = false
         private const val DEFAULT_ENABLE_PERF_LOGGING = false
         private const val DEFAULT_BIND_ALL_USB = false
         private const val DEFAULT_MOUSE_EMULATION = true
@@ -897,10 +894,6 @@ class PreferenceConfiguration {
             config.enablePip = prefs.getBoolean(ENABLE_PIP_PREF_STRING, DEFAULT_ENABLE_PIP)
             config.enablePerfOverlay = prefs.getBoolean(ENABLE_PERF_OVERLAY_STRING, DEFAULT_ENABLE_PERF_OVERLAY)
             config.enablePerfLogging = prefs.getBoolean(ENABLE_PERF_LOGGING, DEFAULT_ENABLE_PERF_LOGGING)
-            config.enablePerfOverlayLite =
-                prefs.getBoolean("checkbox_enable_perf_overlay_lite", DEFAULT_ENABLE_PERF_OVERLAY)
-            config.enablePerfOverlayBottom =
-                prefs.getBoolean("checkbox_enable_perf_overlay_bottom", DEFAULT_PERF_OVERLAY_BOTTOM)
             config.bindAllUsb = prefs.getBoolean(BIND_ALL_USB_STRING, DEFAULT_BIND_ALL_USB)
             config.mouseEmulation = prefs.getBoolean(MOUSE_EMULATION_STRING, DEFAULT_MOUSE_EMULATION)
             config.mouseNavButtons = prefs.getBoolean(MOUSE_NAV_BUTTONS_STRING, DEFAULT_MOUSE_NAV_BUTTONS)
@@ -966,8 +959,6 @@ class PreferenceConfiguration {
             config.enableTouchSensitivity = prefs.getBoolean("checkbox_enable_touch_sensitivity", false)
             config.enableMouseLocalCursor = prefs.getBoolean("checkbox_mouse_local_cursor", false)
             config.enableMultiTouchGestures = prefs.getBoolean("checkbox_multi_touch_gestures", false)
-            config.enablePerfOverlayLiteDialog =
-                prefs.getBoolean("checkbox_enable_perf_overlay_lite_dialog", false)
             config.disableDefaultExtraKeys =
                 prefs.getBoolean("checkbox_enable_clear_default_special_button", false)
             config.enableDeviceRumble = prefs.getBoolean("checkbox_enable_device_rumble", false)

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -4,7 +4,15 @@ import com.papi.nova.api.PolarisSessionStatus
 import com.papi.nova.binding.video.PerfOverlaySample
 import kotlin.math.roundToInt
 
+/**
+ * HUD layouts, declared smallest to largest so a picker can list `entries` as they are.
+ *
+ * [next] is the ring Guide + Y walks. It starts from the default and puts the one-line
+ * Slim pill last, so the three layouts people already know keep their order and Slim is
+ * one press past Debug.
+ */
 enum class NovaHudMode(val preferenceValue: String) {
+    SLIM("slim"),
     MINIMAL("minimal"),
     PERFORMANCE("performance"),
     DEBUG("debug");
@@ -12,13 +20,15 @@ enum class NovaHudMode(val preferenceValue: String) {
     fun next(): NovaHudMode = when (this) {
         MINIMAL -> PERFORMANCE
         PERFORMANCE -> DEBUG
-        DEBUG -> MINIMAL
+        DEBUG -> SLIM
+        SLIM -> MINIMAL
     }
 
     companion object {
         fun fromPreference(value: String?): NovaHudMode {
             val normalized = value?.trim()?.lowercase().orEmpty()
             return when (normalized) {
+                "slim", "pill" -> SLIM
                 "minimal", "fps_only", "nano", "compact" -> MINIMAL
                 "performance", "banner", "strip" -> PERFORMANCE
                 "debug", "full", "command" -> DEBUG
@@ -40,69 +50,6 @@ data class NovaHudLayerHealth(
     val label: String,
     val tone: NovaHudTone
 )
-
-data class NovaHudPerfSample(
-    val fps: Double? = null,
-    val width: Int? = null,
-    val height: Int? = null,
-    val latencyMs: Int? = null,
-    val codec: String? = null,
-    val packetLossPct: Double? = null
-) {
-    companion object {
-        // Compiled once. These used to be built inside fromPerfText, which runs on the
-        // main thread once per perf sample for as long as a game is streaming -- seven
-        // Regex compilations per interval, for patterns that never change.
-        private const val LOCALIZED_NUMBER = """\d+(?:[.,]\d+)?"""
-
-        private val FPS_SUFFIXED = Regex(
-            """(?<![\d.,])($LOCALIZED_NUMBER)\s*(?:fps|FPS)\b""", RegexOption.IGNORE_CASE
-        )
-        private val FPS_LABELLED = Regex(
-            """FPS[:：\s]+($LOCALIZED_NUMBER)""", RegexOption.IGNORE_CASE
-        )
-        private val FPS_TRAILING_ON_FIRST_LINE = Regex(
-            """($LOCALIZED_NUMBER)\s*$""", RegexOption.MULTILINE
-        )
-        private val RESOLUTION = Regex("""(\d{3,4})\s*[x×]\s*(\d{3,4})""")
-        private val LATENCY = Regex(
-            """(?:RTT|latency)[^0-9]*(\d+)\s*ms""", RegexOption.IGNORE_CASE
-        )
-        private val CODEC = Regex("""(?:decoder|codec)[:\s]+(\S+)""", RegexOption.IGNORE_CASE)
-        private val PACKET_LOSS_LABELLED = Regex(
-            """(?:packet loss|frames dropped by your network connection|netdrops)[^0-9]*($LOCALIZED_NUMBER)\s*%""",
-            RegexOption.IGNORE_CASE
-        )
-        private val PACKET_LOSS_SUFFIXED = Regex(
-            """($LOCALIZED_NUMBER)\s*%\s*(?:packet loss|netdrops)""", RegexOption.IGNORE_CASE
-        )
-
-        fun fromPerfText(text: String): NovaHudPerfSample {
-            // Fallback order is behaviour, not formatting: a bare "N fps" wins over a
-            // "FPS: N" label, which wins over a trailing number on the first line.
-            val fpsMatch = FPS_SUFFIXED.find(text)
-                ?: FPS_LABELLED.find(text)
-                ?: FPS_TRAILING_ON_FIRST_LINE.find(text.lines().firstOrNull() ?: "")
-            val resolutionMatch = RESOLUTION.find(text)
-            val latencyMatch = LATENCY.find(text)
-            val codecMatch = CODEC.find(text)
-            val packetLossMatch = PACKET_LOSS_LABELLED.find(text)
-                ?: PACKET_LOSS_SUFFIXED.find(text)
-
-            return NovaHudPerfSample(
-                fps = fpsMatch?.localizedDouble(),
-                width = resolutionMatch?.groupValues?.getOrNull(1)?.toIntOrNull(),
-                height = resolutionMatch?.groupValues?.getOrNull(2)?.toIntOrNull(),
-                latencyMs = latencyMatch?.groupValues?.getOrNull(1)?.toIntOrNull(),
-                codec = codecMatch?.groupValues?.getOrNull(1)?.let(NovaHudUiState::normalizeCodecLabel),
-                packetLossPct = packetLossMatch?.localizedDouble()
-            )
-        }
-
-        private fun MatchResult.localizedDouble(): Double? =
-            groupValues.getOrNull(1)?.replace(',', '.')?.toDoubleOrNull()
-    }
-}
 
 data class NovaHudUiState(
     val mode: NovaHudMode,
@@ -126,9 +73,19 @@ data class NovaHudUiState(
     val streamTruthLabel: String,
     val layerHealth: List<NovaHudLayerHealth>,
     val eventBreadcrumbLabel: String,
-    val sparklineSamples: List<Float>
+    val sparklineSamples: List<Float>,
+    // Debug-only latency budget and frame-flow tiles. Decode time is the one people ask
+    // for; host latency and incoming vs rendered fps are the rest of what the legacy
+    // Moonlight text shows and NovaHUD did not.
+    val decodeTimeLabel: String = "--",
+    val decodeTone: NovaHudTone = NovaHudTone.MUTED,
+    val hostLatencyLabel: String = "--",
+    val incomingFpsLabel: String = "--",
+    val renderedFpsLabel: String = "--"
 ) {
     companion object {
+        private const val SPARKLINE_CAPACITY = 60
+
         fun empty(mode: NovaHudMode = NovaHudMode.MINIMAL): NovaHudUiState = from(
             mode = mode,
             fps = 0.0,
@@ -179,7 +136,11 @@ data class NovaHudUiState(
                 health = PolarisSessionStatus.HealthStatus(grade = "good"),
                 syncStatus = PolarisSessionStatus.SyncStatus(available = true, state = "synced")
             ),
-            sparklineSamples = listOf(55f, 58f, 61f, 57f, 60f, 59f)
+            sparklineSamples = listOf(55f, 58f, 61f, 57f, 60f, 59f),
+            decodeTimeMs = 6.4,
+            hostProcessingLatencyMs = 2.1,
+            incomingFps = 60.0,
+            renderedFps = 60.0
         )
 
         fun from(
@@ -194,13 +155,17 @@ data class NovaHudUiState(
             status: PolarisSessionStatus?,
             sparklineSamples: List<Float>,
             eventBreadcrumbLabel: String = "",
-            lowOnePercentFps: Double = calculateLowOnePercent(sparklineSamples)
+            lowOnePercentFps: Double = calculateLowOnePercent(sparklineSamples),
+            decodeTimeMs: Double = 0.0,
+            hostProcessingLatencyMs: Double? = null,
+            incomingFps: Double = 0.0,
+            renderedFps: Double = 0.0
         ): NovaHudUiState {
             val autoQuality = AutoQualityUiState.from(status, targetFps)
             val healthReason = buildHealthReason(status, latencyMs)
             return NovaHudUiState(
                 mode = mode,
-                fpsLabel = fps.takeIf { it > 0.0 }?.roundToInt()?.toString() ?: "--",
+                fpsLabel = formatFps(fps),
                 targetFpsLabel = formatTargetFps(mode, targetFps),
                 latencyLabel = latencyMs.takeIf { it > 0 }?.let { "${it}ms" } ?: "--ms",
                 bitrateLabel = formatBitrate(mode, bitrateKbps),
@@ -220,8 +185,45 @@ data class NovaHudUiState(
                 streamTruthLabel = buildStreamTruth(status, targetFps, codec, height),
                 layerHealth = buildLayerHealth(status, latencyMs),
                 eventBreadcrumbLabel = eventBreadcrumbLabel,
-                sparklineSamples = sparklineSamples.takeLast(60)
+                // The buffer already caps at the capacity; copying it again once a second
+                // bought nothing.
+                sparklineSamples = if (sparklineSamples.size <= SPARKLINE_CAPACITY) {
+                    sparklineSamples
+                } else {
+                    sparklineSamples.takeLast(SPARKLINE_CAPACITY)
+                },
+                decodeTimeLabel = formatMillis(decodeTimeMs),
+                decodeTone = toneForDecode(decodeTimeMs, targetFps),
+                hostLatencyLabel = formatMillis(hostProcessingLatencyMs ?: 0.0),
+                incomingFpsLabel = formatFps(incomingFps),
+                renderedFpsLabel = formatFps(renderedFps)
             )
+        }
+
+        private fun formatFps(fps: Double): String =
+            fps.takeIf { it > 0.0 }?.roundToInt()?.toString() ?: "--"
+
+        // Under 10 ms the decimal is the difference between decoders: 2.4ms and 8.9ms are
+        // not the same panel. Past that, the whole number is the story.
+        fun formatMillis(ms: Double): String = when {
+            ms <= 0.0 -> "--"
+            ms < 10.0 -> String.format(java.util.Locale.US, "%.1fms", ms)
+            else -> "${ms.roundToInt()}ms"
+        }
+
+        // Decode time is only good or bad against the frame it has to fit in: 13 ms is
+        // fine at 60 fps and a dropped frame at 120. With no target yet, 60 fps is the
+        // budget, which is what most panels show anyway.
+        fun toneForDecode(ms: Double, targetFps: Double): NovaHudTone {
+            if (ms <= 0.0) {
+                return NovaHudTone.MUTED
+            }
+            val frameMs = 1000.0 / (if (targetFps > 0.0) targetFps else 60.0)
+            return when {
+                ms < frameMs * 0.5 -> NovaHudTone.STABLE
+                ms < frameMs -> NovaHudTone.WARNING
+                else -> NovaHudTone.DANGER
+            }
         }
 
         fun normalizeCodecLabel(codec: String): String {
@@ -256,7 +258,8 @@ data class NovaHudUiState(
             return when (mode) {
                 NovaHudMode.DEBUG -> "TGT $rounded"
                 NovaHudMode.PERFORMANCE -> "/$rounded"
-                NovaHudMode.MINIMAL -> ""
+                NovaHudMode.MINIMAL,
+                NovaHudMode.SLIM -> ""
             }
         }
 
@@ -267,7 +270,8 @@ data class NovaHudUiState(
             val full = StreamPolicyUiState.formatMbps(bitrateKbps)
             return when (mode) {
                 NovaHudMode.DEBUG,
-                NovaHudMode.MINIMAL -> full
+                NovaHudMode.MINIMAL,
+                NovaHudMode.SLIM -> full
                 NovaHudMode.PERFORMANCE -> full.replace(" Mbps", "M").replace(" ", "")
             }
         }
@@ -279,7 +283,8 @@ data class NovaHudUiState(
             return when (mode) {
                 NovaHudMode.DEBUG -> "$width×$height"
                 NovaHudMode.PERFORMANCE,
-                NovaHudMode.MINIMAL -> "${height}p"
+                NovaHudMode.MINIMAL,
+                NovaHudMode.SLIM -> "${height}p"
             }
         }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -1,5 +1,6 @@
 package com.papi.nova.ui
 
+import androidx.compose.runtime.Immutable
 import com.papi.nova.api.PolarisSessionStatus
 import com.papi.nova.binding.video.PerfOverlaySample
 import kotlin.math.roundToInt
@@ -46,11 +47,17 @@ enum class NovaHudTone {
     MUTED
 }
 
+@Immutable
 data class NovaHudLayerHealth(
     val label: String,
     val tone: NovaHudTone
 )
 
+// Immutable in fact as well as in name: every field is a val and the two lists are fresh
+// snapshots that nothing writes to afterwards. Telling Compose so lets the pieces of the
+// HUD whose inputs did not change this tick skip recomposition instead of redrawing
+// because a list parameter could not be proven stable.
+@Immutable
 data class NovaHudUiState(
     val mode: NovaHudMode,
     val fpsLabel: String,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -10,6 +10,7 @@ import android.view.KeyEvent
 import android.view.Window
 import android.view.WindowManager
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
@@ -37,6 +38,7 @@ import java.util.UUID
  */
 class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
     private var dialog: Dialog? = null
+    private var dismissWithMotion: (() -> Unit)? = null
     private val doctorActionLock = Any()
     private var doctorReceipt: DoctorActionReceipt? = null
     private var doctorReceiptScopeId: String? = null
@@ -64,6 +66,16 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         composeView.isFocusable = true
         composeView.isFocusableInTouchMode = true
         overlay.setContentView(composeView)
+        // B, Back, and programmatic hides ask the drawer to slide out; it calls dismiss()
+        // when the motion lands. If composition is not running (paused activity, detached
+        // view) nothing would, so a fallback closes the dialog regardless.
+        val dismissMotionRequests = mutableIntStateOf(0)
+        fun requestDismissWithMotion() {
+            if (dialog !== overlay) return
+            dismissMotionRequests.intValue++
+            game.window.decorView.postDelayed({ if (dialog === overlay) dismiss() }, DISMISS_MOTION_FALLBACK_MS)
+        }
+        dismissWithMotion = { requestDismissWithMotion() }
         overlay.setOnKeyListener { _, keyCode, event ->
             when (keyCode) {
                 KeyEvent.KEYCODE_BUTTON_A -> {
@@ -88,7 +100,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     true
                 }
                 KeyEvent.KEYCODE_BUTTON_B -> {
-                    if (event.action == KeyEvent.ACTION_UP) dismiss()
+                    if (event.action == KeyEvent.ACTION_UP) requestDismissWithMotion()
                     true
                 }
                 else -> false
@@ -441,10 +453,14 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             }
         }
 
+        // Static per locale; built once per open instead of once per refresh.
+        val quickKeys = NovaQuickMenuUiState.quickKeyActions(game)
+
         fun buildState(): NovaQuickMenuUiState {
             val gameName = currentProfileGameName()
             return NovaQuickMenuUiState.from(
                 context = game,
+                quickKeys = quickKeys,
                 status = sessionStatus,
                 apiAvailable = apiClient != null,
                 hostStateUnavailable = hostStateUnavailable,
@@ -846,30 +862,6 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     refreshState()
                 }
             },
-            onAiAutoQuality = {
-                haptic {
-                    val status = sessionStatus
-                    if (status == null || apiClient == null || !aiSupported || !status.canAdjustHostTuning) {
-                        return@haptic
-                    }
-                    val next = !aiEnabled
-                    aiEnabled = next
-                    refreshState()
-                    game.launchRuntimeIo("NovaQuickMenuAiAutoQuality") {
-                        val success = apiClient.setAiAutoQualityEnabled(next)
-                        if (success) {
-                            acceptRefreshedSessionStatus(apiClient.getSessionStatus())
-                        }
-                        game.runOnMainIfRuntimeActive {
-                            if (!success) {
-                                aiEnabled = !next
-                                NovaSnackbar.showError(game, game.getString(R.string.nova_quick_menu_ai_toggle_failed), anchor = composeView)
-                            }
-                            refreshState()
-                        }
-                    }
-                }
-            },
             onClearGameProfile = {
                 haptic {
                     val gameName = currentProfileGameName()
@@ -952,12 +944,12 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                         NovaQuickMenuActionId.NOVA_HUD -> {
                             game.toggleNovaHud()
                         }
-                        NovaQuickMenuActionId.NOVA_HUD_MODE -> {
-                            game.cycleNovaHudMode()
-                        }
                         NovaQuickMenuActionId.PERF_STATS -> {
+                            // The two overlays share the top-left corner, so the legacy text
+                            // replaces Nova HUD, and the swap is remembered for the next
+                            // stream: toggleNovaHud persists, dismissNovaHud did not.
                             if (!game.prefConfig.enablePerfOverlay && game.isNovaHudShowing()) {
-                                game.dismissNovaHud()
+                                game.toggleNovaHud()
                             }
                             game.toggleHUD()
                         }
@@ -969,6 +961,12 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                         }
                         else -> Unit
                     }
+                    refreshState()
+                }
+            },
+            onHudModeSelect = { mode ->
+                haptic {
+                    game.setNovaHudMode(mode)
                     refreshState()
                 }
             },
@@ -1052,7 +1050,8 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             NovaComposeTheme(menuOpacityPercent = uiState.menuOpacity.percent) {
                 NovaQuickMenuDrawer(
                     state = uiState,
-                    callbacks = callbacks
+                    callbacks = callbacks,
+                    dismissRequests = dismissMotionRequests.intValue
                 )
             }
         }
@@ -1069,7 +1068,9 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         if (apiClient != null) {
             game.launchReplacingRuntimeIo("NovaQuickMenuStateRefresh") {
                 try {
-                    val refreshedCapabilities = apiClient.getCapabilities()
+                    // Capabilities do not change inside a stream; one fetch per session,
+                    // not one per open.
+                    val refreshedCapabilities = capabilities ?: apiClient.getCapabilities()
                     val refreshedSessionStatus = apiClient.getSessionStatus()
                     val accepted = doctorMenuRefreshRegistry.runIfCurrent(menuValidationGeneration) {
                         synchronized(doctorActionLock) {
@@ -1116,7 +1117,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
     }
 
     override fun hideMenu() {
-        dismiss()
+        dismissWithMotion?.invoke() ?: dismiss()
     }
 
     override fun isMenuOpen(): Boolean {
@@ -1131,6 +1132,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         activeDialog.window?.addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
         activeDialog.dismiss()
         dialog = null
+        dismissWithMotion = null
     }
 
     private fun sendKeysWithFocus(keys: ShortArray) {
@@ -1178,5 +1180,8 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
 
     companion object {
         private const val KEY_UP_DELAY = 25L
+        // Longer than the drawer's spring needs to settle; only reached if composition
+        // never ran the exit motion.
+        private const val DISMISS_MOTION_FALLBACK_MS = 450L
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -81,12 +81,12 @@ data class NovaQuickMenuCallbacks(
     val onStability: () -> Unit = {},
     val onSyncStatus: () -> Unit = {},
     val onToggleAdvanced: () -> Unit = {},
-    val onAiAutoQuality: () -> Unit = {},
     val onClearGameProfile: () -> Unit = {},
     val onMangoHud: () -> Unit = {},
     val onProfilePreference: (String) -> Unit = {},
     val onQuickKey: (NovaQuickMenuActionId) -> Unit = {},
     val onOverlayAction: (NovaQuickMenuActionId) -> Unit = {},
+    val onHudModeSelect: (NovaHudMode) -> Unit = {},
     val onDoctorUndo: () -> Unit = {},
     val onHudOpacityChange: (Int) -> Unit = {},
     val onMenuOpacityChange: (Int) -> Unit = {},
@@ -100,7 +100,6 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.STABILITY -> onStability()
             NovaQuickMenuActionId.SYNC_STATUS -> onSyncStatus()
             NovaQuickMenuActionId.ADVANCED_TUNING -> onToggleAdvanced()
-            NovaQuickMenuActionId.AI_AUTO_QUALITY -> onAiAutoQuality()
             NovaQuickMenuActionId.CLEAR_GAME_PROFILE -> onClearGameProfile()
             NovaQuickMenuActionId.MANGOHUD -> onMangoHud()
             NovaQuickMenuActionId.QUICK_ESC,
@@ -113,7 +112,6 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.QUICK_CTRL_1,
             NovaQuickMenuActionId.QUICK_CTRL_2 -> onQuickKey(action.id)
             NovaQuickMenuActionId.NOVA_HUD,
-            NovaQuickMenuActionId.NOVA_HUD_MODE,
             NovaQuickMenuActionId.PERF_STATS,
             NovaQuickMenuActionId.DIAGNOSE_STREAM,
             NovaQuickMenuActionId.COPY_HUD_DIAGNOSTICS -> onOverlayAction(action.id)
@@ -134,7 +132,8 @@ private const val NovaQuickMenuDrawerDismissProgress = 0.58f
 fun NovaQuickMenuDrawer(
     state: NovaQuickMenuUiState,
     callbacks: NovaQuickMenuCallbacks,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    dismissRequests: Int = 0
 ) {
     NovaMenuBackdropBlur()
     val configuration = LocalConfiguration.current
@@ -188,6 +187,16 @@ fun NovaQuickMenuDrawer(
         } else {
             scope.launch { animateDrawerTo(1f) }
         }
+    }
+
+    // Close, B, and Back used to drop the dialog on the spot while scrim-tap and drag slid
+    // it out. Every exit takes the motion now: the header's Close goes through this copy,
+    // and the host bumps dismissRequests for the controller and Back paths.
+    val contentCallbacks = remember(callbacks) {
+        callbacks.copy(onDismiss = { dismissDrawerWithMotion() })
+    }
+    LaunchedEffect(dismissRequests) {
+        if (dismissRequests > 0) dismissDrawerWithMotion()
     }
 
     // Keyed on Unit: the entrance plays once, when the drawer opens. It used to be
@@ -254,7 +263,7 @@ fun NovaQuickMenuDrawer(
         ) {
             NovaQuickMenuContent(
                 state = state,
-                callbacks = callbacks,
+                callbacks = contentCallbacks,
                 modifier = Modifier.fillMaxSize()
             )
         }
@@ -295,86 +304,104 @@ fun NovaQuickMenuContent(
                 color = surfaces.panelBorder.copy(alpha = NovaInGameOverlayAlpha.Border * LocalNovaMenuOpacityScale.current),
                 shape = drawerShape
             )
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 18.dp)
     ) {
-        Box(
+        // The header stays put. Close, Disconnect, and End Session are under the thumb
+        // however far the sections have been scrolled; they used to scroll away with the
+        // first panel on a Retroid.
+        Column(
             modifier = Modifier
-                .width(44.dp)
-                .height(3.dp)
-                .clip(RoundedCornerShape(NovaRadius.pill))
-                .background(colors.accent.copy(alpha = NovaInGameOverlayAlpha.AccentHandle))
-                .align(Alignment.Start)
-        )
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuHeader(state, callbacks)
-        Spacer(Modifier.height(8.dp))
-        NovaQuickMenuSessionStrip(state, initialFocusRequester)
-        // Daily use first: the strip above already carries the health verdict, so keys,
-        // input, and overlays come before the Doctor and stream cards that explain it.
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = quickKeysTitle) {
-            NovaQuickKeys(state.quickKeys, callbacks)
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = controlsTitle) {
-            state.controlRows.forEach { row ->
-                NovaQuickMenuRow(action = row, callbacks = callbacks)
-            }
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = sessionTitle) {
-            state.sessionRows.filter { it.visible }.forEach { row ->
-                NovaQuickMenuRow(action = row, callbacks = callbacks)
-            }
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuPanel(title = overlaysTitle) {
-            state.overlayRows.forEach { row ->
-                NovaQuickMenuRow(action = row, callbacks = callbacks)
-            }
-            NovaQuickMenuMenuOpacityControl(
-                state = state,
-                callbacks = callbacks
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 18.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(44.dp)
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(NovaRadius.pill))
+                    .background(colors.accent.copy(alpha = NovaInGameOverlayAlpha.AccentHandle))
+                    .align(Alignment.Start)
             )
-            NovaQuickMenuHudOpacityControl(
-                state = state,
-                callbacks = callbacks
-            )
-        }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
-        if (state.doctorReceiptAction.visible) {
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuInfoCard(
-                action = state.doctorReceiptAction,
-                callbacks = callbacks
-            )
+            NovaQuickMenuHeader(state, callbacks)
         }
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuStabilityCard(state.stability, callbacks)
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuInfoCard(
-            action = state.sync,
-            callbacks = callbacks
-        )
-        Spacer(Modifier.height(10.dp))
-        NovaQuickMenuInfoCard(
-            action = state.advancedToggle,
-            callbacks = callbacks
-        )
-        if (state.advancedExpanded) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 18.dp)
+        ) {
+            NovaQuickMenuSessionStrip(state, initialFocusRequester)
+            // Daily use first: the strip above already carries the health verdict, so keys,
+            // input, and overlays come before the Doctor and stream cards that explain it.
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuPanel(title = null) {
-                state.advancedRows.forEach { row ->
+            NovaQuickMenuPanel(title = quickKeysTitle) {
+                NovaQuickKeys(state.quickKeys, callbacks)
+            }
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuPanel(title = controlsTitle) {
+                state.controlRows.forEach { row ->
                     NovaQuickMenuRow(action = row, callbacks = callbacks)
                 }
             }
-            // Observational history from the host; it explains Auto's fallbacks but never
-            // changes a launch, so it lives with the other diagnostics.
-            if (state.postSessionReport.visible) {
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuPanel(title = sessionTitle) {
+                state.sessionRows.filter { it.visible }.forEach { row ->
+                    NovaQuickMenuRow(action = row, callbacks = callbacks)
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuPanel(title = overlaysTitle) {
+                state.overlayRows.forEach { row ->
+                    NovaQuickMenuRow(action = row, callbacks = callbacks)
+                    // The layout picker sits under the switch it configures.
+                    if (row.id == NovaQuickMenuActionId.NOVA_HUD) {
+                        NovaQuickMenuHudModePicker(state.hudMode, callbacks)
+                    }
+                }
+                NovaQuickMenuMenuOpacityControl(
+                    state = state,
+                    callbacks = callbacks
+                )
+                NovaQuickMenuHudOpacityControl(
+                    state = state,
+                    callbacks = callbacks
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
+            if (state.doctorReceiptAction.visible) {
                 Spacer(Modifier.height(10.dp))
-                NovaQuickMenuPostSessionReportCard(state.postSessionReport)
+                NovaQuickMenuInfoCard(
+                    action = state.doctorReceiptAction,
+                    callbacks = callbacks
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuStabilityCard(state.stability, callbacks)
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuInfoCard(
+                action = state.sync,
+                callbacks = callbacks
+            )
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuInfoCard(
+                action = state.advancedToggle,
+                callbacks = callbacks
+            )
+            if (state.advancedExpanded) {
+                Spacer(Modifier.height(10.dp))
+                NovaQuickMenuPanel(title = null) {
+                    state.advancedRows.forEach { row ->
+                        NovaQuickMenuRow(action = row, callbacks = callbacks)
+                    }
+                }
+                // Observational history from the host; it explains Auto's fallbacks but never
+                // changes a launch, so it lives with the other diagnostics.
+                if (state.postSessionReport.visible) {
+                    Spacer(Modifier.height(10.dp))
+                    NovaQuickMenuPostSessionReportCard(state.postSessionReport)
+                }
             }
         }
     }
@@ -493,16 +520,19 @@ private fun NovaQuickMenuDiagnosisCard(
         NovaQuickMenuDoctorCapability.RECHECK -> stringResource(R.string.nova_quick_menu_doctor_capability_recheck)
         NovaQuickMenuDoctorCapability.MANUAL -> stringResource(R.string.nova_quick_menu_doctor_capability_manual)
     }
-    val classification = diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") }
-    val detail = buildList {
-        classification?.let(::add)
-        diagnosis.tryFirst.takeIf { it.isNotBlank() }?.let { add("Try first: $it") }
-        // Confidence only means something next to the evidence it grades.
-        diagnosis.evidenceHighlight.takeIf { it.isNotBlank() }?.let { evidence ->
-            add("Evidence: $evidence")
-            diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
-        }
-    }.joinToString(" · ")
+    // Built once per diagnosis, not once per recomposition of the drawer.
+    val detail = remember(diagnosis) {
+        val classification = diagnosis.classification.takeIf { it in setOf("HOST", "NET", "CLIENT") }
+        buildList {
+            classification?.let(::add)
+            diagnosis.tryFirst.takeIf { it.isNotBlank() }?.let { add("Try first: $it") }
+            // Confidence only means something next to the evidence it grades.
+            diagnosis.evidenceHighlight.takeIf { it.isNotBlank() }?.let { evidence ->
+                add("Evidence: $evidence")
+                diagnosis.confidence.takeIf { it.isNotBlank() }?.let { add("Confidence: $it") }
+            }
+        }.joinToString(" · ")
+    }
     val diagnoseTitle = stringResource(R.string.nova_quick_menu_diagnose_stream)
     val aiSupportingLine = diagnosis.aiExplanation.takeIf { it.isNotBlank() }?.let {
         stringResource(R.string.nova_quick_menu_doctor_ai_explanation, it)
@@ -511,10 +541,10 @@ private fun NovaQuickMenuDiagnosisCard(
         .takeIf { it.isNotBlank() }
         ?.let { "Source: $it" }
     val supportingLine = listOfNotNull(aiSupportingLine, sourceSupportingLine).joinToString("\n")
-    NovaQuickMenuInfoCard(
-        // The finding is the title and the action lives in the chip, so "Recheck" no longer
-        // shows up as title, chip, and button at once.
-        action = NovaQuickMenuAction(
+    // The finding is the title and the action lives in the chip, so "Recheck" no longer
+    // shows up as title, chip, and button at once.
+    val action = remember(diagnosis, detail, capabilityLabel, diagnoseTitle) {
+        NovaQuickMenuAction(
             id = NovaQuickMenuActionId.DIAGNOSE_STREAM,
             label = diagnosis.likelyCause.trim().trimEnd('.').ifBlank { diagnoseTitle },
             caption = detail,
@@ -524,7 +554,10 @@ private fun NovaQuickMenuDiagnosisCard(
                 tone = if (diagnosis.available) NovaQuickMenuTone.INFO else NovaQuickMenuTone.MUTED
             ),
             enabled = diagnosis.available
-        ),
+        )
+    }
+    NovaQuickMenuInfoCard(
+        action = action,
         supportingLine = supportingLine,
         // Doctor findings are whole sentences; give them a second line before ellipsis.
         labelMaxLines = 2,
@@ -673,15 +706,10 @@ private fun NovaQuickMenuStabilityCard(
     callbacks: NovaQuickMenuCallbacks
 ) {
     val colors = LocalNovaComposeColors.current
-    val action = NovaQuickMenuAction(
-        id = NovaQuickMenuActionId.STABILITY,
-        label = stability.title,
-        enabled = stability.enabled
-    )
 
     NovaQuickMenuClickableSurface(
         enabled = stability.enabled,
-        onClick = { callbacks.perform(action) },
+        onClick = { callbacks.perform(stability.action) },
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(14.dp),
         contentDescription = stability.title
@@ -959,66 +987,51 @@ private fun NovaQuickMenuMenuOpacityControl(
     state: NovaQuickMenuUiState,
     callbacks: NovaQuickMenuCallbacks
 ) {
-    val colors = LocalNovaComposeColors.current
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(R.string.nova_quick_menu_menu_opacity),
-                color = colors.textPrimary,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            NovaQuickMenuChipView(
-                NovaQuickMenuChip(
-                    label = state.menuOpacity.percent.toString() + "%",
-                    tone = NovaQuickMenuTone.INFO
-                )
-            )
-        }
-        Text(
-            text = stringResource(R.string.nova_quick_menu_menu_opacity_caption),
-            color = colors.textMuted,
-            fontSize = 10.sp,
-            lineHeight = 13.sp,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(top = 5.dp)
+    // Collapsed until asked for: the row is the setting, the preset strip is the editor.
+    // Two strips open at once were about 120dp of a 312dp Retroid body.
+    var expanded by remember { mutableStateOf(false) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        NovaQuickMenuOpacityHeader(
+            title = stringResource(R.string.nova_quick_menu_menu_opacity),
+            caption = stringResource(R.string.nova_quick_menu_menu_opacity_caption),
+            chip = NovaQuickMenuChip(
+                label = state.menuOpacity.percentLabel,
+                tone = NovaQuickMenuTone.INFO
+            ),
+            expanded = expanded,
+            enabled = true,
+            onToggle = { expanded = !expanded }
         )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            modifier = Modifier.padding(top = 8.dp)
-        ) {
-            state.menuOpacity.presets.forEach { percent ->
-                val selected = percent == state.menuOpacity.percent
-                NovaActionButton(
-                    text = percent.toString() + "%",
-                    onClick = { callbacks.onMenuOpacityChange(percent) },
-                    modifier = Modifier.weight(1f),
-                    primary = selected,
-                    contentDescription = stringResource(
-                        R.string.nova_quick_menu_menu_opacity_preset_cd,
-                        percent
-                    ),
-                    selected = selected,
-                    stateDescription = stringResource(
-                        if (selected) {
-                            R.string.nova_quick_menu_hud_opacity_selected
-                        } else {
-                            R.string.nova_quick_menu_hud_opacity_not_selected
-                        }
-                    ),
-                    cornerRadius = NovaRadius.hero,
-                    minHeight = 44.dp,
-                    fontSize = 10.sp,
-                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
-                )
+        if (expanded) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 2.dp, bottom = 8.dp)
+            ) {
+                state.menuOpacity.presets.forEach { percent ->
+                    val selected = percent == state.menuOpacity.percent
+                    NovaActionButton(
+                        text = percent.toString() + "%",
+                        onClick = { callbacks.onMenuOpacityChange(percent) },
+                        modifier = Modifier.weight(1f),
+                        primary = selected,
+                        contentDescription = stringResource(
+                            R.string.nova_quick_menu_menu_opacity_preset_cd,
+                            percent
+                        ),
+                        selected = selected,
+                        stateDescription = stringResource(
+                            if (selected) {
+                                R.string.nova_quick_menu_hud_opacity_selected
+                            } else {
+                                R.string.nova_quick_menu_hud_opacity_not_selected
+                            }
+                        ),
+                        cornerRadius = NovaRadius.hero,
+                        minHeight = 44.dp,
+                        fontSize = 10.sp,
+                        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
+                    )
+                }
             }
         }
     }
@@ -1029,72 +1042,155 @@ private fun NovaQuickMenuHudOpacityControl(
     state: NovaQuickMenuUiState,
     callbacks: NovaQuickMenuCallbacks
 ) {
-    val colors = LocalNovaComposeColors.current
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(R.string.nova_quick_menu_hud_opacity),
-                color = colors.textPrimary,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            NovaQuickMenuChipView(
-                NovaQuickMenuChip(
-                    label = state.hudOpacity.percent.toString() + "%",
-                    tone = if (state.hudOpacity.enabled) NovaQuickMenuTone.INFO else NovaQuickMenuTone.INACTIVE
-                )
-            )
-        }
-        Text(
-            text = stringResource(
+    var expanded by remember { mutableStateOf(false) }
+    // The strip closes with the HUD: a disabled row should not leave five dead buttons open.
+    val presetsOpen = expanded && state.hudOpacity.enabled
+    Column(modifier = Modifier.fillMaxWidth()) {
+        NovaQuickMenuOpacityHeader(
+            title = stringResource(R.string.nova_quick_menu_hud_opacity),
+            caption = stringResource(
                 if (state.hudOpacity.enabled) {
                     R.string.nova_quick_menu_hud_opacity_caption
                 } else {
                     R.string.nova_quick_menu_hud_opacity_disabled_caption
                 }
             ),
+            chip = NovaQuickMenuChip(
+                label = state.hudOpacity.percentLabel,
+                tone = if (state.hudOpacity.enabled) NovaQuickMenuTone.INFO else NovaQuickMenuTone.INACTIVE
+            ),
+            expanded = presetsOpen,
+            enabled = state.hudOpacity.enabled,
+            onToggle = { expanded = !expanded }
+        )
+        if (presetsOpen) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 2.dp, bottom = 8.dp)
+            ) {
+                state.hudOpacity.presets.forEach { percent ->
+                    val selected = percent == state.hudOpacity.percent
+                    NovaActionButton(
+                        text = percent.toString() + "%",
+                        onClick = { callbacks.onHudOpacityChange(percent) },
+                        modifier = Modifier.weight(1f),
+                        enabled = state.hudOpacity.enabled,
+                        primary = selected,
+                        contentDescription = stringResource(
+                            R.string.nova_quick_menu_hud_opacity_preset_cd,
+                            percent
+                        ),
+                        selected = selected,
+                        stateDescription = stringResource(
+                            if (selected) {
+                                R.string.nova_quick_menu_hud_opacity_selected
+                            } else {
+                                R.string.nova_quick_menu_hud_opacity_not_selected
+                            }
+                        ),
+                        cornerRadius = NovaRadius.hero,
+                        minHeight = 44.dp,
+                        fontSize = 10.sp,
+                        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// The collapsed face of an opacity control: reads like every other Overlays row, and the
+// tap opens the presets beneath it.
+@Composable
+private fun NovaQuickMenuOpacityHeader(
+    title: String,
+    caption: String,
+    chip: NovaQuickMenuChip,
+    expanded: Boolean,
+    enabled: Boolean,
+    onToggle: () -> Unit
+) {
+    val colors = LocalNovaComposeColors.current
+    val toggleHint = stringResource(
+        if (expanded) R.string.nova_quick_menu_opacity_hide_presets else R.string.nova_quick_menu_opacity_show_presets
+    )
+    NovaQuickMenuClickableSurface(
+        enabled = enabled,
+        onClick = onToggle,
+        modifier = Modifier.fillMaxWidth(),
+        flat = true,
+        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 7.dp),
+        contentDescription = listOf(title, chip.label, toggleHint).joinToString(". ")
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    color = colors.textPrimary,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = caption,
+                    color = colors.textMuted,
+                    fontSize = 9.sp,
+                    lineHeight = 12.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            NovaQuickMenuChipView(chip)
+        }
+    }
+}
+
+// Four layouts, one tap each. This was a row that cycled blind: Debug was two presses away
+// and nothing said where the next press would land.
+@Composable
+private fun NovaQuickMenuHudModePicker(
+    hudMode: NovaQuickMenuHudModeState,
+    callbacks: NovaQuickMenuCallbacks
+) {
+    val colors = LocalNovaComposeColors.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 7.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.nova_quick_menu_hud_mode),
+            color = colors.textPrimary,
+            fontSize = 12.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = stringResource(
+                if (hudMode.enabled) {
+                    R.string.nova_quick_menu_hud_mode_caption
+                } else {
+                    R.string.nova_quick_menu_hud_mode_disabled_caption
+                }
+            ),
             color = colors.textMuted,
-            fontSize = 10.sp,
-            lineHeight = 13.sp,
+            fontSize = 9.sp,
+            lineHeight = 12.sp,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(top = 5.dp)
+            modifier = Modifier.padding(top = 2.dp)
         )
         Row(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             modifier = Modifier.padding(top = 8.dp)
         ) {
-            state.hudOpacity.presets.forEach { percent ->
-                val selected = percent == state.hudOpacity.percent
-                NovaActionButton(
-                    text = percent.toString() + "%",
-                    onClick = { callbacks.onHudOpacityChange(percent) },
+            hudMode.options.forEach { option ->
+                NovaQuickMenuPreferenceButton(
+                    option = option,
                     modifier = Modifier.weight(1f),
-                    enabled = state.hudOpacity.enabled,
-                    primary = selected,
-                    contentDescription = stringResource(
-                        R.string.nova_quick_menu_hud_opacity_preset_cd,
-                        percent
-                    ),
-                    selected = selected,
-                    stateDescription = stringResource(
-                        if (selected) {
-                            R.string.nova_quick_menu_hud_opacity_selected
-                        } else {
-                            R.string.nova_quick_menu_hud_opacity_not_selected
-                        }
-                    ),
-                    cornerRadius = NovaRadius.hero,
-                    minHeight = 44.dp,
-                    fontSize = 10.sp,
-                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 10.dp)
+                    onClick = { callbacks.onHudModeSelect(NovaHudMode.fromPreference(option.value)) }
                 )
             }
         }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -19,7 +19,6 @@ enum class NovaQuickMenuActionId {
     STABILITY,
     SYNC_STATUS,
     ADVANCED_TUNING,
-    AI_AUTO_QUALITY,
     CLEAR_GAME_PROFILE,
     MANGOHUD,
     QUICK_ESC,
@@ -32,7 +31,6 @@ enum class NovaQuickMenuActionId {
     QUICK_CTRL_1,
     QUICK_CTRL_2,
     NOVA_HUD,
-    NOVA_HUD_MODE,
     PERF_STATS,
     DIAGNOSE_STREAM,
     DOCTOR_UNDO,
@@ -76,17 +74,35 @@ data class NovaQuickMenuStabilityState(
     val profileTitle: String,
     val profileCaption: String,
     val profileOptions: List<NovaQuickMenuPreferenceOption>
-)
+) {
+    // The card's own tap target, built with the state instead of on every recomposition.
+    val action: NovaQuickMenuAction = NovaQuickMenuAction(
+        id = NovaQuickMenuActionId.STABILITY,
+        label = title,
+        enabled = enabled
+    )
+}
 
 data class NovaQuickMenuHudOpacityState(
     val percent: Int,
     val presets: List<Int>,
     val enabled: Boolean
-)
+) {
+    val percentLabel: String = "$percent%"
+}
 
 data class NovaQuickMenuMenuOpacityState(
     val percent: Int,
     val presets: List<Int>
+) {
+    val percentLabel: String = "$percent%"
+}
+
+/** Every HUD layout as a selectable option, smallest first; [selected] is the live one. */
+data class NovaQuickMenuHudModeState(
+    val options: List<NovaQuickMenuPreferenceOption>,
+    val selected: NovaHudMode,
+    val enabled: Boolean
 )
 
 enum class NovaQuickMenuDoctorCapability {
@@ -137,6 +153,7 @@ data class NovaQuickMenuUiState(
     val postSessionReport: NovaPostSessionReportUiState,
     val hudOpacity: NovaQuickMenuHudOpacityState,
     val menuOpacity: NovaQuickMenuMenuOpacityState,
+    val hudMode: NovaQuickMenuHudModeState,
     val overlayRows: List<NovaQuickMenuAction>,
     val controlRows: List<NovaQuickMenuAction>,
     val sessionRows: List<NovaQuickMenuAction>
@@ -176,7 +193,10 @@ data class NovaQuickMenuUiState(
             isOnExternalDisplay: Boolean,
             fallbackBitrateKbps: Int,
             fallbackTargetFps: Double,
-            doctorReceipt: DoctorActionReceipt? = null
+            doctorReceipt: DoctorActionReceipt? = null,
+            // Static per locale. The host builds it once per open and hands it back in, so
+            // a refresh after every tap does not rebuild nine identical rows from resources.
+            quickKeys: List<NovaQuickMenuAction> = quickKeyActions(context)
         ): NovaQuickMenuUiState {
             val viewerSession = status?.isViewer == true
             val canAdjustHostTuning = status?.canAdjustHostTuning == true
@@ -358,6 +378,20 @@ data class NovaQuickMenuUiState(
                 percent = NovaMenuPreferences.coerceOpacityPercent(menuOpacityPercent),
                 presets = NovaMenuPreferences.OPACITY_PRESETS
             )
+            // One tap per layout. This was a row that cycled blind: Debug was two presses
+            // away and nothing said where the next press would land.
+            val hudModeState = NovaQuickMenuHudModeState(
+                options = NovaHudMode.entries.map { mode ->
+                    NovaQuickMenuPreferenceOption(
+                        value = mode.preferenceValue,
+                        label = hudModeLabel(context, mode),
+                        selected = mode == hudMode,
+                        enabled = hudShowing
+                    )
+                },
+                selected = hudMode,
+                enabled = hudShowing
+            )
             val doctorReceiptAction = doctorReceiptAction(
                 context = context,
                 receipt = doctorReceipt,
@@ -372,16 +406,6 @@ data class NovaQuickMenuUiState(
                     caption = context.getString(R.string.nova_quick_menu_nova_hud_caption),
                     chip = onOffChip(context, hudShowing),
                     enabled = true
-                ),
-                NovaQuickMenuAction(
-                    id = NovaQuickMenuActionId.NOVA_HUD_MODE,
-                    label = context.getString(R.string.nova_quick_menu_hud_mode),
-                    caption = context.getString(R.string.nova_quick_menu_hud_mode_caption),
-                    chip = chip(
-                        hudModeLabel(context, hudMode),
-                        if (hudShowing) NovaQuickMenuTone.INFO else NovaQuickMenuTone.MUTED
-                    ),
-                    enabled = hudShowing
                 ),
                 NovaQuickMenuAction(
                     id = NovaQuickMenuActionId.PERF_STATS,
@@ -470,13 +494,14 @@ data class NovaQuickMenuUiState(
                 // AI may explain evidence, but it no longer owns a mutable
                 // launch-policy control. Presets live in the card above.
                 advancedRows = listOf(clearRow, mangoRow),
-                quickKeys = quickKeyActions(context),
+                quickKeys = quickKeys,
                 diagnosis = diagnosis,
                 diagnosisAction = diagnoseAction(context, status, diagnosis),
                 doctorReceiptAction = doctorReceiptAction,
                 postSessionReport = postSessionReport,
                 hudOpacity = hudOpacity,
                 menuOpacity = menuOpacity,
+                hudMode = hudModeState,
                 overlayRows = overlays,
                 controlRows = controls,
                 sessionRows = sessionRows
@@ -781,50 +806,6 @@ data class NovaQuickMenuUiState(
             )
         }
 
-        private fun aiAction(
-            context: Context,
-            status: PolarisSessionStatus?,
-            apiAvailable: Boolean,
-            hostStateUnavailable: Boolean,
-            supported: Boolean,
-            enabledNow: Boolean,
-            canAdjustHostTuning: Boolean,
-            viewerSession: Boolean,
-            shutdownInProgress: Boolean,
-            policy: StreamPolicyUiState,
-            autoQuality: AutoQualityUiState
-        ): NovaQuickMenuAction {
-            val rowEnabled = apiAvailable && supported && canAdjustHostTuning
-            val chip = when {
-                hostStateUnavailable -> chip(context.getString(R.string.nova_quick_menu_unavailable), NovaQuickMenuTone.MUTED)
-                !apiAvailable && status == null -> chip(context.getString(R.string.nova_quick_menu_not_available), NovaQuickMenuTone.MUTED)
-                !supported -> chip(context.getString(R.string.nova_quick_menu_not_available), NovaQuickMenuTone.MUTED)
-                enabledNow -> chip(context.getString(R.string.nova_quick_menu_on), NovaQuickMenuTone.ACTIVE)
-                else -> chip(context.getString(R.string.nova_quick_menu_off), NovaQuickMenuTone.INACTIVE)
-            }
-            val caption = when {
-                hostStateUnavailable -> context.getString(R.string.nova_quick_menu_host_state_unavailable)
-                !apiAvailable && status == null -> context.getString(R.string.nova_quick_menu_not_polaris_session)
-                !supported -> "server unavailable"
-                shutdownInProgress -> context.getString(R.string.nova_quick_menu_session_ending_caption)
-                !canAdjustHostTuning && viewerSession -> context.getString(R.string.nova_quick_menu_owner_only_caption)
-                !canAdjustHostTuning -> context.getString(R.string.nova_quick_menu_host_controls_unavailable_caption)
-                enabledNow && policy.adaptiveTargetBitrateKbps > 0 ->
-                    "${autoQuality.detail} · ${policy.adaptiveTargetLabel} live bitrate"
-                enabledNow -> autoQuality.detail.ifBlank {
-                    optimizationRuntimeCaption(context, status) ?: context.getString(R.string.nova_quick_menu_ai_caption_default)
-                }
-                else -> "manual stream tuning"
-            }
-            return NovaQuickMenuAction(
-                id = NovaQuickMenuActionId.AI_AUTO_QUALITY,
-                label = context.getString(R.string.nova_quick_menu_ai_auto_quality),
-                caption = caption,
-                chip = chip,
-                enabled = rowEnabled
-            )
-        }
-
         private fun clearProfileAction(
             context: Context,
             apiAvailable: Boolean,
@@ -956,6 +937,7 @@ data class NovaQuickMenuUiState(
 
         private fun hudModeLabel(context: Context, mode: NovaHudMode): String = context.getString(
             when (mode) {
+                NovaHudMode.SLIM -> R.string.nova_quick_menu_hud_mode_slim
                 NovaHudMode.MINIMAL -> R.string.nova_quick_menu_hud_mode_minimal
                 NovaHudMode.PERFORMANCE -> R.string.nova_quick_menu_hud_mode_performance
                 NovaHudMode.DEBUG -> R.string.nova_quick_menu_hud_mode_debug
@@ -1015,7 +997,7 @@ data class NovaQuickMenuUiState(
             ).joinToString(" · ")
         }
 
-        private fun quickKeyActions(context: Context) = listOf(
+        fun quickKeyActions(context: Context): List<NovaQuickMenuAction> = listOf(
             NovaQuickMenuAction(
                 id = NovaQuickMenuActionId.QUICK_ESC,
                 label = context.getString(R.string.game_menu_send_keys_esc)

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -40,6 +40,11 @@ class NovaStreamHud(
     private var targetFps = 0.0
     private var lastFps = 0.0
     private var lastLatency = 0.0
+    private var lastLowOnePercentFps = 0.0
+    private var lastDecodeTimeMs = 0.0
+    private var lastHostLatencyMs: Double? = null
+    private var lastIncomingFps = 0.0
+    private var lastRenderedFps = 0.0
     private var currentBitrateKbps = 0
     var lastCodec = ""
     var lastBitrateKbps = 0
@@ -116,6 +121,11 @@ class NovaStreamHud(
         sessionStats.reset()
         sparklineData.clear()
         eventTrail.clear()
+        lastLowOnePercentFps = 0.0
+        lastDecodeTimeMs = 0.0
+        lastHostLatencyMs = null
+        lastIncomingFps = 0.0
+        lastRenderedFps = 0.0
     }
 
     private fun setupTouchHandler(view: View) {
@@ -218,10 +228,22 @@ class NovaStreamHud(
     }
 
     fun cycleMode() {
+        applyMode(currentMode.next())
+    }
+
+    /** Jump straight to a layout; the Command Center picker uses this instead of cycling blind. */
+    fun setMode(mode: NovaHudMode) {
+        if (mode == currentMode) {
+            return
+        }
+        applyMode(mode)
+    }
+
+    private fun applyMode(mode: NovaHudMode) {
         val view = hudView ?: return
         val savedX = view.x
         val savedY = view.y
-        currentMode = currentMode.next()
+        currentMode = mode
         PreferenceManager.getDefaultSharedPreferences(activity)
             .edit()
             .putString("nova_polaris_hud_mode", currentMode.preferenceValue)
@@ -236,22 +258,11 @@ class NovaStreamHud(
         }
     }
 
-    fun updateFromPerfText(text: String) {
-        val sample = NovaHudPerfSample.fromPerfText(text)
-        activity.runOnUiThread {
-            if (hudView == null) return@runOnUiThread
-            sample.fps?.let(::updateFps)
-            if (sample.width != null && sample.height != null) {
-                width = sample.width
-                height = sample.height
-            }
-            sample.latencyMs?.let(::updateLatency)
-            sample.codec?.let(::applyCodecLabel)
-            sample.packetLossPct?.let(sessionStats::recordPacketLoss)
-            publishState()
-        }
-    }
-
+    /**
+     * The one feed. The decoder emits this struct once a second whether or not any overlay
+     * is up; it carries every number the HUD shows, so the HUD no longer asks the decoder
+     * to also build the legacy overlay text on its own thread just to regex it back out.
+     */
     fun updateFromPerfSample(sample: PerfOverlaySample) {
         activity.runOnUiThread {
             if (hudView == null) return@runOnUiThread
@@ -261,6 +272,10 @@ class NovaStreamHud(
             updateLatency(sample.rttMs)
             applyCodecLabel(sample.codec)
             sessionStats.recordPacketLoss(sample.packetLossPct)
+            lastDecodeTimeMs = sample.decodeTimeMs
+            lastHostLatencyMs = sample.hostProcessingLatencyMs
+            lastIncomingFps = sample.incomingFps
+            lastRenderedFps = sample.renderedFps
             // The display helpers above own the HUD's rolling averages. Preserve the
             // exact cumulative decoder evidence too, so Copy diagnostics reports the
             // same raw sample that Doctor uploads instead of default zero counters.
@@ -270,11 +285,13 @@ class NovaStreamHud(
     }
 
     fun setTargetBitrateKbps(bitrateKbps: Int) {
-        currentBitrateKbps = bitrateKbps
-        lastBitrateKbps = bitrateKbps
-        sessionStats.setLastBitrateKbps(bitrateKbps)
-        streamPolicy = StreamPolicyUiState.from(lastSessionStatus, bitrateKbps, targetFps)
-        publishState()
+        activity.runOnUiThread {
+            currentBitrateKbps = bitrateKbps
+            lastBitrateKbps = bitrateKbps
+            sessionStats.setLastBitrateKbps(bitrateKbps)
+            streamPolicy = StreamPolicyUiState.from(lastSessionStatus, bitrateKbps, targetFps)
+            if (hudView != null) publishState()
+        }
     }
 
     fun setTargetFps(fps: Double) {
@@ -283,7 +300,9 @@ class NovaStreamHud(
         }
         targetFps = fps
         sessionStats.setTargetFps(fps)
-        activity.runOnUiThread { publishState() }
+        activity.runOnUiThread {
+            if (hudView != null) publishState()
+        }
     }
 
     fun update(fps: Double, codec: String, bitrateKbps: Int, width: Int, height: Int, latencyMs: Double) {
@@ -309,6 +328,9 @@ class NovaStreamHud(
 
     fun applySessionStatus(status: PolarisSessionStatus?) {
         activity.runOnUiThread {
+            // Polaris is polled once a second and mostly answers the same thing. A status
+            // that equals the last one changes nothing below, so skip the rebuild.
+            if (status != null && status == lastSessionStatus) return@runOnUiThread
             lastSessionStatus = status
             sessionStats.applySessionStatus(status)
             val resolvedTargetFps = status?.let(::resolveTargetFps) ?: 0.0
@@ -336,9 +358,12 @@ class NovaStreamHud(
         }
         lastFps = fps
         sparklineData.add(fps.toFloat())
+        // One sort per sample. publishState() used to sort the ring buffer a second time
+        // for the same number.
+        lastLowOnePercentFps = sparklineData.lowOnePercent()
         sessionStats.recordFps(
             fps = fps,
-            lowOnePercentFps = sparklineData.lowOnePercent()
+            lowOnePercentFps = lastLowOnePercentFps
         )
 
         // The HUD is observational. Low rendered FPS may be static content or
@@ -380,7 +405,11 @@ class NovaStreamHud(
             status = lastSessionStatus,
             sparklineSamples = sparklineData.snapshot(),
             eventBreadcrumbLabel = eventTrail.latestLabel,
-            lowOnePercentFps = sparklineData.lowOnePercent()
+            lowOnePercentFps = lastLowOnePercentFps,
+            decodeTimeMs = lastDecodeTimeMs,
+            hostProcessingLatencyMs = lastHostLatencyMs,
+            incomingFps = lastIncomingFps,
+            renderedFps = lastRenderedFps
         )
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -56,6 +56,7 @@ fun NovaStreamHudContent(
             NovaHudMode.DEBUG -> NovaStreamHudDebug(state, modifier)
             NovaHudMode.PERFORMANCE -> NovaStreamHudPerformance(state, modifier)
             NovaHudMode.MINIMAL -> NovaStreamHudMinimal(state, modifier)
+            NovaHudMode.SLIM -> NovaStreamHudSlim(state, modifier)
         }
     }
 }
@@ -72,8 +73,9 @@ private fun rememberHudOpacityScale(opacityScale: Float): Float {
 
 @Composable
 private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
+    // 256dp: three metric tiles across need to hold "1920×1080" at 10sp with room left.
     HudPanel(
-        modifier = modifier.width(236.dp),
+        modifier = modifier.width(256.dp),
         cornerRadius = NovaRadius.hero,
         padding = 10.dp
     ) {
@@ -165,6 +167,19 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
         ) {
             HudMetric("CODEC", state.codecLabel.ifBlank { "--" }, Modifier.weight(1f))
             HudMetric("RES", state.resolutionLabel, Modifier.weight(1f))
+            HudMetric("DEC", state.decodeTimeLabel, Modifier.weight(1f), valueTone = state.decodeTone)
+        }
+        // Where the frame's time goes and where its frames go: host encode latency next to
+        // the decode tile above it, then what arrived against what was drawn.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            HudMetric("HOST", state.hostLatencyLabel, Modifier.weight(1f))
+            HudMetric("IN", state.incomingFpsLabel, Modifier.weight(1f))
+            HudMetric("OUT", state.renderedFpsLabel, Modifier.weight(1f))
         }
     }
 }
@@ -318,6 +333,31 @@ private fun NovaStreamHudMinimal(state: NovaHudUiState, modifier: Modifier) {
         }
         if (state.eventBreadcrumbLabel.isNotBlank()) {
             HudEventBreadcrumb(state.eventBreadcrumbLabel)
+        }
+    }
+}
+
+// One line, one glance: the health bar, the frame rate, the round trip. Nothing that
+// needs reading, so no labels, no target, no breadcrumb, no sparkline.
+@Composable
+private fun NovaStreamHudSlim(state: NovaHudUiState, modifier: Modifier) {
+    HudPanel(
+        modifier = modifier,
+        cornerRadius = NovaRadius.pill,
+        padding = 5.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 4.dp, end = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HudStatusDot(state.statusTone, height = 16.dp)
+            HudValueText(
+                text = state.fpsLabel,
+                tone = state.fpsTone,
+                size = 15,
+                modifier = Modifier.padding(start = 6.dp)
+            )
+            HudCompactText(state.latencyLabel, state.latencyTone, startPadding = 7.dp)
         }
     }
 }
@@ -494,7 +534,7 @@ private fun HudTinyLabel(text: String) {
 }
 
 @Composable
-private fun HudValueText(text: String, tone: NovaHudTone, size: Int) {
+private fun HudValueText(text: String, tone: NovaHudTone, size: Int, modifier: Modifier = Modifier) {
     Text(
         text = text,
         color = tone.hudColor(),
@@ -503,7 +543,8 @@ private fun HudValueText(text: String, tone: NovaHudTone, size: Int) {
         fontWeight = FontWeight.Bold,
         fontFamily = FontFamily.SansSerif,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
     )
 }
 
@@ -564,6 +605,10 @@ private fun NovaHudSparkline(
 ) {
     val lineColor = tone.hudColor()
     val hudOpacityScale = LocalNovaHudOpacityScale.current
+    // The sparkline redraws once a second for the life of a stream. Two paths that live
+    // with the composable and get reset cost nothing; two fresh ones per draw were garbage.
+    val linePath = remember { Path() }
+    val fillPath = remember { Path() }
     Canvas(modifier = modifier) {
         if (samples.size < 2 || size.width <= 0f || size.height <= 0f) {
             return@Canvas
@@ -572,8 +617,8 @@ private fun NovaHudSparkline(
         val max = samples.maxOrNull() ?: return@Canvas
         val range = (max - min).coerceAtLeast(5f)
         val stepX = size.width / (samples.size - 1).coerceAtLeast(1)
-        val linePath = Path()
-        val fillPath = Path()
+        linePath.reset()
+        fillPath.reset()
         samples.forEachIndexed { index, value ->
             val x = index * stepX
             val y = size.height - ((value - min) / range) * (size.height - 2f) - 1f

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -145,7 +145,7 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
                 .height(22.dp)
                 .padding(top = 7.dp)
         )
-        HudDiagnosticStrip(state)
+        HudDiagnosticStrip(state.healthReasonLabel, state.healthReasonTone, state.streamTruthLabel)
         HudLayerHealthRow(state.layerHealth)
         HudEventBreadcrumb(state.eventBreadcrumbLabel)
 
@@ -193,7 +193,7 @@ private fun NovaStreamHudPerformance(state: NovaHudUiState, modifier: Modifier) 
     ) {
         HudPerformancePrimaryRow(state)
         HudPerformanceDetailRow(state)
-        HudCompactDiagnosticStrip(state)
+        HudCompactDiagnosticStrip(state.healthReasonLabel, state.healthReasonTone, state.streamTruthLabel)
         HudEventBreadcrumb(state.eventBreadcrumbLabel)
     }
 }
@@ -387,9 +387,16 @@ private fun HudPanel(
     )
 }
 
+// The strips and chips take only the strings and tones they draw. Handed the whole state,
+// they recomposed on every sample because the fps changed, even when their own text
+// had not; with plain parameters Compose skips them until their words actually change.
 @Composable
-private fun HudDiagnosticStrip(state: NovaHudUiState) {
-    if (state.healthReasonLabel.isBlank() && state.streamTruthLabel.isBlank()) return
+private fun HudDiagnosticStrip(
+    healthReasonLabel: String,
+    healthReasonTone: NovaHudTone,
+    streamTruthLabel: String
+) {
+    if (healthReasonLabel.isBlank() && streamTruthLabel.isBlank()) return
     val surfaces = LocalNovaLibrarySurfaces.current
     val hudOpacityScale = LocalNovaHudOpacityScale.current
     Row(
@@ -402,8 +409,8 @@ private fun HudDiagnosticStrip(state: NovaHudUiState) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = state.healthReasonLabel,
-            color = state.healthReasonTone.hudColor(),
+            text = healthReasonLabel,
+            color = healthReasonTone.hudColor(),
             fontSize = 10.sp,
             lineHeight = 12.sp,
             fontWeight = FontWeight.SemiBold,
@@ -412,7 +419,7 @@ private fun HudDiagnosticStrip(state: NovaHudUiState) {
             modifier = Modifier.weight(0.7f)
         )
         Text(
-            text = state.streamTruthLabel,
+            text = streamTruthLabel,
             color = LocalNovaComposeColors.current.textSecondary,
             fontSize = 9.sp,
             lineHeight = 11.sp,
@@ -424,11 +431,15 @@ private fun HudDiagnosticStrip(state: NovaHudUiState) {
 }
 
 @Composable
-private fun HudCompactDiagnosticStrip(state: NovaHudUiState) {
-    if (state.healthReasonLabel == "Stable" && state.streamTruthLabel.isBlank()) return
+private fun HudCompactDiagnosticStrip(
+    healthReasonLabel: String,
+    healthReasonTone: NovaHudTone,
+    streamTruthLabel: String
+) {
+    if (healthReasonLabel == "Stable" && streamTruthLabel.isBlank()) return
     Text(
-        text = listOf(state.healthReasonLabel, state.streamTruthLabel).filter { it.isNotBlank() }.joinToString(" · "),
-        color = state.healthReasonTone.hudColor(),
+        text = listOf(healthReasonLabel, streamTruthLabel).filter { it.isNotBlank() }.joinToString(" · "),
+        color = healthReasonTone.hudColor(),
         fontSize = 8.sp,
         lineHeight = 10.sp,
         fontWeight = FontWeight.SemiBold,
@@ -440,6 +451,8 @@ private fun HudCompactDiagnosticStrip(state: NovaHudUiState) {
 
 @Composable
 private fun HudLayerHealthRow(layers: List<NovaHudLayerHealth>) {
+    // The row itself re-runs each tick (a List parameter is never provably stable), but
+    // each chip takes an immutable value and skips while its label and tone hold.
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -70,22 +70,6 @@
             android:preferKeepClear="true"
             android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/performanceOverlayLite"
-            tools:text="延迟/解码：109ms/7ms 丢包率：69% FPS：60"
-            android:textSize="10sp"
-            android:layout_marginTop="4dp"
-            android:background="@drawable/ic_hud_bg"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
-            android:visibility="gone"
-            android:textAppearance="?android:attr/textAppearanceLarge"
-            android:layout_gravity="center_horizontal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
     </LinearLayout>
 
     <!-- Floating Menu Button -->

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -43,19 +43,6 @@
         <item>1800</item>
     </string-array>
 
-    <string-array name="nova_hud_position_names">
-        <item>Top Left</item>
-        <item>Top Right</item>
-        <item>Bottom Left</item>
-        <item>Bottom Right</item>
-    </string-array>
-    <string-array name="nova_hud_position_values">
-        <item>top_left</item>
-        <item>top_right</item>
-        <item>bottom_left</item>
-        <item>bottom_right</item>
-    </string-array>
-
     <string-array name="android_stream_display_target_names">
         <item>@string/android_stream_display_target_auto</item>
         <item>@string/android_stream_display_target_primary</item>
@@ -118,11 +105,13 @@
     </string-array>
 
     <string-array name="nova_hud_mode_names">
+        <item>Slim</item>
         <item>Minimal</item>
         <item>Performance</item>
         <item>Debug</item>
     </string-array>
     <string-array name="nova_hud_mode_values">
+        <item>slim</item>
         <item>minimal</item>
         <item>performance</item>
         <item>debug</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1009,7 +1009,9 @@
     <string name="nova_quick_menu_nova_hud">Nova HUD</string>
     <string name="nova_quick_menu_nova_hud_caption">Long press the HUD to open Command Center.</string>
     <string name="nova_quick_menu_hud_mode">HUD Mode</string>
-    <string name="nova_quick_menu_hud_mode_caption">Tap to cycle. Guide + Y does the same on a controller.</string>
+    <string name="nova_quick_menu_hud_mode_caption">Pick a layout. Guide + Y cycles through them on a controller.</string>
+    <string name="nova_quick_menu_hud_mode_disabled_caption">Turn Nova HUD on to pick a layout.</string>
+    <string name="nova_quick_menu_hud_mode_slim">Slim</string>
     <string name="nova_quick_menu_hud_mode_minimal">Minimal</string>
     <string name="nova_quick_menu_hud_mode_performance">Performance</string>
     <string name="nova_quick_menu_hud_mode_debug">Debug</string>
@@ -1022,8 +1024,10 @@
     <string name="nova_quick_menu_hud_opacity_preset_cd">Set HUD opacity to %1$d percent</string>
     <string name="nova_quick_menu_hud_opacity_selected">Selected</string>
     <string name="nova_quick_menu_hud_opacity_not_selected">Not selected</string>
+    <string name="nova_quick_menu_opacity_show_presets">Show presets</string>
+    <string name="nova_quick_menu_opacity_hide_presets">Hide presets</string>
     <string name="nova_quick_menu_perf_stats">Stats Overlay</string>
-    <string name="nova_quick_menu_perf_stats_caption">Legacy Moonlight stats text, separate from Nova HUD.</string>
+    <string name="nova_quick_menu_perf_stats_caption">Legacy Moonlight stats text. Replaces Nova HUD while it is on.</string>
     <string name="nova_quick_menu_diagnose_stream">Diagnose This Stream</string>
     <string name="nova_quick_menu_doctor_capability_auto_fix">Auto Fix</string>
     <string name="nova_quick_menu_doctor_capability_run_trial">Run a trial</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -444,7 +444,7 @@
         <CheckBoxPreference
             android:key="nova_polaris_hud"
             android:title="Nova Stream HUD"
-            android:summary="Drag to move, tap to cycle modes (minimal / performance / debug)"
+            android:summary="Drag to move. Long press opens Command Center."
             android:defaultValue="false"
             app:iconSpaceReserved="false" />
         <ListPreference
@@ -454,15 +454,7 @@
             android:entries="@array/nova_hud_mode_names"
             android:entryValues="@array/nova_hud_mode_values"
             android:defaultValue="minimal"
-            android:summary="Minimal for play, Performance for tuning, Debug for dense troubleshooting"
-            app:iconSpaceReserved="false" />
-        <ListPreference
-            android:key="nova_polaris_hud_position"
-            android:title="HUD Position"
-            android:dependency="nova_polaris_hud"
-            android:entries="@array/nova_hud_position_names"
-            android:entryValues="@array/nova_hud_position_values"
-            android:defaultValue="top_left"
+            android:summary="Slim for a glance, Minimal for play, Performance for tuning, Debug for troubleshooting"
             app:iconSpaceReserved="false" />
         <com.papi.nova.preferences.SeekBarPreference
             android:key="nova_polaris_hud_opacity"

--- a/app/src/test/java/com/papi/nova/GameStatsOverlaySourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/GameStatsOverlaySourceGuardTest.kt
@@ -1,0 +1,52 @@
+package com.papi.nova
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameStatsOverlaySourceGuardTest {
+    @Test
+    fun statsOverlayToggleIsPersistedAndReArmsTheDecoderText() {
+        val source = readGameSource()
+        val toggle = source.section("fun toggleHUD()", " fun switchTouchSensitivity()")
+
+        assertTrue(
+            "the Command Center toggle persists the setting; it used to flip an in-memory flag that Settings never saw",
+            toggle.contains("putBoolean(PreferenceConfiguration.ENABLE_PERF_OVERLAY_STRING, enabled)")
+        )
+        assertTrue(
+            "the decoder builds the overlay text only while it is wanted, so the toggle must re-arm it or a stream that started with the setting off shows an empty overlay",
+            toggle.contains("syncPerfTextWanted()")
+        )
+    }
+
+    @Test
+    fun novaHudNoLongerForcesTheDecoderToBuildLegacyText() {
+        val source = readGameSource()
+        val sync = source.section("private fun syncPerfTextWanted()", "fun copyNovaHudDiagnostics()")
+        val perfUpdate = source.section("override fun onPerfUpdate(text:String)", "override fun onPerfSample(sample:PerfOverlaySample)")
+
+        assertFalse(
+            "only the legacy overlay needs the string; the HUD reads the structured sample the decoder emits regardless",
+            sync.contains("novaHud")
+        )
+        assertFalse(
+            "the text callback feeds the legacy TextView and nothing else",
+            perfUpdate.contains("novaHud")
+        )
+    }
+
+    private fun readGameSource(): String =
+        String(Files.readAllBytes(Path.of("src/main/java/com/papi/nova/Game.kt")), StandardCharsets.UTF_8)
+
+    private fun String.section(startMarker: String, endMarker: String): String {
+        val start = indexOf(startMarker)
+        require(start >= 0) { "Missing start marker: $startMarker" }
+        val end = indexOf(endMarker, start)
+        require(end >= 0) { "Missing end marker: $endMarker" }
+        return substring(start, end)
+    }
+}

--- a/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
+++ b/app/src/test/java/com/papi/nova/KotlinGameRuntimeMigrationTest.kt
@@ -307,7 +307,8 @@ class KotlinGameRuntimeMigrationTest {
         assertTrue(source.contains("override fun onPerfSample(sample:PerfOverlaySample)"))
         assertTrue(source.contains("novaHud!!.updateFromPerfSample(sample)"))
         assertTrue(source.contains("override fun onPerfUpdate(text:String)"))
-        assertTrue(source.contains("novaHud!!.updateFromPerfText(text)"))
+        // The text callback feeds only the legacy overlay now; the HUD stopped regexing it.
+        assertFalse(source.contains("updateFromPerfText"))
     }
 
     private fun readGameSource(): String {

--- a/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
+++ b/app/src/test/java/com/papi/nova/preferences/NovaSettingsDefinitionsTest.kt
@@ -123,17 +123,19 @@ class NovaSettingsDefinitionsTest {
     }
 
     @Test
-    fun hudModePreferenceOffersCasualPerformanceAndDebugModes() {
+    fun hudModePreferenceOffersSlimCasualPerformanceAndDebugModes() {
         val definitions = NovaSettingDefinitions.load(context)
         val hudMode = definitions.require("nova_polaris_hud_mode")
 
+        // Smallest first, and the default stays Minimal: Slim is a new stop on the ring,
+        // not a new default.
         assertEquals(NovaSettingValue.StringValue("minimal"), hudMode.defaultValue)
         assertEquals(
-            listOf("minimal", "performance", "debug"),
+            listOf("slim", "minimal", "performance", "debug"),
             hudMode.options.map { it.value }
         )
         assertEquals(
-            listOf("Minimal", "Performance", "Debug"),
+            listOf("Slim", "Minimal", "Performance", "Debug"),
             hudMode.options.map { it.label }
         )
     }

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -106,7 +106,7 @@ class NovaComposeSourceGuardTest {
         assertTrue(
             "a controller B release should dismiss the Command Center while the full press stays local",
             quickMenuHost.contains("KeyEvent.KEYCODE_BUTTON_B ->") &&
-                quickMenuHost.contains("if (event.action == KeyEvent.ACTION_UP) dismiss()")
+                quickMenuHost.contains("if (event.action == KeyEvent.ACTION_UP) requestDismissWithMotion()")
         )
         assertTrue(
             "Command Center dismissal must relinquish its focusable window and restore the stream input target",
@@ -1957,7 +1957,7 @@ class NovaComposeSourceGuardTest {
         )
         val cycleMode = source.section(
             "fun cycleMode()",
-            "fun updateFromPerfText("
+            "fun updateFromPerfSample("
         )
 
         assertTrue(
@@ -2443,6 +2443,10 @@ class NovaComposeSourceGuardTest {
         )
         val minimalHud = source.section(
             "private fun NovaStreamHudMinimal(",
+            "@Composable\nprivate fun NovaStreamHudSlim("
+        )
+        val slimHud = source.section(
+            "private fun NovaStreamHudSlim(",
             "@Composable\nprivate fun HudPanel("
         )
 
@@ -2473,6 +2477,137 @@ class NovaComposeSourceGuardTest {
         assertFalse(
             "minimal HUD should avoid sparkline density during casual play",
             minimalHud.contains("NovaHudSparkline")
+        )
+        assertTrue(
+            "slim HUD is one pill: the health bar, the frame rate, the round trip, nothing labelled",
+            slimHud.contains("cornerRadius = NovaRadius.pill") &&
+                slimHud.contains("state.fpsLabel") &&
+                slimHud.contains("state.latencyLabel") &&
+                !slimHud.contains("HudTinyLabel(") &&
+                !slimHud.contains("state.targetFpsLabel") &&
+                !slimHud.contains("state.bitrateLabel") &&
+                !slimHud.contains("autopilot") &&
+                !slimHud.contains("HudEventBreadcrumb") &&
+                !slimHud.contains("NovaHudSparkline")
+        )
+    }
+
+    @Test
+    fun streamHudDebugShowsTheLatencyBudgetAndFrameFlowTiles() {
+        val source = readNovaStreamHudContent()
+        val debugHud = source.section(
+            "private fun NovaStreamHudDebug(",
+            "@Composable\nprivate fun NovaStreamHudPerformance("
+        )
+        val performanceHud = source.section(
+            "private fun NovaStreamHudPerformance(",
+            "@Composable\nprivate fun NovaStreamHudMinimal("
+        )
+
+        assertTrue(
+            "Debug answers 'how long does my panel take to decode' beside codec and resolution, graded against the frame budget rather than a fixed number",
+            debugHud.contains("HudMetric(\"DEC\", state.decodeTimeLabel") &&
+                debugHud.contains("valueTone = state.decodeTone")
+        )
+        assertTrue(
+            "Debug shows host encode latency and incoming against rendered fps, the legacy text's remaining facts, so the legacy overlay can retire later",
+            debugHud.contains("HudMetric(\"HOST\", state.hostLatencyLabel") &&
+                debugHud.contains("HudMetric(\"IN\", state.incomingFpsLabel") &&
+                debugHud.contains("HudMetric(\"OUT\", state.renderedFpsLabel")
+        )
+        assertFalse(
+            "Performance stays the four-metric row it is pinned to",
+            performanceHud.contains("decodeTimeLabel")
+        )
+    }
+
+    @Test
+    fun commandCenterHeaderStaysFixedWhileSectionsScroll() {
+        val content = readNovaQuickMenuContent()
+        val body = content.section(
+            "fun NovaQuickMenuContent(",
+            "@Composable\nprivate fun NovaQuickMenuHeader("
+        )
+        val header = body.indexOf("NovaQuickMenuHeader(state, callbacks)")
+        val scroll = body.indexOf(".verticalScroll(rememberScrollState())")
+        val strip = body.indexOf("NovaQuickMenuSessionStrip(state, initialFocusRequester)")
+
+        assertTrue(
+            "Close, Disconnect, and End Session must not scroll away: the header lives above the scrolling column, and only the sections scroll",
+            header in 0 until scroll && scroll in 0 until strip
+        )
+    }
+
+    @Test
+    fun commandCenterPicksTheHudModeDirectly() {
+        val content = readNovaQuickMenuContent()
+        val quickMenu = readNovaQuickMenu()
+
+        assertTrue(
+            "HUD Mode is a picker of every layout, not a cycle button that hid where the next press would land",
+            content.contains("private fun NovaQuickMenuHudModePicker(") &&
+                content.contains("hudMode.options.forEach") &&
+                content.contains("callbacks.onHudModeSelect(NovaHudMode.fromPreference(option.value))")
+        )
+        assertTrue(
+            "the picker sits right under the Nova HUD row it configures",
+            content.contains("if (row.id == NovaQuickMenuActionId.NOVA_HUD) {")
+        )
+        assertTrue(
+            "the host jumps the HUD straight to the chosen layout",
+            quickMenu.contains("game.setNovaHudMode(mode)")
+        )
+        assertFalse(
+            "no cycle row survives beside the picker",
+            content.contains("NOVA_HUD_MODE") || quickMenu.contains("NOVA_HUD_MODE")
+        )
+    }
+
+    @Test
+    fun commandCenterOpacityPresetsStayCollapsedUntilOpened() {
+        val content = readNovaQuickMenuContent()
+        val menuOpacity = content.section(
+            "private fun NovaQuickMenuMenuOpacityControl(",
+            "@Composable\nprivate fun NovaQuickMenuHudOpacityControl("
+        )
+        val hudOpacity = content.section(
+            "private fun NovaQuickMenuHudOpacityControl(",
+            "@Composable\nprivate fun NovaQuickMenuOpacityHeader("
+        )
+
+        assertTrue(
+            "menu opacity presets render only after the row is opened; two open strips were most of the Overlays panel on a Retroid",
+            menuOpacity.contains("var expanded by remember { mutableStateOf(false) }") &&
+                menuOpacity.contains("if (expanded) {")
+        )
+        assertTrue(
+            "HUD opacity presets render only after the row is opened, and close again with the HUD",
+            hudOpacity.contains("var expanded by remember { mutableStateOf(false) }") &&
+                hudOpacity.contains("val presetsOpen = expanded && state.hudOpacity.enabled") &&
+                hudOpacity.contains("if (presetsOpen) {")
+        )
+    }
+
+    @Test
+    fun commandCenterEveryExitSlidesTheDrawerOut() {
+        val content = readNovaQuickMenuContent()
+        val quickMenu = readNovaQuickMenu()
+        val drawer = content.section(
+            "fun NovaQuickMenuDrawer(",
+            "@Composable\nfun NovaQuickMenuContent("
+        )
+
+        assertTrue(
+            "Close goes through the drawer's motion like scrim-tap and drag do",
+            drawer.contains("callbacks.copy(onDismiss = { dismissDrawerWithMotion() })") &&
+                drawer.contains("callbacks = contentCallbacks")
+        )
+        assertTrue(
+            "B and Back ask the drawer to slide out instead of dropping the dialog, with a fallback in case composition is not running",
+            drawer.contains("LaunchedEffect(dismissRequests)") &&
+                quickMenu.contains("dismissMotionRequests.intValue++") &&
+                quickMenu.contains("DISMISS_MOTION_FALLBACK_MS") &&
+                quickMenu.contains("dismissWithMotion?.invoke() ?: dismiss()")
         )
     }
 

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -16,43 +16,6 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 class NovaHudUiStateTest {
     @Test
-    fun performanceTextParserExtractsHudSample() {
-        val sample = NovaHudPerfSample.fromPerfText(
-            """
-            Video stream: 1920x1080
-            Decoder: hevc
-            FPS: 59.8
-            RTT: 18 ms
-            Packet loss: 1.5%
-            """.trimIndent()
-        )
-
-        assertEquals(59.8, sample.fps!!, 0.01)
-        assertEquals(1920, sample.width)
-        assertEquals(1080, sample.height)
-        assertEquals(18, sample.latencyMs)
-        assertEquals("HEVC", sample.codec)
-        assertEquals(1.5, sample.packetLossPct!!, 0.01)
-    }
-
-    @Test
-    fun performanceTextParserKeepsLocalizedCommaFpsWhole() {
-        val sample = NovaHudPerfSample.fromPerfText(
-            """
-            1920x1080 119,84 FPS
-            Avc.decoder.low_latency
-            Bildfrekvens från nätverket: 119,84 FPS
-            Renderingsfrekvens: 113,87 FPS
-            Frames dropped by your network connection: 0,00%
-            """.trimIndent()
-        )
-
-        assertEquals(119.84, sample.fps!!, 0.01)
-        assertEquals(1920, sample.width)
-        assertEquals(1080, sample.height)
-    }
-
-    @Test
     fun fullModeFormatsReadableLabelsAndTones() {
         val state = NovaHudUiState.from(
             mode = NovaHudMode.DEBUG,
@@ -152,7 +115,9 @@ class NovaHudUiStateTest {
     }
 
     @Test
-    fun hudModesMapCasualPerformanceAndDebugPreferences() {
+    fun hudModesMapSlimCasualPerformanceAndDebugPreferences() {
+        assertEquals(NovaHudMode.SLIM, NovaHudMode.fromPreference("slim"))
+        assertEquals(NovaHudMode.SLIM, NovaHudMode.fromPreference("pill"))
         assertEquals(NovaHudMode.MINIMAL, NovaHudMode.fromPreference("minimal"))
         assertEquals(NovaHudMode.PERFORMANCE, NovaHudMode.fromPreference("performance"))
         assertEquals(NovaHudMode.DEBUG, NovaHudMode.fromPreference("debug"))
@@ -160,9 +125,58 @@ class NovaHudUiStateTest {
         assertEquals(NovaHudMode.PERFORMANCE, NovaHudMode.fromPreference("banner"))
         assertEquals(NovaHudMode.MINIMAL, NovaHudMode.fromPreference("fps_only"))
         assertEquals(NovaHudMode.MINIMAL, NovaHudMode.fromPreference(null))
+        // Guide + Y walks the ring from the default; Slim is one press past Debug so the
+        // three layouts people already know keep their order.
         assertEquals(NovaHudMode.PERFORMANCE, NovaHudMode.MINIMAL.next())
         assertEquals(NovaHudMode.DEBUG, NovaHudMode.PERFORMANCE.next())
-        assertEquals(NovaHudMode.MINIMAL, NovaHudMode.DEBUG.next())
+        assertEquals(NovaHudMode.SLIM, NovaHudMode.DEBUG.next())
+        assertEquals(NovaHudMode.MINIMAL, NovaHudMode.SLIM.next())
+        // A picker lists them smallest to largest.
+        assertEquals(
+            listOf(NovaHudMode.SLIM, NovaHudMode.MINIMAL, NovaHudMode.PERFORMANCE, NovaHudMode.DEBUG),
+            NovaHudMode.entries
+        )
+    }
+
+    @Test
+    fun debugTilesGradeDecodeTimeAgainstTheFrameBudget() {
+        fun debug(decodeMs: Double, target: Double, host: Double? = null) = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = target,
+            latencyMs = 3,
+            codec = "hevc",
+            bitrateKbps = 20000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = emptyList(),
+            decodeTimeMs = decodeMs,
+            hostProcessingLatencyMs = host,
+            incomingFps = 60.4,
+            renderedFps = 59.6
+        )
+
+        val noSample = debug(0.0, 120.0)
+        assertEquals("--", noSample.decodeTimeLabel)
+        assertEquals(NovaHudTone.MUTED, noSample.decodeTone)
+        assertEquals("--", noSample.hostLatencyLabel)
+
+        // Under 10 ms the decimal is the difference between decoders.
+        val quick = debug(3.0, 120.0, host = 2.14)
+        assertEquals("3.0ms", quick.decodeTimeLabel)
+        assertEquals(NovaHudTone.STABLE, quick.decodeTone)
+        assertEquals("2.1ms", quick.hostLatencyLabel)
+        assertEquals("60", quick.incomingFpsLabel)
+        assertEquals("60", quick.renderedFpsLabel)
+
+        // 13 ms is fine inside a 60 fps frame and a dropped frame at 120.
+        assertEquals("13ms", debug(13.0, 60.0).decodeTimeLabel)
+        assertEquals(NovaHudTone.WARNING, debug(13.0, 60.0).decodeTone)
+        assertEquals(NovaHudTone.DANGER, debug(13.0, 120.0).decodeTone)
+        // With no target yet the budget is 60 fps.
+        assertEquals(NovaHudTone.WARNING, debug(9.0, 0.0).decodeTone)
+        assertEquals(NovaHudTone.STABLE, debug(4.0, 0.0).decodeTone)
     }
 
     @Test
@@ -222,6 +236,19 @@ class NovaHudUiStateTest {
             sparklineSamples = emptyList()
         )
 
+        val slim = NovaHudUiState.from(
+            mode = NovaHudMode.SLIM,
+            fps = 59.7,
+            targetFps = 120.0,
+            latencyMs = 51,
+            codec = "AV1 Main",
+            bitrateKbps = 24187,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = emptyList()
+        )
+
         assertEquals("/120", performance.targetFpsLabel)
         assertEquals("24M", performance.bitrateLabel)
         assertEquals("1080p", performance.resolutionLabel)
@@ -229,6 +256,10 @@ class NovaHudUiStateTest {
         assertEquals(NovaHudTone.DANGER, performance.latencyTone)
         assertEquals("", minimal.targetFpsLabel)
         assertEquals("24 Mbps", debug.bitrateLabel)
+        assertEquals("", slim.targetFpsLabel)
+        assertEquals("60", slim.fpsLabel)
+        assertEquals("51ms", slim.latencyLabel)
+        assertEquals("1080p", slim.resolutionLabel)
     }
 
     @Test
@@ -1222,7 +1253,7 @@ class NovaHudUiStateTest {
     }
 
     @Test
-    fun streamHudConsumesStructuredPerfSamplesBesideTextFallback() {
+    fun streamHudConsumesStructuredPerfSamplesOnly() {
         val source = String(
             Files.readAllBytes(Path.of("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")),
             StandardCharsets.UTF_8
@@ -1231,8 +1262,12 @@ class NovaHudUiStateTest {
         assertTrue(source.contains("fun updateFromPerfSample(sample: PerfOverlaySample)"))
         assertTrue(source.contains("updateFps(sample.fps)"))
         assertTrue(source.contains("sessionStats.recordRawMediaEvidence(sample)"))
-        assertTrue(source.contains("updateFromPerfText(text: String)"))
-        assertTrue(source.contains("NovaHudPerfSample.fromPerfText(text)"))
+        assertTrue(source.contains("lastDecodeTimeMs = sample.decodeTimeMs"))
+        // The text path is gone on purpose. It made the decoder build the legacy overlay
+        // string on the decode thread whenever the HUD was up, to regex out numbers the
+        // struct already carries, and it published the HUD twice per sample.
+        assertFalse(source.contains("updateFromPerfText"))
+        assertFalse(source.contains("fromPerfText"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -33,7 +33,10 @@ class NovaQuickMenuUiStateTest {
         assertEquals("Leave", state.endAction.label)
         assertFalse(state.controlRows.first { it.id == NovaQuickMenuActionId.MOUSE_MODE }.enabled)
         assertFalse(state.controlRows.first { it.id == NovaQuickMenuActionId.KEYBOARD }.enabled)
-        assertFalse(state.advancedRows.any { it.id == NovaQuickMenuActionId.AI_AUTO_QUALITY })
+        assertEquals(
+            listOf(NovaQuickMenuActionId.CLEAR_GAME_PROFILE, NovaQuickMenuActionId.MANGOHUD),
+            state.advancedRows.map { it.id }
+        )
         assertEquals("Owner", state.stability.chip.label)
         assertEquals(NovaQuickMenuTone.MUTED, state.stability.chip.tone)
     }
@@ -189,7 +192,10 @@ class NovaQuickMenuUiStateTest {
 
         assertEquals("Checking stream mode", state.sessionMode.label)
         assertEquals("N/A", state.advancedRows.first { it.id == NovaQuickMenuActionId.MANGOHUD }.chip!!.label)
-        assertFalse(state.advancedRows.any { it.id == NovaQuickMenuActionId.AI_AUTO_QUALITY })
+        assertEquals(
+            listOf(NovaQuickMenuActionId.CLEAR_GAME_PROFILE, NovaQuickMenuActionId.MANGOHUD),
+            state.advancedRows.map { it.id }
+        )
         assertFalse(state.advancedRows.first { it.id == NovaQuickMenuActionId.CLEAR_GAME_PROFILE }.enabled)
     }
 
@@ -679,20 +685,22 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
-    fun overlaysCarryAHudModeRowThatOnlyCyclesWhileTheHudIsShowing() {
+    fun overlaysPickTheHudModeDirectlyAndOnlyWhileTheHudIsShowing() {
         val showing = quickState(status = status(), hudShowing = true, hudMode = NovaHudMode.DEBUG)
         val hidden = quickState(status = status(), hudShowing = false, hudMode = NovaHudMode.PERFORMANCE)
 
-        val showingRow = showing.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD_MODE }
-        assertEquals("HUD Mode", showingRow.label)
-        assertEquals("Debug", showingRow.chip!!.label)
-        assertEquals(NovaQuickMenuTone.INFO, showingRow.chip.tone)
-        assertTrue(showingRow.enabled)
+        // Every layout is one tap away, smallest first. This was a row that cycled blind.
+        assertEquals(listOf("Slim", "Minimal", "Performance", "Debug"), showing.hudMode.options.map { it.label })
+        assertEquals(listOf("slim", "minimal", "performance", "debug"), showing.hudMode.options.map { it.value })
+        assertEquals(NovaHudMode.DEBUG, showing.hudMode.selected)
+        assertEquals(listOf(false, false, false, true), showing.hudMode.options.map { it.selected })
+        assertTrue(showing.hudMode.enabled)
+        assertTrue(showing.hudMode.options.all { it.enabled })
+        assertTrue(showing.overlayRows.none { it.label == "HUD Mode" })
 
-        val hiddenRow = hidden.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD_MODE }
-        assertEquals("Performance", hiddenRow.chip!!.label)
-        assertEquals(NovaQuickMenuTone.MUTED, hiddenRow.chip.tone)
-        assertFalse(hiddenRow.enabled)
+        assertEquals(NovaHudMode.PERFORMANCE, hidden.hudMode.selected)
+        assertFalse(hidden.hudMode.enabled)
+        assertTrue(hidden.hudMode.options.none { it.enabled })
 
         val hudRow = showing.overlayRows.first { it.id == NovaQuickMenuActionId.NOVA_HUD }
         assertEquals("Long press the HUD to open Command Center.", hudRow.caption)

--- a/app/src/test/java/com/papi/nova/ui/NovaStreamHudModeTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaStreamHudModeTest.kt
@@ -42,6 +42,30 @@ class NovaStreamHudModeTest {
     }
 
     @Test
+    fun setModePersistsTheChosenHudModePreference() {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        val content = activity.findViewById<ViewGroup>(R.id.content)
+        content.setViewTreeLifecycleOwner(activity)
+        content.setViewTreeViewModelStoreOwner(activity)
+        content.setViewTreeSavedStateRegistryOwner(activity)
+        val prefs = PreferenceManager.getDefaultSharedPreferences(activity)
+        prefs.edit().putString("nova_polaris_hud_mode", NovaHudMode.MINIMAL.preferenceValue).commit()
+
+        val hud = NovaStreamHud(activity)
+        hud.show()
+
+        // The Command Center picker jumps straight to a layout instead of cycling.
+        hud.setMode(NovaHudMode.SLIM)
+
+        assertEquals(
+            NovaHudMode.SLIM.preferenceValue,
+            prefs.getString("nova_polaris_hud_mode", null)
+        )
+
+        hud.dismiss()
+    }
+
+    @Test
     fun hudLongPressOpensCommandCenterAndPositionPersistsInsideSafeZone() {
         val source = String(
             java.nio.file.Files.readAllBytes(java.nio.file.Path.of("src/main/java/com/papi/nova/ui/NovaStreamHud.kt")),


### PR DESCRIPTION
## Summary

- NovaHUD Debug gains DEC (decode time, graded against the frame budget at the target rate), HOST (host processing latency), and IN / OUT (incoming against rendered fps). That is the decode time asked for in #275 and the rest of what the legacy Moonlight text knew, inside the HUD.
- A fourth layout, Slim: one pill with the health bar, the frame rate, and the round trip. Guide + Y cycles Minimal, Performance, Debug, Slim, and the settings preview renders it.
- Stats Overlay toggled from Command Center works on a stream that started with it off, and the toggle is remembered in Settings. It used to flip an in-memory flag and a View, so the overlay came up empty (the before screenshots show it). Turning it on turns Nova HUD off for the next stream too, and the reverse.
- NovaHUD reads the decoder's structured sample only. The decoder no longer builds the legacy overlay text on the decode thread while just the HUD is showing, and the HUD publishes once per sample instead of twice. The parts of the HUD whose inputs did not change skip recomposition: the state is immutable, and the strips and chips take only the fields they draw.
- Command Center keeps Close, Disconnect, and End Session fixed above the scrolling sections, picks the HUD layout with four buttons instead of cycling blind, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag. Quick keys are built once per open, capabilities are fetched once per session, and the dead AI Auto Quality arm is gone.
- Removed the unreachable lite, bottom, and lite-dialog variants of the legacy overlay, and the HUD Position setting that nothing read.

## Exact candidate

- `Commit:` 45166e6924b4c3557990f40965c38d0d20401d02
- `Tree:` d11c30484ff188a96f69c90c6f9d2e307c741d53
- `Parent:` a8df7dcc6edae96c320854b3458aa3154dea694a
- `Base:` 1895589b (master, Nova 1.4.3)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` (x86_64): 1609 tests, 0 failures, 0 errors
- [x] `:app:lintNonRoot_gameDebug -PlintFailOnError=true`: clean
- [x] `:app:assembleNonRoot_gameDebug` (arm64-v8a), installed on the Retroid Pocket 6 as `com.papi.nova.debug`, paired through Trusted Pair against Polaris 1.4.3 on pc-papi, live Control Ultimate Edition stream at 1920x1080@60 HEVC
- [x] Device: Command Center first paint unchanged; header stays put while scrolled to Advanced; the picker is disabled with its own caption while the HUD is off, enabled after, and stays in sync with Guide + Y; Slim, Minimal, Performance, and Debug all rendered; Debug read DEC 8.1ms, HOST 2.4ms, IN 60, OUT 58 while the legacy text on the same stream read 9.69 ms decode and 2.2 ms host a few minutes later (same sample field, different moments); Stats Overlay toggled from Command Center on a stream that started with it off showed the text at once, and the choice survived a reinstall and relaunch; opacity rows expand and collapse; End Session tore down cleanly (host log: active sessions 0)
- [x] Frame stats from `dumpsys gfxinfo`, 60 s each, the HUD ticking once per second over the static Control title screen:

| build | HUD mode | frames | p50 | p90 | p99 | janky | slow UI thread |
|---|---|---|---|---|---|---|---|
| 1.4.3 | Debug | 59 | 11 ms | 13 ms | 14 ms | 1 | 1 |
| this branch before the skip pass | Debug | 60 | 13 ms | 14 ms | 16 ms | 21 | 21 |
| this branch before the skip pass | Performance | 59 | 11 ms | 12 ms | 13 ms | 0 | 0 |
| this branch | Debug | 59 | 12 ms | 13 ms | 16 ms | 11 | 11 |
| this branch | Performance | 60 | 11 ms | 12 ms | 14 ms | 2 | 1 |

Debug carries three more live tiles than before and pays about a millisecond per tick for them. Performance, Minimal, and Slim are unchanged or cheaper. These are single 60 s runs, so a difference of a frame or two is noise. The decode-thread saving (no legacy text built while only the HUD is up) does not show in these numbers by construction; they measure the View layer.

Screenshots and the raw gfxinfo dumps are under `~/.hermes/artifacts/nova/cc-hud-revamp-2026-09-06/` on MacPapi.

## Not covered

- androidTest is not compiled by CI and already fails to compile on master (NovaGameDetailComposeTest, NovaPolarisSyncSheetComposeTest). The two HUD androidTests were not touched and were not run.
- The companion-display Command Center (the legacy GameMenu on a second screen) is unchanged.
- Polaris on pc-papi was started as `polaris.service` for this QA and stopped again afterwards; it was not running before.
