### PR TITLE
feat(library): call the button Wake Host and tell a sleeping host from one with Polaris down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The library's Start Polaris button is now Wake Host, which is what it does. It tells a sleeping host apart from one that is awake with Polaris down: the first gets a wake packet, the second gets told to start Polaris on the host or enable headless boot. The timeout message says that a wake packet only reaches a sleeping host from its own network.
 - NovaHUD gains a Slim layout: one pill with the health bar, the frame rate, and the round trip. Guide + Y now cycles Minimal, Performance, Debug, Slim.
 - NovaHUD Debug shows decode time (DEC), graded against the frame budget at the target rate, plus host processing latency (HOST) and incoming against rendered frame rate (IN / OUT). That is the rest of what the legacy stats text knew, inside the HUD.
 - Command Center picks the HUD layout with four buttons instead of cycling blind, keeps Close, Disconnect, and End Session fixed above the scrolling sections, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag.

--- a/app/src/main/java/com/papi/nova/PcView.kt
+++ b/app/src/main/java/com/papi/nova/PcView.kt
@@ -53,6 +53,7 @@ import com.papi.nova.grid.PcGridAdapter
 import com.papi.nova.grid.assets.DiskAssetLoader
 import com.papi.nova.manager.PolarisStartupCoordinator
 import com.papi.nova.manager.PolarisStartupStatus
+import com.papi.nova.manager.TcpHostReachabilityProbe
 import com.papi.nova.nvstream.http.ComputerDetails
 import com.papi.nova.nvstream.http.NvApp
 import com.papi.nova.nvstream.http.NvHTTP
@@ -2441,7 +2442,8 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
                     override fun hasGameLibrary(computer: ComputerDetails): Boolean {
                         return probePolarisGameLibrary(computer)
                     }
-                }
+                },
+                reachabilityProbe = TcpHostReachabilityProbe()
             )
             val result = coordinator.start(computer)
             runtimeTasks.runOnMainIfActive {
@@ -2485,6 +2487,8 @@ class PcView : NovaActivity(), AdapterFragmentCallbacks {
                 NovaSnackbar.showError(this, getString(R.string.pcview_polaris_start_timeout))
             PolarisStartupStatus.POLARIS_UNAVAILABLE ->
                 NovaSnackbar.showError(this, getString(R.string.pcview_polaris_start_unavailable))
+            PolarisStartupStatus.POLARIS_NOT_RUNNING ->
+                NovaSnackbar.showError(this, getString(R.string.pcview_polaris_start_not_running))
         }
     }
 

--- a/app/src/main/java/com/papi/nova/manager/PolarisStartupCoordinator.kt
+++ b/app/src/main/java/com/papi/nova/manager/PolarisStartupCoordinator.kt
@@ -10,7 +10,8 @@ enum class PolarisStartupStatus {
     MISSING_MAC,
     WAKE_FAILED,
     TIMEOUT,
-    POLARIS_UNAVAILABLE
+    POLARIS_UNAVAILABLE,
+    POLARIS_NOT_RUNNING
 }
 
 data class PolarisStartupResult(
@@ -18,11 +19,17 @@ data class PolarisStartupResult(
     val computer: ComputerDetails? = null
 )
 
+/**
+ * Wake Host: the one thing a client can do for a host it cannot reach is send a wake
+ * packet, then wait for Polaris to answer. It cannot start Polaris on a machine that
+ * is already awake, so it says which of the two it is looking at instead of pretending.
+ */
 class PolarisStartupCoordinator(
     private val wakeSender: WakeSender,
     private val hostPoller: HostPoller,
     private val polarisProbe: PolarisProbe,
-    private val sleeper: Sleeper = ThreadSleeper
+    private val sleeper: Sleeper = ThreadSleeper,
+    private val reachabilityProbe: HostReachabilityProbe = HostReachabilityProbe.ASSUME_ASLEEP
 ) {
     interface WakeSender {
         @Throws(IOException::class)
@@ -35,6 +42,22 @@ class PolarisStartupCoordinator(
 
     interface PolarisProbe {
         fun hasGameLibrary(computer: ComputerDetails): Boolean
+    }
+
+    /**
+     * Whether the machine itself is up, independent of Polaris. A host that is awake
+     * with nothing listening refuses a TCP connect in milliseconds; a sleeping or
+     * powered-off one answers nothing.
+     */
+    interface HostReachabilityProbe {
+        fun isAwake(computer: ComputerDetails): Boolean
+
+        companion object {
+            /** The pre-probe behaviour: treat every offline host as asleep and wake it. */
+            val ASSUME_ASLEEP: HostReachabilityProbe = object : HostReachabilityProbe {
+                override fun isAwake(computer: ComputerDetails): Boolean = false
+            }
+        }
     }
 
     interface Sleeper {
@@ -51,21 +74,34 @@ class PolarisStartupCoordinator(
         }
 
         var current = ComputerDetails(computer)
-        if (current.state != ComputerDetails.State.ONLINE) {
-            if (current.macAddress.isNullOrBlank()) {
-                return PolarisStartupResult(PolarisStartupStatus.MISSING_MAC, current)
-            }
-            try {
-                wakeSender.wake(current)
-            } catch (_: IOException) {
-                return PolarisStartupResult(PolarisStartupStatus.WAKE_FAILED, current)
+        var hostAwake = current.state == ComputerDetails.State.ONLINE
+        if (!hostAwake) {
+            // Only a machine that answers nothing is a wake packet's job. One that refuses
+            // the connect is up already; its Polaris is down, and no packet fixes that.
+            hostAwake = reachabilityProbe.isAwake(current)
+            if (!hostAwake) {
+                if (current.macAddress.isNullOrBlank()) {
+                    return PolarisStartupResult(PolarisStartupStatus.MISSING_MAC, current)
+                }
+                try {
+                    wakeSender.wake(current)
+                } catch (_: IOException) {
+                    return PolarisStartupResult(PolarisStartupStatus.WAKE_FAILED, current)
+                }
             }
         }
 
         var sawOnlineHost = current.state == ComputerDetails.State.ONLINE
-        val attempts = maxPollAttempts.coerceAtLeast(1)
+        // A sleeping host needs the full budget to boot. An awake one with Polaris down
+        // only needs long enough to catch a service that is starting right now; past
+        // that, waiting is just delaying the answer.
+        val budget = if (hostAwake && !sawOnlineHost) minOf(maxPollAttempts, AWAKE_POLL_ATTEMPTS) else maxPollAttempts
+        val attempts = budget.coerceAtLeast(1)
         repeat(attempts) { attempt ->
-            if (current.state != ComputerDetails.State.ONLINE) {
+            // The cached state can be stale: Polaris may have quit since the list last
+            // polled. Re-poll on every pass after the first so a host that went down is
+            // noticed, instead of blaming its library for thirty seconds.
+            if (attempt > 0 || current.state != ComputerDetails.State.ONLINE) {
                 current = hostPoller.poll(current)
             }
             if (current.state == ComputerDetails.State.ONLINE) {
@@ -81,10 +117,15 @@ class PolarisStartupCoordinator(
             }
         }
 
-        return if (sawOnlineHost) {
-            PolarisStartupResult(PolarisStartupStatus.POLARIS_UNAVAILABLE, current)
-        } else {
-            PolarisStartupResult(PolarisStartupStatus.TIMEOUT, current)
+        return when {
+            // Still answering as a host, just without a Polaris library: a plain Moonlight host.
+            current.state == ComputerDetails.State.ONLINE ->
+                PolarisStartupResult(PolarisStartupStatus.POLARIS_UNAVAILABLE, current)
+            // The machine is up (it was online a moment ago, or it refused the connect) but
+            // nothing answers as a host now: Polaris is not running there.
+            hostAwake || sawOnlineHost ->
+                PolarisStartupResult(PolarisStartupStatus.POLARIS_NOT_RUNNING, current)
+            else -> PolarisStartupResult(PolarisStartupStatus.TIMEOUT, current)
         }
     }
 
@@ -101,5 +142,7 @@ class PolarisStartupCoordinator(
     companion object {
         const val DEFAULT_POLL_ATTEMPTS = 12
         const val DEFAULT_POLL_DELAY_MS = 2500L
+        /** Four polls at the default delay is ten seconds, twice the service's own start delay. */
+        const val AWAKE_POLL_ATTEMPTS = 4
     }
 }

--- a/app/src/main/java/com/papi/nova/manager/TcpHostReachabilityProbe.kt
+++ b/app/src/main/java/com/papi/nova/manager/TcpHostReachabilityProbe.kt
@@ -1,0 +1,54 @@
+package com.papi.nova.manager
+
+import com.papi.nova.nvstream.http.ComputerDetails
+import java.io.IOException
+import java.net.ConnectException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketTimeoutException
+
+/**
+ * Tells a sleeping host from an awake one with Polaris down, without needing Polaris.
+ *
+ * A TCP connect to the host's streaming port is answered by the kernel, not by Polaris:
+ * an awake machine with nothing listening refuses it within milliseconds, while a
+ * sleeping or powered-off one lets it time out or reports no route. Every known
+ * address is tried so a host reached over a VPN or a manual entry is not misread as
+ * asleep because its LAN address is unreachable from here.
+ */
+class TcpHostReachabilityProbe(
+    private val timeoutMs: Int = DEFAULT_TIMEOUT_MS
+) : PolarisStartupCoordinator.HostReachabilityProbe {
+
+    override fun isAwake(computer: ComputerDetails): Boolean {
+        val candidates = listOfNotNull(
+            computer.activeAddress,
+            computer.localAddress,
+            computer.manualAddress,
+            computer.remoteAddress,
+            computer.ipv6Address
+        )
+            .filter { !it.address.isNullOrBlank() }
+            .distinctBy { it.address to it.port }
+        for (tuple in candidates) {
+            try {
+                Socket().use { socket ->
+                    socket.connect(InetSocketAddress(tuple.address, tuple.port), timeoutMs)
+                }
+                return true
+            } catch (_: ConnectException) {
+                // Refused: the machine answered, so it is up. Polaris is what is missing.
+                return true
+            } catch (_: SocketTimeoutException) {
+                // No answer on this address; a sleeping host looks like this.
+            } catch (_: IOException) {
+                // No route, or the address is not reachable from this network.
+            }
+        }
+        return false
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_MS = 1500
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="pcview_menu_header_format">%1$s · %2$s</string>
     <string name="pcview_menu_app_list">Compatibility App List</string>
     <string name="pcview_menu_nova_library">Open Library</string>
-    <string name="pcview_menu_start_polaris">Start Polaris</string>
+    <string name="pcview_menu_start_polaris">Wake Host</string>
     <string name="pcview_menu_section_play">Play</string>
     <string name="pcview_menu_section_manage">Manage</string>
     <string name="pcview_menu_pair_pc">Trusted Pair</string>
@@ -78,8 +78,8 @@
     <string name="pcview_hosts_summary_format">%1$d visible · %2$d total</string>
     <string name="pcview_quick_add_server">Add Server</string>
     <string name="pcview_quick_scan_pair">Scan Pair</string>
-    <string name="pcview_quick_polaris_sync">Start Polaris</string>
-    <string name="pcview_quick_start_polaris">Start Polaris</string>
+    <string name="pcview_quick_polaris_sync">Wake Host</string>
+    <string name="pcview_quick_start_polaris">Wake Host</string>
     <string name="pcview_quick_profiles">Profiles</string>
     <string name="pcview_quick_theme">Theme</string>
     <string name="pcview_quick_github">GitHub</string>
@@ -591,11 +591,12 @@
 	    If it doesn\'t, make sure it\'s configured properly for Wake-On-LAN.
     </string>
     <string name="wol_fail">Failed to send Wake-On-LAN packets</string>
-    <string name="pcview_polaris_starting">Starting Polaris…</string>
+    <string name="pcview_polaris_starting">Waking the host and waiting for Polaris…</string>
     <string name="pcview_polaris_started">Polaris is ready</string>
     <string name="pcview_polaris_start_no_server">No paired Polaris host is available</string>
-    <string name="pcview_polaris_start_pair_first">Pair with this host before starting Polaris from Nova</string>
-    <string name="pcview_polaris_start_timeout">Polaris did not come online. Enable host autostart and try again.</string>
+    <string name="pcview_polaris_start_pair_first">Pair with this host before waking it from Nova</string>
+    <string name="pcview_polaris_start_timeout">The host did not answer. A wake packet only reaches a sleeping host from its own network.</string>
+    <string name="pcview_polaris_start_not_running">The host is awake, but Polaris is not answering. Start it on the host, or enable headless boot so it starts on its own.</string>
     <string name="pcview_polaris_start_unavailable">This host did not report Polaris Library support</string>
     <string name="pcview_polaris_start_failed">Polaris started, but Nova could not open the library</string>
 

--- a/app/src/test/java/com/papi/nova/WakeHostSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/WakeHostSourceGuardTest.kt
@@ -1,0 +1,40 @@
+package com.papi.nova
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WakeHostSourceGuardTest {
+    @Test
+    fun theLibraryButtonPromisesOnlyWhatAClientCanDo() {
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue(
+            "a client can send a wake packet and wait; it cannot start Polaris on an awake host, so the button says Wake Host",
+            strings.contains("<string name=\"pcview_quick_start_polaris\">Wake Host</string>") &&
+                strings.contains("<string name=\"pcview_menu_start_polaris\">Wake Host</string>")
+        )
+        assertFalse(
+            "no surface still calls the action Start Polaris",
+            strings.contains(">Start Polaris<")
+        )
+    }
+
+    @Test
+    fun wakeHostTellsASleepingHostFromOneWithPolarisDown() {
+        val pcView = File("src/main/java/com/papi/nova/PcView.kt").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue(
+            "the startup coordinator gets a real reachability probe, so an awake host with Polaris down is not woken and waited on for nothing",
+            pcView.contains("reachabilityProbe = TcpHostReachabilityProbe()")
+        )
+        assertTrue(
+            "the awake-but-down case gets its own message, naming what to do on the host",
+            pcView.contains("PolarisStartupStatus.POLARIS_NOT_RUNNING ->") &&
+                strings.contains("name=\"pcview_polaris_start_not_running\"") &&
+                strings.contains("enable headless boot")
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/manager/PolarisStartupCoordinatorTest.kt
+++ b/app/src/test/java/com/papi/nova/manager/PolarisStartupCoordinatorTest.kt
@@ -129,10 +129,104 @@ class PolarisStartupCoordinatorTest {
         assertEquals(ComputerDetails.LibraryState.UNAVAILABLE, result.computer?.libraryState)
     }
 
+    @Test
+    fun awakeHostWithPolarisDownIsToldSoInsteadOfBeingWoken() {
+        var wakeCalled = false
+        var pollCount = 0
+
+        val result = coordinator(
+            wake = { wakeCalled = true },
+            poll = {
+                pollCount++
+                it
+            },
+            awake = { true }
+        ).start(
+            computer = pairedComputer(state = ComputerDetails.State.OFFLINE),
+            maxPollAttempts = PolarisStartupCoordinator.DEFAULT_POLL_ATTEMPTS,
+            pollDelayMs = 0
+        )
+
+        // The machine answered the connect, so a wake packet has nothing to do; the
+        // honest answer is that Polaris is not running there, and it should not take
+        // the full boot budget to say so.
+        assertFalse(wakeCalled)
+        assertEquals(PolarisStartupStatus.POLARIS_NOT_RUNNING, result.status)
+        assertEquals(PolarisStartupCoordinator.AWAKE_POLL_ATTEMPTS, pollCount)
+    }
+
+    @Test
+    fun awakeHostWhosePolarisComesUpDuringPollingIsReady() {
+        var wakeCalled = false
+        var pollCount = 0
+        val online = pairedComputer(state = ComputerDetails.State.ONLINE)
+
+        val result = coordinator(
+            wake = { wakeCalled = true },
+            poll = {
+                pollCount++
+                if (pollCount >= 2) online else it
+            },
+            probe = { true },
+            awake = { true }
+        ).start(
+            computer = pairedComputer(state = ComputerDetails.State.OFFLINE),
+            maxPollAttempts = 4,
+            pollDelayMs = 0
+        )
+
+        assertFalse(wakeCalled)
+        assertEquals(PolarisStartupStatus.READY, result.status)
+    }
+
+    @Test
+    fun hostThatWentDownSinceTheLastPollIsReportedAsPolarisNotRunning() {
+        var wakeCalled = false
+        var probeCount = 0
+        val offline = pairedComputer(state = ComputerDetails.State.OFFLINE)
+
+        val result = coordinator(
+            wake = { wakeCalled = true },
+            // The list still says online; the first real poll says otherwise.
+            poll = { offline },
+            probe = {
+                probeCount++
+                false
+            },
+            awake = { true }
+        ).start(
+            computer = pairedComputer(state = ComputerDetails.State.ONLINE),
+            maxPollAttempts = 3,
+            pollDelayMs = 0
+        )
+
+        assertFalse(wakeCalled)
+        assertEquals(1, probeCount)
+        assertEquals(PolarisStartupStatus.POLARIS_NOT_RUNNING, result.status)
+    }
+
+    @Test
+    fun unreachableHostStillGetsTheWakePacketAndTimesOut() {
+        var wakeCalled = false
+
+        val result = coordinator(
+            wake = { wakeCalled = true },
+            awake = { false }
+        ).start(
+            computer = pairedComputer(state = ComputerDetails.State.OFFLINE),
+            maxPollAttempts = 2,
+            pollDelayMs = 0
+        )
+
+        assertTrue(wakeCalled)
+        assertEquals(PolarisStartupStatus.TIMEOUT, result.status)
+    }
+
     private fun coordinator(
         wake: (ComputerDetails) -> Unit = {},
         poll: (ComputerDetails) -> ComputerDetails = { it },
-        probe: (ComputerDetails) -> Boolean = { false }
+        probe: (ComputerDetails) -> Boolean = { false },
+        awake: (ComputerDetails) -> Boolean = { false }
     ) = PolarisStartupCoordinator(
         wakeSender = object : PolarisStartupCoordinator.WakeSender {
             override fun wake(computer: ComputerDetails) = wake(computer)
@@ -145,6 +239,9 @@ class PolarisStartupCoordinatorTest {
         },
         sleeper = object : PolarisStartupCoordinator.Sleeper {
             override fun sleep(delayMs: Long) = Unit
+        },
+        reachabilityProbe = object : PolarisStartupCoordinator.HostReachabilityProbe {
+            override fun isAwake(computer: ComputerDetails): Boolean = awake(computer)
         }
     )
 


### PR DESCRIPTION
## Summary

- The library's Start Polaris button is now Wake Host, which is all a client can do for a host it cannot reach. It cannot start Polaris on a machine that is already awake, and it used to pretend otherwise: wake nothing, wait thirty seconds, then say Polaris did not come online.
- Before waking, the coordinator asks the machine itself. A TCP connect to the streaming port is refused within milliseconds by an awake host with nothing listening and answered by nothing on a sleeping one. The awake case is not woken and is reported within about ten seconds as "The host is awake, but Polaris is not answering. Start it on the host, or enable headless boot so it starts on its own." The silent case still gets the wake packet and the full boot budget, and its timeout message says a wake packet only reaches a sleeping host from its own network, which is what a phone on the road runs into.
- A host that quit since the list last polled is re-polled instead of being blamed for its library for thirty seconds.
- The probe tries every address Nova knows for the host, so a VPN or manual entry is not misread as asleep because the LAN address is out of reach.
- Pairs with papi-ux/polaris#617 (the application menu starts the user service instead of a second process) and headless boot on the host. Together they make the awake-but-down state rare, and this PR makes the button honest when it happens.

## Exact candidate

- `Commit:` de148950050415395757d6a8375c867fc6a23aec
- `Tree:` 041beb80edacbabf644d59146505ab4178d6ae55
- `Parent:` 90ac578eea005e2e4cd930014ba8d47936b12f86
- `Base:` 90ac578e (master)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` (x86_64): 1615 tests, 0 failures, 0 errors (PolarisStartupCoordinatorTest 10, WakeHostSourceGuardTest 2)
- [x] `:app:lintNonRoot_gameDebug -PlintFailOnError=true`: clean
- [x] `:app:assembleNonRoot_gameDebug` (arm64-v8a), installed on the Retroid Pocket 6 as `com.papi.nova.debug`
- [x] Device: the sidebar button reads Wake Host. With `polaris.service` stopped on pc-papi and no stream live, pressing it produced the awake-but-down message about 8 s after the press (screenshot); after starting the service, pressing it again opened the library within 3 s.
- [x] Unit tests pin that the awake case sends no wake packet and polls four times, that a silent host still gets the packet and times out, and that a host which went down since the last poll is reported as Polaris not running.

## Not covered

- The sleeping-host path (wake packet, timeout message) was not exercised on a device; pc-papi did not sleep today. The unit tests cover the branch.
- androidTest is not compiled by CI and already fails to compile on master; nothing there was touched.
