### PR TITLE
feat(hud): put the verdict's explanation first, make Slim a MangoHud bar, add the network row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 - The library's Start Polaris button is now Wake Host, which is what it does. It tells a sleeping host apart from one that is awake with Polaris down: the first gets a wake packet, the second gets told to start Polaris on the host or enable headless boot. The timeout message says that a wake packet only reaches a sleeping host from its own network.
-- NovaHUD gains a Slim layout: one pill with the health bar, the frame rate, and the round trip. Guide + Y now cycles Minimal, Performance, Debug, Slim.
+- Command Center puts the Doctor's reading and the Stream card right under the session strip, where the verdict they explain lives, then Overlays, Controls, Session, and the full Quick Keys grid. Esc, Meta, and Alt + Enter stay pinned under the strip, one reach from the top.
+- NovaHUD gains a Slim layout, a one-line bar in the MangoHud spirit: the health bar, the frame rate with its last minute drawn beside it, then decode time, round trip, and bitrate with inline labels. Guide + Y now cycles Minimal, Performance, Debug, Slim.
 - NovaHUD Debug shows decode time (DEC), graded against the frame budget at the target rate, plus host processing latency (HOST) and incoming against rendered frame rate (IN / OUT). That is the rest of what the legacy stats text knew, inside the HUD.
+- NovaHUD Debug gains a network row: packet loss in the current window (LOSS), graded so zero is the only green, round-trip jitter (JIT), and frames lost this session (DROPS).
 - Command Center picks the HUD layout with four buttons instead of cycling blind, keeps Close, Disconnect, and End Session fixed above the scrolling sections, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag.
 - Stats Overlay toggled from Command Center works on a stream that started with it off, and the toggle is remembered in Settings. Turning it on turns Nova HUD off for the next stream too, and the reverse.
 - NovaHUD reads the decoder's structured sample only. The decoder no longer builds the legacy overlay text while just the HUD is showing, and the HUD updates once per sample instead of twice.

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -88,7 +88,13 @@ data class NovaHudUiState(
     val decodeTone: NovaHudTone = NovaHudTone.MUTED,
     val hostLatencyLabel: String = "--",
     val incomingFpsLabel: String = "--",
-    val renderedFpsLabel: String = "--"
+    val renderedFpsLabel: String = "--",
+    // Debug's network row: loss in the current window, round-trip jitter, and the
+    // session's lost-frame count. The decoder reports all three; nothing showed them.
+    val packetLossLabel: String = "--",
+    val packetLossTone: NovaHudTone = NovaHudTone.MUTED,
+    val jitterLabel: String = "--",
+    val framesLostLabel: String = "--"
 ) {
     companion object {
         private const val SPARKLINE_CAPACITY = 60
@@ -147,7 +153,10 @@ data class NovaHudUiState(
             decodeTimeMs = 6.4,
             hostProcessingLatencyMs = 2.1,
             incomingFps = 60.0,
-            renderedFps = 60.0
+            renderedFps = 60.0,
+            packetLossPct = 0.0,
+            rttVarianceMs = 2,
+            framesLost = 0L
         )
 
         fun from(
@@ -166,7 +175,10 @@ data class NovaHudUiState(
             decodeTimeMs: Double = 0.0,
             hostProcessingLatencyMs: Double? = null,
             incomingFps: Double = 0.0,
-            renderedFps: Double = 0.0
+            renderedFps: Double = 0.0,
+            packetLossPct: Double = -1.0,
+            rttVarianceMs: Int = -1,
+            framesLost: Long = -1L
         ): NovaHudUiState {
             val autoQuality = AutoQualityUiState.from(status, targetFps)
             val healthReason = buildHealthReason(status, latencyMs)
@@ -203,8 +215,32 @@ data class NovaHudUiState(
                 decodeTone = toneForDecode(decodeTimeMs, targetFps),
                 hostLatencyLabel = formatMillis(hostProcessingLatencyMs ?: 0.0),
                 incomingFpsLabel = formatFps(incomingFps),
-                renderedFpsLabel = formatFps(renderedFps)
+                renderedFpsLabel = formatFps(renderedFps),
+                packetLossLabel = formatPercent(packetLossPct),
+                packetLossTone = toneForPacketLoss(packetLossPct),
+                // Jitter means nothing without a round trip to wobble around.
+                jitterLabel = rttVarianceMs.takeIf { it >= 0 && latencyMs > 0 }?.let { "${it}ms" } ?: "--",
+                framesLostLabel = framesLost.takeIf { it >= 0L }?.toString() ?: "--"
             )
+        }
+
+        // Loss is a share of the frames in the last window. Zero is the only good number;
+        // a trace still gets named as one rather than rounding to a green-looking 0%.
+        fun formatPercent(pct: Double): String = when {
+            pct < 0.0 -> "--"
+            pct == 0.0 -> "0%"
+            pct < 0.1 -> "<0.1%"
+            pct < 10.0 -> String.format(java.util.Locale.US, "%.1f%%", pct)
+            else -> "${pct.roundToInt()}%"
+        }
+
+        // Under one percent the stream is losing frames you might not notice; at one
+        // percent and over it is visibly stuttering.
+        fun toneForPacketLoss(pct: Double): NovaHudTone = when {
+            pct < 0.0 -> NovaHudTone.MUTED
+            pct == 0.0 -> NovaHudTone.STABLE
+            pct < 1.0 -> NovaHudTone.WARNING
+            else -> NovaHudTone.DANGER
         }
 
         private fun formatFps(fps: Double): String =
@@ -277,9 +313,10 @@ data class NovaHudUiState(
             val full = StreamPolicyUiState.formatMbps(bitrateKbps)
             return when (mode) {
                 NovaHudMode.DEBUG,
-                NovaHudMode.MINIMAL,
-                NovaHudMode.SLIM -> full
-                NovaHudMode.PERFORMANCE -> full.replace(" Mbps", "M").replace(" ", "")
+                NovaHudMode.MINIMAL -> full
+                // The one-line layouts spend their width on numbers, not units.
+                NovaHudMode.PERFORMANCE,
+                NovaHudMode.SLIM -> full.replace(" Mbps", "M").replace(" ", "")
             }
         }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -332,24 +332,27 @@ fun NovaQuickMenuContent(
                 .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 18.dp)
         ) {
             NovaQuickMenuSessionStrip(state, initialFocusRequester)
-            // Daily use first: the strip above already carries the health verdict, so keys,
-            // input, and overlays come before the Doctor and stream cards that explain it.
+            // The keys a handheld cannot press any other way stay one reach from the top;
+            // the full keyboard grid lives further down with the rest of the panels.
+            if (state.pinnedQuickKeys.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                NovaQuickKeys(state.pinnedQuickKeys, callbacks)
+            }
+            // The strip above is a one-line verdict. What explains it, the Doctor's reading
+            // and what Auto is running, comes next instead of three screens down. The panels
+            // a player adjusts follow, Overlays first because the HUD switch is the frequent
+            // tap, and the Quick Keys grid last of them since its top three are pinned above.
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuPanel(title = quickKeysTitle) {
-                NovaQuickKeys(state.quickKeys, callbacks)
+            NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
+            if (state.doctorReceiptAction.visible) {
+                Spacer(Modifier.height(10.dp))
+                NovaQuickMenuInfoCard(
+                    action = state.doctorReceiptAction,
+                    callbacks = callbacks
+                )
             }
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuPanel(title = controlsTitle) {
-                state.controlRows.forEach { row ->
-                    NovaQuickMenuRow(action = row, callbacks = callbacks)
-                }
-            }
-            Spacer(Modifier.height(10.dp))
-            NovaQuickMenuPanel(title = sessionTitle) {
-                state.sessionRows.filter { it.visible }.forEach { row ->
-                    NovaQuickMenuRow(action = row, callbacks = callbacks)
-                }
-            }
+            NovaQuickMenuStabilityCard(state.stability, callbacks)
             Spacer(Modifier.height(10.dp))
             NovaQuickMenuPanel(title = overlaysTitle) {
                 state.overlayRows.forEach { row ->
@@ -369,16 +372,21 @@ fun NovaQuickMenuContent(
                 )
             }
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuDiagnosisCard(state.diagnosis, callbacks)
-            if (state.doctorReceiptAction.visible) {
-                Spacer(Modifier.height(10.dp))
-                NovaQuickMenuInfoCard(
-                    action = state.doctorReceiptAction,
-                    callbacks = callbacks
-                )
+            NovaQuickMenuPanel(title = controlsTitle) {
+                state.controlRows.forEach { row ->
+                    NovaQuickMenuRow(action = row, callbacks = callbacks)
+                }
             }
             Spacer(Modifier.height(10.dp))
-            NovaQuickMenuStabilityCard(state.stability, callbacks)
+            NovaQuickMenuPanel(title = sessionTitle) {
+                state.sessionRows.filter { it.visible }.forEach { row ->
+                    NovaQuickMenuRow(action = row, callbacks = callbacks)
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+            NovaQuickMenuPanel(title = quickKeysTitle) {
+                NovaQuickKeys(state.quickKeys, callbacks)
+            }
             Spacer(Modifier.height(10.dp))
             NovaQuickMenuInfoCard(
                 action = state.sync,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -147,6 +147,9 @@ data class NovaQuickMenuUiState(
     val advancedExpanded: Boolean,
     val advancedRows: List<NovaQuickMenuAction>,
     val quickKeys: List<NovaQuickMenuAction>,
+    // The grid's own top three, repeated under the session strip so a handheld reaches
+    // Esc without scrolling. Same instances, so both rows fire the same key.
+    val pinnedQuickKeys: List<NovaQuickMenuAction> = emptyList(),
     val diagnosis: NovaQuickMenuDiagnosisState,
     val diagnosisAction: NovaQuickMenuAction,
     val doctorReceiptAction: NovaQuickMenuAction,
@@ -495,6 +498,7 @@ data class NovaQuickMenuUiState(
                 // launch-policy control. Presets live in the card above.
                 advancedRows = listOf(clearRow, mangoRow),
                 quickKeys = quickKeys,
+                pinnedQuickKeys = pinnedQuickKeys(quickKeys),
                 diagnosis = diagnosis,
                 diagnosisAction = diagnoseAction(context, status, diagnosis),
                 doctorReceiptAction = doctorReceiptAction,
@@ -996,6 +1000,17 @@ data class NovaQuickMenuUiState(
                 normalization
             ).joinToString(" · ")
         }
+
+        // Esc for the game's own menu, Meta for the desktop, Alt + Enter for fullscreen: the
+        // keys a handheld has no other way to press, in the order they get reached for.
+        val pinnedQuickKeyIds: List<NovaQuickMenuActionId> = listOf(
+            NovaQuickMenuActionId.QUICK_ESC,
+            NovaQuickMenuActionId.QUICK_META,
+            NovaQuickMenuActionId.QUICK_ALT_ENTER
+        )
+
+        fun pinnedQuickKeys(quickKeys: List<NovaQuickMenuAction>): List<NovaQuickMenuAction> =
+            pinnedQuickKeyIds.mapNotNull { id -> quickKeys.firstOrNull { it.id == id } }
 
         fun quickKeyActions(context: Context): List<NovaQuickMenuAction> = listOf(
             NovaQuickMenuAction(

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHud.kt
@@ -45,6 +45,9 @@ class NovaStreamHud(
     private var lastHostLatencyMs: Double? = null
     private var lastIncomingFps = 0.0
     private var lastRenderedFps = 0.0
+    private var lastPacketLossPct = -1.0
+    private var lastRttVarianceMs = -1
+    private var lastFramesLost = -1L
     private var currentBitrateKbps = 0
     var lastCodec = ""
     var lastBitrateKbps = 0
@@ -126,6 +129,9 @@ class NovaStreamHud(
         lastHostLatencyMs = null
         lastIncomingFps = 0.0
         lastRenderedFps = 0.0
+        lastPacketLossPct = -1.0
+        lastRttVarianceMs = -1
+        lastFramesLost = -1L
     }
 
     private fun setupTouchHandler(view: View) {
@@ -276,6 +282,9 @@ class NovaStreamHud(
             lastHostLatencyMs = sample.hostProcessingLatencyMs
             lastIncomingFps = sample.incomingFps
             lastRenderedFps = sample.renderedFps
+            lastPacketLossPct = sample.packetLossPct
+            lastRttVarianceMs = sample.rttVarianceMs
+            lastFramesLost = sample.framesLost
             // The display helpers above own the HUD's rolling averages. Preserve the
             // exact cumulative decoder evidence too, so Copy diagnostics reports the
             // same raw sample that Doctor uploads instead of default zero counters.
@@ -409,7 +418,10 @@ class NovaStreamHud(
             decodeTimeMs = lastDecodeTimeMs,
             hostProcessingLatencyMs = lastHostLatencyMs,
             incomingFps = lastIncomingFps,
-            renderedFps = lastRenderedFps
+            renderedFps = lastRenderedFps,
+            packetLossPct = lastPacketLossPct,
+            rttVarianceMs = lastRttVarianceMs,
+            framesLost = lastFramesLost
         )
     }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -181,6 +181,18 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
             HudMetric("IN", state.incomingFpsLabel, Modifier.weight(1f))
             HudMetric("OUT", state.renderedFpsLabel, Modifier.weight(1f))
         }
+        // The network row: what the link is doing to frames right now, how much the round
+        // trip wobbles, and how many frames the whole session has lost.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            HudMetric("LOSS", state.packetLossLabel, Modifier.weight(1f), valueTone = state.packetLossTone)
+            HudMetric("JIT", state.jitterLabel, Modifier.weight(1f))
+            HudMetric("DROPS", state.framesLostLabel, Modifier.weight(1f))
+        }
     }
 }
 
@@ -337,8 +349,10 @@ private fun NovaStreamHudMinimal(state: NovaHudUiState, modifier: Modifier) {
     }
 }
 
-// One line, one glance: the health bar, the frame rate, the round trip. Nothing that
-// needs reading, so no labels, no target, no breadcrumb, no sparkline.
+// One line, one glance, the way MangoHud's bar reads: the health bar, the frame rate with
+// its last minute drawn beside it, then the three facts that explain a bad number. Each
+// fact carries an inline label because two millisecond values cannot be told apart by
+// position. No target, no autopilot text, no breadcrumb, no stacked tiles.
 @Composable
 private fun NovaStreamHudSlim(state: NovaHudUiState, modifier: Modifier) {
     HudPanel(
@@ -347,7 +361,7 @@ private fun NovaStreamHudSlim(state: NovaHudUiState, modifier: Modifier) {
         padding = 5.dp
     ) {
         Row(
-            modifier = Modifier.padding(start = 4.dp, end = 6.dp),
+            modifier = Modifier.padding(start = 4.dp, end = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             HudStatusDot(state.statusTone, height = 16.dp)
@@ -357,7 +371,17 @@ private fun NovaStreamHudSlim(state: NovaHudUiState, modifier: Modifier) {
                 size = 15,
                 modifier = Modifier.padding(start = 6.dp)
             )
-            HudCompactText(state.latencyLabel, state.latencyTone, startPadding = 7.dp)
+            NovaHudSparkline(
+                samples = state.sparklineSamples,
+                tone = state.fpsTone,
+                modifier = Modifier
+                    .padding(start = 6.dp)
+                    .width(44.dp)
+                    .height(14.dp)
+            )
+            HudSlimStat("DEC", state.decodeTimeLabel, state.decodeTone)
+            HudSlimStat("RTT", state.latencyLabel, state.latencyTone)
+            HudSlimStat("BIT", state.bitrateLabel, NovaHudTone.MUTED)
         }
     }
 }
@@ -385,6 +409,26 @@ private fun HudPanel(
             .padding(padding),
         content = content
     )
+}
+
+// Slim's inline fact: a 7 sp label glued to its value, so two millisecond numbers in one
+// line read apart without the stacked tile Debug uses.
+@Composable
+private fun HudSlimStat(label: String, value: String, tone: NovaHudTone) {
+    Row(
+        modifier = Modifier.padding(start = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            color = LocalNovaComposeColors.current.textMuted,
+            fontSize = 7.sp,
+            lineHeight = 8.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1
+        )
+        HudCompactText(value, tone, startPadding = 3.dp)
+    }
 }
 
 // The strips and chips take only the strings and tones they draw. Handed the whole state,

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -2215,7 +2215,7 @@ class NovaComposeSourceGuardTest {
     }
 
     @Test
-    fun commandCenterFirstPaintPutsSessionHealthThenDailyControlsBeforeDiagnostics() {
+    fun commandCenterFirstPaintPutsSessionHealthThenItsExplanationBeforeTheDailyPanels() {
         val content = readNovaQuickMenuContent()
         val body = content.section(
             "fun NovaQuickMenuContent(",
@@ -2235,6 +2235,7 @@ class NovaComposeSourceGuardTest {
         )
 
         val sessionStrip = body.indexOf("NovaQuickMenuSessionStrip(state, initialFocusRequester)")
+        val pinnedKeys = body.indexOf("NovaQuickKeys(state.pinnedQuickKeys, callbacks)")
         val quickKeysPanel = body.indexOf("NovaQuickMenuPanel(title = quickKeysTitle)")
         val controlsPanel = body.indexOf("title = controlsTitle")
         val sessionPanel = body.indexOf("NovaQuickMenuPanel(title = sessionTitle)")
@@ -2246,21 +2247,24 @@ class NovaComposeSourceGuardTest {
         val reportCard = body.indexOf("NovaQuickMenuPostSessionReportCard(state.postSessionReport)")
 
         assertTrue(
-            "Command Center first paint should keep the session strip, which carries the health verdict, immediately after the header",
-            sessionStrip >= 0 && quickKeysPanel > sessionStrip
+            "Command Center first paint should keep the session strip, which carries the health verdict, immediately after the header, with the three keys a handheld cannot press any other way right under it",
+            sessionStrip >= 0 && pinnedKeys > sessionStrip && diagnosisCard > pinnedKeys
         )
         assertTrue(
-            "the controls a player touches every session (Quick Keys, Controls, Session, Overlays) come before the Doctor and stream cards that explain the strip's verdict; on a Retroid those cards used to push the keys two pages down",
-            quickKeysPanel in 0 until controlsPanel &&
-                controlsPanel in 0 until sessionPanel &&
-                sessionPanel in 0 until overlaysPanel &&
-                overlaysPanel in 0 until diagnosisCard
-        )
-        assertTrue(
-            "Doctor, stream target, sync, and Advanced keep their explanatory order below the controls",
+            "the strip is a one-line verdict, so the Doctor's reading and the Stream card that explain it come next instead of three screens down",
             diagnosisCard in 0 until stabilityCard &&
-                stabilityCard in 0 until syncCard &&
-                syncCard in 0 until advancedToggleCard
+                stabilityCard in 0 until overlaysPanel
+        )
+        assertTrue(
+            "the panels a player adjusts follow: Overlays first because the HUD switch is the frequent tap, then Controls and Session, and the full Quick Keys grid last of them because its top three are already pinned under the strip",
+            overlaysPanel in 0 until controlsPanel &&
+                controlsPanel in 0 until sessionPanel &&
+                sessionPanel in 0 until quickKeysPanel &&
+                quickKeysPanel in 0 until syncCard
+        )
+        assertTrue(
+            "sync and Advanced stay at the end",
+            syncCard in 0 until advancedToggleCard
         )
         assertTrue(
             "the host safe profile is observational history and lives inside the expanded Advanced section, not in the first paint",
@@ -2479,16 +2483,18 @@ class NovaComposeSourceGuardTest {
             minimalHud.contains("NovaHudSparkline")
         )
         assertTrue(
-            "slim HUD is one pill: the health bar, the frame rate, the round trip, nothing labelled",
+            "slim HUD is one pill that reads like MangoHud's bar: the health bar, the frame rate with its last minute drawn beside it, then decode, round trip, and bitrate with inline labels; no target, no autopilot text, no breadcrumb, no stacked tiles",
             slimHud.contains("cornerRadius = NovaRadius.pill") &&
                 slimHud.contains("state.fpsLabel") &&
-                slimHud.contains("state.latencyLabel") &&
+                slimHud.contains("NovaHudSparkline(") &&
+                slimHud.contains("HudSlimStat(\"DEC\", state.decodeTimeLabel, state.decodeTone)") &&
+                slimHud.contains("HudSlimStat(\"RTT\", state.latencyLabel, state.latencyTone)") &&
+                slimHud.contains("HudSlimStat(\"BIT\", state.bitrateLabel") &&
+                !slimHud.contains("HudMetric(") &&
                 !slimHud.contains("HudTinyLabel(") &&
                 !slimHud.contains("state.targetFpsLabel") &&
-                !slimHud.contains("state.bitrateLabel") &&
                 !slimHud.contains("autopilot") &&
-                !slimHud.contains("HudEventBreadcrumb") &&
-                !slimHud.contains("NovaHudSparkline")
+                !slimHud.contains("HudEventBreadcrumb")
         )
     }
 
@@ -2514,6 +2520,13 @@ class NovaComposeSourceGuardTest {
             debugHud.contains("HudMetric(\"HOST\", state.hostLatencyLabel") &&
                 debugHud.contains("HudMetric(\"IN\", state.incomingFpsLabel") &&
                 debugHud.contains("HudMetric(\"OUT\", state.renderedFpsLabel")
+        )
+        assertTrue(
+            "Debug's last row is the network: loss in the current window graded so zero is the only green, round-trip jitter, and the session's lost-frame count",
+            debugHud.contains("HudMetric(\"LOSS\", state.packetLossLabel") &&
+                debugHud.contains("valueTone = state.packetLossTone") &&
+                debugHud.contains("HudMetric(\"JIT\", state.jitterLabel") &&
+                debugHud.contains("HudMetric(\"DROPS\", state.framesLostLabel")
         )
         assertFalse(
             "Performance stays the four-metric row it is pinned to",

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -260,6 +260,68 @@ class NovaHudUiStateTest {
         assertEquals("60", slim.fpsLabel)
         assertEquals("51ms", slim.latencyLabel)
         assertEquals("1080p", slim.resolutionLabel)
+        // Slim spends its one line on numbers, so the bitrate drops its unit like Performance.
+        assertEquals("24M", slim.bitrateLabel)
+    }
+
+    @Test
+    fun debugNetworkRowGradesLossSoZeroIsTheOnlyGreen() {
+        fun debug(loss: Double, jitter: Int = 2, lost: Long = 0L, latency: Int = 9) = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = 60.0,
+            latencyMs = latency,
+            codec = "hevc",
+            bitrateKbps = 20000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = emptyList(),
+            packetLossPct = loss,
+            rttVarianceMs = jitter,
+            framesLost = lost
+        )
+
+        val noSample = NovaHudUiState.from(
+            mode = NovaHudMode.DEBUG,
+            fps = 60.0,
+            targetFps = 60.0,
+            latencyMs = 9,
+            codec = "hevc",
+            bitrateKbps = 20000,
+            width = 1920,
+            height = 1080,
+            status = status(),
+            sparklineSamples = emptyList()
+        )
+        assertEquals("--", noSample.packetLossLabel)
+        assertEquals(NovaHudTone.MUTED, noSample.packetLossTone)
+        assertEquals("--", noSample.jitterLabel)
+        assertEquals("--", noSample.framesLostLabel)
+
+        val clean = debug(0.0)
+        assertEquals("0%", clean.packetLossLabel)
+        assertEquals(NovaHudTone.STABLE, clean.packetLossTone)
+        assertEquals("2ms", clean.jitterLabel)
+        assertEquals("0", clean.framesLostLabel)
+
+        // A trace of loss is named as one instead of rounding to a green-looking 0%.
+        val trace = debug(0.04)
+        assertEquals("<0.1%", trace.packetLossLabel)
+        assertEquals(NovaHudTone.WARNING, trace.packetLossTone)
+
+        val some = debug(0.34, lost = 12L)
+        assertEquals("0.3%", some.packetLossLabel)
+        assertEquals(NovaHudTone.WARNING, some.packetLossTone)
+        assertEquals("12", some.framesLostLabel)
+
+        assertEquals("2.6%", debug(2.6).packetLossLabel)
+        assertEquals(NovaHudTone.DANGER, debug(2.6).packetLossTone)
+        assertEquals("12%", debug(12.4).packetLossLabel)
+
+        // Jitter means nothing without a round trip to wobble around.
+        assertEquals("--", debug(0.0, latency = 0).jitterLabel)
+        assertEquals("0ms", debug(0.0, jitter = 0).jitterLabel)
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -200,6 +200,25 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
+    fun pinnedQuickKeysAreTheThreeAHandheldCannotPressAnyOtherWay() {
+        val state = NovaQuickMenuUiState.preview(context)
+
+        assertEquals(
+            "Esc for the game's own menu, Meta for the desktop, Alt + Enter for fullscreen: the keys worth one reach from the top, in that order",
+            listOf(
+                NovaQuickMenuActionId.QUICK_ESC,
+                NovaQuickMenuActionId.QUICK_META,
+                NovaQuickMenuActionId.QUICK_ALT_ENTER
+            ),
+            state.pinnedQuickKeys.map { it.id }
+        )
+        assertTrue(
+            "the pinned row reuses the grid's own actions, so the grid stays the whole keyboard and both rows fire the same key",
+            state.pinnedQuickKeys.all { pinned -> state.quickKeys.any { it === pinned } }
+        )
+    }
+
+    @Test
     fun previewStateExposesCoreActionsForComposeContent() {
         val state = NovaQuickMenuUiState.preview(context).copy(advancedExpanded = true)
 


### PR DESCRIPTION
## Summary

- Command Center opened on a one-line verdict and buried what explained it. The session strip says how the stream is doing; the Doctor's reading and the Stream card that say why, and what Auto is running, sat below Quick Keys, Controls, Session, and Overlays, three screens down on a Retroid. They now come right after the strip. Overlays follows because the HUD switch is the frequent tap, then Controls and Session, then the full Quick Keys grid, then Sync and Advanced.
- Esc, Meta, and Alt + Enter stay pinned in one row directly under the strip, so reaching the game's own menu on a handheld never needs a scroll. The pinned row reuses the grid's own action instances: the grid stays the whole keyboard and both rows fire the same key.
- This reverses the 1.4.3 order deliberately. Keys-first assumed the strip was enough, and it is not when the number is bad.
- NovaHUD Slim is now a one-line bar in the MangoHud spirit: the health bar, the frame rate with its last minute drawn beside it, then decode time, round trip, and bitrate with 7 sp inline labels, so two millisecond values are never told apart by position. Bitrate drops its unit like Performance. Minimal stays the sparse two-line card, so Slim is about height, not about hiding data.
- NovaHUD Debug gains a network row. The decoder has reported packet loss, round-trip variance, and the session's lost-frame count in every sample and no HUD mode showed them. LOSS is graded so zero is the only green: a trace reads "<0.1%" in warning rather than rounding to a green-looking 0%, under one percent is warning, one percent and over is danger. JIT reads "--" while there is no round trip to wobble around. DROPS is the session's cumulative count.
- Source guards re-pin the new first-paint order, the Slim composition, and the Debug network row. Unit tests cover the pinned-key selection and identity, the Slim bitrate form, and the loss grading and formatting edges.

## Exact candidate

- `Commit:` 32ebb144e6daa987dfb264d12a5d670cac08a6d3
- `Tree:` 665527e18cfc6067c49c33c49736fdb3c404a5d5
- `Parent:` bcaaedeb
- `Base:` bcaaedeb (master)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` (x86_64): 1617 tests, 0 failures, 0 errors. Note: pc-papi's `/tmp` is a tmpfs with a per-user quota that other sessions' Polaris asan/tsan build trees have filled; Robolectric and Mockito extract into the Java temp dir, so the suite fails there with "Disk quota exceeded" regardless of the code. The green run used an init script that points the Test tasks' `java.io.tmpdir` under `/home`. Nothing in the repo changed for that.
- [x] `:app:lintNonRoot_gameDebug -PlintFailOnError=true`: clean
- [x] `:app:assembleNonRoot_gameDebug` (arm64-v8a), installed on the Retroid Pocket 6 as `com.papi.nova.debug`
- [x] Device, Command Center: first paint is header, session strip, the pinned Esc / Meta / Alt + Enter row, the Doctor card, the Stream card with its Launch preset; scrolling continues Overlays (HUD switch, mode picker, Stats Overlay, Copy Diagnostics, both opacity rows), Controls, Session, the full Quick Keys grid, Sync Status, Advanced.
- [x] Device, Slim: one pill, health bar, fps, sparkline, `DEC 6.2ms`, `RTT 3ms`, `BIT 17M`. Guide + Y still walks Slim, Minimal, Performance, Debug, Slim, and the mode persists.
- [x] Device, Debug: fourth row `LOSS 0%` (green), `JIT 0ms`, `DROPS 2` under HOST / IN / OUT.
- [x] `dumpsys gfxinfo`, 60 s windows on the RP6. The HUD recomposes once per sample, so these are the UI thread's one frame per second, not video frames. Control would not come up on the host this evening (the session showed the host desktop at 12 fps), so this PR's rows are from that desktop session; the reference rows from #283 were taken inside Control at 60 fps. The UI-thread work is the same either way.

| HUD layout | Session | Frames | Janky | p50 | p90 | p99 |
|---|---|---|---|---|---|---|
| Slim, this PR, window 1 | desktop, 12 fps | 59 | 2 | 11 ms | 13 ms | 14 ms |
| Slim, this PR, window 2 | desktop, 12 fps | 59 | 9 | 12 ms | 13 ms | 15 ms |
| Debug, this PR (4 rows), window 1 | desktop, 12 fps | 59 | 11 | 12 ms | 14 ms | 16 ms |
| Debug, this PR (4 rows), window 2 | desktop, 12 fps | 59 | 13 | 12 ms | 14 ms | 15 ms |
| Debug, #283 v2 (3 rows), reference | Control, 60 fps | 59 | 11 | 12 ms | 13 ms | 16 ms |
| Performance, #283, reference | Control, 60 fps | 59 | 0 | 11 ms | 12 ms | 13 ms |

Read: Slim with its sparkline lands where Performance already was, 11 to 12 ms p50. Debug's fourth row is inside run-to-run noise against the three-row version. Janky counts move by several frames between identical windows, so treat those as a range, not a delta.

## Not covered

- androidTest is not compiled by CI and already fails to compile on master for unrelated reasons; the HUD androidTests were not touched or run.
- The companion-display Command Center is still the legacy GameMenu, as before.
- MangoHud draws per-frame frametimes; the HUD's samples arrive once a second, so the Slim sparkline is a 60 second trend of the frame rate, not per-frame jitter.
- No 60 fps game capture of the new Slim bar this evening; the desktop session capture shows the same layout with a flat line at 12 fps.
