### PR TITLE
fix(ui): honest Play and Doctor labels, then Nova 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,23 @@
 
 ## Unreleased
 
+## 1.4.4 - 2026-09-06
+
+Matched client for Polaris 1.4.4: Wake Host, a Command Center that leads with the verdict's explanation, a MangoHud-style Slim HUD, decode time and a network row in Debug, and labels that say what they do.
+
 - The library's Start Polaris button is now Wake Host, which is what it does. It tells a sleeping host apart from one that is awake with Polaris down: the first gets a wake packet, the second gets told to start Polaris on the host or enable headless boot. The timeout message says that a wake packet only reaches a sleeping host from its own network.
 - The library's Continue card says Play when the host is not running the game, and Resume only while it is.
-- Command Center's Doctor card no longer opens its advice by repeating its own title, and the subtitle reads "Session controls for…" instead of promising Quick Keys first.
 - Command Center puts the Doctor's reading and the Stream card right under the session strip, where the verdict they explain lives, then Overlays, Controls, Session, and the full Quick Keys grid. Esc, Meta, and Alt + Enter stay pinned under the strip, one reach from the top.
+- Command Center picks the HUD layout with four buttons instead of cycling blind, keeps Close, Disconnect, and End Session fixed above the scrolling sections, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag.
+- Command Center's Doctor card no longer opens its advice by repeating its own title, and the subtitle reads "Session controls for…" instead of promising Quick Keys first.
 - NovaHUD gains a Slim layout, a one-line bar in the MangoHud spirit: the health bar, the frame rate with its last minute drawn beside it, then decode time, round trip, and bitrate with inline labels. Guide + Y now cycles Minimal, Performance, Debug, Slim.
 - NovaHUD Debug shows decode time (DEC), graded against the frame budget at the target rate, plus host processing latency (HOST) and incoming against rendered frame rate (IN / OUT). That is the rest of what the legacy stats text knew, inside the HUD.
 - NovaHUD Debug gains a network row: packet loss in the current window (LOSS), graded so zero is the only green, round-trip jitter (JIT), and frames lost this session (DROPS).
-- Command Center picks the HUD layout with four buttons instead of cycling blind, keeps Close, Disconnect, and End Session fixed above the scrolling sections, folds the two opacity preset strips behind their rows, and slides out on Close, B, and Back the way it already did on scrim and drag.
 - Stats Overlay toggled from Command Center works on a stream that started with it off, and the toggle is remembered in Settings. Turning it on turns Nova HUD off for the next stream too, and the reverse.
 - NovaHUD reads the decoder's structured sample only. The decoder no longer builds the legacy overlay text while just the HUD is showing, and the HUD updates once per sample instead of twice.
 - The HUD Position setting is gone. It never did anything; drag the HUD to place it.
+- versionName 1.4.4, versionCode 46; installs cleanly over 1.4.3.
+- Publishes signed ARM64, ARMv7, and x86_64 APKs plus SHA-256 sidecars.
 
 ## 1.4.3 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - The library's Start Polaris button is now Wake Host, which is what it does. It tells a sleeping host apart from one that is awake with Polaris down: the first gets a wake packet, the second gets told to start Polaris on the host or enable headless boot. The timeout message says that a wake packet only reaches a sleeping host from its own network.
+- The library's Continue card says Play when the host is not running the game, and Resume only while it is.
+- Command Center's Doctor card no longer opens its advice by repeating its own title, and the subtitle reads "Session controls for…" instead of promising Quick Keys first.
 - Command Center puts the Doctor's reading and the Stream card right under the session strip, where the verdict they explain lives, then Overlays, Controls, Session, and the full Quick Keys grid. Esc, Meta, and Alt + Enter stay pinned under the strip, one reach from the top.
 - NovaHUD gains a Slim layout, a one-line bar in the MangoHud spirit: the health bar, the frame rate with its last minute drawn beside it, then decode time, round trip, and bitrate with inline labels. Guide + Y now cycles Minimal, Performance, Debug, Slim.
 - NovaHUD Debug shows decode time (DEC), graded against the frame budget at the target rate, plus host processing latency (HOST) and incoming against rendered frame rate (IN / OUT). That is the rest of what the legacy stats text knew, inside the HUD.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.4.3"
-        versionCode = 45
+        versionName "1.4.4"
+        versionCode = 46
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/AppView.kt
+++ b/app/src/main/java/com/papi/nova/AppView.kt
@@ -613,10 +613,12 @@ class AppView : NovaActivity(), AdapterFragmentCallbacks {
                 )
             }
         actionView?.setText(
-            if (appOwnedByAnotherClient) {
-                R.string.applist_menu_watch
-            } else {
-                R.string.pcview_card_action_resume
+            when {
+                appOwnedByAnotherClient -> R.string.applist_menu_watch
+                // Resume is only honest while the host is still running the game. Otherwise
+                // this button launches it, and the kicker above already says Continue.
+                appIsRunning -> R.string.pcview_card_action_resume
+                else -> R.string.applist_hero_action_play
             },
         )
         endSessionView?.visibility = if (appIsRunning && !appOwnedByAnotherClient) {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -659,12 +659,16 @@ data class NovaQuickMenuUiState(
                     else -> NovaQuickMenuDoctorCapability.MANUAL
                 }
             }
+            val likelyCause = doctor?.likelyCause?.takeIf { it.isNotBlank() }
+                ?: "Connect to Polaris for HOST / NET / CLIENT diagnostics."
             return NovaQuickMenuDiagnosisState(
                 classification = doctor?.classification?.takeIf { it.isNotBlank() } ?: "UNKNOWN",
-                likelyCause = doctor?.likelyCause?.takeIf { it.isNotBlank() } ?: "Connect to Polaris for HOST / NET / CLIENT diagnostics.",
+                likelyCause = likelyCause,
                 evidence = doctor?.evidence ?: emptyList(),
                 evidenceHighlight = doctorEvidenceHighlight(status),
-                tryFirst = doctor?.firstTry.orEmpty(),
+                // The host's first-try line usually opens by restating the finding, which is
+                // already the card's title. Keep only the advice that follows it.
+                tryFirst = doctor?.firstTry.orEmpty().withoutLeadingSentence(likelyCause),
                 confidence = doctor?.confidence.orEmpty(),
                 available = available,
                 actionId = actionId,
@@ -952,6 +956,22 @@ data class NovaQuickMenuUiState(
             val mine = trim().trimEnd('.', '!')
             val theirs = other.trim().trimEnd('.', '!')
             return mine.isNotBlank() && mine.equals(theirs, ignoreCase = true)
+        }
+
+        // "Streaming telemetry looks ready. Keep this page open..." under a title that already
+        // says "Streaming telemetry looks ready" read as a stutter once the Doctor card led the
+        // page. Drop that opening sentence; if nothing follows it, the row disappears.
+        private fun String.withoutLeadingSentence(title: String): String {
+            val mine = trim()
+            val head = title.trim().trimEnd('.', '!')
+            if (head.isBlank() || !mine.startsWith(head, ignoreCase = true)) {
+                return mine
+            }
+            val boundary = mine.getOrNull(head.length)
+            if (boundary != null && boundary !in ".! ") {
+                return mine
+            }
+            return mine.substring(head.length).trimStart('.', '!', ' ')
         }
 
         private fun PolarisSessionStatus.hdrDowngradeDetail(context: Context): String? {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,6 +706,7 @@
     <string name="applist_hero_summary_continue">Pick up where you left off</string>
     <string name="applist_hero_summary_resume">Resume your active session on this device</string>
     <string name="applist_hero_summary_watch">Another device owns the current session</string>
+    <string name="applist_hero_action_play">Play</string>
     <string name="applist_refresh_title">App List</string>
     <string name="applist_refresh_msg">Refreshing apps…</string>
     <string name="applist_refresh_error_title">Error</string>
@@ -971,9 +972,9 @@
     <string name="nova_quick_menu_mode_source_explicit">Explicit choice</string>
     <string name="nova_quick_menu_mode_role_owner">Owner</string>
     <string name="nova_quick_menu_command_center_title">Command Center</string>
-    <string name="nova_quick_menu_command_center_subtitle">Quick keys, stream tuning, and session controls</string>
-    <string name="nova_quick_menu_headless_subtitle">Quick keys and controls for Private Stream</string>
-    <string name="nova_quick_menu_virtual_subtitle">Quick keys and controls for virtual display streaming</string>
+    <string name="nova_quick_menu_command_center_subtitle">Stream health, tuning, and session controls</string>
+    <string name="nova_quick_menu_headless_subtitle">Session controls for Private Stream</string>
+    <string name="nova_quick_menu_virtual_subtitle">Session controls for virtual display streaming</string>
     <string name="nova_quick_menu_shutdown_subtitle">Host shutdown is in progress. Session actions are limited.</string>
     <string name="nova_quick_menu_health_checking">Checking session health</string>
     <string name="nova_quick_menu_health_host_render">Host is rendering below the stream FPS target.</string>

--- a/app/src/test/java/com/papi/nova/HonestLabelsSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/HonestLabelsSourceGuardTest.kt
@@ -1,0 +1,38 @@
+package com.papi.nova
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HonestLabelsSourceGuardTest {
+    @Test
+    fun theLibraryHeroSaysResumeOnlyWhileTheHostIsStillRunningTheGame() {
+        val appView = File("src/main/java/com/papi/nova/AppView.kt").readText()
+        val strings = File("src/main/res/values/strings.xml").readText()
+        val heroStart = appView.indexOf("val appIsRunning = lastRunningAppId == finalTargetApp.app.appId")
+        val hero = appView.substring(heroStart, appView.indexOf("endSessionView?.visibility", heroStart))
+
+        assertTrue(
+            "Resume is only honest while the host is still running the game; otherwise the button launches it, so it says Play",
+            hero.contains("appIsRunning -> R.string.pcview_card_action_resume") &&
+                hero.contains("else -> R.string.applist_hero_action_play") &&
+                strings.contains("<string name=\"applist_hero_action_play\">Play</string>")
+        )
+    }
+
+    @Test
+    fun commandCenterSubtitleNoLongerPromisesQuickKeysFirst() {
+        val strings = File("src/main/res/values/strings.xml").readText()
+
+        assertTrue(
+            "Quick Keys is the last panel now, so the subtitle names what the page is for",
+            strings.contains("<string name=\"nova_quick_menu_headless_subtitle\">Session controls for Private Stream</string>") &&
+                strings.contains("<string name=\"nova_quick_menu_virtual_subtitle\">Session controls for virtual display streaming</string>")
+        )
+        assertFalse(
+            "no Command Center subtitle leads with Quick keys",
+            strings.contains("_subtitle\">Quick keys")
+        )
+    }
+}

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,13 +81,13 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/45.txt"
+            "fastlane/metadata/android/en-US/changelogs/46.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.4.3\""))
-        assertTrue(build.contains("versionCode = 45"))
-        assertTrue(changelog.contains("## 1.4.3 - 2026-09-05"))
+        assertTrue(build.contains("versionName \"1.4.4\""))
+        assertTrue(build.contains("versionCode = 46"))
+        assertTrue(changelog.contains("## 1.4.4 - 2026-09-06"))
         assertTrue(changelog.contains("Steam Input remains manual and read-only."))
         assertTrue(changelog.contains("Polaris owns encoder probing, fallback, and launch policy"))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
@@ -108,7 +108,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.4.3"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.4.4"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -177,6 +177,49 @@ class NovaQuickMenuUiStateTest {
     }
 
     @Test
+    fun doctorTryFirstDoesNotRepeatTheTitleNowThatTheCardLeadsThePage() {
+        fun diagnosis(likelyCause: String, tryFirst: String) = quickState(
+            status = status(
+                doctor = PolarisSessionStatus.DoctorStatus(
+                    available = true,
+                    version = 2,
+                    resultId = "doctor-$likelyCause",
+                    primaryIssue = "none",
+                    likelyCause = likelyCause,
+                    tryFirst = listOf(tryFirst)
+                )
+            )
+        ).diagnosis
+
+        val ready = diagnosis(
+            "Streaming telemetry looks ready.",
+            "Streaming telemetry looks ready. Keep this page open if you are trying to catch an intermittent problem."
+        )
+        assertEquals("Streaming telemetry looks ready.", ready.likelyCause)
+        assertEquals(
+            "the finding is already the card's title, so the try-first line keeps only the advice that follows it",
+            "Keep this page open if you are trying to catch an intermittent problem.",
+            ready.tryFirst
+        )
+
+        assertEquals(
+            "a try-first that only restates the title disappears instead of saying it twice",
+            "",
+            diagnosis("No confirmed issue", "No confirmed issue.").tryFirst
+        )
+        assertEquals(
+            "advice that does not open with the title is untouched",
+            "Move closer to the access point.",
+            diagnosis("Network jitter on the link", "Move closer to the access point.").tryFirst
+        )
+        assertEquals(
+            "a title that is only a prefix of a longer word is not a repeated sentence",
+            "Streaming telemetry looks readyish today.",
+            diagnosis("Streaming telemetry looks ready", "Streaming telemetry looks readyish today.").tryFirst
+        )
+    }
+
+    @Test
     fun controllerToggleCopyClarifiesTouchOverlayInsteadOfPhysicalGamepad() {
         val state = quickState(status = status(), currentGameName = "Portal")
         val touchControls = state.controlRows.first { it.id == NovaQuickMenuActionId.CONTROLLER }
@@ -223,7 +266,7 @@ class NovaQuickMenuUiStateTest {
         val state = NovaQuickMenuUiState.preview(context).copy(advancedExpanded = true)
 
         assertEquals("Command Center", state.title)
-        assertEquals("Quick keys and controls for Private Stream", state.subtitle)
+        assertEquals("Session controls for Private Stream", state.subtitle)
         assertEquals("Disconnect", state.disconnectAction.label)
         assertEquals("End Session", state.endAction.label)
         assertTrue(state.quickKeys.any { it.id == NovaQuickMenuActionId.QUICK_ESC && it.label == "ESC" })

--- a/fastlane/metadata/android/en-US/changelogs/46.txt
+++ b/fastlane/metadata/android/en-US/changelogs/46.txt
@@ -1,0 +1,2 @@
+Nova 1.4.4
+Wake Host tells a sleeping host from one that is awake with Polaris down. Command Center leads with the Doctor's reading and the Stream card, keeps Esc, Meta, and Alt + Enter one reach from the top, and picks the HUD layout directly. NovaHUD gains a Slim one-line bar with a frame-rate sparkline, and Debug shows decode time, host latency, in/out frame rate, and a network row. Stats Overlay toggled mid-stream works. Matched client for Polaris 1.4.4.


### PR DESCRIPTION
## Summary

Two commits: three label fixes, then the 1.4.4 release prep.

- **Play, not Resume.** The library's Continue card said Resume whether or not the host was running the game; the kicker and summary were honest, the button was not. Resume now appears only while the host is running that game, otherwise Play. Watch is unchanged.
- **The Doctor card stops repeating itself.** It leads Command Center since #285, and its advice opened by restating its own title. The state builder drops that opening sentence and keeps the advice that follows; a first-try that only restates the title disappears.
- **Subtitle.** "Session controls for Private Stream" and "Session controls for virtual display streaming" instead of promising Quick Keys first, now that Quick Keys is the last panel.
- **Release prep 1.4.4.** versionName 1.4.4, versionCode 46; the Unreleased section becomes `## 1.4.4 - 2026-09-06` with a one-line summary and the same bullets, an empty Unreleased stays above it; store notes for build 46 under 500 code points; NovaReleaseMetadataTest re-pinned.

## Exact candidate

- `Commit:` 46b93893662f0192120da126c2944949e95a51a8 e65e8f81f7559f0e9a846efdfb18c327287c92e9
- `Tree:` 
- `Parent:` e18b0bbe
- `Base:` e18b0bbe (master)

## Verification

- [x] `:app:testNonRoot_gameDebugUnitTest` (x86_64): 1620 tests, 0 failures, 0 errors, run with the Test-task tmpdir init script because pc-papi's `/tmp` quota is full (nothing in the repo changed for that)
- [x] `:app:lintNonRoot_gameDebug -PlintFailOnError=true`: clean
- [x] `bash scripts/check-public-docs.sh` and `bash scripts/check-public-surface.sh`: pass on the 1.4.4 tree
- [x] `:app:assembleNonRoot_gameDebug` (arm64-v8a), installed on the Retroid Pocket 6 as `com.papi.nova.debug`
- [x] Device: Settings > Overlays & Controls > Live HUD preview renders the wider Slim bar inside its card (fps, sparkline, DEC, RTT, BIT). With no app running on the host the Continue card reads Play; Command Center's header reads "Session controls for virtual display streaming"; the Doctor card shows "Streaming telemetry looks ready" once, with "Try first: Keep this page open if you are trying to catch an intermittent problem." under it.
- [ ] After merge: `bin/release.sh` on a `master` checkout equal to origin/master tags v1.4.4; the tag build publishes six assets; the published arm64 APK gets a smoke pass on the RP6.

## Not covered

- androidTest is not compiled by CI and already fails to compile on master for unrelated reasons.
