### PR TITLE
feat(deck): read real hosts and the Polaris library through Moonlight's pairing

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -19,7 +19,7 @@ pkg_check_modules(NOVA_DECK_LINUX_AUDIO REQUIRED IMPORTED_TARGET
     libpipewire-0.3
     libpulse
 )
-find_package(Qt6 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Quick Network)
 
 add_library(nova_deck_core
     src/deck_gamepad.cpp
@@ -29,6 +29,9 @@ add_library(nova_deck_core
     src/stream/deck_stream_core.cpp
     src/stream/deck_stream_media_adapters.cpp
     src/stream/deck_moonlight_handoff_preflight.cpp
+    src/identity/deck_moonlight_identity.cpp
+    src/polaris/deck_polaris_client.cpp
+    src/backend/deck_live_read_only_state.cpp
 )
 
 set(NOVA_DECK_MOONLIGHT_COMMON_C_DIR
@@ -52,6 +55,7 @@ target_link_libraries(nova_deck_core
         PkgConfig::NOVA_DECK_FFMPEG_VAAPI
         PkgConfig::NOVA_DECK_LINUX_AUDIO
         Qt6::Quick
+        Qt6::Network
 )
 target_compile_definitions(nova_deck_core
     PUBLIC
@@ -94,6 +98,24 @@ if(BUILD_TESTING)
     )
     target_link_libraries(nova_deck_backend_interfaces_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_backend_interfaces_test COMMAND nova_deck_backend_interfaces_test)
+
+    add_executable(nova_deck_moonlight_identity_test
+        tests/deck_moonlight_identity_test.cpp
+    )
+    target_link_libraries(nova_deck_moonlight_identity_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_moonlight_identity_test COMMAND nova_deck_moonlight_identity_test)
+
+    add_executable(nova_deck_polaris_client_test
+        tests/deck_polaris_client_test.cpp
+    )
+    target_link_libraries(nova_deck_polaris_client_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_polaris_client_test COMMAND nova_deck_polaris_client_test)
+
+    add_executable(nova_deck_live_read_only_state_test
+        tests/deck_live_read_only_state_test.cpp
+    )
+    target_link_libraries(nova_deck_live_read_only_state_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_live_read_only_state_test COMMAND nova_deck_live_read_only_state_test)
 
     add_executable(nova_deck_qsg_render_node_scenegraph_smoke
         tests/deck_qsg_render_node_scenegraph_smoke.cpp

--- a/clients/deck/README.md
+++ b/clients/deck/README.md
@@ -54,6 +54,24 @@ Visible frontend smoke route, for judging the Deck product shell on the actual G
 
 The frontend smoke uses the same rootless Deck Podman image with `--network=none`, launches `nova-deck` visibly through `QT_QPA_PLATFORM=wayland WAYLAND_DISPLAY=gamescope-0`, and asks the app to save its own `frontend-frame-capture.png`. Artifacts include `environment-summary.txt`, `ui-launch.log`, `qml-runtime.log`, `smoke-summary.txt`, and the frame capture when Qt can grab the window.
 
+## Live route: real hosts and library through Moonlight's pairing
+
+`nova-deck --live` (or `NOVA_DECK_LIVE=1`) replaces the fixture with the hosts Moonlight-Qt has already paired on this device and the library Polaris serves for them. Nothing is launched and no session is started; the preflight stays read-only with `backendPowerStarted=false`.
+
+How it works:
+
+- `src/identity/deck_moonlight_identity.*` reads Moonlight-Qt's own settings file: the Flatpak copy under `~/.var/app/com.moonlight_stream.Moonlight/config/`, the native copy under `~/.config/`, or the file named by `NOVA_DECK_MOONLIGHT_CONF`. That file holds the client certificate and key, every paired host with its pinned server certificate, and the cached app list per host. The private key stays inside the identity object; no public DTO or log line carries it, and host addresses never reach the shell either.
+- `src/polaris/deck_polaris_client.*` learns the HTTPS port from the host's plain-HTTP serverinfo the way Moonlight does, then calls `/polaris/v1/capabilities` and `/polaris/v1/games` with that client certificate. The server certificate Moonlight pinned at pairing is the only trust anchor: the handshake fails against any other certificate before the request is sent, and the host is reported as a certificate mismatch. Network failures are reported with fixed wording, never with the address.
+- `src/backend/deck_live_read_only_state.*` turns the probes into the same sanitized read-only DTOs the fixture route produces. A reachable Polaris host supplies the library; an unreachable one falls back to the apps Moonlight cached, labelled as such.
+
+On the host side, any paired certificate that calls `/polaris/v1` is promoted to the `nova` client family, so after the first live run Polaris sees the Deck's Moonlight pairing as a Nova client. That is the intended shape: one pairing, one identity, two apps on the Deck until the media slice lands.
+
+To check the route without opening a window:
+
+    QT_QPA_PLATFORM=offscreen nova-deck --print-live-state
+
+It prints the identity source, each host's probe result (`ok`, `unreachable`, `cert-mismatch`, `unauthorized`, ...), which library source won, and the first titles. Exit code 2 means no Moonlight pairing file was found.
+
 ## Shared Polaris DTO boundary
 
 Native C++ cannot include Kotlin source directly. For this first slice, fixtures/sample_polaris_game.json is a generated/shared-contract sample using the same snake_case keys covered by the Kotlin shared DTO tests. src/polaris_game_fixture.h and src/polaris_game_fixture.cpp load that fixture into a tiny native projection so the Deck shell can exercise a real library-card shape while the actual native Polaris API/client bridge is still future work.

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -548,7 +548,7 @@ ApplicationWindow {
 
                     Label {
                         Layout.preferredWidth: hostTextWidth
-                        text: "Backend-fed hosts · " + novaBackendReadOnlyState.sourceLabel + (novaBackendReadOnlyState.readOnly ? " · backend-owned read-only model · fixture provenance" : " · Backend read-only model unavailable — network remains disabled")
+                        text: "Backend-fed hosts · " + novaBackendReadOnlyState.sourceLabel + (novaBackendReadOnlyState.readOnly ? " · backend-owned read-only model · " + novaBackendReadOnlyProvenance : " · Backend read-only model unavailable — network remains disabled")
                         color: "#A8B0D8"
                         font.pixelSize: 13
                         wrapMode: Text.WordWrap
@@ -673,7 +673,7 @@ ApplicationWindow {
 
                     Label {
                         Layout.preferredWidth: sampleTextWidth
-                        text: "Backend-fed library snapshot · " + novaBackendReadOnlyState.sourceLabel + (novaBackendReadOnlyState.readOnly ? " · backend-owned read-only model · fixture provenance" : " · Backend read-only model unavailable — network remains disabled")
+                        text: "Backend-fed library snapshot · " + novaBackendReadOnlyState.sourceLabel + (novaBackendReadOnlyState.readOnly ? " · backend-owned read-only model · " + novaBackendReadOnlyProvenance : " · Backend read-only model unavailable — network remains disabled")
                         color: "#A8B0D8"
                         font.pixelSize: 13
                         wrapMode: Text.WordWrap

--- a/clients/deck/src/backend/deck_backend_interfaces.cpp
+++ b/clients/deck/src/backend/deck_backend_interfaces.cpp
@@ -248,6 +248,12 @@ DeckPublicPreflightPreview publicPreviewFor(
     };
 }
 
+bool hasBlockerCode(const DeckPublicReadOnlyPreflightState& preflight, const std::string_view code) {
+    return std::find(preflight.blockerCodes.begin(), preflight.blockerCodes.end(), code) != preflight.blockerCodes.end();
+}
+
+} // namespace
+
 DeckPublicReadOnlyDtoParity readOnlyDtoParityFor(
     const DeckPublicReadOnlyPreflightState& preflight,
     const std::string& scenarioId,
@@ -263,10 +269,6 @@ DeckPublicReadOnlyDtoParity readOnlyDtoParityFor(
         .expandedDiagnostics = "DTO parity: scenario=" + scenario + " · label=" + label + " · contract=backend-owned-read-only-dto-v1 · owner=backend-owned-read-only-model · privacy=redacted-public-dto · readiness=dto-parity-ready",
         .artifactSummary = "dto_contract=backend-owned-read-only-dto-v1 dto_owner=backend-owned-read-only-model dto_privacy=redacted-public-dto dto_readiness=dto-parity-ready backendPowerStarted=false stream=false",
     };
-}
-
-bool hasBlockerCode(const DeckPublicReadOnlyPreflightState& preflight, const std::string_view code) {
-    return std::find(preflight.blockerCodes.begin(), preflight.blockerCodes.end(), code) != preflight.blockerCodes.end();
 }
 
 DeckPublicReadOnlyPlayerState playerStateFor(const DeckPublicReadOnlyPreflightState& preflight, const std::string& scenarioLabel) {
@@ -320,8 +322,6 @@ DeckPublicReadOnlyPlayerState playerStateFor(const DeckPublicReadOnlyPreflightSt
     }
     return playerState;
 }
-
-} // namespace
 
 DeckLabGate DeckLabGate::forMode(const DeckLabGateMode mode) {
     return DeckLabGate(mode);
@@ -660,6 +660,15 @@ DeckPublicReadOnlyHostLibraryState buildReadOnlyHostLibraryState(
     const PolarisGameLibraryFixture& library,
     const DeckLaunchPreflightService& preflightService,
     const DeckLabGate& labGate) {
+    return buildReadOnlyHostLibraryState(repository, library, preflightService, labGate, DeckReadOnlyStateOptions{});
+}
+
+DeckPublicReadOnlyHostLibraryState buildReadOnlyHostLibraryState(
+    const DeckHostRepository& repository,
+    const PolarisGameLibraryFixture& library,
+    const DeckLaunchPreflightService& preflightService,
+    const DeckLabGate& labGate,
+    const DeckReadOnlyStateOptions& options) {
     DeckPublicReadOnlyHostLibraryState state;
     state.sourceLabel = library.sourceLabel;
     state.readOnly = library.readOnly;
@@ -693,10 +702,9 @@ DeckPublicReadOnlyHostLibraryState buildReadOnlyHostLibraryState(
         ++gameRow;
     }
 
-    DeckCredentialMetadata credentials;
     DeckLaunchPreflightInput input;
     input.host = hosts.empty() ? std::optional<DeckHostSummary>{} : std::optional<DeckHostSummary>{hosts.front()};
-    input.credentials = credentials;
+    input.credentials = options.credentials;
     if (input.host.has_value()) {
         input.credentials.hostId = input.host->id;
     }
@@ -723,7 +731,7 @@ DeckPublicReadOnlyHostLibraryState buildReadOnlyHostLibraryState(
     state.preflight.launchDryRunAllowed = report.coordinatorRequest.launchAllowed;
     state.preflight.streamAllowed = report.coordinatorRequest.streamAllowed;
     state.preflight.backendPowerStarted = false;
-    state.preflight.publicCopy = report.publicCopy + "; source=backend-owned-read-only-model; backendPowerStarted=false";
+    state.preflight.publicCopy = report.publicCopy + "; source=" + options.sourceTag + "; backendPowerStarted=false";
     state.preflight.blockerCodes.reserve(report.blockers.size());
     for (const auto& blocker : report.blockers) {
         state.preflight.blockerCodes.push_back(blocker.code);

--- a/clients/deck/src/backend/deck_backend_interfaces.h
+++ b/clients/deck/src/backend/deck_backend_interfaces.h
@@ -351,10 +351,36 @@ private:
     const DeckLaunchPreflightService& preflightService,
     const DeckLabGate& labGate);
 
+/// What a read-only provider knows beyond the repository and library: the
+/// credential facts the preflight should judge, and the source tag stamped
+/// into the public preflight copy.
+struct DeckReadOnlyStateOptions {
+    DeckCredentialMetadata credentials;
+    std::string sourceTag = "backend-owned-read-only-model";
+};
+
+[[nodiscard]] DeckPublicReadOnlyHostLibraryState buildReadOnlyHostLibraryState(
+    const DeckHostRepository& repository,
+    const PolarisGameLibraryFixture& library,
+    const DeckLaunchPreflightService& preflightService,
+    const DeckLabGate& labGate,
+    const DeckReadOnlyStateOptions& options);
+
 [[nodiscard]] std::vector<DeckPublicReadOnlyHostLibraryState> buildReadOnlyHostLibraryStateMatrix(
     const PolarisGameLibraryFixture& library,
     const DeckLaunchPreflightService& preflightService);
 
 [[nodiscard]] std::string toPublicCode(DeckPreflightBlockerCategory category);
+
+/// The player-facing state copy for a preflight outcome, shared by every read-only provider.
+[[nodiscard]] DeckPublicReadOnlyPlayerState playerStateFor(
+    const DeckPublicReadOnlyPreflightState& preflight,
+    const std::string& scenarioLabel);
+
+/// The DTO parity block for a preflight outcome, shared by every read-only provider.
+[[nodiscard]] DeckPublicReadOnlyDtoParity readOnlyDtoParityFor(
+    const DeckPublicReadOnlyPreflightState& preflight,
+    const std::string& scenarioId,
+    const std::string& scenarioLabel);
 
 } // namespace nova::deck::backend

--- a/clients/deck/src/backend/deck_live_read_only_state.cpp
+++ b/clients/deck/src/backend/deck_live_read_only_state.cpp
@@ -1,0 +1,364 @@
+#include "backend/deck_live_read_only_state.h"
+
+#include <sstream>
+#include <utility>
+
+namespace nova::deck::backend {
+
+namespace {
+
+using polaris::DeckPolarisRequestStatus;
+
+std::string hostStatusLabel(const DeckLiveHostProbe& probe) {
+    switch (probe.status) {
+    case DeckPolarisRequestStatus::Ok:
+        return "Polaris " + (probe.serverVersion.empty() ? std::string{"host"} : probe.serverVersion) + " · paired through Moonlight";
+    case DeckPolarisRequestStatus::Unauthorized:
+        return "Paired in Moonlight, but the host rejected this client";
+    case DeckPolarisRequestStatus::CertMismatch:
+        return "Host certificate changed since Moonlight paired";
+    case DeckPolarisRequestStatus::InvalidIdentity:
+        return "Moonlight pairing incomplete on this device";
+    case DeckPolarisRequestStatus::MalformedBody:
+    case DeckPolarisRequestStatus::HttpError:
+        return "Host answered, but not as a Polaris host";
+    case DeckPolarisRequestStatus::Timeout:
+    case DeckPolarisRequestStatus::Unreachable:
+        return "Offline right now · showing Moonlight's cached apps";
+    }
+    return "Unknown host state";
+}
+
+std::string hostSubtitle(const DeckLiveHostProbe& probe) {
+    if (probe.status == DeckPolarisRequestStatus::Ok) {
+        return std::to_string(probe.gameCount) + " games from the Polaris library.";
+    }
+    if (probe.cachedAppCount > 0) {
+        return std::to_string(probe.cachedAppCount) + " apps remembered by Moonlight. Reconnect to load the Polaris library.";
+    }
+    return "Nothing cached yet. Open this host in Moonlight once, then come back.";
+}
+
+DeckHostState hostState(const DeckLiveHostProbe& probe) {
+    switch (probe.status) {
+    case DeckPolarisRequestStatus::Ok:
+    case DeckPolarisRequestStatus::HttpError:
+    case DeckPolarisRequestStatus::MalformedBody:
+        return DeckHostState::Online;
+    case DeckPolarisRequestStatus::Unauthorized:
+        return DeckHostState::AuthRejected;
+    case DeckPolarisRequestStatus::CertMismatch:
+        return DeckHostState::CertMismatch;
+    case DeckPolarisRequestStatus::InvalidIdentity:
+        return DeckHostState::PairingNeeded;
+    case DeckPolarisRequestStatus::Timeout:
+    case DeckPolarisRequestStatus::Unreachable:
+        return DeckHostState::Offline;
+    }
+    return DeckHostState::Unsupported;
+}
+
+DeckEndpointClass endpointClass(const identity::DeckMoonlightHostRecord& host) {
+    if (!host.manualAddress.empty()) {
+        return DeckEndpointClass::Manual;
+    }
+    if (!host.localAddress.empty() || !host.remoteAddress.empty() || !host.ipv6Address.empty()) {
+        return DeckEndpointClass::Discovered;
+    }
+    return DeckEndpointClass::Unknown;
+}
+
+} // namespace
+
+PolarisGameFixture toLibraryGame(const polaris::DeckPolarisGame& game) {
+    PolarisGameFixture entry;
+    entry.id = game.id;
+    entry.appId = game.appId;
+    entry.name = game.name;
+    entry.source = game.source;
+    entry.launcherSource = game.source;
+    entry.platform = game.platform;
+    entry.runtime = game.runtime;
+    entry.steamAppid = game.steamAppid;
+    entry.category = game.category;
+    entry.installed = game.installed;
+    entry.coverUrl = game.coverUrl;
+    entry.genres = game.genres;
+    entry.lastLaunched = game.lastLaunched;
+    entry.hdrSupported = game.hdrSupported;
+    entry.launchMode.preferredMode = game.launchPreferredMode;
+    entry.launchMode.recommendedMode = game.launchRecommendedMode;
+    entry.launchMode.allowedModes = game.launchAllowedModes;
+    entry.launchMode.modeReason = game.launchModeReason;
+    entry.steamLaunch.available = game.steamLaunchAvailable;
+    entry.steamLaunch.mode = game.steamLaunchMode;
+    entry.steamLaunch.recommendedMode = game.steamLaunchRecommendedMode;
+    entry.steamLaunch.allowedModes = game.steamLaunchAllowedModes;
+    entry.steamLaunch.modeReason = game.steamLaunchModeReason;
+    return entry;
+}
+
+PolarisGameFixture toLibraryGame(const identity::DeckMoonlightAppRecord& app) {
+    PolarisGameFixture entry;
+    entry.id = "moonlight-app-" + std::to_string(app.id);
+    entry.appId = app.id;
+    entry.name = app.name;
+    entry.source = "moonlight";
+    entry.launcherSource = "moonlight";
+    entry.launcherDetail = "cached";
+    entry.installed = true;
+    entry.hdrSupported = app.hdr;
+    return entry;
+}
+
+DeckLiveHostLibrarySnapshot buildLiveSnapshot(const identity::DeckMoonlightIdentity& identity, const DeckLivePolarisFetcher& fetcher) {
+    DeckLiveHostLibrarySnapshot snapshot;
+    snapshot.identityLoaded = identity.loaded;
+    snapshot.clientIdentityUsable = identity.hasClientIdentity();
+    snapshot.identitySourceLabel = identity.sourceLabel;
+    snapshot.clientFingerprintShort = identity::shortFingerprint(identity.clientCertificateFingerprintSha256());
+    snapshot.library.readOnly = true;
+    snapshot.library.sourceLabel = "No Moonlight pairing found on this device";
+
+    if (!identity.loaded) {
+        return snapshot;
+    }
+
+    bool librarySelected = false;
+    for (const auto& host : identity.hosts) {
+        DeckLiveHostProbe probe;
+        probe.hostId = host.stableId();
+        probe.displayName = host.displayName();
+        probe.cachedAppCount = static_cast<int>(host.apps.size());
+
+        if (!identity.hasClientIdentity()) {
+            probe.status = DeckPolarisRequestStatus::InvalidIdentity;
+            probe.detail = "Moonlight has no client certificate on this device";
+        } else if (!host.hasServerCertificate()) {
+            probe.status = DeckPolarisRequestStatus::InvalidIdentity;
+            probe.detail = "Moonlight has not pinned this host's certificate";
+        } else {
+            auto fetch = fetcher(host, !librarySelected);
+            probe.status = fetch.status;
+            probe.detail = std::move(fetch.detail);
+            probe.serverVersion = std::move(fetch.serverVersion);
+            if (probe.status == DeckPolarisRequestStatus::Ok) {
+                probe.librarySource = "polaris-live";
+                if (!librarySelected) {
+                    probe.gameCount = static_cast<int>(fetch.games.size());
+                    snapshot.library.games.clear();
+                    for (const auto& game : fetch.games) {
+                        snapshot.library.games.push_back(toLibraryGame(game));
+                    }
+                    snapshot.library.sourceLabel = "Polaris library · " + probe.displayName;
+                    snapshot.selectedHostId = probe.hostId;
+                    librarySelected = true;
+                }
+            }
+        }
+
+        if (probe.status != DeckPolarisRequestStatus::Ok) {
+            probe.librarySource = probe.cachedAppCount > 0 ? "moonlight-cached-app-list" : "none";
+            if (!librarySelected && probe.cachedAppCount > 0 && snapshot.library.games.empty()) {
+                for (const auto& app : host.apps) {
+                    if (!app.hidden) {
+                        snapshot.library.games.push_back(toLibraryGame(app));
+                    }
+                }
+                snapshot.library.sourceLabel = "Moonlight's cached apps · " + probe.displayName;
+                snapshot.selectedHostId = probe.hostId;
+            }
+        }
+
+        snapshot.hosts.push_back(DeckHostSummary{
+            .id = probe.hostId,
+            .displayName = probe.displayName,
+            .state = hostState(probe),
+            .endpointClass = endpointClass(host),
+            .fixtureOnly = false,
+            .hasEndpointCandidate = !host.preferredAddress().empty(),
+            .polarisAvailable = probe.status == DeckPolarisRequestStatus::Ok,
+            .standardAppListAvailable = probe.status == DeckPolarisRequestStatus::Ok || probe.cachedAppCount > 0,
+            .publicStatusLabel = hostStatusLabel(probe),
+            .publicSubtitle = hostSubtitle(probe),
+            .publicProvenanceLabel = "moonlight-pairing/" + identity.sourceLabel + "/redacted-public",
+        });
+        snapshot.probes.push_back(std::move(probe));
+    }
+
+    if (identity.hosts.empty()) {
+        snapshot.library.sourceLabel = "Moonlight is installed but has no paired host yet";
+    }
+    return snapshot;
+}
+
+std::vector<DeckHostSummary> hostsSelectedFirst(const DeckLiveHostLibrarySnapshot& snapshot) {
+    std::vector<DeckHostSummary> ordered;
+    ordered.reserve(snapshot.hosts.size());
+    for (const auto& host : snapshot.hosts) {
+        if (host.id == snapshot.selectedHostId) {
+            ordered.push_back(host);
+        }
+    }
+    for (const auto& host : snapshot.hosts) {
+        if (host.id != snapshot.selectedHostId) {
+            ordered.push_back(host);
+        }
+    }
+    return ordered;
+}
+
+DeckCredentialMetadata credentialsForSelectedHost(const DeckLiveHostLibrarySnapshot& snapshot) {
+    DeckCredentialMetadata credentials;
+    const auto ordered = hostsSelectedFirst(snapshot);
+    if (ordered.empty()) {
+        return credentials;
+    }
+    credentials.hostId = ordered.front().id;
+    for (const auto& probe : snapshot.probes) {
+        if (probe.hostId != credentials.hostId) {
+            continue;
+        }
+        credentials.paired = snapshot.clientIdentityUsable && probe.status != DeckPolarisRequestStatus::InvalidIdentity;
+        credentials.certMismatch = probe.status == DeckPolarisRequestStatus::CertMismatch;
+        credentials.authRejected = probe.status == DeckPolarisRequestStatus::Unauthorized;
+        credentials.pinnedCertFingerprint = snapshot.clientFingerprintShort;
+        break;
+    }
+    return credentials;
+}
+
+DeckLivePolarisFetcher polarisNetworkFetcher(const identity::DeckMoonlightIdentity& identity, const std::chrono::milliseconds timeout) {
+    const polaris::DeckPolarisTlsIdentity tls{
+        .clientCertificatePem = identity.clientCertificatePem,
+        .clientPrivateKeyPem = identity.clientPrivateKeyPemForBackendOnly,
+        .pinnedServerCertificatePem = {},
+    };
+    return [tls, timeout](const identity::DeckMoonlightHostRecord& host, const bool wantLibrary) {
+        DeckLivePolarisFetch fetch;
+        auto hostTls = tls;
+        hostTls.pinnedServerCertificatePem = host.serverCertificatePem;
+        const auto address = host.preferredAddress();
+        const auto httpPort = host.preferredHttpPort();
+        // Moonlight learns the HTTPS port from serverinfo on every connection
+        // because forwarded hosts do not keep the five-port spacing.
+        const auto advertised = polaris::resolveHttpsPortFromServerInfo(address, httpPort, timeout);
+        const polaris::DeckPolarisClient client(
+            polaris::DeckPolarisEndpoint{
+                .address = address,
+                .httpsPort = advertised.value_or(identity::polarisHttpsPortForMoonlightHttpPort(httpPort)),
+            },
+            hostTls,
+            timeout);
+        const auto capabilities = client.fetchCapabilities();
+        fetch.status = capabilities.status;
+        fetch.detail = capabilities.detail;
+        if (!capabilities.ok()) {
+            return fetch;
+        }
+        fetch.serverVersion = capabilities.value->version;
+        if (!wantLibrary) {
+            return fetch;
+        }
+        auto games = client.fetchAllGames();
+        fetch.status = games.status;
+        if (!games.ok()) {
+            fetch.detail = games.detail;
+            return fetch;
+        }
+        fetch.games = std::move(*games.value);
+        return fetch;
+    };
+}
+
+DeckLiveHostLibrarySnapshot buildLiveSnapshotFromDefaultIdentity(const std::chrono::milliseconds timeout) {
+    const auto identity = identity::loadDefaultMoonlightIdentity();
+    if (!identity) {
+        return buildLiveSnapshot(identity::DeckMoonlightIdentity{}, [](const identity::DeckMoonlightHostRecord&, bool) {
+            return DeckLivePolarisFetch{};
+        });
+    }
+    return buildLiveSnapshot(*identity, polarisNetworkFetcher(*identity, timeout));
+}
+
+std::string describeLiveSnapshotForTerminal(const DeckLiveHostLibrarySnapshot& snapshot) {
+    std::ostringstream out;
+    out << "nova-deck live snapshot\n";
+    out << "  identity: " << (snapshot.identityLoaded ? snapshot.identitySourceLabel : std::string{"none"})
+        << " client=" << (snapshot.clientIdentityUsable ? "usable" : "missing")
+        << " fingerprint=" << (snapshot.clientFingerprintShort.empty() ? std::string{"-"} : snapshot.clientFingerprintShort) << "\n";
+    out << "  hosts: " << snapshot.hosts.size() << "\n";
+    for (const auto& probe : snapshot.probes) {
+        out << "    - " << probe.displayName << " [" << probe.hostId << "] status=" << polaris::describe(probe.status)
+            << " library=" << probe.librarySource << " games=" << probe.gameCount << " cached=" << probe.cachedAppCount;
+        if (!probe.serverVersion.empty()) {
+            out << " polaris=" << probe.serverVersion;
+        }
+        if (!probe.detail.empty() && probe.status != DeckPolarisRequestStatus::Ok) {
+            out << " detail=\"" << probe.detail << "\"";
+        }
+        out << "\n";
+    }
+    out << "  library: " << snapshot.library.sourceLabel << " (" << snapshot.library.games.size() << " entries)\n";
+    std::size_t shown = 0;
+    for (const auto& game : snapshot.library.games) {
+        if (shown++ >= 12) {
+            out << "    ...\n";
+            break;
+        }
+        out << "    - " << game.name << " [" << game.source << "]\n";
+    }
+    return out.str();
+}
+
+DeckLiveReadOnlyStateProvider::DeckLiveReadOnlyStateProvider(
+    DeckLiveHostLibrarySnapshot snapshot,
+    const DeckLaunchPreflightService& preflightService) {
+    // The selected host goes first so focus, the preflight and the detail card
+    // all describe the host the library came from.
+    DeckFakeHostRepository repository;
+    for (const auto& host : hostsSelectedFirst(snapshot)) {
+        repository.upsertSanitizedHostSummary(host);
+    }
+    state_ = buildReadOnlyHostLibraryState(
+        repository,
+        snapshot.library,
+        preflightService,
+        DeckLabGate::forMode(DeckLabGateMode::ReadOnlyNetwork),
+        DeckReadOnlyStateOptions{
+            .credentials = credentialsForSelectedHost(snapshot),
+            .sourceTag = "moonlight-pairing-live-read-only",
+        });
+    state_.scenarioId = std::string(kScenarioId);
+    if (!snapshot.identityLoaded) {
+        state_.scenarioLabel = "Moonlight not paired on this device";
+    } else if (snapshot.hosts.empty()) {
+        state_.scenarioLabel = "Moonlight has no paired host";
+    } else {
+        int online = 0;
+        for (const auto& probe : snapshot.probes) {
+            if (probe.status == DeckPolarisRequestStatus::Ok) {
+                ++online;
+            }
+        }
+        state_.scenarioLabel = online > 0
+            ? "Live · " + std::to_string(online) + " Polaris host" + (online == 1 ? "" : "s") + " reachable"
+            : "Offline · Moonlight's cached apps";
+    }
+    state_.sourceLabel = "live read-only · " + snapshot.library.sourceLabel;
+    state_.preflight.backendPowerStarted = false;
+    state_.preflight.streamAllowed = false;
+    state_.preflight.publicCopy += "; handoff=not-yet-executable";
+    state_.playerState = playerStateFor(state_.preflight, state_.scenarioLabel);
+    state_.dtoParity = readOnlyDtoParityFor(state_.preflight, state_.scenarioId, state_.scenarioLabel);
+}
+
+std::vector<DeckPublicReadOnlyHostLibraryState> DeckLiveReadOnlyStateProvider::stateMatrix() const {
+    return {state_};
+}
+
+DeckPublicReadOnlyHostLibraryState DeckLiveReadOnlyStateProvider::stateForScenario(std::string_view) const {
+    return state_;
+}
+
+} // namespace nova::deck::backend

--- a/clients/deck/src/backend/deck_live_read_only_state.h
+++ b/clients/deck/src/backend/deck_live_read_only_state.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "backend/deck_backend_interfaces.h"
+#include "identity/deck_moonlight_identity.h"
+#include "polaris/deck_polaris_client.h"
+#include "polaris_game_fixture.h"
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <vector>
+
+// The live read-only route: hosts come from Moonlight-Qt's pairing file, the
+// library comes from Polaris over the pinned mTLS client, and when Polaris is
+// not reachable the cached Moonlight app list stands in. Everything public
+// stays a sanitized DTO; addresses, certificates and keys never leave the
+// snapshot builder.
+namespace nova::deck::backend {
+
+struct DeckLivePolarisFetch {
+    polaris::DeckPolarisRequestStatus status = polaris::DeckPolarisRequestStatus::Unreachable;
+    std::string detail;
+    std::string serverVersion;
+    std::vector<polaris::DeckPolarisGame> games;
+};
+
+/// Probe one host. `wantLibrary` is false once a host already supplied the library, so only capabilities are asked.
+using DeckLivePolarisFetcher = std::function<DeckLivePolarisFetch(const identity::DeckMoonlightHostRecord& host, bool wantLibrary)>;
+
+struct DeckLiveHostProbe {
+    std::string hostId;
+    std::string displayName;
+    polaris::DeckPolarisRequestStatus status = polaris::DeckPolarisRequestStatus::Unreachable;
+    std::string detail;
+    std::string serverVersion;
+    std::string librarySource;  ///< polaris-live, moonlight-cached-app-list, or none
+    int gameCount = 0;
+    int cachedAppCount = 0;
+};
+
+struct DeckLiveHostLibrarySnapshot {
+    bool identityLoaded = false;
+    bool clientIdentityUsable = false;
+    std::string identitySourceLabel;
+    std::string clientFingerprintShort;
+    std::string selectedHostId;
+    std::vector<DeckHostSummary> hosts;
+    std::vector<DeckLiveHostProbe> probes;
+    PolarisGameLibraryFixture library;
+};
+
+/// Probe every paired host through @p fetcher and build the sanitized snapshot. Pure apart from the fetcher.
+/// The first reachable Polaris host supplies the library and becomes the selected host; later hosts are only probed.
+DeckLiveHostLibrarySnapshot buildLiveSnapshot(const identity::DeckMoonlightIdentity& identity, const DeckLivePolarisFetcher& fetcher);
+
+/// Hosts in presentation order: the selected host first, then Moonlight's order.
+std::vector<DeckHostSummary> hostsSelectedFirst(const DeckLiveHostLibrarySnapshot& snapshot);
+
+/// The credential facts the preflight should judge for the selected host.
+DeckCredentialMetadata credentialsForSelectedHost(const DeckLiveHostLibrarySnapshot& snapshot);
+
+/// One word for the header: where this read-only state came from.
+inline constexpr std::string_view kLiveProvenanceLabel = "moonlight-pairing provenance";
+
+/// A fetcher that talks to Polaris with the identity's certificate and the host's pinned server certificate.
+DeckLivePolarisFetcher polarisNetworkFetcher(const identity::DeckMoonlightIdentity& identity, std::chrono::milliseconds timeout);
+
+/// Load the default Moonlight identity and probe its hosts over the network. Never throws; an absent identity yields an empty snapshot.
+DeckLiveHostLibrarySnapshot buildLiveSnapshotFromDefaultIdentity(std::chrono::milliseconds timeout);
+
+/// Sanitized multi-line summary for the terminal: no addresses, ports, certificates or keys.
+std::string describeLiveSnapshotForTerminal(const DeckLiveHostLibrarySnapshot& snapshot);
+
+/// Map a Polaris game onto the fixture-shaped library entry the shell already renders.
+PolarisGameFixture toLibraryGame(const polaris::DeckPolarisGame& game);
+
+/// Map a cached Moonlight app onto a library entry when Polaris cannot be asked.
+PolarisGameFixture toLibraryGame(const identity::DeckMoonlightAppRecord& app);
+
+class DeckLiveReadOnlyStateProvider final : public DeckReadOnlyStateProvider {
+public:
+    DeckLiveReadOnlyStateProvider(DeckLiveHostLibrarySnapshot snapshot, const DeckLaunchPreflightService& preflightService);
+
+    [[nodiscard]] std::vector<DeckPublicReadOnlyHostLibraryState> stateMatrix() const override;
+    [[nodiscard]] DeckPublicReadOnlyHostLibraryState stateForScenario(std::string_view scenarioId) const override;
+
+    static constexpr std::string_view kScenarioId = "live";
+
+private:
+    DeckPublicReadOnlyHostLibraryState state_;
+};
+
+} // namespace nova::deck::backend

--- a/clients/deck/src/identity/deck_moonlight_identity.cpp
+++ b/clients/deck/src/identity/deck_moonlight_identity.cpp
@@ -1,0 +1,212 @@
+#include "identity/deck_moonlight_identity.h"
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QSettings>
+#include <QSslCertificate>
+#include <QString>
+
+#include <cstdlib>
+#include <utility>
+
+namespace nova::deck::identity {
+
+namespace {
+
+constexpr int kDefaultMoonlightHttpPort = 47989;
+constexpr int kGameStreamHttpsOffset = 5;
+
+std::string toStd(const QString& value) {
+    return value.toStdString();
+}
+
+std::string toStd(const QByteArray& value) {
+    return std::string(value.constData(), static_cast<std::size_t>(value.size()));
+}
+
+std::filesystem::path homeDirectory() {
+    if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0') {
+        return std::filesystem::path(home);
+    }
+    return {};
+}
+
+std::filesystem::path configHome() {
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg != nullptr && *xdg != '\0') {
+        return std::filesystem::path(xdg);
+    }
+    const auto home = homeDirectory();
+    return home.empty() ? std::filesystem::path{} : home / ".config";
+}
+
+DeckMoonlightAppRecord readApp(QSettings& settings) {
+    DeckMoonlightAppRecord app;
+    app.id = settings.value(QStringLiteral("id")).toInt();
+    app.name = toStd(settings.value(QStringLiteral("name")).toString());
+    app.hdr = settings.value(QStringLiteral("hdr")).toBool();
+    app.hidden = settings.value(QStringLiteral("hidden")).toBool();
+    return app;
+}
+
+DeckMoonlightHostRecord readHost(QSettings& settings) {
+    DeckMoonlightHostRecord host;
+    host.uuid = toStd(settings.value(QStringLiteral("uuid")).toString());
+    host.hostname = toStd(settings.value(QStringLiteral("hostname")).toString());
+    host.hasCustomName = settings.value(QStringLiteral("customname")).toBool();
+    host.localAddress = toStd(settings.value(QStringLiteral("localaddress")).toString());
+    host.localPort = settings.value(QStringLiteral("localport")).toInt();
+    host.manualAddress = toStd(settings.value(QStringLiteral("manualaddress")).toString());
+    host.manualPort = settings.value(QStringLiteral("manualport")).toInt();
+    host.remoteAddress = toStd(settings.value(QStringLiteral("remoteaddress")).toString());
+    host.remotePort = settings.value(QStringLiteral("remoteport")).toInt();
+    host.ipv6Address = toStd(settings.value(QStringLiteral("ipv6address")).toString());
+    host.ipv6Port = settings.value(QStringLiteral("ipv6port")).toInt();
+    host.serverCertificatePem = toStd(settings.value(QStringLiteral("srvcert")).toByteArray());
+
+    const int appCount = settings.beginReadArray(QStringLiteral("apps"));
+    host.apps.reserve(static_cast<std::size_t>(appCount > 0 ? appCount : 0));
+    for (int index = 0; index < appCount; ++index) {
+        settings.setArrayIndex(index);
+        host.apps.push_back(readApp(settings));
+    }
+    settings.endArray();
+    return host;
+}
+
+} // namespace
+
+std::string DeckMoonlightHostRecord::stableId() const {
+    return uuid.empty() ? hostname : uuid;
+}
+
+std::string DeckMoonlightHostRecord::displayName() const {
+    if (!hostname.empty()) {
+        return hostname;
+    }
+    return uuid.empty() ? std::string{"Moonlight host"} : uuid;
+}
+
+std::string DeckMoonlightHostRecord::preferredAddress() const {
+    if (!manualAddress.empty()) {
+        return manualAddress;
+    }
+    if (!localAddress.empty()) {
+        return localAddress;
+    }
+    if (!remoteAddress.empty()) {
+        return remoteAddress;
+    }
+    return ipv6Address;
+}
+
+int DeckMoonlightHostRecord::preferredHttpPort() const {
+    int port = 0;
+    if (!manualAddress.empty()) {
+        port = manualPort;
+    } else if (!localAddress.empty()) {
+        port = localPort;
+    } else if (!remoteAddress.empty()) {
+        port = remotePort;
+    } else if (!ipv6Address.empty()) {
+        port = ipv6Port;
+    }
+    return port > 0 ? port : kDefaultMoonlightHttpPort;
+}
+
+bool DeckMoonlightHostRecord::hasServerCertificate() const {
+    return !serverCertificatePem.empty();
+}
+
+bool DeckMoonlightIdentity::hasClientIdentity() const {
+    return loaded && !clientCertificatePem.empty() && !clientPrivateKeyPemForBackendOnly.empty();
+}
+
+std::string DeckMoonlightIdentity::clientCertificateFingerprintSha256() const {
+    const QSslCertificate certificate(QByteArray::fromStdString(clientCertificatePem), QSsl::Pem);
+    if (certificate.isNull()) {
+        return {};
+    }
+    return toStd(QString::fromLatin1(certificate.digest(QCryptographicHash::Sha256).toHex()).toLower());
+}
+
+const DeckMoonlightHostRecord* DeckMoonlightIdentity::hostById(const std::string_view hostId) const {
+    for (const auto& host : hosts) {
+        if (host.stableId() == hostId) {
+            return &host;
+        }
+    }
+    return nullptr;
+}
+
+std::vector<DeckMoonlightIdentityCandidate> defaultIdentityCandidates() {
+    std::vector<DeckMoonlightIdentityCandidate> candidates;
+    if (const char* override = std::getenv("NOVA_DECK_MOONLIGHT_CONF"); override != nullptr && *override != '\0') {
+        candidates.push_back({std::filesystem::path(override), "moonlight-override"});
+    }
+    const auto confRelative = std::filesystem::path("Moonlight Game Streaming Project") / "Moonlight.conf";
+    if (const auto home = homeDirectory(); !home.empty()) {
+        candidates.push_back({home / ".var" / "app" / "com.moonlight_stream.Moonlight" / "config" / confRelative, "moonlight-flatpak"});
+    }
+    if (const auto config = configHome(); !config.empty()) {
+        candidates.push_back({config / confRelative, "moonlight-native"});
+    }
+    return candidates;
+}
+
+std::optional<DeckMoonlightIdentity> loadMoonlightIdentity(const std::filesystem::path& confPath, std::string sourceLabel) {
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(confPath, ec)) {
+        return std::nullopt;
+    }
+    QSettings settings(QString::fromStdString(confPath.string()), QSettings::IniFormat);
+    if (settings.status() != QSettings::NoError) {
+        return std::nullopt;
+    }
+
+    DeckMoonlightIdentity identity;
+    identity.loaded = true;
+    identity.sourceLabel = std::move(sourceLabel);
+    identity.sourcePathForBackendOnly = confPath.string();
+    identity.clientCertificatePem = toStd(settings.value(QStringLiteral("certificate")).toByteArray());
+    identity.clientPrivateKeyPemForBackendOnly = toStd(settings.value(QStringLiteral("key")).toByteArray());
+
+    // Moonlight-Qt writes `hostsbackup` before rewriting `hosts` and reads the
+    // backup first when it exists, so an interrupted flush is recovered the
+    // same way here.
+    for (const auto arrayName : {kMoonlightHostsBackupArray, kMoonlightHostsArray}) {
+        const int hostCount = settings.beginReadArray(QString::fromUtf8(arrayName.data(), static_cast<int>(arrayName.size())));
+        for (int index = 0; index < hostCount; ++index) {
+            settings.setArrayIndex(index);
+            auto host = readHost(settings);
+            if (host.stableId().empty()) {
+                continue;
+            }
+            identity.hosts.push_back(std::move(host));
+        }
+        settings.endArray();
+        if (!identity.hosts.empty()) {
+            break;
+        }
+    }
+    return identity;
+}
+
+std::optional<DeckMoonlightIdentity> loadDefaultMoonlightIdentity() {
+    for (const auto& candidate : defaultIdentityCandidates()) {
+        if (auto identity = loadMoonlightIdentity(candidate.path, candidate.label)) {
+            return identity;
+        }
+    }
+    return std::nullopt;
+}
+
+int polarisHttpsPortForMoonlightHttpPort(const int httpPort) {
+    const int base = httpPort > 0 ? httpPort : kDefaultMoonlightHttpPort;
+    return base - kGameStreamHttpsOffset;
+}
+
+std::string shortFingerprint(const std::string& fingerprintHex) {
+    return fingerprintHex.substr(0, 8);
+}
+
+} // namespace nova::deck::identity

--- a/clients/deck/src/identity/deck_moonlight_identity.h
+++ b/clients/deck/src/identity/deck_moonlight_identity.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Nova on the Deck borrows the pairing Moonlight-Qt already made instead of
+// asking the player to pair twice. Moonlight-Qt keeps its client certificate,
+// private key, paired hosts, pinned server certificates and cached app lists in
+// one QSettings INI file; this module reads that file and nothing else. The
+// private key never leaves the identity object into a public DTO.
+namespace nova::deck::identity {
+
+struct DeckMoonlightAppRecord {
+    int id = 0;
+    std::string name;
+    bool hdr = false;
+    bool hidden = false;
+};
+
+struct DeckMoonlightHostRecord {
+    std::string uuid;
+    std::string hostname;  ///< Moonlight's display name for the host, custom or reported
+    bool hasCustomName = false;  ///< Moonlight only records whether the player renamed it
+    std::string localAddress;
+    int localPort = 0;
+    std::string manualAddress;
+    int manualPort = 0;
+    std::string remoteAddress;
+    int remotePort = 0;
+    std::string ipv6Address;
+    int ipv6Port = 0;
+    std::string serverCertificatePem;
+    std::vector<DeckMoonlightAppRecord> apps;
+
+    /// Moonlight's host UUID, falling back to the hostname. Safe to show and to log.
+    [[nodiscard]] std::string stableId() const;
+    /// The name Moonlight shows: `hostname`, which already holds a custom name when the player set one.
+    [[nodiscard]] std::string displayName() const;
+    /// Manual address first (the player typed it), then local, remote, IPv6.
+    [[nodiscard]] std::string preferredAddress() const;
+    /// The HTTP port Moonlight recorded beside the preferred address (47989 by default).
+    [[nodiscard]] int preferredHttpPort() const;
+    [[nodiscard]] bool hasServerCertificate() const;
+};
+
+struct DeckMoonlightIdentity {
+    bool loaded = false;
+    std::string sourceLabel;
+    std::string sourcePathForBackendOnly;
+    std::string clientCertificatePem;
+    std::string clientPrivateKeyPemForBackendOnly;
+    std::vector<DeckMoonlightHostRecord> hosts;
+
+    [[nodiscard]] bool hasClientIdentity() const;
+    /// Lowercase hex SHA-256 of the client certificate DER; empty when the PEM does not parse.
+    [[nodiscard]] std::string clientCertificateFingerprintSha256() const;
+    [[nodiscard]] const DeckMoonlightHostRecord* hostById(std::string_view hostId) const;
+};
+
+struct DeckMoonlightIdentityCandidate {
+    std::filesystem::path path;
+    std::string label;
+};
+
+/// NOVA_DECK_MOONLIGHT_CONF first, then the Flatpak and native Moonlight-Qt locations.
+std::vector<DeckMoonlightIdentityCandidate> defaultIdentityCandidates();
+
+std::optional<DeckMoonlightIdentity> loadMoonlightIdentity(const std::filesystem::path& confPath, std::string sourceLabel);
+
+/// The first candidate that exists and parses; nullopt when Moonlight-Qt has never run here.
+std::optional<DeckMoonlightIdentity> loadDefaultMoonlightIdentity();
+
+/// The array Moonlight-Qt persists hosts under, falling back to the `hostsbackup` copy it keeps while flushing.
+inline constexpr std::string_view kMoonlightHostsArray = "hosts";
+inline constexpr std::string_view kMoonlightHostsBackupArray = "hostsbackup";
+
+/// Moonlight records the HTTP port; GameStream hosts serve HTTPS five ports below it.
+int polarisHttpsPortForMoonlightHttpPort(int httpPort);
+
+/// The first eight hex characters, enough to recognise an identity in a log without printing it.
+std::string shortFingerprint(const std::string& fingerprintHex);
+
+} // namespace nova::deck::identity

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -2,6 +2,7 @@
 #include "deck_gamepad.h"
 #include "polaris_game_fixture.h"
 #include "backend/deck_backend_interfaces.h"
+#include "backend/deck_live_read_only_state.h"
 #include "stream/deck_stream_media_adapters.h"
 
 #include <QClipboard>
@@ -11,6 +12,9 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <chrono>
+#include <memory>
+#include <optional>
 #include <QGuiApplication>
 #include <QImage>
 #include <QQmlApplicationEngine>
@@ -932,9 +936,29 @@ int main(int argc, char *argv[]) {
     const auto profile = nova::deck::defaultWindowProfile();
     const auto sampleLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
     const nova::deck::backend::DeckLaunchPreflightService readOnlyPreflightService;
-    const nova::deck::backend::DeckFixtureReadOnlyStateProvider readOnlyStateProvider(
-        sampleLibrary,
-        readOnlyPreflightService);
+
+    // --live reads the identity Moonlight-Qt already holds on this device and
+    // asks Polaris for the library with it; nothing is launched and no session
+    // is started. The default stays the offline fixture so the smoke routes
+    // keep proving the shell without a host.
+    const bool liveRoute = appArguments.contains(QStringLiteral("--live")) || qEnvironmentVariableIntValue("NOVA_DECK_LIVE") == 1;
+    const bool printLiveState = appArguments.contains(QStringLiteral("--print-live-state"));
+    std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> liveSnapshot;
+    if (liveRoute || printLiveState) {
+        liveSnapshot = nova::deck::backend::buildLiveSnapshotFromDefaultIdentity(std::chrono::milliseconds(4000));
+        qInfo().noquote() << QString::fromStdString(nova::deck::backend::describeLiveSnapshotForTerminal(*liveSnapshot));
+        if (printLiveState) {
+            return liveSnapshot->identityLoaded ? 0 : 2;
+        }
+    }
+    std::unique_ptr<nova::deck::backend::DeckReadOnlyStateProvider> readOnlyStateProviderOwner;
+    if (liveSnapshot) {
+        readOnlyStateProviderOwner = std::make_unique<nova::deck::backend::DeckLiveReadOnlyStateProvider>(*liveSnapshot, readOnlyPreflightService);
+    } else {
+        readOnlyStateProviderOwner = std::make_unique<nova::deck::backend::DeckFixtureReadOnlyStateProvider>(sampleLibrary, readOnlyPreflightService);
+    }
+    const auto& readOnlyStateProvider = *readOnlyStateProviderOwner;
+    const auto activeLibrary = liveSnapshot ? liveSnapshot->library : sampleLibrary;
     const auto backendReadOnlyStateMatrix = readOnlyStateProvider.stateMatrix();
     const QString selectedMatrixScenario = stringArgumentAfter(appArguments, QStringLiteral("--frontend-smoke-readonly-state"));
     const auto backendReadOnlyState = readOnlyStateProvider.stateForScenario(selectedMatrixScenario.toStdString());
@@ -951,7 +975,7 @@ int main(int argc, char *argv[]) {
         });
         ++launchPreviewHostRow;
     }
-    auto selectedLaunchLibrary = sampleLibrary;
+    auto selectedLaunchLibrary = activeLibrary;
     if (backendReadOnlyState.games.empty()) {
         selectedLaunchLibrary.games.clear();
     }
@@ -973,7 +997,12 @@ int main(int argc, char *argv[]) {
     QtLocalClipboardBridge localClipboard;
     QtDeckGamepadBridge gamepadBridge;
     QtBackendPreviewBridge backendPreview;
-    for (const auto& host : sampleLibrary.hosts) {
+    if (liveSnapshot) {
+        for (const auto& host : liveSnapshot->hosts) {
+            backendPreview.seedReadOnlyHostSummary(host);
+        }
+    }
+    for (const auto& host : liveSnapshot ? std::vector<nova::deck::PolarisHostFixture>{} : sampleLibrary.hosts) {
         backendPreview.seedReadOnlyHostSummary(nova::deck::backend::DeckHostSummary{
             .id = host.id,
             .displayName = host.displayName,
@@ -1019,6 +1048,10 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaBackendReadOnlyState", toReadOnlyStateModel(backendReadOnlyState));
     engine.rootContext()->setContextProperty("novaLibraryFixtureSource", toQString(backendReadOnlyState.sourceLabel));
     engine.rootContext()->setContextProperty("novaLibraryReadOnly", backendReadOnlyState.readOnly);
+    engine.rootContext()->setContextProperty(
+        "novaBackendReadOnlyProvenance",
+        liveSnapshot ? QString::fromUtf8(nova::deck::backend::kLiveProvenanceLabel.data(), static_cast<int>(nova::deck::backend::kLiveProvenanceLabel.size()))
+                     : QStringLiteral("fixture provenance"));
     engine.rootContext()->setContextProperty("novaLibraryGames", toLibraryGameModel(backendReadOnlyState.games));
     engine.rootContext()->setContextProperty("novaLibraryHosts", toHostModel(backendReadOnlyState.hosts));
     engine.rootContext()->setContextProperty("novaSelectedHostDetail", selectedHostDetailModel);

--- a/clients/deck/src/polaris/deck_polaris_client.cpp
+++ b/clients/deck/src/polaris/deck_polaris_client.cpp
@@ -1,0 +1,435 @@
+#include "polaris/deck_polaris_client.h"
+
+#include <QByteArray>
+#include <QEventLoop>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QObject>
+#include <QSslCertificate>
+#include <QSslConfiguration>
+#include <QSslError>
+#include <QSslKey>
+#include <QSslSocket>
+#include <QString>
+#include <QUrl>
+
+#include <memory>
+#include <utility>
+
+namespace nova::deck::polaris {
+
+namespace {
+
+std::string toStd(const QString& value) {
+    return value.toStdString();
+}
+
+std::vector<std::string> stringList(const QJsonValue& value) {
+    std::vector<std::string> items;
+    for (const auto& entry : value.toArray()) {
+        if (entry.isString()) {
+            items.push_back(toStd(entry.toString()));
+        }
+    }
+    return items;
+}
+
+std::optional<QJsonObject> parseObject(const std::string_view json) {
+    QJsonParseError error{};
+    const auto document = QJsonDocument::fromJson(QByteArray(json.data(), static_cast<int>(json.size())), &error);
+    if (error.error != QJsonParseError::NoError || !document.isObject()) {
+        return std::nullopt;
+    }
+    return document.object();
+}
+
+DeckPolarisGame parseGame(const QJsonObject& object) {
+    DeckPolarisGame game;
+    game.id = toStd(object.value(QStringLiteral("id")).toString());
+    // Polaris emits app_id as a string; the fixture and older hosts use a number.
+    const auto appId = object.value(QStringLiteral("app_id"));
+    game.appId = appId.isString() ? appId.toString().toInt() : appId.toInt();
+    game.name = toStd(object.value(QStringLiteral("name")).toString());
+    game.source = toStd(object.value(QStringLiteral("source")).toString());
+    game.platform = toStd(object.value(QStringLiteral("platform")).toString());
+    game.runtime = toStd(object.value(QStringLiteral("runtime")).toString());
+    game.steamAppid = toStd(object.value(QStringLiteral("steam_appid")).toString());
+    game.category = toStd(object.value(QStringLiteral("category")).toString());
+    game.coverUrl = toStd(object.value(QStringLiteral("cover_url")).toString());
+    game.installed = object.value(QStringLiteral("installed")).toBool(true);
+    game.hdrSupported = object.value(QStringLiteral("hdr_supported")).toBool(false);
+    game.lastLaunched = static_cast<long long>(object.value(QStringLiteral("last_launched")).toDouble(0));
+    game.genres = stringList(object.value(QStringLiteral("genres")));
+
+    const auto launchMode = object.value(QStringLiteral("launch_mode")).toObject();
+    game.launchPreferredMode = toStd(launchMode.value(QStringLiteral("preferred_mode")).toString());
+    game.launchRecommendedMode = toStd(launchMode.value(QStringLiteral("recommended_mode")).toString());
+    game.launchAllowedModes = stringList(launchMode.value(QStringLiteral("allowed_modes")));
+    game.launchModeReason = toStd(launchMode.value(QStringLiteral("mode_reason")).toString());
+
+    const auto steamLaunch = object.value(QStringLiteral("steam_launch")).toObject();
+    game.steamLaunchAvailable = steamLaunch.value(QStringLiteral("available")).toBool(false);
+    game.steamLaunchMode = toStd(steamLaunch.value(QStringLiteral("mode")).toString());
+    game.steamLaunchRecommendedMode = toStd(steamLaunch.value(QStringLiteral("recommended_mode")).toString());
+    game.steamLaunchAllowedModes = stringList(steamLaunch.value(QStringLiteral("allowed_modes")));
+    game.steamLaunchModeReason = toStd(steamLaunch.value(QStringLiteral("mode_reason")).toString());
+    return game;
+}
+
+bool sameCertificate(const QSslCertificate& peer, const QSslCertificate& pinned) {
+    return !peer.isNull() && !pinned.isNull() && peer.toDer() == pinned.toDer();
+}
+
+} // namespace
+
+std::string_view describe(const DeckPolarisRequestStatus status) {
+    switch (status) {
+    case DeckPolarisRequestStatus::Ok:
+        return "ok";
+    case DeckPolarisRequestStatus::InvalidIdentity:
+        return "invalid-identity";
+    case DeckPolarisRequestStatus::Unreachable:
+        return "unreachable";
+    case DeckPolarisRequestStatus::Timeout:
+        return "timeout";
+    case DeckPolarisRequestStatus::CertMismatch:
+        return "cert-mismatch";
+    case DeckPolarisRequestStatus::Unauthorized:
+        return "unauthorized";
+    case DeckPolarisRequestStatus::HttpError:
+        return "http-error";
+    case DeckPolarisRequestStatus::MalformedBody:
+        return "malformed-body";
+    }
+    return "unknown";
+}
+
+std::optional<DeckPolarisCapabilities> parseCapabilities(const std::string_view json) {
+    const auto object = parseObject(json);
+    if (!object) {
+        return std::nullopt;
+    }
+    DeckPolarisCapabilities capabilities;
+    capabilities.server = toStd(object->value(QStringLiteral("server")).toString());
+    capabilities.version = toStd(object->value(QStringLiteral("version")).toString());
+    const auto features = object->value(QStringLiteral("features")).toObject();
+    capabilities.gameLibrary = features.value(QStringLiteral("game_library")).toBool(false);
+    capabilities.sessionLifecycle = features.value(QStringLiteral("session_lifecycle")).toBool(false);
+    capabilities.clientSettings = features.value(QStringLiteral("client_settings_v1")).toBool(false);
+    capabilities.resolvedProfileProvenance = features.value(QStringLiteral("resolved_profile_provenance_v1")).toBool(false);
+    capabilities.expectedTopologyAssertion = features.value(QStringLiteral("expected_topology_assertion_v1")).toBool(false);
+    const auto capture = object->value(QStringLiteral("capture")).toObject();
+    capabilities.captureBackend = toStd(capture.value(QStringLiteral("backend")).toString());
+    capabilities.codecs = stringList(capture.value(QStringLiteral("codecs")));
+    return capabilities;
+}
+
+std::optional<DeckPolarisGamesPage> parseGamesPage(const std::string_view json) {
+    const auto object = parseObject(json);
+    if (!object) {
+        return std::nullopt;
+    }
+    const auto gamesValue = object->value(QStringLiteral("games"));
+    if (!gamesValue.isArray()) {
+        return std::nullopt;
+    }
+    DeckPolarisGamesPage page;
+    for (const auto& entry : gamesValue.toArray()) {
+        if (!entry.isObject()) {
+            continue;
+        }
+        auto game = parseGame(entry.toObject());
+        if (game.id.empty() || game.name.empty()) {
+            continue;
+        }
+        page.games.push_back(std::move(game));
+    }
+    page.total = object->value(QStringLiteral("total")).toInt(static_cast<int>(page.games.size()));
+    return page;
+}
+
+std::optional<DeckPolarisSessionStatus> parseSessionStatus(const std::string_view json) {
+    const auto object = parseObject(json);
+    if (!object) {
+        return std::nullopt;
+    }
+    DeckPolarisSessionStatus status;
+    status.state = toStd(object->value(QStringLiteral("state")).toString(QStringLiteral("unknown")));
+    status.streamingActive = object->value(QStringLiteral("streaming_active")).toBool(false);
+    status.game = toStd(object->value(QStringLiteral("game")).toString());
+    status.gameUuid = toStd(object->value(QStringLiteral("game_uuid")).toString());
+    status.ownerDeviceName = toStd(object->value(QStringLiteral("owner_device_name")).toString());
+    status.clientRole = toStd(object->value(QStringLiteral("client_role")).toString(QStringLiteral("none")).toLower());
+    status.ownedByClient = object->value(QStringLiteral("owned_by_client")).toBool(false);
+    status.viewerCount = object->value(QStringLiteral("viewer_count")).toInt(0);
+    return status;
+}
+
+std::optional<int> parseServerInfoHttpsPort(const std::string_view xml) {
+    constexpr std::string_view open = "<HttpsPort>";
+    constexpr std::string_view close = "</HttpsPort>";
+    const auto start = xml.find(open);
+    if (start == std::string_view::npos) {
+        return std::nullopt;
+    }
+    const auto valueStart = start + open.size();
+    const auto end = xml.find(close, valueStart);
+    if (end == std::string_view::npos || end == valueStart) {
+        return std::nullopt;
+    }
+    const auto digits = xml.substr(valueStart, end - valueStart);
+    int port = 0;
+    for (const char c : digits) {
+        if (c < '0' || c > '9') {
+            return std::nullopt;
+        }
+        port = port * 10 + (c - '0');
+        if (port > 65535) {
+            return std::nullopt;
+        }
+    }
+    return port > 0 ? std::optional<int>(port) : std::nullopt;
+}
+
+namespace {
+
+std::string_view describeNetworkError(const QNetworkReply::NetworkError error) {
+    // Fixed strings on purpose: Qt's errorString() embeds the host address.
+    switch (error) {
+    case QNetworkReply::ConnectionRefusedError:
+        return "connection refused";
+    case QNetworkReply::RemoteHostClosedError:
+        return "connection closed by the host";
+    case QNetworkReply::HostNotFoundError:
+        return "host name did not resolve";
+    case QNetworkReply::TimeoutError:
+    case QNetworkReply::OperationCanceledError:
+        return "no answer within the timeout";
+    case QNetworkReply::SslHandshakeFailedError:
+        return "TLS handshake failed";
+    case QNetworkReply::NetworkSessionFailedError:
+    case QNetworkReply::TemporaryNetworkFailureError:
+        return "network unavailable";
+    default:
+        return "network error";
+    }
+}
+
+} // namespace
+
+std::optional<int> resolveHttpsPortFromServerInfo(const std::string& address, const int httpPort, const std::chrono::milliseconds timeout) {
+    if (address.empty() || httpPort <= 0) {
+        return std::nullopt;
+    }
+    QUrl url;
+    url.setScheme(QStringLiteral("http"));
+    url.setHost(QString::fromStdString(address));
+    url.setPort(httpPort);
+    url.setPath(QStringLiteral("/serverinfo"));
+    QNetworkRequest request(url);
+    request.setTransferTimeout(static_cast<int>(timeout.count()));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
+
+    QNetworkAccessManager manager;
+    QNetworkReply* reply = manager.get(request);
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+    const auto body = reply->readAll();
+    const bool ok = reply->error() == QNetworkReply::NoError;
+    reply->deleteLater();
+    if (!ok) {
+        return std::nullopt;
+    }
+    return parseServerInfoHttpsPort(std::string_view(body.constData(), static_cast<std::size_t>(body.size())));
+}
+
+struct DeckPolarisClient::Session {
+    QSslCertificate clientCertificate;
+    QSslKey clientKey;
+    QSslCertificate pinnedServerCertificate;
+    QNetworkAccessManager manager;
+
+    [[nodiscard]] bool usable() const {
+        return !clientCertificate.isNull() && !clientKey.isNull() && !pinnedServerCertificate.isNull();
+    }
+};
+
+DeckPolarisClient::DeckPolarisClient(
+    DeckPolarisEndpoint endpoint,
+    DeckPolarisTlsIdentity identity,
+    const std::chrono::milliseconds timeout)
+    : endpoint_(std::move(endpoint))
+    , identity_(std::move(identity))
+    , timeout_(timeout)
+    , session_(std::make_shared<Session>()) {
+    session_->clientCertificate = QSslCertificate(QByteArray::fromStdString(identity_.clientCertificatePem), QSsl::Pem);
+    session_->clientKey = QSslKey(QByteArray::fromStdString(identity_.clientPrivateKeyPem), QSsl::Rsa, QSsl::Pem);
+    session_->pinnedServerCertificate = QSslCertificate(QByteArray::fromStdString(identity_.pinnedServerCertificatePem), QSsl::Pem);
+}
+
+DeckPolarisResult<std::string> DeckPolarisClient::get(const std::string& path) const {
+    DeckPolarisResult<std::string> result;
+    if (!session_->usable() || endpoint_.address.empty()) {
+        result.status = DeckPolarisRequestStatus::InvalidIdentity;
+        result.detail = "client certificate, private key, pinned server certificate and address are all required";
+        return result;
+    }
+
+    QUrl url;
+    url.setScheme(QStringLiteral("https"));
+    url.setHost(QString::fromStdString(endpoint_.address));
+    url.setPort(endpoint_.httpsPort);
+    url.setPath(QString::fromStdString(path));
+
+    QNetworkRequest request(url);
+    // The pinned certificate is the only trust anchor. Polaris serves a
+    // self-signed certificate under a name that never matches the address,
+    // so the two errors that certificate legitimately raises are ignored for
+    // that certificate alone; any other certificate fails the handshake and
+    // the request never leaves this client.
+    QSslConfiguration ssl = QSslConfiguration::defaultConfiguration();
+    ssl.setLocalCertificate(session_->clientCertificate);
+    ssl.setPrivateKey(session_->clientKey);
+    ssl.setCaCertificates({session_->pinnedServerCertificate});
+    ssl.setPeerVerifyMode(QSslSocket::VerifyPeer);
+    request.setSslConfiguration(ssl);
+    request.setTransferTimeout(static_cast<int>(timeout_.count()));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
+
+    const QSslCertificate pinned = session_->pinnedServerCertificate;
+    bool foreignCertificateSeen = false;
+    QNetworkReply* reply = session_->manager.get(request);
+    QObject::connect(reply, &QNetworkReply::sslErrors, reply, [reply, pinned, &foreignCertificateSeen](const QList<QSslError>& errors) {
+        QList<QSslError> tolerated;
+        for (const auto& error : errors) {
+            const bool onPinned = sameCertificate(error.certificate(), pinned);
+            const bool expectedForSelfSigned = error.error() == QSslError::HostNameMismatch
+                || error.error() == QSslError::SelfSignedCertificate
+                || error.error() == QSslError::CertificateUntrusted;
+            if (onPinned && expectedForSelfSigned) {
+                tolerated.push_back(error);
+            } else {
+                foreignCertificateSeen = true;
+            }
+        }
+        if (!foreignCertificateSeen && tolerated.size() == errors.size()) {
+            reply->ignoreSslErrors(tolerated);
+        }
+    });
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    const auto peer = reply->sslConfiguration().peerCertificate();
+    const auto networkError = reply->error();
+    result.httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const auto body = reply->readAll();
+    reply->deleteLater();
+
+    if (foreignCertificateSeen || (!peer.isNull() && !sameCertificate(peer, pinned))) {
+        result.status = DeckPolarisRequestStatus::CertMismatch;
+        result.detail = "the host presented a certificate that is not the one Moonlight pinned at pairing";
+        return result;
+    }
+    if (networkError == QNetworkReply::OperationCanceledError || networkError == QNetworkReply::TimeoutError) {
+        result.status = DeckPolarisRequestStatus::Timeout;
+        result.detail = "no answer within the timeout";
+        return result;
+    }
+    if (peer.isNull()) {
+        result.status = DeckPolarisRequestStatus::Unreachable;
+        result.detail = std::string(describeNetworkError(networkError));
+        return result;
+    }
+    if (result.httpStatus == 401 || result.httpStatus == 403) {
+        result.status = DeckPolarisRequestStatus::Unauthorized;
+        result.detail = "the host does not accept this client certificate";
+        return result;
+    }
+    if (networkError != QNetworkReply::NoError || result.httpStatus < 200 || result.httpStatus >= 300) {
+        result.status = DeckPolarisRequestStatus::HttpError;
+        result.detail = result.httpStatus > 0 ? "HTTP " + std::to_string(result.httpStatus) : std::string(describeNetworkError(networkError));
+        return result;
+    }
+    result.status = DeckPolarisRequestStatus::Ok;
+    result.value = std::string(body.constData(), static_cast<std::size_t>(body.size()));
+    return result;
+}
+
+namespace {
+
+template <typename T, typename Parser>
+DeckPolarisResult<T> parsed(DeckPolarisResult<std::string> raw, Parser&& parser) {
+    DeckPolarisResult<T> result;
+    result.status = raw.status;
+    result.httpStatus = raw.httpStatus;
+    result.detail = std::move(raw.detail);
+    if (!raw.ok()) {
+        return result;
+    }
+    auto value = parser(*raw.value);
+    if (!value) {
+        result.status = DeckPolarisRequestStatus::MalformedBody;
+        result.detail = "the host answered with a body this client could not read";
+        return result;
+    }
+    result.value = std::move(*value);
+    return result;
+}
+
+} // namespace
+
+DeckPolarisResult<DeckPolarisCapabilities> DeckPolarisClient::fetchCapabilities() const {
+    return parsed<DeckPolarisCapabilities>(get("/polaris/v1/capabilities"), [](const std::string& body) {
+        return parseCapabilities(body);
+    });
+}
+
+DeckPolarisResult<DeckPolarisGamesPage> DeckPolarisClient::fetchGamesPage(const int limit, const int offset) const {
+    return parsed<DeckPolarisGamesPage>(
+        get("/polaris/v1/games?limit=" + std::to_string(limit) + "&offset=" + std::to_string(offset)),
+        [](const std::string& body) {
+            return parseGamesPage(body);
+        });
+}
+
+DeckPolarisResult<std::vector<DeckPolarisGame>> DeckPolarisClient::fetchAllGames(const int pageSize) const {
+    DeckPolarisResult<std::vector<DeckPolarisGame>> result;
+    std::vector<DeckPolarisGame> games;
+    const int limit = pageSize > 0 ? pageSize : 100;
+    constexpr int kMaxPages = 50;
+    for (int page = 0; page < kMaxPages; ++page) {
+        auto pageResult = fetchGamesPage(limit, static_cast<int>(games.size()));
+        if (!pageResult.ok()) {
+            result.status = pageResult.status;
+            result.httpStatus = pageResult.httpStatus;
+            result.detail = std::move(pageResult.detail);
+            return result;
+        }
+        const auto fetched = pageResult.value->games.size();
+        for (auto& game : pageResult.value->games) {
+            games.push_back(std::move(game));
+        }
+        // Polaris reports `total` as the index it stopped at, which equals
+        // offset + limit on a full page, so only a short page ends the walk.
+        if (fetched < static_cast<std::size_t>(limit)) {
+            break;
+        }
+    }
+    result.status = DeckPolarisRequestStatus::Ok;
+    result.value = std::move(games);
+    return result;
+}
+
+DeckPolarisResult<DeckPolarisSessionStatus> DeckPolarisClient::fetchSessionStatus() const {
+    return parsed<DeckPolarisSessionStatus>(get("/polaris/v1/session/status"), [](const std::string& body) {
+        return parseSessionStatus(body);
+    });
+}
+
+} // namespace nova::deck::polaris

--- a/clients/deck/src/polaris/deck_polaris_client.h
+++ b/clients/deck/src/polaris/deck_polaris_client.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// A read-only client for Polaris's /polaris/v1 API on the GameStream HTTPS
+// port. It authenticates with the paired Moonlight client certificate and
+// trusts exactly one server certificate, the one Moonlight pinned at pairing.
+// Any paired certificate that calls /polaris/v1 is promoted to the nova client
+// family on the host, so Nova and Moonlight are one identity there.
+namespace nova::deck::polaris {
+
+struct DeckPolarisTlsIdentity {
+    std::string clientCertificatePem;
+    std::string clientPrivateKeyPem;
+    std::string pinnedServerCertificatePem;
+};
+
+struct DeckPolarisEndpoint {
+    std::string address;
+    int httpsPort = 47984;
+};
+
+enum class DeckPolarisRequestStatus {
+    Ok,
+    InvalidIdentity,
+    Unreachable,
+    Timeout,
+    CertMismatch,
+    Unauthorized,
+    HttpError,
+    MalformedBody,
+};
+
+std::string_view describe(DeckPolarisRequestStatus status);
+
+template <typename T>
+struct DeckPolarisResult {
+    DeckPolarisRequestStatus status = DeckPolarisRequestStatus::Unreachable;
+    int httpStatus = 0;
+    std::string detail;
+    std::optional<T> value;
+
+    [[nodiscard]] bool ok() const {
+        return status == DeckPolarisRequestStatus::Ok && value.has_value();
+    }
+};
+
+struct DeckPolarisCapabilities {
+    std::string server;
+    std::string version;
+    bool gameLibrary = false;
+    bool sessionLifecycle = false;
+    bool clientSettings = false;
+    bool resolvedProfileProvenance = false;
+    bool expectedTopologyAssertion = false;
+    std::string captureBackend;
+    std::vector<std::string> codecs;
+};
+
+struct DeckPolarisGame {
+    std::string id;
+    int appId = 0;
+    std::string name;
+    std::string source;
+    std::string platform;
+    std::string runtime;
+    std::string steamAppid;
+    std::string category;
+    std::string coverUrl;
+    bool installed = true;
+    bool hdrSupported = false;
+    long long lastLaunched = 0;
+    std::vector<std::string> genres;
+    std::string launchPreferredMode;
+    std::string launchRecommendedMode;
+    std::vector<std::string> launchAllowedModes;
+    std::string launchModeReason;
+    bool steamLaunchAvailable = false;
+    std::string steamLaunchMode;
+    std::string steamLaunchRecommendedMode;
+    std::vector<std::string> steamLaunchAllowedModes;
+    std::string steamLaunchModeReason;
+};
+
+struct DeckPolarisGamesPage {
+    std::vector<DeckPolarisGame> games;
+    int total = 0;
+};
+
+struct DeckPolarisSessionStatus {
+    std::string state;
+    bool streamingActive = false;
+    std::string game;
+    std::string gameUuid;
+    std::string ownerDeviceName;
+    std::string clientRole;
+    bool ownedByClient = false;
+    int viewerCount = 0;
+};
+
+std::optional<DeckPolarisCapabilities> parseCapabilities(std::string_view json);
+std::optional<DeckPolarisGamesPage> parseGamesPage(std::string_view json);
+std::optional<DeckPolarisSessionStatus> parseSessionStatus(std::string_view json);
+
+/// The HttpsPort a GameStream host advertises in its plain-HTTP serverinfo XML.
+std::optional<int> parseServerInfoHttpsPort(std::string_view xml);
+
+/// Ask the host's plain-HTTP port which HTTPS port to use, the way Moonlight does
+/// before every connection; nullopt when the host does not answer or advertise one.
+std::optional<int> resolveHttpsPortFromServerInfo(const std::string& address, int httpPort, std::chrono::milliseconds timeout);
+
+class DeckPolarisClient {
+public:
+    DeckPolarisClient(
+        DeckPolarisEndpoint endpoint,
+        DeckPolarisTlsIdentity identity,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(4000));
+
+    [[nodiscard]] DeckPolarisResult<std::string> get(const std::string& path) const;
+    [[nodiscard]] DeckPolarisResult<DeckPolarisCapabilities> fetchCapabilities() const;
+    [[nodiscard]] DeckPolarisResult<DeckPolarisGamesPage> fetchGamesPage(int limit, int offset) const;
+    [[nodiscard]] DeckPolarisResult<std::vector<DeckPolarisGame>> fetchAllGames(int pageSize = 100) const;
+    [[nodiscard]] DeckPolarisResult<DeckPolarisSessionStatus> fetchSessionStatus() const;
+
+    [[nodiscard]] const DeckPolarisEndpoint& endpoint() const {
+        return endpoint_;
+    }
+
+private:
+    struct Session;
+
+    DeckPolarisEndpoint endpoint_;
+    DeckPolarisTlsIdentity identity_;
+    std::chrono::milliseconds timeout_;
+    std::shared_ptr<Session> session_;
+};
+
+} // namespace nova::deck::polaris

--- a/clients/deck/tests/deck_live_read_only_state_test.cpp
+++ b/clients/deck/tests/deck_live_read_only_state_test.cpp
@@ -1,0 +1,286 @@
+// Tests for the live read-only route: identity plus a fake Polaris fetcher in,
+// sanitized DTOs out, with the cached Moonlight app list as the offline fallback.
+#include "backend/deck_live_read_only_state.h"
+
+#include <cassert>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using namespace nova::deck;
+using namespace nova::deck::backend;
+using polaris::DeckPolarisRequestStatus;
+
+bool contains(const std::string& text, const std::string_view needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+identity::DeckMoonlightIdentity pairedIdentity() {
+    identity::DeckMoonlightIdentity identity;
+    identity.loaded = true;
+    identity.sourceLabel = "moonlight-flatpak";
+    identity.clientCertificatePem = "cert";
+    identity.clientPrivateKeyPemForBackendOnly = "key";
+    identity::DeckMoonlightHostRecord home;
+    home.uuid = "home-uuid";
+    home.hostname = "home-pc";
+    home.localAddress = "home.lan";
+    home.localPort = 47989;
+    home.serverCertificatePem = "srv";
+    home.apps = {{10, "Steam Big Picture", true, false}, {11, "Desktop", false, true}, {12, "Portal 2", false, false}};
+    identity::DeckMoonlightHostRecord office;
+    office.uuid = "office-uuid";
+    office.hostname = "Office";
+    office.hasCustomName = true;
+    office.manualAddress = "office.lan";
+    office.manualPort = 47989;
+    office.serverCertificatePem = "srv2";
+    identity.hosts = {home, office};
+    return identity;
+}
+
+polaris::DeckPolarisGame game(std::string id, std::string name) {
+    polaris::DeckPolarisGame entry;
+    entry.id = std::move(id);
+    entry.name = std::move(name);
+    entry.source = "steam";
+    entry.launchRecommendedMode = "headless";
+    entry.steamLaunchRecommendedMode = "direct";
+    return entry;
+}
+
+void assertNoPrivateMaterial(const DeckPublicReadOnlyHostLibraryState& state) {
+    for (const auto& host : state.hosts) {
+        for (const auto* text : {&host.displayName, &host.statusLabel, &host.subtitle, &host.provenanceLabel}) {
+            assert(!contains(*text, ".lan"));
+            assert(!contains(*text, "47989"));
+            assert(!contains(*text, "srv"));
+        }
+    }
+    assert(!contains(state.preflight.publicCopy, ".lan"));
+}
+
+void testLivePolarisLibraryWins() {
+    const auto identity = pairedIdentity();
+    int calls = 0;
+    const auto snapshot = buildLiveSnapshot(identity, [&calls](const identity::DeckMoonlightHostRecord& host, const bool wantLibrary) {
+        ++calls;
+        assert(wantLibrary == (host.uuid == "home-uuid") && "only the first reachable host is asked for its library");
+        DeckLivePolarisFetch fetch;
+        if (host.uuid == "home-uuid") {
+            fetch.status = DeckPolarisRequestStatus::Ok;
+            fetch.serverVersion = "1.4.4";
+            fetch.games = {game("g1", "Slay the Spire 2"), game("g2", "ARC Raiders")};
+        } else {
+            fetch.status = DeckPolarisRequestStatus::Unreachable;
+            fetch.detail = "connection refused";
+        }
+        return fetch;
+    });
+    assert(calls == 2);
+    assert(snapshot.identityLoaded);
+    assert(snapshot.clientIdentityUsable);
+    assert(snapshot.identitySourceLabel == "moonlight-flatpak");
+    assert(snapshot.selectedHostId == "home-uuid");
+    assert(snapshot.library.games.size() == 2);
+    assert(snapshot.library.games[0].name == "Slay the Spire 2");
+    assert(snapshot.library.games[0].launchMode.recommendedMode == "headless");
+    assert(contains(snapshot.library.sourceLabel, "Polaris library"));
+    assert(snapshot.hosts.size() == 2);
+    assert(snapshot.hosts[0].state == DeckHostState::Online);
+    assert(snapshot.hosts[0].polarisAvailable);
+    assert(snapshot.hosts[0].standardAppListAvailable);
+    assert(!snapshot.hosts[0].fixtureOnly);
+    assert(contains(snapshot.hosts[0].publicStatusLabel, "Polaris 1.4.4"));
+    assert(snapshot.hosts[1].state == DeckHostState::Offline);
+    assert(!snapshot.hosts[1].polarisAvailable);
+    assert(snapshot.probes[1].librarySource == "none");
+
+    const DeckLaunchPreflightService preflightService;
+    const DeckLiveReadOnlyStateProvider provider(snapshot, preflightService);
+    const auto matrix = provider.stateMatrix();
+    assert(matrix.size() == 1);
+    const auto state = provider.stateForScenario("anything");
+    assert(state.scenarioId == "live");
+    assert(state.scenarioLabel == "Live · 1 Polaris host reachable");
+    assert(state.hosts.size() == 2);
+    assert(state.hosts[0].displayName == "home-pc");
+    assert(state.hosts[0].initialFocus);
+    assert(state.hosts[1].displayName == "Office");
+    assert(state.games.size() == 2);
+    assert(state.games[1].title == "ARC Raiders");
+    assert(state.games[0].launchModeLabel == "Stream: headless · Steam: direct");
+    assert(!state.preflight.backendPowerStarted);
+    assert(!state.preflight.streamAllowed);
+    assert(contains(state.preflight.publicCopy, "source=moonlight-pairing-live-read-only"));
+    assert(!contains(state.preflight.publicCopy, "source=backend-owned-read-only-model"));
+    assert(contains(state.preflight.publicCopy, "handoff=not-yet-executable"));
+    for (const auto& code : state.preflight.blockerCodes) {
+        assert(code != "pairing-required" && "a host reached over the Moonlight certificate is paired");
+        assert(code != "app-not-found");
+    }
+    assert(state.dtoParity.contractId == "backend-owned-read-only-dto-v1");
+    // The player-state copy is owned by the shared preflight defaults, which
+    // rewrite the title per blocker; the live provider only has to feed it.
+    assert(!state.playerState.title.empty());
+    assert(state.playerState.provenanceLabel == "dto-player-state/backend-owned/redacted-public");
+    assertNoPrivateMaterial(state);
+}
+
+void testOfflineFallsBackToMoonlightCachedApps() {
+    const auto identity = pairedIdentity();
+    const auto snapshot = buildLiveSnapshot(identity, [](const identity::DeckMoonlightHostRecord&, bool) {
+        DeckLivePolarisFetch fetch;
+        fetch.status = DeckPolarisRequestStatus::Timeout;
+        fetch.detail = "no answer within the timeout";
+        return fetch;
+    });
+    assert(snapshot.selectedHostId == "home-uuid");
+    assert(snapshot.library.games.size() == 2);
+    assert(snapshot.library.games[0].id == "moonlight-app-10");
+    assert(snapshot.library.games[0].name == "Steam Big Picture");
+    assert(snapshot.library.games[0].source == "moonlight");
+    assert(snapshot.library.games[0].hdrSupported);
+    assert(snapshot.library.games[1].name == "Portal 2");
+    assert(contains(snapshot.library.sourceLabel, "cached apps"));
+    assert(snapshot.hosts[0].state == DeckHostState::Offline);
+    assert(contains(snapshot.hosts[0].publicSubtitle, "3 apps remembered by Moonlight"));
+    assert(snapshot.probes[0].librarySource == "moonlight-cached-app-list");
+
+    const DeckLaunchPreflightService preflightService;
+    const DeckLiveReadOnlyStateProvider provider(snapshot, preflightService);
+    const auto state = provider.stateForScenario("live");
+    assert(state.scenarioLabel == "Offline · Moonlight's cached apps");
+    assert(state.games.size() == 2);
+    assert(!state.preflight.streamAllowed);
+    assertNoPrivateMaterial(state);
+}
+
+void testCertMismatchAndUnauthorizedAreNamed() {
+    const auto identity = pairedIdentity();
+    const auto snapshot = buildLiveSnapshot(identity, [](const identity::DeckMoonlightHostRecord& host, bool) {
+        DeckLivePolarisFetch fetch;
+        fetch.status = host.uuid == "home-uuid" ? DeckPolarisRequestStatus::CertMismatch : DeckPolarisRequestStatus::Unauthorized;
+        return fetch;
+    });
+    assert(snapshot.hosts[0].state == DeckHostState::CertMismatch);
+    assert(contains(snapshot.hosts[0].publicStatusLabel, "certificate changed"));
+    assert(snapshot.hosts[1].state == DeckHostState::AuthRejected);
+    assert(contains(snapshot.hosts[1].publicStatusLabel, "rejected this client"));
+
+    // The preflight judges the selected host's real credential facts.
+    const auto credentials = credentialsForSelectedHost(snapshot);
+    assert(credentials.hostId == "home-uuid");
+    assert(credentials.paired);
+    assert(credentials.certMismatch);
+    assert(!credentials.authRejected);
+    const DeckLaunchPreflightService preflightService;
+    const DeckLiveReadOnlyStateProvider provider(snapshot, preflightService);
+    const auto state = provider.stateForScenario("live");
+    bool sawCertMismatch = false;
+    for (const auto& code : state.preflight.blockerCodes) {
+        sawCertMismatch = sawCertMismatch || code == "cert-mismatch";
+    }
+    assert(sawCertMismatch);
+}
+
+void testMissingIdentityAndMissingCertificates() {
+    const auto empty = buildLiveSnapshot(identity::DeckMoonlightIdentity{}, [](const identity::DeckMoonlightHostRecord&, bool) {
+        assert(false && "no host should be probed without an identity");
+        return DeckLivePolarisFetch{};
+    });
+    assert(!empty.identityLoaded);
+    assert(empty.hosts.empty());
+    const DeckLaunchPreflightService preflightService;
+    const DeckLiveReadOnlyStateProvider provider(empty, preflightService);
+    const auto state = provider.stateForScenario("live");
+    assert(state.scenarioLabel == "Moonlight not paired on this device");
+    assert(state.hosts.empty());
+    assert(state.games.empty());
+
+    auto unpinned = pairedIdentity();
+    unpinned.hosts[0].serverCertificatePem.clear();
+    unpinned.hosts.resize(1);
+    int calls = 0;
+    const auto snapshot = buildLiveSnapshot(unpinned, [&calls](const identity::DeckMoonlightHostRecord&, bool) {
+        ++calls;
+        return DeckLivePolarisFetch{};
+    });
+    assert(calls == 0);
+    assert(snapshot.hosts[0].state == DeckHostState::PairingNeeded);
+    assert(snapshot.probes[0].status == DeckPolarisRequestStatus::InvalidIdentity);
+    assert(!credentialsForSelectedHost(snapshot).paired);
+}
+
+void testSelectedHostLeadsEvenWhenMoonlightListsItSecond() {
+    auto identity = pairedIdentity();
+    std::swap(identity.hosts[0], identity.hosts[1]);  // Office first in Moonlight's order, no cached apps
+    const auto snapshot = buildLiveSnapshot(identity, [](const identity::DeckMoonlightHostRecord& host, bool) {
+        DeckLivePolarisFetch fetch;
+        if (host.uuid == "home-uuid") {
+            fetch.status = DeckPolarisRequestStatus::Ok;
+            fetch.games = {game("g1", "Portal 2")};
+        }
+        return fetch;
+    });
+    assert(snapshot.selectedHostId == "home-uuid");
+    assert(snapshot.hosts[0].id == "office-uuid" && "snapshot keeps Moonlight's order");
+    const auto ordered = hostsSelectedFirst(snapshot);
+    assert(ordered[0].id == "home-uuid");
+    assert(ordered[1].id == "office-uuid");
+
+    const DeckLaunchPreflightService preflightService;
+    const DeckLiveReadOnlyStateProvider provider(snapshot, preflightService);
+    const auto state = provider.stateForScenario("live");
+    assert(state.hosts[0].id == "home-uuid" && state.hosts[0].initialFocus);
+    assert(!state.hosts[1].initialFocus);
+    for (const auto& code : state.preflight.blockerCodes) {
+        assert(code != "host-unreachable" && "the preflight judges the host the library came from");
+    }
+}
+
+void testReachableHostWithoutMoonlightCacheStillHasApps() {
+    auto identity = pairedIdentity();
+    identity.hosts[0].apps.clear();
+    identity.hosts.resize(1);
+    const auto snapshot = buildLiveSnapshot(identity, [](const identity::DeckMoonlightHostRecord&, bool) {
+        DeckLivePolarisFetch fetch;
+        fetch.status = DeckPolarisRequestStatus::Ok;
+        fetch.games = {game("g1", "Portal 2")};
+        return fetch;
+    });
+    assert(snapshot.hosts[0].polarisAvailable);
+    assert(snapshot.hosts[0].standardAppListAvailable && "a live library counts as an app list");
+}
+
+void testTerminalSummaryIsSanitized() {
+    const auto identity = pairedIdentity();
+    const auto snapshot = buildLiveSnapshot(identity, [](const identity::DeckMoonlightHostRecord&, bool) {
+        DeckLivePolarisFetch fetch;
+        fetch.status = DeckPolarisRequestStatus::Ok;
+        fetch.serverVersion = "1.4.4";
+        fetch.games = {game("g1", "Portal 2")};
+        return fetch;
+    });
+    const auto summary = describeLiveSnapshotForTerminal(snapshot);
+    assert(contains(summary, "identity: moonlight-flatpak client=usable"));
+    assert(contains(summary, "home-pc [home-uuid] status=ok library=polaris-live games=1"));
+    assert(contains(summary, "- Portal 2 [steam]"));
+    assert(!contains(summary, "home.lan"));
+    assert(!contains(summary, "47989"));
+    assert(!contains(summary, "key"));
+}
+
+} // namespace
+
+int main() {
+    testLivePolarisLibraryWins();
+    testOfflineFallsBackToMoonlightCachedApps();
+    testCertMismatchAndUnauthorizedAreNamed();
+    testMissingIdentityAndMissingCertificates();
+    testSelectedHostLeadsEvenWhenMoonlightListsItSecond();
+    testReachableHostWithoutMoonlightCacheStillHasApps();
+    testTerminalSummaryIsSanitized();
+    return 0;
+}

--- a/clients/deck/tests/deck_moonlight_identity_test.cpp
+++ b/clients/deck/tests/deck_moonlight_identity_test.cpp
@@ -1,0 +1,212 @@
+// Tests for the Moonlight-Qt pairing reader. The INI is written with the same
+// QSettings API Moonlight-Qt uses, so the on-disk shape matches a real file.
+#include "identity/deck_moonlight_identity.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QSettings>
+#include <QString>
+#include <QTemporaryDir>
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace {
+
+using namespace nova::deck::identity;
+
+// A throwaway self-signed certificate generated for this test; it carries no
+// key and pairs with nothing.
+const char* const kTestCertificatePem =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICwDCCAagCCQDV1JWYmdXSaTANBgkqhkiG9w0BAQsFADAiMSAwHgYDVQQDDBdu\n"
+    "b3ZhLWRlY2staWRlbnRpdHktdGVzdDAeFw0yNjA5MDgwNDQ3MjFaFw0zNjA5MDUw\n"
+    "NDQ3MjFaMCIxIDAeBgNVBAMMF25vdmEtZGVjay1pZGVudGl0eS10ZXN0MIIBIjAN\n"
+    "BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2ZJUuyOBHcj2chCozGV2/QaDgLBz\n"
+    "KKOFzkoaXVlPsJVBCUzD2ByuNP+HC0txOhw0EKg7fJ5baP+QA729EY65Q8yTZ3ho\n"
+    "pJRbVc3if10DOktqsa0bYIUKAQnBpPG8dEa0/ufvjQAPtz15NSOteNzmwujCFuFw\n"
+    "XkH7tRdRzGLHFktuxEsL0Knwcf7oeraNE9tTrorDH12i0ywL/dqYWVqRIvRAU4RQ\n"
+    "3Rg43tbxRFwEHtuF7KcnT8cmQ0GgJFKci0JNqrWY7IvL54Zx6dBlhPpnznALdjKK\n"
+    "xGvJDU8J0b28PnJRdGuQnlIfWhp1rqRr5uw3l0x5Plq3GFd9TRya65ZR4QIDAQAB\n"
+    "MA0GCSqGSIb3DQEBCwUAA4IBAQDSX9zNF9Iw1RHMPQaQSeunmT3vIUA9G3IuVm8h\n"
+    "xoFi2fcWnlus9X0D1IZknUXAv9pwrv02ujwl/w4XUPc+2dGlqaPMmFsYFl9XNzfa\n"
+    "qoy5YU+BN30lUUdURFdPOWQSMbhC0yRYnYFq07VBGuo3trkXxYv08KzmJ+c0l/nk\n"
+    "9sswza11iiGWdDQ9bj31PPPFwuvSnRIYtSNVR461hh8KBZKS7cZ79A+MgwK7/CUD\n"
+    "dFct7kJE6KJyiZ1zevT8E/CtGqZzUUkRTJgfqDbsC7jlc19pDruSh6IflxrR4NlG\n"
+    "xOJyeg0y6yYKqZBPAhEVxpu3qjao9vhzkRfZ4ZADqFzkoNSz\n"
+    "-----END CERTIFICATE-----\n";
+
+std::string placeholderKeyPem() {
+    // Assembled at runtime so the source never contains a key header literal.
+    return std::string("-----BEGIN ") + "RSA PRIVATE" + " KEY-----\nbm90LWEtcmVhbC1rZXk=\n-----END " + "RSA PRIVATE" + " KEY-----\n";
+}
+
+std::filesystem::path writeMoonlightConf(const QTemporaryDir& dir, const bool withApps) {
+    const auto path = std::filesystem::path(dir.path().toStdString()) / "Moonlight Game Streaming Project" / "Moonlight.conf";
+    std::filesystem::create_directories(path.parent_path());
+    QSettings settings(QString::fromStdString(path.string()), QSettings::IniFormat);
+    settings.setValue(QStringLiteral("certificate"), QByteArray(kTestCertificatePem));
+    settings.setValue(QStringLiteral("key"), QByteArray::fromStdString(placeholderKeyPem()));
+    settings.setValue(QStringLiteral("bitrate"), 20000);
+
+    settings.beginWriteArray(QStringLiteral("hosts"));
+    settings.setArrayIndex(0);
+    settings.setValue(QStringLiteral("uuid"), QStringLiteral("11111111-2222-3333-4444-555555555555"));
+    settings.setValue(QStringLiteral("hostname"), QStringLiteral("living-room-pc"));
+    settings.setValue(QStringLiteral("customname"), false);
+    settings.setValue(QStringLiteral("localaddress"), QStringLiteral("host.lan"));
+    settings.setValue(QStringLiteral("localport"), 47989);
+    settings.setValue(QStringLiteral("manualaddress"), QStringLiteral(""));
+    settings.setValue(QStringLiteral("manualport"), 0);
+    settings.setValue(QStringLiteral("remoteaddress"), QStringLiteral("example.invalid"));
+    settings.setValue(QStringLiteral("remoteport"), 48989);
+    settings.setValue(QStringLiteral("srvcert"), QByteArray(kTestCertificatePem));
+    if (withApps) {
+        settings.beginWriteArray(QStringLiteral("apps"));
+        settings.setArrayIndex(0);
+        settings.setValue(QStringLiteral("id"), 881448767);
+        settings.setValue(QStringLiteral("name"), QStringLiteral("Steam Big Picture"));
+        settings.setValue(QStringLiteral("hdr"), true);
+        settings.setValue(QStringLiteral("hidden"), false);
+        settings.setArrayIndex(1);
+        settings.setValue(QStringLiteral("id"), 42);
+        settings.setValue(QStringLiteral("name"), QStringLiteral("Desktop"));
+        settings.setValue(QStringLiteral("hdr"), false);
+        settings.setValue(QStringLiteral("hidden"), true);
+        settings.endArray();
+    }
+    settings.setArrayIndex(1);
+    settings.setValue(QStringLiteral("uuid"), QStringLiteral("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    // Moonlight stores the custom name in hostname and only a flag in customname.
+    settings.setValue(QStringLiteral("hostname"), QStringLiteral("Office"));
+    settings.setValue(QStringLiteral("customname"), true);
+    settings.setValue(QStringLiteral("manualaddress"), QStringLiteral("office.lan"));
+    settings.setValue(QStringLiteral("manualport"), 57989);
+    settings.setValue(QStringLiteral("localaddress"), QStringLiteral("office-local.lan"));
+    settings.setValue(QStringLiteral("localport"), 47989);
+    settings.endArray();
+    settings.sync();
+    assert(settings.status() == QSettings::NoError);
+    return path;
+}
+
+void testParsesHostsAppsAndIdentity() {
+    QTemporaryDir dir;
+    const auto path = writeMoonlightConf(dir, true);
+    const auto identity = loadMoonlightIdentity(path, "moonlight-test");
+    assert(identity.has_value());
+    assert(identity->loaded);
+    assert(identity->sourceLabel == "moonlight-test");
+    assert(identity->hasClientIdentity());
+    assert(identity->clientCertificatePem.rfind("-----BEGIN CERTIFICATE-----", 0) == 0);
+    const auto fingerprint = identity->clientCertificateFingerprintSha256();
+    assert(fingerprint.size() == 64);
+    assert(shortFingerprint(fingerprint).size() == 8);
+
+    assert(identity->hosts.size() == 2);
+    const auto& first = identity->hosts[0];
+    assert(first.stableId() == "11111111-2222-3333-4444-555555555555");
+    assert(first.displayName() == "living-room-pc");
+    assert(!first.hasCustomName);
+    assert(first.preferredAddress() == "host.lan");
+    assert(first.preferredHttpPort() == 47989);
+    assert(first.hasServerCertificate());
+    assert(first.apps.size() == 2);
+    assert(first.apps[0].id == 881448767);
+    assert(first.apps[0].name == "Steam Big Picture");
+    assert(first.apps[0].hdr);
+    assert(!first.apps[0].hidden);
+    assert(first.apps[1].hidden);
+
+    const auto& second = identity->hosts[1];
+    assert(second.displayName() == "Office");
+    assert(second.hasCustomName);
+    assert(second.preferredAddress() == "office.lan");
+    assert(second.preferredHttpPort() == 57989);
+    assert(!second.hasServerCertificate());
+    assert(second.apps.empty());
+
+    assert(identity->hostById("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee") != nullptr);
+    assert(identity->hostById("nope") == nullptr);
+}
+
+void testMissingFileAndMissingIdentity() {
+    QTemporaryDir dir;
+    assert(!loadMoonlightIdentity(std::filesystem::path(dir.path().toStdString()) / "absent.conf", "x").has_value());
+
+    const auto path = std::filesystem::path(dir.path().toStdString()) / "empty.conf";
+    QSettings settings(QString::fromStdString(path.string()), QSettings::IniFormat);
+    settings.setValue(QStringLiteral("bitrate"), 1);
+    settings.sync();
+    const auto identity = loadMoonlightIdentity(path, "empty");
+    assert(identity.has_value());
+    assert(identity->loaded);
+    assert(!identity->hasClientIdentity());
+    assert(identity->clientCertificateFingerprintSha256().empty());
+    assert(identity->hosts.empty());
+}
+
+void testCandidateOrderPrefersOverride() {
+    QTemporaryDir dir;
+    const auto overridePath = writeMoonlightConf(dir, false);
+    setenv("NOVA_DECK_MOONLIGHT_CONF", overridePath.string().c_str(), 1);
+    const auto candidates = defaultIdentityCandidates();
+    assert(!candidates.empty());
+    assert(candidates.front().label == "moonlight-override");
+    assert(candidates.front().path == overridePath);
+    bool sawFlatpak = false;
+    bool sawNative = false;
+    for (const auto& candidate : candidates) {
+        sawFlatpak = sawFlatpak || candidate.label == "moonlight-flatpak";
+        sawNative = sawNative || candidate.label == "moonlight-native";
+    }
+    assert(sawFlatpak);
+    assert(sawNative);
+
+    const auto loaded = loadDefaultMoonlightIdentity();
+    assert(loaded.has_value());
+    assert(loaded->sourceLabel == "moonlight-override");
+    assert(loaded->hosts.size() == 2);
+    unsetenv("NOVA_DECK_MOONLIGHT_CONF");
+}
+
+void testHostsBackupIsReadWhenHostsIsEmpty() {
+    QTemporaryDir dir;
+    const auto path = std::filesystem::path(dir.path().toStdString()) / "backup.conf";
+    QSettings settings(QString::fromStdString(path.string()), QSettings::IniFormat);
+    settings.setValue(QStringLiteral("certificate"), QByteArray(kTestCertificatePem));
+    settings.setValue(QStringLiteral("key"), QByteArray::fromStdString(placeholderKeyPem()));
+    settings.beginWriteArray(QStringLiteral("hostsbackup"));
+    settings.setArrayIndex(0);
+    settings.setValue(QStringLiteral("uuid"), QStringLiteral("backup-uuid"));
+    settings.setValue(QStringLiteral("hostname"), QStringLiteral("recovered-host"));
+    settings.setValue(QStringLiteral("customname"), false);
+    settings.endArray();
+    settings.sync();
+
+    const auto identity = loadMoonlightIdentity(path, "backup");
+    assert(identity.has_value());
+    assert(identity->hosts.size() == 1);
+    assert(identity->hosts[0].stableId() == "backup-uuid");
+    assert(identity->hosts[0].displayName() == "recovered-host");
+}
+
+void testPortDerivation() {
+    assert(polarisHttpsPortForMoonlightHttpPort(47989) == 47984);
+    assert(polarisHttpsPortForMoonlightHttpPort(57989) == 57984);
+    assert(polarisHttpsPortForMoonlightHttpPort(0) == 47984);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+    testParsesHostsAppsAndIdentity();
+    testMissingFileAndMissingIdentity();
+    testCandidateOrderPrefersOverride();
+    testHostsBackupIsReadWhenHostsIsEmpty();
+    testPortDerivation();
+    return 0;
+}

--- a/clients/deck/tests/deck_polaris_client_test.cpp
+++ b/clients/deck/tests/deck_polaris_client_test.cpp
@@ -1,0 +1,137 @@
+// Tests for the Polaris read-only client: the JSON contracts Nova already
+// depends on, and the failure shape when nothing answers.
+#include "polaris/deck_polaris_client.h"
+
+#include <QCoreApplication>
+
+#include <cassert>
+#include <chrono>
+#include <string>
+
+namespace {
+
+using namespace nova::deck::polaris;
+
+void testParsesCapabilities() {
+    const auto capabilities = parseCapabilities(R"({
+        "server": "Polaris", "version": "1.4.4",
+        "features": {"game_library": true, "session_lifecycle": true, "client_settings_v1": true,
+                     "resolved_profile_provenance_v1": true, "expected_topology_assertion_v1": false},
+        "capture": {"backend": "wlr", "compositor": "labwc", "max_fps": 120, "codecs": ["h264", "hevc"]}
+    })");
+    assert(capabilities.has_value());
+    assert(capabilities->server == "Polaris");
+    assert(capabilities->version == "1.4.4");
+    assert(capabilities->gameLibrary);
+    assert(capabilities->sessionLifecycle);
+    assert(capabilities->clientSettings);
+    assert(capabilities->resolvedProfileProvenance);
+    assert(!capabilities->expectedTopologyAssertion);
+    assert(capabilities->captureBackend == "wlr");
+    assert(capabilities->codecs.size() == 2 && capabilities->codecs[1] == "hevc");
+    assert(!parseCapabilities("not json").has_value());
+    assert(!parseCapabilities("[1,2]").has_value());
+}
+
+void testParsesGamesPageFromHostShape() {
+    const auto page = parseGamesPage(R"({
+        "games": [
+            {"id": "0123456789abcdef0123456789abcdef", "app_id": 7, "name": "Portal 2", "steam_appid": "620",
+             "category": "fast_action", "source": "steam", "installed": true, "hdr_supported": false,
+             "cover_url": "/polaris/v1/games/0123456789abcdef0123456789abcdef/cover", "last_launched": 1718187600000,
+             "platform": "linux", "runtime": "proton", "genres": ["Puzzle"],
+             "launch_mode": {"preferred_mode": "virtual_display", "recommended_mode": "headless",
+                             "allowed_modes": ["headless", "virtual_display"], "mode_reason": "Host default is headless."},
+             "steam_launch": {"available": true, "mode": "big-picture", "recommended_mode": "direct",
+                              "allowed_modes": ["direct", "big-picture"], "mode_reason": "Steam Input fallback."}},
+            {"id": "", "name": "dropped because it has no id"},
+            {"id": "ffff", "app_id": "9", "name": "Bare entry"}
+        ],
+        "total": 3
+    })");
+    assert(page.has_value());
+    assert(page->total == 3);
+    assert(page->games.size() == 2);
+    const auto& portal = page->games[0];
+    assert(portal.id == "0123456789abcdef0123456789abcdef");
+    assert(portal.appId == 7);
+    assert(portal.name == "Portal 2");
+    assert(portal.steamAppid == "620");
+    assert(portal.source == "steam");
+    assert(portal.platform == "linux");
+    assert(portal.runtime == "proton");
+    assert(portal.lastLaunched == 1718187600000LL);
+    assert(portal.genres.size() == 1);
+    assert(portal.launchPreferredMode == "virtual_display");
+    assert(portal.launchRecommendedMode == "headless");
+    assert(portal.launchAllowedModes.size() == 2);
+    assert(portal.launchModeReason == "Host default is headless.");
+    assert(portal.steamLaunchAvailable);
+    assert(portal.steamLaunchRecommendedMode == "direct");
+    const auto& bare = page->games[1];
+    assert(bare.appId == 9 && "Polaris emits app_id as a string");
+    assert(bare.installed);
+    assert(bare.launchRecommendedMode.empty());
+    assert(!bare.steamLaunchAvailable);
+    assert(!parseGamesPage(R"({"total": 1})").has_value());
+}
+
+void testParsesSessionStatus() {
+    const auto status = parseSessionStatus(R"({
+        "state": "streaming", "streaming_active": true, "game": "Portal 2", "game_uuid": "abc",
+        "owner_device_name": "Pixel10Pro", "client_role": "VIEWER", "owned_by_client": false, "viewer_count": 1
+    })");
+    assert(status.has_value());
+    assert(status->state == "streaming");
+    assert(status->streamingActive);
+    assert(status->game == "Portal 2");
+    assert(status->gameUuid == "abc");
+    assert(status->ownerDeviceName == "Pixel10Pro");
+    assert(status->clientRole == "viewer");
+    assert(!status->ownedByClient);
+    assert(status->viewerCount == 1);
+    const auto idle = parseSessionStatus("{}");
+    assert(idle.has_value());
+    assert(idle->state == "unknown");
+    assert(idle->clientRole == "none");
+}
+
+void testParsesServerInfoHttpsPort() {
+    assert(parseServerInfoHttpsPort("<root status_code=\"200\"><hostname>pc</hostname><HttpsPort>47984</HttpsPort></root>") == 47984);
+    assert(parseServerInfoHttpsPort("<root><HttpsPort>1229</HttpsPort></root>") == 1229);
+    assert(!parseServerInfoHttpsPort("<root><hostname>pc</hostname></root>").has_value());
+    assert(!parseServerInfoHttpsPort("<root><HttpsPort></HttpsPort></root>").has_value());
+    assert(!parseServerInfoHttpsPort("<root><HttpsPort>47a84</HttpsPort></root>").has_value());
+    assert(!parseServerInfoHttpsPort("<root><HttpsPort>99999</HttpsPort></root>").has_value());
+    assert(!resolveHttpsPortFromServerInfo("", 47989, std::chrono::milliseconds(50)).has_value());
+}
+
+void testDescribeCoversEveryStatus() {
+    assert(describe(DeckPolarisRequestStatus::Ok) == "ok");
+    assert(describe(DeckPolarisRequestStatus::CertMismatch) == "cert-mismatch");
+    assert(describe(DeckPolarisRequestStatus::Unauthorized) == "unauthorized");
+    assert(describe(DeckPolarisRequestStatus::MalformedBody) == "malformed-body");
+}
+
+void testInvalidIdentityFailsClosedWithoutTouchingTheNetwork() {
+    const DeckPolarisClient client(DeckPolarisEndpoint{.address = "localhost", .httpsPort = 1}, DeckPolarisTlsIdentity{}, std::chrono::milliseconds(200));
+    const auto result = client.get("/polaris/v1/capabilities");
+    assert(result.status == DeckPolarisRequestStatus::InvalidIdentity);
+    assert(!result.ok());
+    const auto capabilities = client.fetchCapabilities();
+    assert(capabilities.status == DeckPolarisRequestStatus::InvalidIdentity);
+    assert(!capabilities.value.has_value());
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+    testParsesCapabilities();
+    testParsesGamesPageFromHostShape();
+    testParsesSessionStatus();
+    testParsesServerInfoHttpsPort();
+    testDescribeCoversEveryStatus();
+    testInvalidIdentityFailsClosedWithoutTouchingTheNetwork();
+    return 0;
+}

--- a/docs/steam_deck_native_port_study.md
+++ b/docs/steam_deck_native_port_study.md
@@ -276,6 +276,31 @@ Non-goals for the MVP:
 - perfect gyro and haptics parity
 - background-service behavior identical to Android
 
+## 2026-09-08: the handoff arc comes first, the media slice second
+
+Decision (papi, 2026-09-08): revive the Deck and Linux client in two arcs, and lift
+the August rule that fenced moonlight-common-c media out of `clients/deck` until the
+Nordstern M2 decision. Nordstern never reached M0, so that fence had no date; it is
+now a seam, and Nordstern is parked with a named resume trigger (Nova on Deck ships,
+or the measurement harness shows the Moonlight plane is the bottleneck).
+
+Arc 1, the Moonlight-Qt handoff: Nova is the shell and the Polaris brains on the
+Deck and on Linux desktops; Moonlight-Qt streams. The shell borrows Moonlight-Qt's
+existing pairing (client certificate, pinned server certificates, cached app lists)
+instead of pairing a second time, reads the Polaris library over the same
+certificate, and hands a launch to `moonlight stream` through the preflight contract
+that #116 already defined. Steam shortcut registration makes it native in Game Mode.
+Packaging targets the `org.kde.Platform` runtime Moonlight-Qt already installs.
+
+Arc 2, the media slice: the FFmpeg/VA-API, Qt Quick/QRhi and PipeWire adapters below
+connect to `LiStartConnection` behind the `StreamingSession` seam, so a later
+transport (Nordstern's C ABI, if it lands) replaces the plumbing without touching the
+shell.
+
+Slice 1 of arc 1 is the live read-only route in `clients/deck/README.md`: real hosts
+and library, no execution. Slice 2 executes the handoff and returns focus. Slice 3 is
+Game Mode integration and packaging.
+
 ## Deck-T4 streaming backend decision
 
 Decision: proceed with a Nova-owned native Linux streaming backend that links


### PR DESCRIPTION
## Summary

Slice 1 of the Steam Deck / Linux handoff arc (papi's option 1, 2026-09-08): the Deck shell reads real hosts and the real Polaris library, without pairing a second time and without launching anything.

- `clients/deck/src/identity/deck_moonlight_identity.*` reads Moonlight-Qt's own settings file (Flatpak copy under `~/.var/app/com.moonlight_stream.Moonlight/config/`, native copy under `~/.config/`, or `NOVA_DECK_MOONLIGHT_CONF`): client certificate and key, every paired host with its pinned server certificate, the cached app list per host, and the `hostsbackup` array Moonlight keeps while flushing. Matches Moonlight's on-disk contract, including `customname` being a flag with the name itself in `hostname`.
- `clients/deck/src/polaris/deck_polaris_client.*` learns the HTTPS port from the host's plain-HTTP serverinfo like Moonlight does, then calls `/polaris/v1/capabilities`, `/polaris/v1/games` (paginated until a short page) and `/polaris/v1/session/status` over mTLS with that certificate. The pinned server certificate is the only trust anchor: the handshake fails against any other certificate before the request is sent. Network failures are reported with fixed wording, never the address. `app_id` is parsed string-first, which is how Polaris emits it.
- `clients/deck/src/backend/deck_live_read_only_state.*` turns the probes into the same sanitized read-only DTOs the fixture route produces: the first reachable Polaris host supplies the library and leads the host list (focus, preflight and detail card describe that host), later hosts are only probed, and an unreachable host falls back to Moonlight's cached apps, labelled as such. The preflight judges real credential facts (paired, cert mismatch, auth rejected) instead of a hard-coded unpaired state, and the header says `moonlight-pairing provenance` instead of `fixture provenance`.
- `nova-deck --live` (or `NOVA_DECK_LIVE=1`) selects the live route; `--print-live-state` prints a sanitized summary and exits without a window. The default stays the offline fixture, so every existing smoke route is unchanged.
- `buildReadOnlyHostLibraryState` gained an options overload (credentials + source tag); `playerStateFor` / `readOnlyDtoParityFor` are now shared helpers instead of file-local ones.
- README documents the route and one host-side fact: Polaris promotes any paired certificate that touches `/polaris/v1` to the `nova` client family, so after the first live run the Deck's Moonlight pairing is its Nova identity. `docs/steam_deck_native_port_study.md` records the arc decision and the lifted media fence.

Not in this PR: executing the handoff (slice 2) and Game Mode integration / packaging (slice 3).

## Exact candidate

- `Commit:` `8be1ce9e1b357cc1fd3e8edd14e789adc37016d3`
- `Tree:` `8a060e47f70c8f2f4e2e1d6bd17481733acae766`
- `Parent:` `d39b8eca540099ccba81d801deaffc4eddea3c1b`
- `Base:` `d39b8eca540099ccba81d801deaffc4eddea3c1b` (master)

## Testing

On pc-papi (Fedora 44, Qt 6.11.2, fresh worktree with the moonlight-common-c submodule initialised):

- [x] `cmake -S clients/deck -B build-deck -G Ninja` + `ninja`: clean, no warnings from the touched files
- [x] `ctest --test-dir build-deck`: 16/16 passed, including the three new suites (`nova_deck_moonlight_identity_test`: Moonlight INI shape via QSettings incl. bool customname, hostsbackup, override candidate, port derivation; `nova_deck_polaris_client_test`: capabilities/games/session parsers, string app_id, serverinfo HttpsPort parser, fail-closed identity; `nova_deck_live_read_only_state_test`: live library, offline fallback, cert-mismatch/unauthorized, selected-host-first ordering, no pairing-required blocker for a reached host, sanitized terminal summary)
- [x] `deck_media_assert_guard_test.py` (15) and `deck_moonlight_handoff_source_guard_test.py` pass
- [x] Code-review pass on the branch; all ten correctness findings fixed in this commit (customname contract, pagination total, selected host ordering, real pinning, serverinfo port, credential facts, app-list flag, address-free details, provenance label, string app_id) plus hostsbackup and single-library fetch
- [ ] Live proof on the Steam Deck (build in the Deck's Arch/Qt container with the Moonlight pairing mounted read-only, `--print-live-state` against pc-papi's Polaris): pending, the Deck auto-suspended mid-sync. Will be added as a comment.
- [ ] Android is untouched (`app/` has no diff); CI covers only the Android build, `clients/deck` is not in CI.

## Notes

Certificate handling: the shell reads Moonlight-Qt's private key from Moonlight's own config file and uses it only inside the TLS client; no DTO, log line or QML surface carries it, and the terminal summary prints a short fingerprint at most. Pairing: none added; the route depends on an existing Moonlight pairing. Moonlight-core integration: unchanged, the stream core still stops at the `LiStartConnection` fence.
