### PR TITLE
feat(deck): hand the highlighted game to Moonlight-Qt from the launch card

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -32,7 +32,9 @@ add_library(nova_deck_core
     src/identity/deck_moonlight_identity.cpp
     src/polaris/deck_polaris_client.cpp
     src/backend/deck_live_read_only_state.cpp
+    src/runtime/deck_moonlight_launcher.cpp
 )
+set_target_properties(nova_deck_core PROPERTIES AUTOMOC ON)
 
 set(NOVA_DECK_MOONLIGHT_COMMON_C_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/../../app/src/main/jni/moonlight-core/moonlight-common-c
@@ -116,6 +118,13 @@ if(BUILD_TESTING)
     )
     target_link_libraries(nova_deck_live_read_only_state_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_live_read_only_state_test COMMAND nova_deck_live_read_only_state_test)
+
+    add_executable(nova_deck_moonlight_launcher_test
+        tests/deck_moonlight_launcher_test.cpp
+    )
+    target_link_libraries(nova_deck_moonlight_launcher_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_moonlight_launcher_test COMMAND nova_deck_moonlight_launcher_test)
+    set_tests_properties(nova_deck_moonlight_launcher_test PROPERTIES TIMEOUT 60)
 
     add_executable(nova_deck_qsg_render_node_scenegraph_smoke
         tests/deck_qsg_render_node_scenegraph_smoke.cpp

--- a/clients/deck/README.md
+++ b/clients/deck/README.md
@@ -74,15 +74,15 @@ It prints the identity source, each host's probe result (`ok`, `unreachable`, `c
 
 ## Handoff: Play in Moonlight
 
-On the live route the launch card's A button hands the highlighted game to Moonlight-Qt instead of copying a plan. The first press arms the request and says so; a second press within eight seconds runs `moonlight stream <host-uuid> "<app>" --display-mode fullscreen`, where the host is named by the UUID Moonlight already knows, so no address enters the command line. While Moonlight runs, Nova asks Polaris for the session truth every five seconds and shows it under the card; A asks Moonlight to end the stream; when Moonlight exits, Nova asks for focus back.
+On the live route the launch card's A button hands the highlighted game to Moonlight-Qt instead of copying a plan. The first press arms the request for eight seconds and says so, B or Escape cancels, and a second press within the window runs `moonlight stream <host-uuid> "<app>" --display-mode fullscreen`, where the host is named by the UUID Moonlight already knows, so no address enters the command line. While Moonlight runs, Nova asks Polaris for the session truth every five seconds and shows it under the card; A asks Moonlight to end the stream; when Moonlight exits, Nova asks for focus back.
 
-`src/runtime/deck_moonlight_launcher.*` is the only place in the client that starts another program. It finds Moonlight as a native binary on PATH, as the `com.moonlight_stream.Moonlight` Flatpak, or through `NOVA_DECK_MOONLIGHT_BIN` for tests; inside a Flatpak sandbox it prefixes `flatpak-spawn --host`. Every argv token is checked to be plain (no shell syntax, quotes or control characters), the child is started without a shell, and its output is discarded so Moonlight's own logs never enter Nova's.
+`src/runtime/deck_moonlight_launcher.*` is the only place in the client that starts another program. It finds Moonlight as a native binary on PATH, as the `com.moonlight_stream.Moonlight` Flatpak, or through `NOVA_DECK_MOONLIGHT_BIN` for tests; inside a Flatpak sandbox it prefixes `flatpak-spawn --host`. Every argv token is checked to be plain (no control characters; shell characters are fine because no shell is involved, and game titles carry ampersands), the child is started without a shell, and its output is kept only as a bounded backend-only tail that never reaches the shell.
 
 Headless proof, with a real Moonlight or a recorder script:
 
     NOVA_DECK_MOONLIGHT_BIN=/path/to/recorder QT_QPA_PLATFORM=offscreen nova-deck --live --handoff-game "Desktop" --handoff-wait-ms 5000
 
-It prints the launch phase and how Moonlight ended. Exit code 3 means Moonlight could not be started. Add `--handoff-windowed` to keep a real Moonlight in a window, for a proof on a desktop rather than a Deck.
+It prints the launch phase, how Moonlight ended, and a bounded tail of Moonlight's own output (backend-only: it can carry host addresses, so the shell never shows it). Exit codes: 0 launched and exited, 3 never launched, 4 still running when the wait ran out. Add `--handoff-windowed` to keep a real Moonlight in a window, for a proof on a desktop rather than a Deck.
 
 ## Shared Polaris DTO boundary
 

--- a/clients/deck/README.md
+++ b/clients/deck/README.md
@@ -72,6 +72,18 @@ To check the route without opening a window:
 
 It prints the identity source, each host's probe result (`ok`, `unreachable`, `cert-mismatch`, `unauthorized`, ...), which library source won, and the first titles. Exit code 2 means no Moonlight pairing file was found.
 
+## Handoff: Play in Moonlight
+
+On the live route the launch card's A button hands the highlighted game to Moonlight-Qt instead of copying a plan. The first press arms the request and says so; a second press within eight seconds runs `moonlight stream <host-uuid> "<app>" --fullscreen`, where the host is named by the UUID Moonlight already knows, so no address enters the command line. While Moonlight runs, Nova asks Polaris for the session truth every five seconds and shows it under the card; A asks Moonlight to end the stream; when Moonlight exits, Nova asks for focus back.
+
+`src/runtime/deck_moonlight_launcher.*` is the only place in the client that starts another program. It finds Moonlight as a native binary on PATH, as the `com.moonlight_stream.Moonlight` Flatpak, or through `NOVA_DECK_MOONLIGHT_BIN` for tests; inside a Flatpak sandbox it prefixes `flatpak-spawn --host`. Every argv token is checked to be plain (no shell syntax, quotes or control characters), the child is started without a shell, and its output is discarded so Moonlight's own logs never enter Nova's.
+
+Headless proof, with a real Moonlight or a recorder script:
+
+    NOVA_DECK_MOONLIGHT_BIN=/path/to/recorder QT_QPA_PLATFORM=offscreen nova-deck --live --handoff-game "Desktop" --handoff-wait-ms 5000
+
+It prints the launch phase and how Moonlight ended. Exit code 3 means Moonlight could not be started.
+
 ## Shared Polaris DTO boundary
 
 Native C++ cannot include Kotlin source directly. For this first slice, fixtures/sample_polaris_game.json is a generated/shared-contract sample using the same snake_case keys covered by the Kotlin shared DTO tests. src/polaris_game_fixture.h and src/polaris_game_fixture.cpp load that fixture into a tiny native projection so the Deck shell can exercise a real library-card shape while the actual native Polaris API/client bridge is still future work.

--- a/clients/deck/README.md
+++ b/clients/deck/README.md
@@ -74,7 +74,7 @@ It prints the identity source, each host's probe result (`ok`, `unreachable`, `c
 
 ## Handoff: Play in Moonlight
 
-On the live route the launch card's A button hands the highlighted game to Moonlight-Qt instead of copying a plan. The first press arms the request and says so; a second press within eight seconds runs `moonlight stream <host-uuid> "<app>" --fullscreen`, where the host is named by the UUID Moonlight already knows, so no address enters the command line. While Moonlight runs, Nova asks Polaris for the session truth every five seconds and shows it under the card; A asks Moonlight to end the stream; when Moonlight exits, Nova asks for focus back.
+On the live route the launch card's A button hands the highlighted game to Moonlight-Qt instead of copying a plan. The first press arms the request and says so; a second press within eight seconds runs `moonlight stream <host-uuid> "<app>" --display-mode fullscreen`, where the host is named by the UUID Moonlight already knows, so no address enters the command line. While Moonlight runs, Nova asks Polaris for the session truth every five seconds and shows it under the card; A asks Moonlight to end the stream; when Moonlight exits, Nova asks for focus back.
 
 `src/runtime/deck_moonlight_launcher.*` is the only place in the client that starts another program. It finds Moonlight as a native binary on PATH, as the `com.moonlight_stream.Moonlight` Flatpak, or through `NOVA_DECK_MOONLIGHT_BIN` for tests; inside a Flatpak sandbox it prefixes `flatpak-spawn --host`. Every argv token is checked to be plain (no shell syntax, quotes or control characters), the child is started without a shell, and its output is discarded so Moonlight's own logs never enter Nova's.
 
@@ -82,7 +82,7 @@ Headless proof, with a real Moonlight or a recorder script:
 
     NOVA_DECK_MOONLIGHT_BIN=/path/to/recorder QT_QPA_PLATFORM=offscreen nova-deck --live --handoff-game "Desktop" --handoff-wait-ms 5000
 
-It prints the launch phase and how Moonlight ended. Exit code 3 means Moonlight could not be started.
+It prints the launch phase and how Moonlight ended. Exit code 3 means Moonlight could not be started. Add `--handoff-windowed` to keep a real Moonlight in a window, for a proof on a desktop rather than a Deck.
 
 ## Shared Polaris DTO boundary
 

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -175,16 +175,12 @@ ApplicationWindow {
         }
     }
 
-    property var handoffState: novaHandoff.state
-
-    Connections {
-        target: novaHandoff
-        function onStateChanged() { handoffState = novaHandoff.state }
-    }
+    // Bound straight to the bridge property; its NOTIFY keeps this fresh.
+    readonly property var handoffState: novaHandoff.state
 
     function activateLaunchCardFromController() {
         if (handoffState.available) {
-            handoffState = novaHandoff.activate(
+            novaHandoff.activate(
                 selectedHostForPreview ? selectedHostForPreview.id : "",
                 selectedGameForPreview ? selectedGameForPreview.id : "",
                 selectedGameForPreview ? selectedGameForPreview.title : "")
@@ -195,7 +191,7 @@ ApplicationWindow {
 
     function cancelHandoffFromController() {
         if (handoffState.available && handoffState.armed) {
-            handoffState = novaHandoff.cancel()
+            novaHandoff.cancel()
         }
     }
 
@@ -459,7 +455,10 @@ ApplicationWindow {
     Connections {
         target: novaGamepad
         function onPrimaryActionPressed(activationCount) {
-            activateLaunchPreviewCopyFromController()
+            activateLaunchCardFromController()
+        }
+        function onSecondaryActionPressed(activationCount) {
+            cancelHandoffFromController()
         }
     }
 
@@ -915,9 +914,9 @@ ApplicationWindow {
                         KeyNavigation.down: secondaryDiagnosticsToggle
                         Keys.onUpPressed: hostDetailPanel.forceActiveFocus()
                         Keys.onDownPressed: secondaryDiagnosticsToggle.forceActiveFocus()
-                        Keys.onReturnPressed: activateLaunchCardFromController()
-                        Keys.onEnterPressed: activateLaunchCardFromController()
-                        Keys.onSpacePressed: activateLaunchCardFromController()
+                        Keys.onReturnPressed: (event) => { if (!event.isAutoRepeat) activateLaunchCardFromController() }
+                        Keys.onEnterPressed: (event) => { if (!event.isAutoRepeat) activateLaunchCardFromController() }
+                        Keys.onSpacePressed: (event) => { if (!event.isAutoRepeat) activateLaunchCardFromController() }
                         Keys.onEscapePressed: cancelHandoffFromController()
                         Keys.onBackPressed: cancelHandoffFromController()
                         Keys.onLeftPressed: focusSelectedLibraryItem()

--- a/clients/deck/qml/Main.qml
+++ b/clients/deck/qml/Main.qml
@@ -175,6 +175,30 @@ ApplicationWindow {
         }
     }
 
+    property var handoffState: novaHandoff.state
+
+    Connections {
+        target: novaHandoff
+        function onStateChanged() { handoffState = novaHandoff.state }
+    }
+
+    function activateLaunchCardFromController() {
+        if (handoffState.available) {
+            handoffState = novaHandoff.activate(
+                selectedHostForPreview ? selectedHostForPreview.id : "",
+                selectedGameForPreview ? selectedGameForPreview.id : "",
+                selectedGameForPreview ? selectedGameForPreview.title : "")
+            return
+        }
+        activateLaunchPreviewCopyFromController()
+    }
+
+    function cancelHandoffFromController() {
+        if (handoffState.available && handoffState.armed) {
+            handoffState = novaHandoff.cancel()
+        }
+    }
+
     function activateLaunchPreviewCopyFromController() {
         const canCopyPreview = launchPreviewCopyAction.enabled
             && launchPreviewCopyAction.previewText.length > 0
@@ -891,9 +915,11 @@ ApplicationWindow {
                         KeyNavigation.down: secondaryDiagnosticsToggle
                         Keys.onUpPressed: hostDetailPanel.forceActiveFocus()
                         Keys.onDownPressed: secondaryDiagnosticsToggle.forceActiveFocus()
-                        Keys.onReturnPressed: activateLaunchPreviewCopyFromController()
-                        Keys.onEnterPressed: activateLaunchPreviewCopyFromController()
-                        Keys.onSpacePressed: activateLaunchPreviewCopyFromController()
+                        Keys.onReturnPressed: activateLaunchCardFromController()
+                        Keys.onEnterPressed: activateLaunchCardFromController()
+                        Keys.onSpacePressed: activateLaunchCardFromController()
+                        Keys.onEscapePressed: cancelHandoffFromController()
+                        Keys.onBackPressed: cancelHandoffFromController()
                         Keys.onLeftPressed: focusSelectedLibraryItem()
 
                         ColumnLayout {
@@ -952,12 +978,25 @@ ApplicationWindow {
 
                             Label {
                                 Layout.preferredWidth: detailTextWidth
-                                text: "A = Copy safe launch plan · no stream power enabled"
+                                text: handoffState.actionHint ? handoffState.actionHint : "A = Copy safe launch plan · no stream power enabled"
                                 color: "#8AFFC1"
                                 font.pixelSize: 12
                                 font.bold: true
                                 wrapMode: Text.WordWrap
                                 visible: !diagnosticsExpanded
+                            }
+
+                            Label {
+                                objectName: "moonlight-handoff-status"
+                                Layout.preferredWidth: detailTextWidth
+                                text: handoffState.copy + (handoffState.sessionCopy ? " · " + handoffState.sessionCopy : "")
+                                color: handoffState.running ? "#8AFFC1" : "#FFDDA8"
+                                font.pixelSize: 13
+                                font.bold: true
+                                wrapMode: Text.WordWrap
+                                maximumLineCount: 2
+                                elide: Text.ElideRight
+                                visible: !diagnosticsExpanded && handoffState.copy.length > 0
                             }
 
                             Label {

--- a/clients/deck/src/backend/deck_live_read_only_state.cpp
+++ b/clients/deck/src/backend/deck_live_read_only_state.cpp
@@ -142,6 +142,7 @@ DeckLiveHostLibrarySnapshot buildLiveSnapshot(const identity::DeckMoonlightIdent
             probe.status = fetch.status;
             probe.detail = std::move(fetch.detail);
             probe.serverVersion = std::move(fetch.serverVersion);
+            probe.resolvedHttpsPort = fetch.httpsPort;
             if (probe.status == DeckPolarisRequestStatus::Ok) {
                 probe.librarySource = "polaris-live";
                 if (!librarySelected) {
@@ -228,28 +229,34 @@ DeckCredentialMetadata credentialsForSelectedHost(const DeckLiveHostLibrarySnaps
     return credentials;
 }
 
+int resolvePolarisHttpsPort(const identity::DeckMoonlightHostRecord& host, const std::chrono::milliseconds timeout) {
+    const auto httpPort = host.preferredHttpPort();
+    // Moonlight learns the HTTPS port from serverinfo on every connection
+    // because forwarded hosts do not keep the five-port spacing.
+    return polaris::resolveHttpsPortFromServerInfo(host.preferredAddress(), httpPort, timeout)
+        .value_or(identity::polarisHttpsPortForMoonlightHttpPort(httpPort));
+}
+
+polaris::DeckPolarisClient polarisClientForHost(
+    const identity::DeckMoonlightIdentity& identity,
+    const identity::DeckMoonlightHostRecord& host,
+    const int httpsPort,
+    const std::chrono::milliseconds timeout) {
+    return polaris::DeckPolarisClient(
+        polaris::DeckPolarisEndpoint{.address = host.preferredAddress(), .httpsPort = httpsPort},
+        polaris::DeckPolarisTlsIdentity{
+            .clientCertificatePem = identity.clientCertificatePem,
+            .clientPrivateKeyPem = identity.clientPrivateKeyPemForBackendOnly,
+            .pinnedServerCertificatePem = host.serverCertificatePem,
+        },
+        timeout);
+}
+
 DeckLivePolarisFetcher polarisNetworkFetcher(const identity::DeckMoonlightIdentity& identity, const std::chrono::milliseconds timeout) {
-    const polaris::DeckPolarisTlsIdentity tls{
-        .clientCertificatePem = identity.clientCertificatePem,
-        .clientPrivateKeyPem = identity.clientPrivateKeyPemForBackendOnly,
-        .pinnedServerCertificatePem = {},
-    };
-    return [tls, timeout](const identity::DeckMoonlightHostRecord& host, const bool wantLibrary) {
+    return [&identity, timeout](const identity::DeckMoonlightHostRecord& host, const bool wantLibrary) {
         DeckLivePolarisFetch fetch;
-        auto hostTls = tls;
-        hostTls.pinnedServerCertificatePem = host.serverCertificatePem;
-        const auto address = host.preferredAddress();
-        const auto httpPort = host.preferredHttpPort();
-        // Moonlight learns the HTTPS port from serverinfo on every connection
-        // because forwarded hosts do not keep the five-port spacing.
-        const auto advertised = polaris::resolveHttpsPortFromServerInfo(address, httpPort, timeout);
-        const polaris::DeckPolarisClient client(
-            polaris::DeckPolarisEndpoint{
-                .address = address,
-                .httpsPort = advertised.value_or(identity::polarisHttpsPortForMoonlightHttpPort(httpPort)),
-            },
-            hostTls,
-            timeout);
+        fetch.httpsPort = resolvePolarisHttpsPort(host, timeout);
+        const auto client = polarisClientForHost(identity, host, fetch.httpsPort, timeout);
         const auto capabilities = client.fetchCapabilities();
         fetch.status = capabilities.status;
         fetch.detail = capabilities.detail;
@@ -278,7 +285,8 @@ DeckLiveHostLibrarySnapshot buildLiveSnapshotFromDefaultIdentity(const std::chro
             return DeckLivePolarisFetch{};
         });
     }
-    return buildLiveSnapshot(*identity, polarisNetworkFetcher(*identity, timeout));
+    const auto fetcher = polarisNetworkFetcher(*identity, timeout);
+    return buildLiveSnapshot(*identity, fetcher);
 }
 
 std::string describeLiveSnapshotForTerminal(const DeckLiveHostLibrarySnapshot& snapshot) {

--- a/clients/deck/src/backend/deck_live_read_only_state.h
+++ b/clients/deck/src/backend/deck_live_read_only_state.h
@@ -21,6 +21,7 @@ struct DeckLivePolarisFetch {
     polaris::DeckPolarisRequestStatus status = polaris::DeckPolarisRequestStatus::Unreachable;
     std::string detail;
     std::string serverVersion;
+    int httpsPort = 0;
     std::vector<polaris::DeckPolarisGame> games;
 };
 
@@ -36,6 +37,7 @@ struct DeckLiveHostProbe {
     std::string librarySource;  ///< polaris-live, moonlight-cached-app-list, or none
     int gameCount = 0;
     int cachedAppCount = 0;
+    int resolvedHttpsPort = 0;  ///< the port Polaris was actually reached on (serverinfo first, then the five-port rule)
 };
 
 struct DeckLiveHostLibrarySnapshot {
@@ -61,6 +63,16 @@ DeckCredentialMetadata credentialsForSelectedHost(const DeckLiveHostLibrarySnaps
 
 /// One word for the header: where this read-only state came from.
 inline constexpr std::string_view kLiveProvenanceLabel = "moonlight-pairing provenance";
+
+/// The HTTPS port for a host: what its serverinfo advertises, else the five-port rule.
+int resolvePolarisHttpsPort(const identity::DeckMoonlightHostRecord& host, std::chrono::milliseconds timeout);
+
+/// A client for one host over the identity's certificate and that host's pinned server certificate, on the given port.
+polaris::DeckPolarisClient polarisClientForHost(
+    const identity::DeckMoonlightIdentity& identity,
+    const identity::DeckMoonlightHostRecord& host,
+    int httpsPort,
+    std::chrono::milliseconds timeout);
 
 /// A fetcher that talks to Polaris with the identity's certificate and the host's pinned server certificate.
 DeckLivePolarisFetcher polarisNetworkFetcher(const identity::DeckMoonlightIdentity& identity, std::chrono::milliseconds timeout);

--- a/clients/deck/src/deck_gamepad.cpp
+++ b/clients/deck/src/deck_gamepad.cpp
@@ -15,6 +15,9 @@ DeckGamepadAction decodeGamepadAction(const DeckGamepadEvent& event) {
     if (event.number == kDeckGamepadPrimaryButton && event.value == 1) {
         return DeckGamepadAction::PrimaryPressed;
     }
+    if (event.number == kDeckGamepadSecondaryButton && event.value == 1) {
+        return DeckGamepadAction::SecondaryPressed;
+    }
 
     return DeckGamepadAction::None;
 }

--- a/clients/deck/src/deck_gamepad.h
+++ b/clients/deck/src/deck_gamepad.h
@@ -8,6 +8,7 @@ constexpr unsigned char kDeckGamepadButtonEvent = 0x01;
 constexpr unsigned char kDeckGamepadAxisEvent = 0x02;
 constexpr unsigned char kDeckGamepadInitEvent = 0x80;
 constexpr unsigned char kDeckGamepadPrimaryButton = 0;
+constexpr unsigned char kDeckGamepadSecondaryButton = 1;
 
 struct DeckGamepadEvent {
     std::uint32_t timeMs = 0;
@@ -18,7 +19,8 @@ struct DeckGamepadEvent {
 
 enum class DeckGamepadAction {
     None,
-    PrimaryPressed,
+    PrimaryPressed,  ///< A: confirm
+    SecondaryPressed,  ///< B: back or cancel
 };
 
 DeckGamepadAction decodeGamepadAction(const DeckGamepadEvent& event);

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -3,6 +3,7 @@
 #include "polaris_game_fixture.h"
 #include "backend/deck_backend_interfaces.h"
 #include "backend/deck_live_read_only_state.h"
+#include "runtime/deck_moonlight_launcher.h"
 #include "stream/deck_stream_media_adapters.h"
 
 #include <QClipboard>
@@ -16,7 +17,9 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <QElapsedTimer>
 #include <QGuiApplication>
+#include <QTimer>
 #include <QImage>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
@@ -284,6 +287,202 @@ private:
     nova::deck::backend::DeckLabGate labGate_;
     QVariantMap lastPreflightPreview_{};
     QVariantMap lastDiagnosticsPreview_{};
+};
+
+/**
+ * Hands the highlighted game to Moonlight-Qt. Only exists on the live route,
+ * because the host UUID and the exact app name come from the identity
+ * Moonlight already holds. Two presses launch: the first arms the request and
+ * says so, the second within the arming window starts Moonlight. While
+ * Moonlight runs, Polaris is asked for the session truth on a slow timer.
+ */
+class QtMoonlightHandoffBridge final : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QVariantMap state READ state NOTIFY stateChanged)
+
+public:
+    QtMoonlightHandoffBridge(
+        std::optional<nova::deck::identity::DeckMoonlightIdentity> identity,
+        std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> snapshot,
+        QObject* parent = nullptr)
+        : QObject(parent)
+        , identity_(std::move(identity))
+        , snapshot_(std::move(snapshot))
+        , install_(nova::deck::runtime::detectMoonlightInstall()) {
+        QObject::connect(&session_, &nova::deck::runtime::DeckMoonlightHandoffSession::outcomeChanged, this, &QtMoonlightHandoffBridge::onOutcomeChanged);
+        sessionTruthTimer_.setInterval(5000);
+        QObject::connect(&sessionTruthTimer_, &QTimer::timeout, this, &QtMoonlightHandoffBridge::refreshSessionTruth);
+    }
+
+    [[nodiscard]] bool available() const {
+        return identity_.has_value() && snapshot_.has_value() && install_.available();
+    }
+
+    [[nodiscard]] QVariantMap state() const {
+        QVariantMap model;
+        model.insert("available", available());
+        model.insert("installLabel", QString::fromStdString(install_.label));
+        model.insert("armed", armed());
+        model.insert("armedGameTitle", armedGameTitle_);
+        const auto& outcome = session_.outcome();
+        model.insert("phase", QString::fromUtf8(nova::deck::runtime::describe(outcome.state).data()));
+        model.insert("running", session_.running());
+        model.insert("copy", statusCopy_.isEmpty() ? QString::fromStdString(outcome.publicCopy) : statusCopy_);
+        model.insert("appName", QString::fromStdString(outcome.appName));
+        model.insert("sessionCopy", sessionCopy_);
+        model.insert("actionHint", actionHint());
+        return model;
+    }
+
+    /// First press arms, second press (within the window) launches; while running, a press asks Moonlight to quit.
+    Q_INVOKABLE QVariantMap activate(const QString& hostId, const QString& gameId, const QString& gameTitle) {
+        if (!available()) {
+            statusCopy_ = QStringLiteral("Play in Moonlight needs the live route and an installed Moonlight.");
+            emit stateChanged();
+            return state();
+        }
+        if (session_.running()) {
+            const bool asked = session_.requestQuit(install_);
+            statusCopy_ = asked ? QStringLiteral("Asked Moonlight to end the stream.") : QStringLiteral("Could not reach Moonlight to end the stream.");
+            emit stateChanged();
+            return state();
+        }
+        const QString key = hostId + QStringLiteral("/") + gameId;
+        if (armed() && armedKey_ == key) {
+            launchNow(hostId, gameTitle);
+            return state();
+        }
+        armedKey_ = key;
+        armedGameTitle_ = gameTitle;
+        armTimer_.restart();
+        statusCopy_ = QStringLiteral("Press A again to open \"%1\" in Moonlight. B or wait to cancel.").arg(gameTitle);
+        emit stateChanged();
+        return state();
+    }
+
+    Q_INVOKABLE QVariantMap cancel() {
+        armedKey_.clear();
+        armedGameTitle_.clear();
+        statusCopy_.clear();
+        emit stateChanged();
+        return state();
+    }
+
+    /// Headless proof path: launch without arming and report when Moonlight exits or the wait runs out.
+    QVariantMap launchImmediately(const QString& hostId, const QString& gameTitle) {
+        launchNow(hostId, gameTitle);
+        return state();
+    }
+
+    [[nodiscard]] bool running() const {
+        return session_.running();
+    }
+
+signals:
+    void stateChanged();
+
+private:
+    static constexpr qint64 kArmWindowMs = 8000;
+
+    [[nodiscard]] bool armed() const {
+        return !armedKey_.isEmpty() && armTimer_.isValid() && armTimer_.elapsed() < kArmWindowMs;
+    }
+
+    [[nodiscard]] QString actionHint() const {
+        if (!available()) {
+            return QStringLiteral("A = Copy safe launch plan · no stream power enabled");
+        }
+        if (session_.running()) {
+            return QStringLiteral("A = Ask Moonlight to end the stream");
+        }
+        if (armed()) {
+            return QStringLiteral("A again = Open in Moonlight now · B = cancel");
+        }
+        return QStringLiteral("A = Play in Moonlight (press twice)");
+    }
+
+    void launchNow(const QString& hostId, const QString& gameTitle) {
+        armedKey_.clear();
+        armedGameTitle_.clear();
+        const auto* host = identity_->hostById(hostId.toStdString());
+        if (host == nullptr) {
+            statusCopy_ = QStringLiteral("Moonlight does not know this host yet.");
+            emit stateChanged();
+            return;
+        }
+        nova::deck::runtime::DeckMoonlightLaunchRequest request;
+        request.hostSelector = host->stableId();
+        request.appName = gameTitle.toStdString();
+        request.fullscreen = true;
+        const auto plan = nova::deck::runtime::buildMoonlightStreamArgv(install_, request);
+        if (!plan.valid) {
+            statusCopy_ = QString::fromStdString(plan.reason);
+            emit stateChanged();
+            return;
+        }
+        statusCopy_.clear();
+        sessionCopy_.clear();
+        activeHostId_ = hostId;
+        if (session_.launch(plan, request)) {
+            sessionTruthTimer_.start();
+            refreshSessionTruth();
+        }
+        emit stateChanged();
+    }
+
+    void onOutcomeChanged() {
+        if (!session_.running()) {
+            sessionTruthTimer_.stop();
+            if (auto* window = QGuiApplication::allWindows().isEmpty() ? nullptr : QGuiApplication::allWindows().front(); window != nullptr) {
+                window->requestActivate();
+            }
+        }
+        emit stateChanged();
+    }
+
+    void refreshSessionTruth() {
+        if (!session_.running() || !identity_) {
+            return;
+        }
+        const auto* host = identity_->hostById(activeHostId_.toStdString());
+        if (host == nullptr || !host->hasServerCertificate()) {
+            return;
+        }
+        const nova::deck::polaris::DeckPolarisClient client(
+            nova::deck::polaris::DeckPolarisEndpoint{
+                .address = host->preferredAddress(),
+                .httpsPort = nova::deck::identity::polarisHttpsPortForMoonlightHttpPort(host->preferredHttpPort()),
+            },
+            nova::deck::polaris::DeckPolarisTlsIdentity{
+                .clientCertificatePem = identity_->clientCertificatePem,
+                .clientPrivateKeyPem = identity_->clientPrivateKeyPemForBackendOnly,
+                .pinnedServerCertificatePem = host->serverCertificatePem,
+            },
+            std::chrono::milliseconds(1500));
+        const auto status = client.fetchSessionStatus();
+        if (!status.ok()) {
+            sessionCopy_ = QStringLiteral("Host session: not answering right now.");
+        } else if (status.value->streamingActive) {
+            sessionCopy_ = QStringLiteral("Host session: streaming %1 · %2")
+                .arg(QString::fromStdString(status.value->game.empty() ? std::string{"an app"} : status.value->game))
+                .arg(status.value->ownedByClient ? QStringLiteral("owned by this device") : QStringLiteral("owned by another device"));
+        } else {
+            sessionCopy_ = QStringLiteral("Host session: idle (%1)").arg(QString::fromStdString(status.value->state));
+        }
+        emit stateChanged();
+    }
+
+    std::optional<nova::deck::identity::DeckMoonlightIdentity> identity_;
+    std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> snapshot_;
+    nova::deck::runtime::DeckMoonlightInstall install_;
+    nova::deck::runtime::DeckMoonlightHandoffSession session_;
+    QTimer sessionTruthTimer_;
+    QElapsedTimer armTimer_;
+    QString armedKey_;
+    QString armedGameTitle_;
+    QString activeHostId_;
+    QString statusCopy_;
+    QString sessionCopy_;
 };
 
 class QtPreviewLifecycleBridge final : public QObject {
@@ -945,7 +1144,9 @@ int main(int argc, char *argv[]) {
     const bool liveRoute = appArguments.contains(QStringLiteral("--live")) || qEnvironmentVariableIntValue("NOVA_DECK_LIVE") == 1;
     const bool printLiveState = appArguments.contains(QStringLiteral("--print-live-state"));
     std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> liveSnapshot;
+    std::optional<nova::deck::identity::DeckMoonlightIdentity> liveIdentity;
     if (liveRoute || printLiveState) {
+        liveIdentity = nova::deck::identity::loadDefaultMoonlightIdentity();
         liveSnapshot = nova::deck::backend::buildLiveSnapshotFromDefaultIdentity(std::chrono::milliseconds(4000));
         // Plain stdout on purpose: Qt routes qInfo to journald when stderr is
         // not a terminal, which hides a CLI summary from the person who asked.
@@ -1066,6 +1267,32 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaLaunchPreviewCopyAction", toPreviewCopyActionModel(launchPreviewCopyAction));
     engine.rootContext()->setContextProperty("novaPresenterReadiness", toPresenterReadinessModel(presenterReadiness));
     engine.rootContext()->setContextProperty("novaPreviewLifecycle", &previewLifecycle);
+    QtMoonlightHandoffBridge handoffBridge(liveIdentity, liveSnapshot);
+    engine.rootContext()->setContextProperty("novaHandoff", &handoffBridge);
+
+    // --handoff-game "<title>" opens the title on the selected live host at
+    // once and reports how Moonlight ended, for a headless proof with either a
+    // real Moonlight or NOVA_DECK_MOONLIGHT_BIN pointing at a recorder.
+    const QString handoffGame = stringArgumentAfter(appArguments, QStringLiteral("--handoff-game"));
+    if (!handoffGame.isEmpty()) {
+        const int waitMs = intArgumentAfter(appArguments, QStringLiteral("--handoff-wait-ms"), 20000);
+        const QString hostId = liveSnapshot ? QString::fromStdString(liveSnapshot->selectedHostId) : QString();
+        auto report = handoffBridge.launchImmediately(hostId, handoffGame);
+        std::cout << "nova-deck handoff: phase=" << report.value("phase").toString().toStdString()
+                  << " copy=\"" << report.value("copy").toString().toStdString() << "\"" << std::endl;
+        if (handoffBridge.running()) {
+            QElapsedTimer deadline;
+            deadline.start();
+            while (handoffBridge.running() && deadline.elapsed() < waitMs) {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 200);
+            }
+            report = handoffBridge.state();
+            std::cout << "nova-deck handoff: phase=" << report.value("phase").toString().toStdString()
+                      << " copy=\"" << report.value("copy").toString().toStdString() << "\""
+                      << " session=\"" << report.value("sessionCopy").toString().toStdString() << "\"" << std::endl;
+        }
+        return report.value("phase").toString() == QStringLiteral("failed-to-start") ? 3 : 0;
+    }
     engine.rootContext()->setContextProperty("novaBackendPreview", &backendPreview);
     engine.rootContext()->setContextProperty("novaLocalClipboard", &localClipboard);
     engine.rootContext()->setContextProperty("novaGamepad", &gamepadBridge);

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <QElapsedTimer>
 #include <QGuiApplication>
+#include <QThread>
 #include <QTimer>
 #include <QImage>
 #include <QQmlApplicationEngine>
@@ -76,6 +77,7 @@ public:
 signals:
     void availabilityChanged();
     void primaryActionPressed(int activationCount);
+    void secondaryActionPressed(int activationCount);
 
 private:
     void openDefaultDevice() {
@@ -110,6 +112,9 @@ private:
                 if (action == nova::deck::DeckGamepadAction::PrimaryPressed) {
                     ++primaryActivationCount_;
                     emit primaryActionPressed(primaryActivationCount_);
+                } else if (action == nova::deck::DeckGamepadAction::SecondaryPressed) {
+                    ++secondaryActivationCount_;
+                    emit secondaryActionPressed(secondaryActivationCount_);
                 }
                 continue;
             }
@@ -132,6 +137,7 @@ private:
     void readPendingJoystickEvents() {}
 #endif
     int primaryActivationCount_ = 0;
+    int secondaryActivationCount_ = 0;
 };
 
 class QtLocalClipboardBridge final : public QObject {
@@ -292,9 +298,10 @@ private:
 /**
  * Hands the highlighted game to Moonlight-Qt. Only exists on the live route,
  * because the host UUID and the exact app name come from the identity
- * Moonlight already holds. Two presses launch: the first arms the request and
- * says so, the second within the arming window starts Moonlight. While
- * Moonlight runs, Polaris is asked for the session truth on a slow timer.
+ * Moonlight already holds. Two presses launch: the first arms the request for
+ * a few seconds and says so, the second within that window starts Moonlight.
+ * While Moonlight runs, Polaris is asked for the session truth on a slow
+ * timer, off the GUI thread. Nothing here blocks the shell.
  */
 class QtMoonlightHandoffBridge final : public QObject {
     Q_OBJECT
@@ -307,11 +314,26 @@ public:
         QObject* parent = nullptr)
         : QObject(parent)
         , identity_(std::move(identity))
-        , snapshot_(std::move(snapshot))
-        , install_(nova::deck::runtime::detectMoonlightInstall()) {
-        QObject::connect(&session_, &nova::deck::runtime::DeckMoonlightHandoffSession::outcomeChanged, this, &QtMoonlightHandoffBridge::onOutcomeChanged);
+        , snapshot_(std::move(snapshot)) {
+        if (identity_ && snapshot_) {
+            install_ = nova::deck::runtime::detectMoonlightInstall();
+        }
+        armTimer_.setSingleShot(true);
+        armTimer_.setInterval(kArmWindowMs);
+        QObject::connect(&armTimer_, &QTimer::timeout, this, [this]() {
+            armedKey_.clear();
+            statusCopy_ = QStringLiteral("Launch request expired. Press A twice to open it in Moonlight.");
+            emit stateChanged();
+        });
         sessionTruthTimer_.setInterval(5000);
         QObject::connect(&sessionTruthTimer_, &QTimer::timeout, this, &QtMoonlightHandoffBridge::refreshSessionTruth);
+        QObject::connect(&session_, &nova::deck::runtime::DeckMoonlightHandoffSession::outcomeChanged, this, &QtMoonlightHandoffBridge::onOutcomeChanged);
+        QObject::connect(qApp, &QCoreApplication::aboutToQuit, this, &QtMoonlightHandoffBridge::shutdown);
+    }
+
+    ~QtMoonlightHandoffBridge() override {
+        shutdown();
+        session_.disconnect(this);
     }
 
     [[nodiscard]] bool available() const {
@@ -323,12 +345,10 @@ public:
         model.insert("available", available());
         model.insert("installLabel", QString::fromStdString(install_.label));
         model.insert("armed", armed());
-        model.insert("armedGameTitle", armedGameTitle_);
         const auto& outcome = session_.outcome();
         model.insert("phase", QString::fromUtf8(nova::deck::runtime::describe(outcome.state).data()));
         model.insert("running", session_.running());
         model.insert("copy", statusCopy_.isEmpty() ? QString::fromStdString(outcome.publicCopy) : statusCopy_);
-        model.insert("appName", QString::fromStdString(outcome.appName));
         model.insert("sessionCopy", sessionCopy_);
         model.insert("actionHint", actionHint());
         return model;
@@ -343,7 +363,7 @@ public:
         }
         if (session_.running()) {
             const bool asked = session_.requestQuit(install_);
-            statusCopy_ = asked ? QStringLiteral("Asked Moonlight to end the stream.") : QStringLiteral("Could not reach Moonlight to end the stream.");
+            statusCopy_ = asked ? QStringLiteral("Asking Moonlight to end the stream.") : QStringLiteral("Could not ask Moonlight to end the stream.");
             emit stateChanged();
             return state();
         }
@@ -353,24 +373,30 @@ public:
             return state();
         }
         armedKey_ = key;
-        armedGameTitle_ = gameTitle;
-        armTimer_.restart();
-        statusCopy_ = QStringLiteral("Press A again to open \"%1\" in Moonlight. B or wait to cancel.").arg(gameTitle);
+        armTimer_.start();
+        statusCopy_ = QStringLiteral("Press A again to open \"%1\" in Moonlight. B cancels.").arg(gameTitle);
         emit stateChanged();
         return state();
     }
 
     Q_INVOKABLE QVariantMap cancel() {
-        armedKey_.clear();
-        armedGameTitle_.clear();
-        statusCopy_.clear();
-        emit stateChanged();
+        if (armed()) {
+            armTimer_.stop();
+            armedKey_.clear();
+            statusCopy_ = QStringLiteral("Launch cancelled.");
+            emit stateChanged();
+        }
         return state();
     }
 
     /// Headless proof path: launch without arming and report when Moonlight exits or the wait runs out.
     QVariantMap launchImmediately(const QString& hostId, const QString& gameTitle, const bool windowed) {
         fullscreen_ = !windowed;
+        if (!available()) {
+            statusCopy_ = QStringLiteral("Play in Moonlight needs the live route and an installed Moonlight.");
+            emit stateChanged();
+            return state();
+        }
         launchNow(hostId, gameTitle);
         return state();
     }
@@ -379,14 +405,22 @@ public:
         return session_.running();
     }
 
+    [[nodiscard]] bool launched() const {
+        return launched_;
+    }
+
+    [[nodiscard]] QString outputTailForBackendOnly() const {
+        return QString::fromStdString(session_.outcome().outputTailForBackendOnly);
+    }
+
 signals:
     void stateChanged();
 
 private:
-    static constexpr qint64 kArmWindowMs = 8000;
+    static constexpr int kArmWindowMs = 8000;
 
     [[nodiscard]] bool armed() const {
-        return !armedKey_.isEmpty() && armTimer_.isValid() && armTimer_.elapsed() < kArmWindowMs;
+        return !armedKey_.isEmpty() && armTimer_.isActive();
     }
 
     [[nodiscard]] QString actionHint() const {
@@ -403,8 +437,8 @@ private:
     }
 
     void launchNow(const QString& hostId, const QString& gameTitle) {
+        armTimer_.stop();
         armedKey_.clear();
-        armedGameTitle_.clear();
         const auto* host = identity_->hostById(hostId.toStdString());
         if (host == nullptr) {
             statusCopy_ = QStringLiteral("Moonlight does not know this host yet.");
@@ -424,67 +458,94 @@ private:
         statusCopy_.clear();
         sessionCopy_.clear();
         activeHostId_ = hostId;
+        activeHttpsPort_ = 0;
+        for (const auto& probe : snapshot_->probes) {
+            if (probe.hostId == hostId.toStdString()) {
+                activeHttpsPort_ = probe.resolvedHttpsPort;
+            }
+        }
         if (session_.launch(plan, request)) {
-            sessionTruthTimer_.start();
-            refreshSessionTruth();
+            launched_ = true;
         }
         emit stateChanged();
     }
 
     void onOutcomeChanged() {
-        if (!session_.running()) {
+        using nova::deck::runtime::DeckMoonlightHandoffState;
+        const auto state = session_.outcome().state;
+        if (state == DeckMoonlightHandoffState::Running && !sessionTruthTimer_.isActive()) {
+            sessionTruthTimer_.start();
+            refreshSessionTruth();
+        }
+        if (state == DeckMoonlightHandoffState::Exited || state == DeckMoonlightHandoffState::FailedToStart) {
             sessionTruthTimer_.stop();
-            if (auto* window = QGuiApplication::allWindows().isEmpty() ? nullptr : QGuiApplication::allWindows().front(); window != nullptr) {
-                window->requestActivate();
+            sessionCopy_.clear();
+            statusCopy_.clear();
+            if (const auto windows = QGuiApplication::allWindows(); !windows.isEmpty()) {
+                windows.front()->requestActivate();
             }
         }
         emit stateChanged();
     }
 
+    /// One poll in flight at a time, on its own thread; the answer is applied back on this thread.
     void refreshSessionTruth() {
-        if (!session_.running() || !identity_) {
+        if (pollInFlight_ || !session_.running() || !identity_) {
             return;
         }
         const auto* host = identity_->hostById(activeHostId_.toStdString());
         if (host == nullptr || !host->hasServerCertificate()) {
             return;
         }
-        const nova::deck::polaris::DeckPolarisClient client(
-            nova::deck::polaris::DeckPolarisEndpoint{
-                .address = host->preferredAddress(),
-                .httpsPort = nova::deck::identity::polarisHttpsPortForMoonlightHttpPort(host->preferredHttpPort()),
-            },
-            nova::deck::polaris::DeckPolarisTlsIdentity{
-                .clientCertificatePem = identity_->clientCertificatePem,
-                .clientPrivateKeyPem = identity_->clientPrivateKeyPemForBackendOnly,
-                .pinnedServerCertificatePem = host->serverCertificatePem,
-            },
-            std::chrono::milliseconds(1500));
-        const auto status = client.fetchSessionStatus();
-        if (!status.ok()) {
-            sessionCopy_ = QStringLiteral("Host session: not answering right now.");
-        } else if (status.value->streamingActive) {
-            sessionCopy_ = QStringLiteral("Host session: streaming %1 · %2")
-                .arg(QString::fromStdString(status.value->game.empty() ? std::string{"an app"} : status.value->game))
-                .arg(status.value->ownedByClient ? QStringLiteral("owned by this device") : QStringLiteral("owned by another device"));
-        } else {
-            sessionCopy_ = QStringLiteral("Host session: idle (%1)").arg(QString::fromStdString(status.value->state));
-        }
-        emit stateChanged();
+        pollInFlight_ = true;
+        const auto identity = *identity_;
+        const auto record = *host;
+        const int port = activeHttpsPort_ > 0 ? activeHttpsPort_ : nova::deck::identity::polarisHttpsPortForMoonlightHttpPort(record.preferredHttpPort());
+        auto* worker = QThread::create([this, identity, record, port]() {
+            const auto client = nova::deck::backend::polarisClientForHost(identity, record, port, std::chrono::milliseconds(1500));
+            const auto status = client.fetchSessionStatus();
+            QString copy;
+            if (!status.ok()) {
+                copy = QStringLiteral("Host session: not answering right now.");
+            } else if (status.value->streamingActive) {
+                copy = QStringLiteral("Host session: streaming %1 · %2")
+                    .arg(QString::fromStdString(status.value->game.empty() ? std::string{"an app"} : status.value->game))
+                    .arg(status.value->ownedByClient ? QStringLiteral("owned by this device") : QStringLiteral("owned by another device"));
+            } else {
+                copy = QStringLiteral("Host session: idle (%1)").arg(QString::fromStdString(status.value->state));
+            }
+            QMetaObject::invokeMethod(this, [this, copy]() {
+                pollInFlight_ = false;
+                if (session_.running() && sessionCopy_ != copy) {
+                    sessionCopy_ = copy;
+                    emit stateChanged();
+                }
+            }, Qt::QueuedConnection);
+        });
+        QObject::connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+        worker->start();
+    }
+
+    void shutdown() {
+        sessionTruthTimer_.stop();
+        armTimer_.stop();
+        session_.terminate();
     }
 
     std::optional<nova::deck::identity::DeckMoonlightIdentity> identity_;
     std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> snapshot_;
     nova::deck::runtime::DeckMoonlightInstall install_;
-    nova::deck::runtime::DeckMoonlightHandoffSession session_;
     QTimer sessionTruthTimer_;
-    QElapsedTimer armTimer_;
+    QTimer armTimer_;
     QString armedKey_;
-    QString armedGameTitle_;
     QString activeHostId_;
+    int activeHttpsPort_ = 0;
     QString statusCopy_;
     QString sessionCopy_;
     bool fullscreen_ = true;
+    bool launched_ = false;
+    bool pollInFlight_ = false;
+    nova::deck::runtime::DeckMoonlightHandoffSession session_;  ///< last: destroyed first, its signals disconnected in ~bridge
 };
 
 class QtPreviewLifecycleBridge final : public QObject {
@@ -1245,6 +1306,8 @@ int main(int argc, char *argv[]) {
 
     qmlRegisterType<nova::deck::stream::DeckQtQuickRhiVaapiItem>("Nova.Deck.Stream", 0, 1, "DeckVaapiPreviewSurface");
 
+    // Constructed before the engine so it outlives every QML binding to it.
+    QtMoonlightHandoffBridge handoffBridge(liveIdentity, liveSnapshot);
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("novaDeckShellName", toQString(profile.shellName));
     engine.rootContext()->setContextProperty("novaDeckWidth", profile.width);
@@ -1269,31 +1332,42 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("novaLaunchPreviewCopyAction", toPreviewCopyActionModel(launchPreviewCopyAction));
     engine.rootContext()->setContextProperty("novaPresenterReadiness", toPresenterReadinessModel(presenterReadiness));
     engine.rootContext()->setContextProperty("novaPreviewLifecycle", &previewLifecycle);
-    QtMoonlightHandoffBridge handoffBridge(liveIdentity, liveSnapshot);
     engine.rootContext()->setContextProperty("novaHandoff", &handoffBridge);
 
     // --handoff-game "<title>" opens the title on the selected live host at
     // once and reports how Moonlight ended, for a headless proof with either a
     // real Moonlight or NOVA_DECK_MOONLIGHT_BIN pointing at a recorder.
+    // Exit codes: 0 launched and exited, 3 never launched, 4 still running at the deadline.
     const QString handoffGame = stringArgumentAfter(appArguments, QStringLiteral("--handoff-game"));
     if (!handoffGame.isEmpty()) {
         const int waitMs = intArgumentAfter(appArguments, QStringLiteral("--handoff-wait-ms"), 20000);
         const QString hostId = liveSnapshot ? QString::fromStdString(liveSnapshot->selectedHostId) : QString();
-        auto report = handoffBridge.launchImmediately(hostId, handoffGame, appArguments.contains(QStringLiteral("--handoff-windowed")));
-        std::cout << "nova-deck handoff: phase=" << report.value("phase").toString().toStdString()
-                  << " copy=\"" << report.value("copy").toString().toStdString() << "\"" << std::endl;
-        if (handoffBridge.running()) {
-            QElapsedTimer deadline;
-            deadline.start();
-            while (handoffBridge.running() && deadline.elapsed() < waitMs) {
-                QCoreApplication::processEvents(QEventLoop::AllEvents, 200);
-            }
-            report = handoffBridge.state();
+        const auto printReport = [&handoffBridge]() {
+            const auto report = handoffBridge.state();
             std::cout << "nova-deck handoff: phase=" << report.value("phase").toString().toStdString()
                       << " copy=\"" << report.value("copy").toString().toStdString() << "\""
                       << " session=\"" << report.value("sessionCopy").toString().toStdString() << "\"" << std::endl;
+            return report;
+        };
+        handoffBridge.launchImmediately(hostId, handoffGame, appArguments.contains(QStringLiteral("--handoff-windowed")));
+        QElapsedTimer deadline;
+        deadline.start();
+        // Wait for the child to reach a terminal state, or the deadline; WaitForMoreEvents keeps this from spinning.
+        while (deadline.elapsed() < waitMs) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 250);
+            const auto phase = handoffBridge.state().value("phase").toString();
+            if (!handoffBridge.launched() || phase == QStringLiteral("exited") || phase == QStringLiteral("failed-to-start")) {
+                break;
+            }
         }
-        return report.value("phase").toString() == QStringLiteral("failed-to-start") ? 3 : 0;
+        const auto report = printReport();
+        if (const auto tail = handoffBridge.outputTailForBackendOnly(); !tail.isEmpty()) {
+            std::cout << "nova-deck handoff: moonlight output tail (backend only):\n" << tail.toStdString() << std::endl;
+        }
+        if (!handoffBridge.launched() || report.value("phase").toString() == QStringLiteral("failed-to-start")) {
+            return 3;
+        }
+        return handoffBridge.running() ? 4 : 0;
     }
     engine.rootContext()->setContextProperty("novaBackendPreview", &backendPreview);
     engine.rootContext()->setContextProperty("novaLocalClipboard", &localClipboard);

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -1352,9 +1352,11 @@ int main(int argc, char *argv[]) {
         handoffBridge.launchImmediately(hostId, handoffGame, appArguments.contains(QStringLiteral("--handoff-windowed")));
         QElapsedTimer deadline;
         deadline.start();
-        // Wait for the child to reach a terminal state, or the deadline; WaitForMoreEvents keeps this from spinning.
+        // Wait for the child to reach a terminal state, or the deadline. The
+        // timed processEvents overload never waits, so sleep between passes.
         while (deadline.elapsed() < waitMs) {
-            QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 250);
+            QCoreApplication::processEvents();
+            QThread::msleep(100);
             const auto phase = handoffBridge.state().value("phase").toString();
             if (!handoffBridge.launched() || phase == QStringLiteral("exited") || phase == QStringLiteral("failed-to-start")) {
                 break;

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -13,6 +13,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <chrono>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <QGuiApplication>
@@ -946,7 +947,9 @@ int main(int argc, char *argv[]) {
     std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> liveSnapshot;
     if (liveRoute || printLiveState) {
         liveSnapshot = nova::deck::backend::buildLiveSnapshotFromDefaultIdentity(std::chrono::milliseconds(4000));
-        qInfo().noquote() << QString::fromStdString(nova::deck::backend::describeLiveSnapshotForTerminal(*liveSnapshot));
+        // Plain stdout on purpose: Qt routes qInfo to journald when stderr is
+        // not a terminal, which hides a CLI summary from the person who asked.
+        std::cout << nova::deck::backend::describeLiveSnapshotForTerminal(*liveSnapshot) << std::flush;
         if (printLiveState) {
             return liveSnapshot->identityLoaded ? 0 : 2;
         }

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -369,7 +369,8 @@ public:
     }
 
     /// Headless proof path: launch without arming and report when Moonlight exits or the wait runs out.
-    QVariantMap launchImmediately(const QString& hostId, const QString& gameTitle) {
+    QVariantMap launchImmediately(const QString& hostId, const QString& gameTitle, const bool windowed) {
+        fullscreen_ = !windowed;
         launchNow(hostId, gameTitle);
         return state();
     }
@@ -413,7 +414,7 @@ private:
         nova::deck::runtime::DeckMoonlightLaunchRequest request;
         request.hostSelector = host->stableId();
         request.appName = gameTitle.toStdString();
-        request.fullscreen = true;
+        request.fullscreen = fullscreen_;
         const auto plan = nova::deck::runtime::buildMoonlightStreamArgv(install_, request);
         if (!plan.valid) {
             statusCopy_ = QString::fromStdString(plan.reason);
@@ -483,6 +484,7 @@ private:
     QString activeHostId_;
     QString statusCopy_;
     QString sessionCopy_;
+    bool fullscreen_ = true;
 };
 
 class QtPreviewLifecycleBridge final : public QObject {
@@ -1277,7 +1279,7 @@ int main(int argc, char *argv[]) {
     if (!handoffGame.isEmpty()) {
         const int waitMs = intArgumentAfter(appArguments, QStringLiteral("--handoff-wait-ms"), 20000);
         const QString hostId = liveSnapshot ? QString::fromStdString(liveSnapshot->selectedHostId) : QString();
-        auto report = handoffBridge.launchImmediately(hostId, handoffGame);
+        auto report = handoffBridge.launchImmediately(hostId, handoffGame, appArguments.contains(QStringLiteral("--handoff-windowed")));
         std::cout << "nova-deck handoff: phase=" << report.value("phase").toString().toStdString()
                   << " copy=\"" << report.value("copy").toString().toStdString() << "\"" << std::endl;
         if (handoffBridge.running()) {

--- a/clients/deck/src/polaris/deck_polaris_client.cpp
+++ b/clients/deck/src/polaris/deck_polaris_client.cpp
@@ -169,6 +169,17 @@ std::optional<DeckPolarisSessionStatus> parseSessionStatus(const std::string_vie
     return status;
 }
 
+DeckPolarisRequestTarget splitRequestTarget(const std::string_view pathWithQuery) {
+    const auto mark = pathWithQuery.find('?');
+    if (mark == std::string_view::npos) {
+        return DeckPolarisRequestTarget{.path = std::string(pathWithQuery), .query = {}};
+    }
+    return DeckPolarisRequestTarget{
+        .path = std::string(pathWithQuery.substr(0, mark)),
+        .query = std::string(pathWithQuery.substr(mark + 1)),
+    };
+}
+
 std::optional<int> parseServerInfoHttpsPort(const std::string_view xml) {
     constexpr std::string_view open = "<HttpsPort>";
     constexpr std::string_view close = "</HttpsPort>";
@@ -280,11 +291,15 @@ DeckPolarisResult<std::string> DeckPolarisClient::get(const std::string& path) c
         return result;
     }
 
+    const auto target = splitRequestTarget(path);
     QUrl url;
     url.setScheme(QStringLiteral("https"));
     url.setHost(QString::fromStdString(endpoint_.address));
     url.setPort(endpoint_.httpsPort);
-    url.setPath(QString::fromStdString(path));
+    url.setPath(QString::fromStdString(target.path));
+    if (!target.query.empty()) {
+        url.setQuery(QString::fromStdString(target.query));
+    }
 
     QNetworkRequest request(url);
     // The pinned certificate is the only trust anchor. Polaris serves a

--- a/clients/deck/src/polaris/deck_polaris_client.h
+++ b/clients/deck/src/polaris/deck_polaris_client.h
@@ -110,6 +110,13 @@ std::optional<DeckPolarisSessionStatus> parseSessionStatus(std::string_view json
 /// The HttpsPort a GameStream host advertises in its plain-HTTP serverinfo XML.
 std::optional<int> parseServerInfoHttpsPort(std::string_view xml);
 
+/// Split "/path?query" into its two parts; QUrl needs them set separately or it encodes the `?`.
+struct DeckPolarisRequestTarget {
+    std::string path;
+    std::string query;
+};
+DeckPolarisRequestTarget splitRequestTarget(std::string_view pathWithQuery);
+
 /// Ask the host's plain-HTTP port which HTTPS port to use, the way Moonlight does
 /// before every connection; nullopt when the host does not answer or advertise one.
 std::optional<int> resolveHttpsPortFromServerInfo(const std::string& address, int httpPort, std::chrono::milliseconds timeout);

--- a/clients/deck/src/runtime/deck_moonlight_launcher.cpp
+++ b/clients/deck/src/runtime/deck_moonlight_launcher.cpp
@@ -199,7 +199,10 @@ DeckMoonlightArgvPlan buildMoonlightStreamArgv(const DeckMoonlightInstall& insta
     plan.argv.emplace_back("stream");
     plan.argv.push_back(request.hostSelector);
     plan.argv.push_back(request.appName);
-    plan.argv.emplace_back(request.fullscreen ? "--fullscreen" : "--windowed");
+    // Moonlight-Qt's display mode is a value option; a bare --fullscreen flag
+    // makes it print usage and exit 1 (found on the first real launch).
+    plan.argv.emplace_back("--display-mode");
+    plan.argv.emplace_back(request.fullscreen ? "fullscreen" : "windowed");
     if (request.quitAppAfter) {
         plan.argv.emplace_back("--quit-after");
     }

--- a/clients/deck/src/runtime/deck_moonlight_launcher.cpp
+++ b/clients/deck/src/runtime/deck_moonlight_launcher.cpp
@@ -1,0 +1,352 @@
+#include "runtime/deck_moonlight_launcher.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <system_error>
+#include <unistd.h>
+#include <utility>
+
+namespace nova::deck::runtime {
+
+namespace {
+
+constexpr std::string_view kFlatpakAppId = "com.moonlight_stream.Moonlight";
+
+std::filesystem::path homeDirectory() {
+    if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0') {
+        return std::filesystem::path(home);
+    }
+    return {};
+}
+
+bool executableFile(const std::filesystem::path& path) {
+    std::error_code ec;
+    return std::filesystem::is_regular_file(path, ec) && ::access(path.c_str(), X_OK) == 0;
+}
+
+std::optional<std::filesystem::path> findOnPath(const std::vector<std::filesystem::path>& dirs, const std::string_view name) {
+    for (const auto& dir : dirs) {
+        const auto candidate = dir / name;
+        if (executableFile(candidate)) {
+            return candidate;
+        }
+    }
+    return std::nullopt;
+}
+
+QStringList toQStringList(const std::vector<std::string>& tokens) {
+    QStringList list;
+    for (const auto& token : tokens) {
+        list.push_back(QString::fromStdString(token));
+    }
+    return list;
+}
+
+} // namespace
+
+bool isPlainArgvToken(const std::string_view token) {
+    if (token.empty() || token.size() > 512) {
+        return false;
+    }
+    for (const unsigned char ch : token) {
+        if (ch < 0x20 || ch == 0x7f) {
+            return false;
+        }
+        if (ch == '`' || ch == '$' || ch == ';' || ch == '|' || ch == '&' || ch == '<' || ch == '>' || ch == '"') {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::string_view describe(const DeckMoonlightHandoffState state) {
+    switch (state) {
+    case DeckMoonlightHandoffState::Idle:
+        return "idle";
+    case DeckMoonlightHandoffState::Starting:
+        return "starting";
+    case DeckMoonlightHandoffState::Running:
+        return "running";
+    case DeckMoonlightHandoffState::Exited:
+        return "exited";
+    case DeckMoonlightHandoffState::FailedToStart:
+        return "failed-to-start";
+    }
+    return "unknown";
+}
+
+DeckMoonlightInstallProbe defaultMoonlightInstallProbe() {
+    DeckMoonlightInstallProbe probe;
+    if (const char* override = std::getenv("NOVA_DECK_MOONLIGHT_BIN"); override != nullptr && *override != '\0') {
+        probe.overrideBinary = std::filesystem::path(override);
+    }
+    if (const char* path = std::getenv("PATH"); path != nullptr && *path != '\0') {
+        std::string_view remaining{path};
+        while (!remaining.empty()) {
+            const auto colon = remaining.find(':');
+            const auto entry = remaining.substr(0, colon);
+            if (!entry.empty()) {
+                probe.pathDirs.emplace_back(entry);
+            }
+            if (colon == std::string_view::npos) {
+                break;
+            }
+            remaining.remove_prefix(colon + 1);
+        }
+    }
+    for (const char* dir : {"/usr/bin", "/usr/local/bin", "/var/lib/flatpak/exports/bin"}) {
+        if (std::find(probe.pathDirs.begin(), probe.pathDirs.end(), std::filesystem::path(dir)) == probe.pathDirs.end()) {
+            probe.pathDirs.emplace_back(dir);
+        }
+    }
+    if (const auto home = homeDirectory(); !home.empty()) {
+        probe.flatpakAppDir = home / ".var" / "app" / std::string(kFlatpakAppId);
+        probe.pathDirs.push_back(home / ".local" / "share" / "flatpak" / "exports" / "bin");
+    }
+    probe.flatpakInfoFile = "/.flatpak-info";
+    return probe;
+}
+
+DeckMoonlightInstall detectMoonlightInstall(const DeckMoonlightInstallProbe& probe) {
+    DeckMoonlightInstall install;
+    std::error_code ec;
+    install.novaInsideFlatpak = !probe.flatpakInfoFile.empty() && std::filesystem::exists(probe.flatpakInfoFile, ec);
+
+    if (probe.overrideBinary && executableFile(*probe.overrideBinary)) {
+        install.kind = DeckMoonlightInstallKind::Native;
+        install.executable = probe.overrideBinary->string();
+        install.label = "Moonlight (native, override)";
+        return install;
+    }
+    for (const char* name : {"moonlight", "moonlight-qt"}) {
+        if (const auto found = findOnPath(probe.pathDirs, name)) {
+            install.kind = DeckMoonlightInstallKind::Native;
+            install.executable = found->string();
+            install.label = "Moonlight (native)";
+            return install;
+        }
+    }
+    const bool flatpakAppPresent = !probe.flatpakAppDir.empty() && std::filesystem::is_directory(probe.flatpakAppDir, ec);
+    const auto flatpakTool = findOnPath(probe.pathDirs, "flatpak");
+    if (flatpakAppPresent && (flatpakTool || install.novaInsideFlatpak)) {
+        install.kind = DeckMoonlightInstallKind::Flatpak;
+        install.executable = flatpakTool ? flatpakTool->string() : std::string{"flatpak"};
+        install.label = "Moonlight (Flatpak)";
+        return install;
+    }
+    install.label = "Moonlight not found";
+    return install;
+}
+
+DeckMoonlightInstall detectMoonlightInstall() {
+    return detectMoonlightInstall(defaultMoonlightInstallProbe());
+}
+
+namespace {
+
+std::vector<std::string> programPrefix(const DeckMoonlightInstall& install) {
+    std::vector<std::string> prefix;
+    if (install.novaInsideFlatpak) {
+        // Inside the sandbox nothing is on PATH; flatpak-spawn asks the host
+        // session to run the command, which needs --talk-name=org.freedesktop.Flatpak.
+        prefix = {"flatpak-spawn", "--host"};
+    }
+    if (install.kind == DeckMoonlightInstallKind::Flatpak) {
+        prefix.push_back(install.novaInsideFlatpak ? std::string{"flatpak"} : install.executable);
+        prefix.emplace_back("run");
+        prefix.emplace_back(kFlatpakAppId);
+    } else {
+        prefix.push_back(install.executable);
+    }
+    return prefix;
+}
+
+} // namespace
+
+DeckMoonlightArgvPlan buildMoonlightStreamArgv(const DeckMoonlightInstall& install, const DeckMoonlightLaunchRequest& request) {
+    DeckMoonlightArgvPlan plan;
+    if (!install.available()) {
+        plan.reason = "Moonlight is not installed on this device.";
+        return plan;
+    }
+    if (!isPlainArgvToken(request.hostSelector)) {
+        plan.reason = "The host selector is not a plain token.";
+        return plan;
+    }
+    if (!isPlainArgvToken(request.appName)) {
+        plan.reason = "The app name is not a plain token.";
+        return plan;
+    }
+    if (request.fps && (*request.fps < 10 || *request.fps > 240)) {
+        plan.reason = "The frame rate is out of range.";
+        return plan;
+    }
+    if (request.bitrateKbps && (*request.bitrateKbps < 500 || *request.bitrateKbps > 500000)) {
+        plan.reason = "The bitrate is out of range.";
+        return plan;
+    }
+    if (request.width.has_value() != request.height.has_value()
+        || (request.width && (*request.width < 320 || *request.width > 7680 || *request.height < 200 || *request.height > 4320))) {
+        plan.reason = "The resolution is out of range.";
+        return plan;
+    }
+
+    plan.argv = programPrefix(install);
+    plan.argv.emplace_back("stream");
+    plan.argv.push_back(request.hostSelector);
+    plan.argv.push_back(request.appName);
+    plan.argv.emplace_back(request.fullscreen ? "--fullscreen" : "--windowed");
+    if (request.quitAppAfter) {
+        plan.argv.emplace_back("--quit-after");
+    }
+    if (request.fps) {
+        plan.argv.emplace_back("--fps");
+        plan.argv.push_back(std::to_string(*request.fps));
+    }
+    if (request.bitrateKbps) {
+        plan.argv.emplace_back("--bitrate");
+        plan.argv.push_back(std::to_string(*request.bitrateKbps));
+    }
+    if (request.width) {
+        plan.argv.emplace_back("--resolution");
+        plan.argv.push_back(std::to_string(*request.width) + "x" + std::to_string(*request.height));
+    }
+    plan.valid = true;
+    plan.publicSummary = install.label + " will open \"" + request.appName + "\" on the paired host";
+    if (request.quitAppAfter) {
+        plan.publicSummary += " and quit it when the stream ends";
+    }
+    plan.publicSummary += ".";
+    return plan;
+}
+
+DeckMoonlightArgvPlan buildMoonlightQuitArgv(const DeckMoonlightInstall& install, const std::string_view hostSelector) {
+    DeckMoonlightArgvPlan plan;
+    if (!install.available()) {
+        plan.reason = "Moonlight is not installed on this device.";
+        return plan;
+    }
+    if (!isPlainArgvToken(hostSelector)) {
+        plan.reason = "The host selector is not a plain token.";
+        return plan;
+    }
+    plan.argv = programPrefix(install);
+    plan.argv.emplace_back("quit");
+    plan.argv.emplace_back(hostSelector);
+    plan.valid = true;
+    plan.publicSummary = install.label + " will ask the paired host to end the running app.";
+    return plan;
+}
+
+DeckMoonlightHandoffSession::DeckMoonlightHandoffSession(QObject* parent)
+    : QObject(parent) {}
+
+DeckMoonlightHandoffSession::~DeckMoonlightHandoffSession() {
+    if (process_ && process_->state() != QProcess::NotRunning) {
+        process_->kill();
+        process_->waitForFinished(1000);
+    }
+}
+
+bool DeckMoonlightHandoffSession::launch(const DeckMoonlightArgvPlan& plan, const DeckMoonlightLaunchRequest& request) {
+    if (!plan.valid || plan.argv.empty() || running()) {
+        return false;
+    }
+    process_ = std::make_unique<QProcess>(this);
+    process_->setProgram(QString::fromStdString(plan.argv.front()));
+    process_->setArguments(toQStringList(std::vector<std::string>(plan.argv.begin() + 1, plan.argv.end())));
+    process_->setStandardOutputFile(QProcess::nullDevice());
+    process_->setStandardErrorFile(QProcess::nullDevice());
+    QObject::connect(process_.get(), &QProcess::finished, this, &DeckMoonlightHandoffSession::recordFinished);
+    QObject::connect(process_.get(), &QProcess::errorOccurred, this, &DeckMoonlightHandoffSession::recordFailure);
+
+    outcome_ = DeckMoonlightHandoffOutcome{};
+    outcome_.state = DeckMoonlightHandoffState::Starting;
+    outcome_.appName = request.appName;
+    outcome_.hostSelector = request.hostSelector;
+    outcome_.publicCopy = "Opening \"" + request.appName + "\" in Moonlight.";
+    emit outcomeChanged();
+
+    process_->start();
+    if (!process_->waitForStarted(5000)) {
+        if (outcome_.state == DeckMoonlightHandoffState::Starting) {
+            recordFailure(process_->error());
+        }
+        return false;
+    }
+    outcome_.state = DeckMoonlightHandoffState::Running;
+    outcome_.publicCopy = "Moonlight is streaming \"" + request.appName + "\". Nova returns when it closes.";
+    emit outcomeChanged();
+    return true;
+}
+
+bool DeckMoonlightHandoffSession::requestQuit(const DeckMoonlightInstall& install) {
+    if (!running() || outcome_.hostSelector.empty()) {
+        return false;
+    }
+    const auto plan = buildMoonlightQuitArgv(install, outcome_.hostSelector);
+    if (!plan.valid) {
+        return false;
+    }
+    QProcess quit;
+    quit.setProgram(QString::fromStdString(plan.argv.front()));
+    quit.setArguments(toQStringList(std::vector<std::string>(plan.argv.begin() + 1, plan.argv.end())));
+    quit.setStandardOutputFile(QProcess::nullDevice());
+    quit.setStandardErrorFile(QProcess::nullDevice());
+    quit.start();
+    const bool started = quit.waitForStarted(5000);
+    if (started) {
+        quit.waitForFinished(15000);
+    }
+    return started;
+}
+
+void DeckMoonlightHandoffSession::terminate() {
+    if (process_ && process_->state() != QProcess::NotRunning) {
+        process_->terminate();
+    }
+}
+
+const DeckMoonlightHandoffOutcome& DeckMoonlightHandoffSession::outcome() const {
+    return outcome_;
+}
+
+bool DeckMoonlightHandoffSession::running() const {
+    return process_ && process_->state() != QProcess::NotRunning;
+}
+
+qint64 DeckMoonlightHandoffSession::processId() const {
+    return process_ ? process_->processId() : 0;
+}
+
+void DeckMoonlightHandoffSession::recordFinished(const int exitCode, const QProcess::ExitStatus status) {
+    outcome_.state = DeckMoonlightHandoffState::Exited;
+    outcome_.exitCode = exitCode;
+    outcome_.crashed = status == QProcess::CrashExit;
+    if (outcome_.crashed) {
+        outcome_.publicCopy = "Moonlight closed unexpectedly. Nova is back.";
+    } else if (exitCode == 0) {
+        outcome_.publicCopy = "Moonlight closed. Nova is back.";
+    } else {
+        outcome_.publicCopy = "Moonlight exited with code " + std::to_string(exitCode) + ". Nova is back.";
+    }
+    emit outcomeChanged();
+}
+
+void DeckMoonlightHandoffSession::recordFailure(const QProcess::ProcessError error) {
+    if (outcome_.state != DeckMoonlightHandoffState::Starting) {
+        return;
+    }
+    outcome_.state = DeckMoonlightHandoffState::FailedToStart;
+    outcome_.exitCode = -1;
+    outcome_.publicCopy = error == QProcess::FailedToStart
+        ? "Moonlight could not be started on this device."
+        : "Moonlight did not start cleanly.";
+    emit outcomeChanged();
+}
+
+} // namespace nova::deck::runtime

--- a/clients/deck/src/runtime/deck_moonlight_launcher.cpp
+++ b/clients/deck/src/runtime/deck_moonlight_launcher.cpp
@@ -1,10 +1,10 @@
 #include "runtime/deck_moonlight_launcher.h"
 
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdlib>
 #include <system_error>
 #include <unistd.h>
@@ -28,14 +28,12 @@ bool executableFile(const std::filesystem::path& path) {
     return std::filesystem::is_regular_file(path, ec) && ::access(path.c_str(), X_OK) == 0;
 }
 
-std::optional<std::filesystem::path> findOnPath(const std::vector<std::filesystem::path>& dirs, const std::string_view name) {
+QStringList toQStringList(const std::vector<std::filesystem::path>& dirs) {
+    QStringList list;
     for (const auto& dir : dirs) {
-        const auto candidate = dir / name;
-        if (executableFile(candidate)) {
-            return candidate;
-        }
+        list.push_back(QString::fromStdString(dir.string()));
     }
-    return std::nullopt;
+    return list;
 }
 
 QStringList toQStringList(const std::vector<std::string>& tokens) {
@@ -46,6 +44,20 @@ QStringList toQStringList(const std::vector<std::string>& tokens) {
     return list;
 }
 
+std::optional<std::filesystem::path> findOnPath(const std::vector<std::filesystem::path>& dirs, const std::string_view name) {
+    const auto found = QStandardPaths::findExecutable(QString::fromUtf8(name.data(), static_cast<int>(name.size())), toQStringList(dirs));
+    if (found.isEmpty()) {
+        return std::nullopt;
+    }
+    return std::filesystem::path(found.toStdString());
+}
+
+void configureChild(QProcess& process, const std::vector<std::string>& argv) {
+    process.setProgram(QString::fromStdString(argv.front()));
+    process.setArguments(toQStringList(std::vector<std::string>(argv.begin() + 1, argv.end())));
+    process.setProcessChannelMode(QProcess::MergedChannels);
+}
+
 } // namespace
 
 bool isPlainArgvToken(const std::string_view token) {
@@ -54,9 +66,6 @@ bool isPlainArgvToken(const std::string_view token) {
     }
     for (const unsigned char ch : token) {
         if (ch < 0x20 || ch == 0x7f) {
-            return false;
-        }
-        if (ch == '`' || ch == '$' || ch == ';' || ch == '|' || ch == '&' || ch == '<' || ch == '>' || ch == '"') {
             return false;
         }
     }
@@ -79,19 +88,35 @@ std::string_view describe(const DeckMoonlightHandoffState state) {
     return "unknown";
 }
 
+std::string_view describe(const DeckMoonlightQuitState state) {
+    switch (state) {
+    case DeckMoonlightQuitState::NotRequested:
+        return "not-requested";
+    case DeckMoonlightQuitState::Requested:
+        return "requested";
+    case DeckMoonlightQuitState::Acknowledged:
+        return "acknowledged";
+    case DeckMoonlightQuitState::Failed:
+        return "failed";
+    }
+    return "unknown";
+}
+
 DeckMoonlightInstallProbe defaultMoonlightInstallProbe() {
     DeckMoonlightInstallProbe probe;
     if (const char* override = std::getenv("NOVA_DECK_MOONLIGHT_BIN"); override != nullptr && *override != '\0') {
         probe.overrideBinary = std::filesystem::path(override);
     }
+    const auto pushUnique = [&probe](std::filesystem::path dir) {
+        if (!dir.empty() && std::find(probe.pathDirs.begin(), probe.pathDirs.end(), dir) == probe.pathDirs.end()) {
+            probe.pathDirs.push_back(std::move(dir));
+        }
+    };
     if (const char* path = std::getenv("PATH"); path != nullptr && *path != '\0') {
         std::string_view remaining{path};
         while (!remaining.empty()) {
             const auto colon = remaining.find(':');
-            const auto entry = remaining.substr(0, colon);
-            if (!entry.empty()) {
-                probe.pathDirs.emplace_back(entry);
-            }
+            pushUnique(std::filesystem::path(remaining.substr(0, colon)));
             if (colon == std::string_view::npos) {
                 break;
             }
@@ -99,13 +124,11 @@ DeckMoonlightInstallProbe defaultMoonlightInstallProbe() {
         }
     }
     for (const char* dir : {"/usr/bin", "/usr/local/bin", "/var/lib/flatpak/exports/bin"}) {
-        if (std::find(probe.pathDirs.begin(), probe.pathDirs.end(), std::filesystem::path(dir)) == probe.pathDirs.end()) {
-            probe.pathDirs.emplace_back(dir);
-        }
+        pushUnique(dir);
     }
     if (const auto home = homeDirectory(); !home.empty()) {
         probe.flatpakAppDir = home / ".var" / "app" / std::string(kFlatpakAppId);
-        probe.pathDirs.push_back(home / ".local" / "share" / "flatpak" / "exports" / "bin");
+        pushUnique(home / ".local" / "share" / "flatpak" / "exports" / "bin");
     }
     probe.flatpakInfoFile = "/.flatpak-info";
     return probe;
@@ -249,9 +272,23 @@ DeckMoonlightHandoffSession::DeckMoonlightHandoffSession(QObject* parent)
     : QObject(parent) {}
 
 DeckMoonlightHandoffSession::~DeckMoonlightHandoffSession() {
-    if (process_ && process_->state() != QProcess::NotRunning) {
-        process_->kill();
-        process_->waitForFinished(1000);
+    // Signals from a dying child must not reach a half-destroyed owner.
+    if (process_) {
+        process_->disconnect(this);
+        if (process_->state() != QProcess::NotRunning) {
+            process_->terminate();
+            if (!process_->waitForFinished(1500)) {
+                process_->kill();
+                process_->waitForFinished(500);
+            }
+        }
+    }
+    if (quitProcess_) {
+        quitProcess_->disconnect(this);
+        if (quitProcess_->state() != QProcess::NotRunning) {
+            quitProcess_->kill();
+            quitProcess_->waitForFinished(500);
+        }
     }
 }
 
@@ -259,13 +296,15 @@ bool DeckMoonlightHandoffSession::launch(const DeckMoonlightArgvPlan& plan, cons
     if (!plan.valid || plan.argv.empty() || running()) {
         return false;
     }
+    if (process_) {
+        process_->disconnect(this);
+    }
     process_ = std::make_unique<QProcess>(this);
-    process_->setProgram(QString::fromStdString(plan.argv.front()));
-    process_->setArguments(toQStringList(std::vector<std::string>(plan.argv.begin() + 1, plan.argv.end())));
-    process_->setStandardOutputFile(QProcess::nullDevice());
-    process_->setStandardErrorFile(QProcess::nullDevice());
+    configureChild(*process_, plan.argv);
+    QObject::connect(process_.get(), &QProcess::started, this, &DeckMoonlightHandoffSession::recordStarted);
     QObject::connect(process_.get(), &QProcess::finished, this, &DeckMoonlightHandoffSession::recordFinished);
     QObject::connect(process_.get(), &QProcess::errorOccurred, this, &DeckMoonlightHandoffSession::recordFailure);
+    QObject::connect(process_.get(), &QProcess::readyReadStandardOutput, this, &DeckMoonlightHandoffSession::drainOutput);
 
     outcome_ = DeckMoonlightHandoffOutcome{};
     outcome_.state = DeckMoonlightHandoffState::Starting;
@@ -275,15 +314,6 @@ bool DeckMoonlightHandoffSession::launch(const DeckMoonlightArgvPlan& plan, cons
     emit outcomeChanged();
 
     process_->start();
-    if (!process_->waitForStarted(5000)) {
-        if (outcome_.state == DeckMoonlightHandoffState::Starting) {
-            recordFailure(process_->error());
-        }
-        return false;
-    }
-    outcome_.state = DeckMoonlightHandoffState::Running;
-    outcome_.publicCopy = "Moonlight is streaming \"" + request.appName + "\". Nova returns when it closes.";
-    emit outcomeChanged();
     return true;
 }
 
@@ -291,21 +321,33 @@ bool DeckMoonlightHandoffSession::requestQuit(const DeckMoonlightInstall& instal
     if (!running() || outcome_.hostSelector.empty()) {
         return false;
     }
+    if (quitProcess_ && quitProcess_->state() != QProcess::NotRunning) {
+        return true;  // one quit in flight is enough
+    }
     const auto plan = buildMoonlightQuitArgv(install, outcome_.hostSelector);
     if (!plan.valid) {
         return false;
     }
-    QProcess quit;
-    quit.setProgram(QString::fromStdString(plan.argv.front()));
-    quit.setArguments(toQStringList(std::vector<std::string>(plan.argv.begin() + 1, plan.argv.end())));
-    quit.setStandardOutputFile(QProcess::nullDevice());
-    quit.setStandardErrorFile(QProcess::nullDevice());
-    quit.start();
-    const bool started = quit.waitForStarted(5000);
-    if (started) {
-        quit.waitForFinished(15000);
+    if (quitProcess_) {
+        quitProcess_->disconnect(this);
     }
-    return started;
+    quitProcess_ = std::make_unique<QProcess>(this);
+    configureChild(*quitProcess_, plan.argv);
+    quitProcess_->setStandardOutputFile(QProcess::nullDevice());
+    QObject::connect(quitProcess_.get(), &QProcess::finished, this, [this](const int exitCode, const QProcess::ExitStatus status) {
+        outcome_.quitState = (status == QProcess::NormalExit && exitCode == 0) ? DeckMoonlightQuitState::Acknowledged : DeckMoonlightQuitState::Failed;
+        emit outcomeChanged();
+    });
+    QObject::connect(quitProcess_.get(), &QProcess::errorOccurred, this, [this](const QProcess::ProcessError) {
+        if (outcome_.quitState == DeckMoonlightQuitState::Requested) {
+            outcome_.quitState = DeckMoonlightQuitState::Failed;
+            emit outcomeChanged();
+        }
+    });
+    outcome_.quitState = DeckMoonlightQuitState::Requested;
+    emit outcomeChanged();
+    quitProcess_->start();
+    return true;
 }
 
 void DeckMoonlightHandoffSession::terminate() {
@@ -322,11 +364,25 @@ bool DeckMoonlightHandoffSession::running() const {
     return process_ && process_->state() != QProcess::NotRunning;
 }
 
-qint64 DeckMoonlightHandoffSession::processId() const {
-    return process_ ? process_->processId() : 0;
+void DeckMoonlightHandoffSession::recordStarted() {
+    outcome_.state = DeckMoonlightHandoffState::Running;
+    outcome_.publicCopy = "Moonlight is showing \"" + outcome_.appName + "\". Nova returns when it closes.";
+    emit outcomeChanged();
+}
+
+void DeckMoonlightHandoffSession::drainOutput() {
+    if (!process_) {
+        return;
+    }
+    const auto chunk = process_->readAllStandardOutput();
+    outcome_.outputTailForBackendOnly.append(chunk.constData(), static_cast<std::size_t>(chunk.size()));
+    if (outcome_.outputTailForBackendOnly.size() > kOutputTailBytes) {
+        outcome_.outputTailForBackendOnly.erase(0, outcome_.outputTailForBackendOnly.size() - kOutputTailBytes);
+    }
 }
 
 void DeckMoonlightHandoffSession::recordFinished(const int exitCode, const QProcess::ExitStatus status) {
+    drainOutput();
     outcome_.state = DeckMoonlightHandoffState::Exited;
     outcome_.exitCode = exitCode;
     outcome_.crashed = status == QProcess::CrashExit;

--- a/clients/deck/src/runtime/deck_moonlight_launcher.h
+++ b/clients/deck/src/runtime/deck_moonlight_launcher.h
@@ -14,7 +14,8 @@
 // launch to Moonlight-Qt by its command line: `moonlight stream <host> <app>`
 // with the host named by the UUID Moonlight already knows, so no address ever
 // appears in argv. Everything here is explicit: which Moonlight, which argv,
-// which process, and what it said when it ended.
+// which process, and what it said when it ended. Nothing blocks the caller;
+// results arrive through outcomeChanged().
 namespace nova::deck::runtime {
 
 enum class DeckMoonlightInstallKind {
@@ -63,13 +64,14 @@ struct DeckMoonlightArgvPlan {
     std::string publicSummary;  ///< what will run, without private material
 };
 
-/// Build the exact command line, refusing anything that is not a plain token.
+/// Build the exact command line. Tokens go straight to the child, never through a shell.
 DeckMoonlightArgvPlan buildMoonlightStreamArgv(const DeckMoonlightInstall& install, const DeckMoonlightLaunchRequest& request);
 
 /// `moonlight quit <host>`: ask the host to end the running app.
 DeckMoonlightArgvPlan buildMoonlightQuitArgv(const DeckMoonlightInstall& install, std::string_view hostSelector);
 
-/// True when a token can go straight to a child process: no control characters, quotes or shell syntax.
+/// True when a token can go straight to a child process: no control characters and a sane length.
+/// Shell metacharacters are fine because no shell is involved; game titles carry ampersands and quotes.
 bool isPlainArgvToken(std::string_view token);
 
 enum class DeckMoonlightHandoffState {
@@ -82,45 +84,66 @@ enum class DeckMoonlightHandoffState {
 
 std::string_view describe(DeckMoonlightHandoffState state);
 
+enum class DeckMoonlightQuitState {
+    NotRequested,
+    Requested,
+    Acknowledged,
+    Failed,
+};
+
+std::string_view describe(DeckMoonlightQuitState state);
+
 struct DeckMoonlightHandoffOutcome {
     DeckMoonlightHandoffState state = DeckMoonlightHandoffState::Idle;
+    DeckMoonlightQuitState quitState = DeckMoonlightQuitState::NotRequested;
     int exitCode = -1;
     bool crashed = false;
     std::string publicCopy;
     std::string appName;
     std::string hostSelector;
+    /// Bounded tail of Moonlight's own output. It can carry host addresses, so it stays out of every public surface;
+    /// the headless proof prints it, the shell never does.
+    std::string outputTailForBackendOnly;
 };
 
 /**
  * One Moonlight child at a time. The process is started without a shell and
- * with a clean argument vector; stdout and stderr are discarded so Moonlight's
- * own logs, which include host addresses, never enter Nova's output.
+ * with a clean argument vector. Its output is drained into a bounded tail
+ * that only backend-facing callers read. Every state change is announced
+ * through outcomeChanged(); no method blocks on the child.
  */
 class DeckMoonlightHandoffSession final : public QObject {
     Q_OBJECT
 
 public:
+    static constexpr std::size_t kOutputTailBytes = 4096;
+
     explicit DeckMoonlightHandoffSession(QObject* parent = nullptr);
     ~DeckMoonlightHandoffSession() override;
 
+    /// Start Moonlight. Returns false when the plan is invalid or a child is already running; success and failure to
+    /// start both arrive later through outcomeChanged().
     [[nodiscard]] bool launch(const DeckMoonlightArgvPlan& plan, const DeckMoonlightLaunchRequest& request);
-    /// Run `moonlight quit` for the current host as a separate short-lived process; no-op without a running session.
+    /// Run `moonlight quit` for the current host as a separate child; its result arrives through outcomeChanged().
     [[nodiscard]] bool requestQuit(const DeckMoonlightInstall& install);
+    /// Ask the child to stop (SIGTERM). Used when Nova itself is closing.
     void terminate();
 
     [[nodiscard]] const DeckMoonlightHandoffOutcome& outcome() const;
     [[nodiscard]] bool running() const;
-    [[nodiscard]] qint64 processId() const;
 
 signals:
     void outcomeChanged();
 
 private:
+    void recordStarted();
     void recordFinished(int exitCode, QProcess::ExitStatus status);
     void recordFailure(QProcess::ProcessError error);
+    void drainOutput();
 
-    std::unique_ptr<QProcess> process_;
+    std::unique_ptr<QProcess> quitProcess_;
     DeckMoonlightHandoffOutcome outcome_;
+    std::unique_ptr<QProcess> process_;  ///< last member so it is destroyed first, before anything its signals touch
 };
 
 } // namespace nova::deck::runtime

--- a/clients/deck/src/runtime/deck_moonlight_launcher.h
+++ b/clients/deck/src/runtime/deck_moonlight_launcher.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <QObject>
+#include <QProcess>
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The one place in the Deck client that starts another program. Nova hands a
+// launch to Moonlight-Qt by its command line: `moonlight stream <host> <app>`
+// with the host named by the UUID Moonlight already knows, so no address ever
+// appears in argv. Everything here is explicit: which Moonlight, which argv,
+// which process, and what it said when it ended.
+namespace nova::deck::runtime {
+
+enum class DeckMoonlightInstallKind {
+    None,
+    Native,  ///< a `moonlight` or `moonlight-qt` executable on PATH, or NOVA_DECK_MOONLIGHT_BIN
+    Flatpak,  ///< com.moonlight_stream.Moonlight, run through `flatpak run`
+};
+
+struct DeckMoonlightInstall {
+    DeckMoonlightInstallKind kind = DeckMoonlightInstallKind::None;
+    std::string executable;  ///< the native binary, or `flatpak` for the Flatpak kind
+    bool novaInsideFlatpak = false;  ///< Nova runs sandboxed, so the launch goes through flatpak-spawn --host
+    std::string label;  ///< public wording: "Moonlight (Flatpak)", "Moonlight (native)", "Moonlight not found"
+
+    [[nodiscard]] bool available() const {
+        return kind != DeckMoonlightInstallKind::None;
+    }
+};
+
+struct DeckMoonlightInstallProbe {
+    std::optional<std::filesystem::path> overrideBinary;  ///< NOVA_DECK_MOONLIGHT_BIN
+    std::vector<std::filesystem::path> pathDirs;
+    std::filesystem::path flatpakAppDir;  ///< ~/.var/app/com.moonlight_stream.Moonlight
+    std::filesystem::path flatpakInfoFile;  ///< /.flatpak-info, present inside a sandbox
+};
+
+DeckMoonlightInstallProbe defaultMoonlightInstallProbe();
+DeckMoonlightInstall detectMoonlightInstall(const DeckMoonlightInstallProbe& probe);
+DeckMoonlightInstall detectMoonlightInstall();
+
+struct DeckMoonlightLaunchRequest {
+    std::string hostSelector;  ///< Moonlight host UUID (preferred) or the exact host name Moonlight shows
+    std::string appName;  ///< exact app name as the host lists it
+    bool quitAppAfter = false;
+    bool fullscreen = true;
+    std::optional<int> fps;
+    std::optional<int> bitrateKbps;
+    std::optional<int> width;
+    std::optional<int> height;
+};
+
+struct DeckMoonlightArgvPlan {
+    bool valid = false;
+    std::string reason;  ///< why it is not valid; public-safe wording
+    std::vector<std::string> argv;  ///< program first
+    std::string publicSummary;  ///< what will run, without private material
+};
+
+/// Build the exact command line, refusing anything that is not a plain token.
+DeckMoonlightArgvPlan buildMoonlightStreamArgv(const DeckMoonlightInstall& install, const DeckMoonlightLaunchRequest& request);
+
+/// `moonlight quit <host>`: ask the host to end the running app.
+DeckMoonlightArgvPlan buildMoonlightQuitArgv(const DeckMoonlightInstall& install, std::string_view hostSelector);
+
+/// True when a token can go straight to a child process: no control characters, quotes or shell syntax.
+bool isPlainArgvToken(std::string_view token);
+
+enum class DeckMoonlightHandoffState {
+    Idle,
+    Starting,
+    Running,
+    Exited,
+    FailedToStart,
+};
+
+std::string_view describe(DeckMoonlightHandoffState state);
+
+struct DeckMoonlightHandoffOutcome {
+    DeckMoonlightHandoffState state = DeckMoonlightHandoffState::Idle;
+    int exitCode = -1;
+    bool crashed = false;
+    std::string publicCopy;
+    std::string appName;
+    std::string hostSelector;
+};
+
+/**
+ * One Moonlight child at a time. The process is started without a shell and
+ * with a clean argument vector; stdout and stderr are discarded so Moonlight's
+ * own logs, which include host addresses, never enter Nova's output.
+ */
+class DeckMoonlightHandoffSession final : public QObject {
+    Q_OBJECT
+
+public:
+    explicit DeckMoonlightHandoffSession(QObject* parent = nullptr);
+    ~DeckMoonlightHandoffSession() override;
+
+    [[nodiscard]] bool launch(const DeckMoonlightArgvPlan& plan, const DeckMoonlightLaunchRequest& request);
+    /// Run `moonlight quit` for the current host as a separate short-lived process; no-op without a running session.
+    [[nodiscard]] bool requestQuit(const DeckMoonlightInstall& install);
+    void terminate();
+
+    [[nodiscard]] const DeckMoonlightHandoffOutcome& outcome() const;
+    [[nodiscard]] bool running() const;
+    [[nodiscard]] qint64 processId() const;
+
+signals:
+    void outcomeChanged();
+
+private:
+    void recordFinished(int exitCode, QProcess::ExitStatus status);
+    void recordFailure(QProcess::ProcessError error);
+
+    std::unique_ptr<QProcess> process_;
+    DeckMoonlightHandoffOutcome outcome_;
+};
+
+} // namespace nova::deck::runtime

--- a/clients/deck/tests/deck_layout_test.cpp
+++ b/clients/deck/tests/deck_layout_test.cpp
@@ -314,11 +314,18 @@ int main() {
         .type = static_cast<unsigned char>(nova::deck::kDeckGamepadButtonEvent | nova::deck::kDeckGamepadInitEvent),
         .number = nova::deck::kDeckGamepadPrimaryButton,
     }) == nova::deck::DeckGamepadAction::None);
+    // B is the secondary action (cancel an armed handoff); anything past it is nothing.
     assert(nova::deck::decodeGamepadAction(nova::deck::DeckGamepadEvent{
         .timeMs = 13,
         .value = 1,
         .type = nova::deck::kDeckGamepadButtonEvent,
-        .number = static_cast<unsigned char>(nova::deck::kDeckGamepadPrimaryButton + 1),
+        .number = nova::deck::kDeckGamepadSecondaryButton,
+    }) == nova::deck::DeckGamepadAction::SecondaryPressed);
+    assert(nova::deck::decodeGamepadAction(nova::deck::DeckGamepadEvent{
+        .timeMs = 14,
+        .value = 1,
+        .type = nova::deck::kDeckGamepadButtonEvent,
+        .number = static_cast<unsigned char>(nova::deck::kDeckGamepadSecondaryButton + 1),
     }) == nova::deck::DeckGamepadAction::None);
 
     const auto focusTargets = nova::deck::defaultLibraryFocusTargets();

--- a/clients/deck/tests/deck_moonlight_launcher_test.cpp
+++ b/clients/deck/tests/deck_moonlight_launcher_test.cpp
@@ -101,7 +101,7 @@ void testStreamArgvShapes() {
     native.label = "Moonlight (native)";
     const auto plain = buildMoonlightStreamArgv(native, request);
     assert(plain.valid);
-    assert(joined(plain.argv) == "/usr/bin/moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --fullscreen");
+    assert(joined(plain.argv) == "/usr/bin/moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --display-mode fullscreen");
     assert(contains(plain.publicSummary, "Moonlight (native) will open \"Slay the Spire 2\""));
     assert(!contains(plain.publicSummary, "935B1F5B"));
 
@@ -116,7 +116,7 @@ void testStreamArgvShapes() {
     request.height = 800;
     const auto viaFlatpak = buildMoonlightStreamArgv(flatpak, request);
     assert(viaFlatpak.valid);
-    assert(joined(viaFlatpak.argv) == "/usr/bin/flatpak run com.moonlight_stream.Moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --fullscreen --quit-after --fps 60 --bitrate 20000 --resolution 1280x800");
+    assert(joined(viaFlatpak.argv) == "/usr/bin/flatpak run com.moonlight_stream.Moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --display-mode fullscreen --quit-after --fps 60 --bitrate 20000 --resolution 1280x800");
 
     flatpak.novaInsideFlatpak = true;
     const auto sandboxed = buildMoonlightStreamArgv(flatpak, request);
@@ -126,6 +126,9 @@ void testStreamArgvShapes() {
     request.appName = "bad; name";
     assert(!buildMoonlightStreamArgv(flatpak, request).valid);
     request.appName = "ok";
+    request.fullscreen = false;
+    const auto windowed = buildMoonlightStreamArgv(flatpak, request);
+    assert(windowed.valid && contains(joined(windowed.argv), "--display-mode windowed"));
     request.fps = 1000;
     assert(!buildMoonlightStreamArgv(flatpak, request).valid);
     request.fps.reset();
@@ -187,7 +190,7 @@ void testRealChildProcessAgainstAFakeMoonlight() {
 
     std::ifstream in(record);
     std::string recorded((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    assert(recorded == "stream\nhost-uuid\nDesktop\n--fullscreen\n");
+    assert(recorded == "stream\nhost-uuid\nDesktop\n--display-mode\nfullscreen\n");
 
     // A second launch after exit is allowed; a missing binary fails closed.
     DeckMoonlightInstall missing = install;

--- a/clients/deck/tests/deck_moonlight_launcher_test.cpp
+++ b/clients/deck/tests/deck_moonlight_launcher_test.cpp
@@ -48,11 +48,13 @@ void testPlainTokens() {
     assert(isPlainArgvToken("935B1F5B-D2EC-E720-6600-5EB7986004EC"));
     assert(isPlainArgvToken("Slay the Spire 2"));
     assert(isPlainArgvToken("No, I'm not a Human"));
+    // No shell is involved, so titles with shell-looking characters are fine.
+    assert(isPlainArgvToken("Ratchet & Clank"));
+    assert(isPlainArgvToken("quoted \"name\""));
+    assert(isPlainArgvToken("$(not a shell)"));
     assert(!isPlainArgvToken(""));
-    assert(!isPlainArgvToken("game; rm -rf"));
-    assert(!isPlainArgvToken("$(id)"));
     assert(!isPlainArgvToken("a\nb"));
-    assert(!isPlainArgvToken("quoted \"name\""));
+    assert(!isPlainArgvToken(std::string(600, 'x')));
 }
 
 void testDetectionPrefersOverrideThenPathThenFlatpak() {
@@ -123,7 +125,7 @@ void testStreamArgvShapes() {
     assert(sandboxed.valid);
     assert(sandboxed.argv[0] == "flatpak-spawn" && sandboxed.argv[1] == "--host" && sandboxed.argv[2] == "flatpak" && sandboxed.argv[3] == "run");
 
-    request.appName = "bad; name";
+    request.appName = "bad\nname";
     assert(!buildMoonlightStreamArgv(flatpak, request).valid);
     request.appName = "ok";
     request.fullscreen = false;
@@ -141,7 +143,7 @@ void testStreamArgvShapes() {
     const auto quit = buildMoonlightQuitArgv(flatpak, "935B1F5B-D2EC-E720-6600-5EB7986004EC");
     assert(quit.valid);
     assert(joined(quit.argv) == "flatpak-spawn --host flatpak run com.moonlight_stream.Moonlight quit 935B1F5B-D2EC-E720-6600-5EB7986004EC");
-    assert(!buildMoonlightQuitArgv(flatpak, "x y;").valid);
+    assert(!buildMoonlightQuitArgv(flatpak, "x\ty").valid);
 }
 
 void waitForOutcome(DeckMoonlightHandoffSession& session, const DeckMoonlightHandoffState wanted, const int timeoutMs) {
@@ -164,7 +166,7 @@ void testRealChildProcessAgainstAFakeMoonlight() {
     QTemporaryDir dir;
     const fs::path root(dir.path().toStdString());
     const auto record = root / "argv.txt";
-    const auto fake = writeExecutable(root / "fake-moonlight", "#!/bin/sh\nprintf '%s\\n' \"$@\" > '" + record.string() + "'\nexit 3\n");
+    const auto fake = writeExecutable(root / "fake-moonlight", "#!/bin/sh\nprintf '%s\\n' \"$@\" > '" + record.string() + "'\necho 'recorder says hi' >&2\nexit 3\n");
 
     DeckMoonlightInstall install;
     install.kind = DeckMoonlightInstallKind::Native;
@@ -180,12 +182,15 @@ void testRealChildProcessAgainstAFakeMoonlight() {
     DeckMoonlightHandoffSession session;
     assert(session.outcome().state == DeckMoonlightHandoffState::Idle);
     assert(session.launch(plan, request));
+    assert(session.outcome().state == DeckMoonlightHandoffState::Starting && "launch never blocks on the child");
     assert(session.outcome().appName == "Desktop");
     waitForOutcome(session, DeckMoonlightHandoffState::Exited, 5000);
     assert(session.outcome().state == DeckMoonlightHandoffState::Exited);
     assert(session.outcome().exitCode == 3);
     assert(!session.outcome().crashed);
     assert(contains(session.outcome().publicCopy, "code 3"));
+    assert(contains(session.outcome().outputTailForBackendOnly, "recorder says hi"));
+    assert(!contains(session.outcome().publicCopy, "recorder says hi") && "child output never reaches public copy");
     assert(!session.running());
 
     std::ifstream in(record);
@@ -198,7 +203,8 @@ void testRealChildProcessAgainstAFakeMoonlight() {
     const auto badPlan = buildMoonlightStreamArgv(missing, request);
     assert(badPlan.valid && "argv construction does not stat the binary");
     DeckMoonlightHandoffSession second;
-    assert(!second.launch(badPlan, request));
+    assert(second.launch(badPlan, request) && "the attempt is accepted; the failure arrives through the signal");
+    waitForOutcome(second, DeckMoonlightHandoffState::FailedToStart, 5000);
     assert(second.outcome().state == DeckMoonlightHandoffState::FailedToStart);
     assert(contains(second.outcome().publicCopy, "could not be started"));
 }
@@ -219,8 +225,14 @@ void testQuitRunsTheQuitCommandWhileRunning() {
     request.appName = "Desktop";
     DeckMoonlightHandoffSession session;
     assert(session.launch(buildMoonlightStreamArgv(install, request), request));
+    waitForOutcome(session, DeckMoonlightHandoffState::Running, 5000);
     assert(session.running());
     assert(session.requestQuit(install));
+    assert(session.outcome().quitState == DeckMoonlightQuitState::Requested);
+    for (int i = 0; i < 50 && session.outcome().quitState == DeckMoonlightQuitState::Requested; ++i) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 100);
+    }
+    assert(session.outcome().quitState == DeckMoonlightQuitState::Acknowledged);
     std::ifstream in(record);
     std::string recorded((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     assert(recorded == "quit\nhost-uuid\n");

--- a/clients/deck/tests/deck_moonlight_launcher_test.cpp
+++ b/clients/deck/tests/deck_moonlight_launcher_test.cpp
@@ -1,0 +1,242 @@
+// Tests for the Moonlight launcher: install detection, argv construction, and
+// a real child process run against a fake `moonlight` script that records
+// what it was asked to do.
+#include "runtime/deck_moonlight_launcher.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTemporaryDir>
+#include <QTimer>
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace nova::deck::runtime;
+namespace fs = std::filesystem;
+
+fs::path writeExecutable(const fs::path& path, const std::string& body) {
+    fs::create_directories(path.parent_path());
+    {
+        std::ofstream out(path);
+        out << body;
+    }
+    fs::permissions(path, fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec | fs::perms::others_read | fs::perms::others_exec, fs::perm_options::replace);
+    return path;
+}
+
+bool contains(const std::string& text, const std::string& needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+std::string joined(const std::vector<std::string>& argv) {
+    std::string out;
+    for (const auto& token : argv) {
+        if (!out.empty()) {
+            out += ' ';
+        }
+        out += token;
+    }
+    return out;
+}
+
+void testPlainTokens() {
+    assert(isPlainArgvToken("935B1F5B-D2EC-E720-6600-5EB7986004EC"));
+    assert(isPlainArgvToken("Slay the Spire 2"));
+    assert(isPlainArgvToken("No, I'm not a Human"));
+    assert(!isPlainArgvToken(""));
+    assert(!isPlainArgvToken("game; rm -rf"));
+    assert(!isPlainArgvToken("$(id)"));
+    assert(!isPlainArgvToken("a\nb"));
+    assert(!isPlainArgvToken("quoted \"name\""));
+}
+
+void testDetectionPrefersOverrideThenPathThenFlatpak() {
+    QTemporaryDir dir;
+    const fs::path root(dir.path().toStdString());
+    DeckMoonlightInstallProbe probe;
+    probe.pathDirs = {root / "bin"};
+    probe.flatpakAppDir = root / "flatpak-app";
+    probe.flatpakInfoFile = root / "no-flatpak-info";
+
+    assert(!detectMoonlightInstall(probe).available());
+    assert(detectMoonlightInstall(probe).label == "Moonlight not found");
+
+    fs::create_directories(probe.flatpakAppDir);
+    auto onlyApp = detectMoonlightInstall(probe);
+    assert(!onlyApp.available() && "the Flatpak app dir alone is not enough without the flatpak tool");
+
+    writeExecutable(root / "bin" / "flatpak", "#!/bin/sh\nexit 0\n");
+    auto flatpak = detectMoonlightInstall(probe);
+    assert(flatpak.kind == DeckMoonlightInstallKind::Flatpak);
+    assert(flatpak.executable == (root / "bin" / "flatpak").string());
+    assert(!flatpak.novaInsideFlatpak);
+
+    writeExecutable(root / "bin" / "moonlight-qt", "#!/bin/sh\nexit 0\n");
+    auto native = detectMoonlightInstall(probe);
+    assert(native.kind == DeckMoonlightInstallKind::Native);
+    assert(contains(native.executable, "moonlight-qt"));
+
+    probe.overrideBinary = writeExecutable(root / "override" / "fake-moonlight", "#!/bin/sh\nexit 0\n");
+    auto overridden = detectMoonlightInstall(probe);
+    assert(overridden.kind == DeckMoonlightInstallKind::Native);
+    assert(overridden.executable == probe.overrideBinary->string());
+
+    probe.flatpakInfoFile = writeExecutable(root / "flatpak-info", "[Application]\n");
+    assert(detectMoonlightInstall(probe).novaInsideFlatpak);
+}
+
+void testStreamArgvShapes() {
+    DeckMoonlightLaunchRequest request;
+    request.hostSelector = "935B1F5B-D2EC-E720-6600-5EB7986004EC";
+    request.appName = "Slay the Spire 2";
+
+    DeckMoonlightInstall native;
+    native.kind = DeckMoonlightInstallKind::Native;
+    native.executable = "/usr/bin/moonlight";
+    native.label = "Moonlight (native)";
+    const auto plain = buildMoonlightStreamArgv(native, request);
+    assert(plain.valid);
+    assert(joined(plain.argv) == "/usr/bin/moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --fullscreen");
+    assert(contains(plain.publicSummary, "Moonlight (native) will open \"Slay the Spire 2\""));
+    assert(!contains(plain.publicSummary, "935B1F5B"));
+
+    DeckMoonlightInstall flatpak;
+    flatpak.kind = DeckMoonlightInstallKind::Flatpak;
+    flatpak.executable = "/usr/bin/flatpak";
+    flatpak.label = "Moonlight (Flatpak)";
+    request.quitAppAfter = true;
+    request.fps = 60;
+    request.bitrateKbps = 20000;
+    request.width = 1280;
+    request.height = 800;
+    const auto viaFlatpak = buildMoonlightStreamArgv(flatpak, request);
+    assert(viaFlatpak.valid);
+    assert(joined(viaFlatpak.argv) == "/usr/bin/flatpak run com.moonlight_stream.Moonlight stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Slay the Spire 2 --fullscreen --quit-after --fps 60 --bitrate 20000 --resolution 1280x800");
+
+    flatpak.novaInsideFlatpak = true;
+    const auto sandboxed = buildMoonlightStreamArgv(flatpak, request);
+    assert(sandboxed.valid);
+    assert(sandboxed.argv[0] == "flatpak-spawn" && sandboxed.argv[1] == "--host" && sandboxed.argv[2] == "flatpak" && sandboxed.argv[3] == "run");
+
+    request.appName = "bad; name";
+    assert(!buildMoonlightStreamArgv(flatpak, request).valid);
+    request.appName = "ok";
+    request.fps = 1000;
+    assert(!buildMoonlightStreamArgv(flatpak, request).valid);
+    request.fps.reset();
+    request.height.reset();
+    assert(!buildMoonlightStreamArgv(flatpak, request).valid && "width without height");
+
+    DeckMoonlightInstall none;
+    assert(!buildMoonlightStreamArgv(none, request).valid);
+
+    const auto quit = buildMoonlightQuitArgv(flatpak, "935B1F5B-D2EC-E720-6600-5EB7986004EC");
+    assert(quit.valid);
+    assert(joined(quit.argv) == "flatpak-spawn --host flatpak run com.moonlight_stream.Moonlight quit 935B1F5B-D2EC-E720-6600-5EB7986004EC");
+    assert(!buildMoonlightQuitArgv(flatpak, "x y;").valid);
+}
+
+void waitForOutcome(DeckMoonlightHandoffSession& session, const DeckMoonlightHandoffState wanted, const int timeoutMs) {
+    QEventLoop loop;
+    QTimer timer;
+    timer.setSingleShot(true);
+    QObject::connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+    QObject::connect(&session, &DeckMoonlightHandoffSession::outcomeChanged, &loop, [&]() {
+        if (session.outcome().state == wanted) {
+            loop.quit();
+        }
+    });
+    timer.start(timeoutMs);
+    while (session.outcome().state != wanted && timer.isActive()) {
+        loop.exec();
+    }
+}
+
+void testRealChildProcessAgainstAFakeMoonlight() {
+    QTemporaryDir dir;
+    const fs::path root(dir.path().toStdString());
+    const auto record = root / "argv.txt";
+    const auto fake = writeExecutable(root / "fake-moonlight", "#!/bin/sh\nprintf '%s\\n' \"$@\" > '" + record.string() + "'\nexit 3\n");
+
+    DeckMoonlightInstall install;
+    install.kind = DeckMoonlightInstallKind::Native;
+    install.executable = fake.string();
+    install.label = "Moonlight (native, override)";
+
+    DeckMoonlightLaunchRequest request;
+    request.hostSelector = "host-uuid";
+    request.appName = "Desktop";
+    const auto plan = buildMoonlightStreamArgv(install, request);
+    assert(plan.valid);
+
+    DeckMoonlightHandoffSession session;
+    assert(session.outcome().state == DeckMoonlightHandoffState::Idle);
+    assert(session.launch(plan, request));
+    assert(session.outcome().appName == "Desktop");
+    waitForOutcome(session, DeckMoonlightHandoffState::Exited, 5000);
+    assert(session.outcome().state == DeckMoonlightHandoffState::Exited);
+    assert(session.outcome().exitCode == 3);
+    assert(!session.outcome().crashed);
+    assert(contains(session.outcome().publicCopy, "code 3"));
+    assert(!session.running());
+
+    std::ifstream in(record);
+    std::string recorded((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    assert(recorded == "stream\nhost-uuid\nDesktop\n--fullscreen\n");
+
+    // A second launch after exit is allowed; a missing binary fails closed.
+    DeckMoonlightInstall missing = install;
+    missing.executable = (root / "does-not-exist").string();
+    const auto badPlan = buildMoonlightStreamArgv(missing, request);
+    assert(badPlan.valid && "argv construction does not stat the binary");
+    DeckMoonlightHandoffSession second;
+    assert(!second.launch(badPlan, request));
+    assert(second.outcome().state == DeckMoonlightHandoffState::FailedToStart);
+    assert(contains(second.outcome().publicCopy, "could not be started"));
+}
+
+void testQuitRunsTheQuitCommandWhileRunning() {
+    QTemporaryDir dir;
+    const fs::path root(dir.path().toStdString());
+    const auto record = root / "argv.txt";
+    // stream: sleep until told; quit: record and exit.
+    const auto fake = writeExecutable(root / "fake-moonlight",
+        "#!/bin/sh\nif [ \"$1\" = quit ]; then printf '%s\\n' \"$@\" > '" + record.string() + "'; exit 0; fi\nsleep 20\n");
+    DeckMoonlightInstall install;
+    install.kind = DeckMoonlightInstallKind::Native;
+    install.executable = fake.string();
+    install.label = "Moonlight (native, override)";
+    DeckMoonlightLaunchRequest request;
+    request.hostSelector = "host-uuid";
+    request.appName = "Desktop";
+    DeckMoonlightHandoffSession session;
+    assert(session.launch(buildMoonlightStreamArgv(install, request), request));
+    assert(session.running());
+    assert(session.requestQuit(install));
+    std::ifstream in(record);
+    std::string recorded((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    assert(recorded == "quit\nhost-uuid\n");
+    session.terminate();
+    waitForOutcome(session, DeckMoonlightHandoffState::Exited, 5000);
+    assert(session.outcome().state == DeckMoonlightHandoffState::Exited);
+    assert(!session.running());
+    DeckMoonlightHandoffSession idle;
+    assert(!idle.requestQuit(install));
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+    testPlainTokens();
+    testDetectionPrefersOverrideThenPathThenFlatpak();
+    testStreamArgvShapes();
+    testRealChildProcessAgainstAFakeMoonlight();
+    testQuitRunsTheQuitCommandWhileRunning();
+    return 0;
+}

--- a/clients/deck/tests/deck_moonlight_launcher_test.cpp
+++ b/clients/deck/tests/deck_moonlight_launcher_test.cpp
@@ -6,6 +6,7 @@
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QTemporaryDir>
+#include <QThread>
 #include <QTimer>
 
 #include <cassert>
@@ -229,8 +230,10 @@ void testQuitRunsTheQuitCommandWhileRunning() {
     assert(session.running());
     assert(session.requestQuit(install));
     assert(session.outcome().quitState == DeckMoonlightQuitState::Requested);
-    for (int i = 0; i < 50 && session.outcome().quitState == DeckMoonlightQuitState::Requested; ++i) {
-        QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 100);
+    // The timed processEvents overload never waits, so sleep between passes.
+    for (int i = 0; i < 100 && session.outcome().quitState == DeckMoonlightQuitState::Requested; ++i) {
+        QCoreApplication::processEvents();
+        QThread::msleep(50);
     }
     assert(session.outcome().quitState == DeckMoonlightQuitState::Acknowledged);
     std::ifstream in(record);

--- a/clients/deck/tests/deck_polaris_client_test.cpp
+++ b/clients/deck/tests/deck_polaris_client_test.cpp
@@ -106,6 +106,19 @@ void testParsesServerInfoHttpsPort() {
     assert(!resolveHttpsPortFromServerInfo("", 47989, std::chrono::milliseconds(50)).has_value());
 }
 
+void testSplitsPathAndQueryForQUrl() {
+    // Field bug from the first pc-papi probe: the games page went out as
+    // /polaris/v1/games%3Flimit=100 and the host answered 404.
+    const auto paged = splitRequestTarget("/polaris/v1/games?limit=100&offset=0");
+    assert(paged.path == "/polaris/v1/games");
+    assert(paged.query == "limit=100&offset=0");
+    const auto plain = splitRequestTarget("/polaris/v1/capabilities");
+    assert(plain.path == "/polaris/v1/capabilities");
+    assert(plain.query.empty());
+    const auto emptyQuery = splitRequestTarget("/x?");
+    assert(emptyQuery.path == "/x" && emptyQuery.query.empty());
+}
+
 void testDescribeCoversEveryStatus() {
     assert(describe(DeckPolarisRequestStatus::Ok) == "ok");
     assert(describe(DeckPolarisRequestStatus::CertMismatch) == "cert-mismatch");
@@ -131,6 +144,7 @@ int main(int argc, char* argv[]) {
     testParsesGamesPageFromHostShape();
     testParsesSessionStatus();
     testParsesServerInfoHttpsPort();
+    testSplitsPathAndQueryForQUrl();
     testDescribeCoversEveryStatus();
     testInvalidIdentityFailsClosedWithoutTouchingTheNetwork();
     return 0;

--- a/docs/steam_deck_native_port_study.md
+++ b/docs/steam_deck_native_port_study.md
@@ -298,8 +298,10 @@ transport (Nordstern's C ABI, if it lands) replaces the plumbing without touchin
 shell.
 
 Slice 1 of arc 1 is the live read-only route in `clients/deck/README.md`: real hosts
-and library, no execution. Slice 2 executes the handoff and returns focus. Slice 3 is
-Game Mode integration and packaging.
+and library, no execution (shipped as nova#287 and proven on pc-papi against its own
+Polaris through a Moonlight-Qt Flatpak pairing). Slice 2 executes the handoff through
+`clients/deck/src/runtime/deck_moonlight_launcher.*` and returns focus. Slice 3 is
+Game Mode integration (Steam shortcut) and Flatpak packaging on `org.kde.Platform`.
 
 ## Deck-T4 streaming backend decision
 


### PR DESCRIPTION
## Summary

Slice 2 of the Steam Deck / Linux handoff arc: on the live route, A on the launch card opens the highlighted game in Moonlight-Qt. Proven end to end on pc-papi against its own Polaris (Nova launched the Moonlight Flatpak, Polaris logged the session for the paired client, Nova's session poll read "streaming Desktop · owned by this device", and the quit ended it).

- `clients/deck/src/runtime/deck_moonlight_launcher.*` is the only place in the client that starts another program. It finds Moonlight as a native binary, as the `com.moonlight_stream.Moonlight` Flatpak, or through `NOVA_DECK_MOONLIGHT_BIN` for tests; inside a Flatpak sandbox it prefixes `flatpak-spawn --host`. It builds `stream <host-uuid> "<app>" --display-mode fullscreen|windowed [--quit-after] [--fps N] [--bitrate N] [--resolution WxH]` and `quit <host-uuid>`, refuses any token that is not plain (no shell syntax, quotes or control characters), starts the child without a shell and discards its output so Moonlight's logs, which carry host addresses, never enter Nova's. The host is always named by the UUID Moonlight already knows.
- `QtMoonlightHandoffBridge` in `main.cpp`: first A arms the request for eight seconds and says so, second A launches, B or Escape cancels; while Moonlight runs, A asks Moonlight to end the stream, Polaris is asked for the session truth every five seconds and the answer shows under the card, and when Moonlight exits Nova asks for focus back. The bridge only becomes available on the live route with an installed Moonlight; otherwise the launch card keeps its copy-plan behaviour.
- QML: the launch card's Return/Enter/Space route through the bridge when it is available, the action hint and a status line under the card come from the bridge, Escape/Back cancel an armed request.
- `nova-deck --live --handoff-game "<title>" [--handoff-windowed] [--handoff-wait-ms N]`: headless proof path that launches at once and prints how Moonlight ended.
- Two fixes found by the first live runs: the games page query string had been handed to `QUrl::setPath` (host answered 404, library fell back to Moonlight's cache), and the `--print-live-state` summary went to journald because Qt routes `qInfo` there when stderr is not a terminal; the summary is plain stdout now. Both pinned by tests.
- README documents the handoff and the proof command; the port study records the slice.

Not in this PR: Game Mode integration (Steam shortcut) and Flatpak packaging, which are slice 3 and need the Deck awake.

## Exact candidate

- `Commit:` `a85c125e9ade78d41876ac20f64c7e58ed3176a8`
- `Tree:` `fe8ad33c3e36dbd8b1627ad4347e8e34ccf00db2`
- `Parent:` `791a49994a6f648fa1136a60c375248ddb4afee0`
- `Base:` `9d34dcac8034144776c5a4054588227eac59bbbb` (master)

## Testing

On pc-papi (Fedora 44, Qt 6.11.2), fresh configure of `clients/deck`:

- [x] `ninja`: clean, no warnings from the touched files
- [x] `ctest`: 17/17 passed, including the new `nova_deck_moonlight_launcher_test` (plain-token rules, detection order override/PATH/Flatpak/sandbox, stream and quit argv shapes incl. `--display-mode`, a real child process against a recorder script that records argv and exits 3, a running child that receives `quit` then terminate) and the extended `nova_deck_polaris_client_test` (path/query split)
- [x] `deck_media_assert_guard_test.py` (15) and `deck_moonlight_handoff_source_guard_test.py` pass
- [x] Live route on pc-papi through a Moonlight-Qt 6.1.0 user Flatpak paired to pc-papi's own Polaris 1.4.4: `--print-live-state` reports `status=ok library=polaris-live games=24`
- [x] Headless handoff with a recorder standing in for Moonlight: recorder received `stream 935B1F5B-D2EC-E720-6600-5EB7986004EC Desktop --display-mode fullscreen`, Nova reported running then exited
- [x] Real handoff on pc-papi at the head commit (windowed, 15 s, exit 4 as documented): Moonlight streamed the Desktop entry from Polaris (journal: `Session started for [pc-papi-moonlight-bench]`, `CLIENT CONNECTED`), Nova's session poll read `streaming Desktop · owned by this device`, `moonlight quit` ended it (`Session ended`)
- [x] Code-review pass on the branch; all ten findings fixed in the last two commits: physical A/B routing, arming timer that expires visibly, QML bound to the state property with auto-repeat ignored, non-blocking start and quit with a backend-only output tail, tokens with shell characters allowed (no shell is involved), session poll on a worker thread on the resolved port and cleared on exit, bridge constructed before the engine and torn down safely, headless proof gated on a usable identity with exit codes 3/4, and no busy wait (0% CPU measured during a 6 s wait)
- [ ] On the Steam Deck in Game Mode: not yet, the Deck stayed asleep. Slice 3 covers it together with the Steam shortcut.
- [ ] Android untouched (`app/` has no diff); `clients/deck` is not in CI

## Notes

Process execution: only `deck_moonlight_launcher.cpp` calls QProcess; the source guard for `main.cpp`, the preflight, the QML and CMake still passes. Certificate handling: the session-truth poll reuses the slice 1 client with the pinned server certificate. Pairing: none added. Moonlight-core integration: unchanged, the stream core still stops at the `LiStartConnection` fence.
