### PR TITLE
feat(deck): package the shell as a Flatpak and register it with Steam for Game Mode

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(nova_deck_core
     src/polaris/deck_polaris_client.cpp
     src/backend/deck_live_read_only_state.cpp
     src/runtime/deck_moonlight_launcher.cpp
+    src/runtime/deck_steam_shortcuts.cpp
 )
 set_target_properties(nova_deck_core PROPERTIES AUTOMOC ON)
 
@@ -126,6 +127,12 @@ if(BUILD_TESTING)
     add_test(NAME nova_deck_moonlight_launcher_test COMMAND nova_deck_moonlight_launcher_test)
     set_tests_properties(nova_deck_moonlight_launcher_test PROPERTIES TIMEOUT 60)
 
+    add_executable(nova_deck_steam_shortcuts_test
+        tests/deck_steam_shortcuts_test.cpp
+    )
+    target_link_libraries(nova_deck_steam_shortcuts_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_steam_shortcuts_test COMMAND nova_deck_steam_shortcuts_test)
+
     add_executable(nova_deck_qsg_render_node_scenegraph_smoke
         tests/deck_qsg_render_node_scenegraph_smoke.cpp
     )
@@ -187,6 +194,17 @@ if(NOVA_DECK_BUILD_QT_SHELL)
                 Qt6::Quick
                 Qt6::QuickControls2
         )
+
+        include(GNUInstallDirs)
+        install(TARGETS nova-deck RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        install(FILES fixtures/sample_polaris_game.json fixtures/sample_polaris_library.json
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/nova-deck/fixtures)
+        install(FILES packaging/flatpak/com.papi_ux.Nova.desktop
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+        install(FILES packaging/flatpak/com.papi_ux.Nova.svg
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
+        install(FILES packaging/flatpak/com.papi_ux.Nova.metainfo.xml
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 
         if(BUILD_TESTING)
             add_test(NAME nova_deck_qt_shell_smoke COMMAND nova-deck --smoke-exit)

--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -21,7 +21,7 @@ pkg_check_modules(NOVA_DECK_LINUX_AUDIO REQUIRED IMPORTED_TARGET
 )
 find_package(Qt6 REQUIRED COMPONENTS Quick Network)
 
-add_library(nova_deck_core
+add_library(nova_deck_core STATIC
     src/deck_gamepad.cpp
     src/deck_layout.cpp
     src/polaris_game_fixture.cpp
@@ -45,11 +45,13 @@ set(NOVA_DECK_MOONLIGHT_COMMON_C_DIR
 if(EXISTS "${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}/src/Limelight.h")
     # moonlight-common-c defaults to a shared library when BUILD_SHARED_LIBS is
     # unset; the Deck shell links it statically so an installed binary (the
-    # Flatpak, a Deck copy) carries it instead of hunting for the .so.
-    if(NOT DEFINED BUILD_SHARED_LIBS)
+    # Flatpak, a Deck copy) carries it instead of hunting for the .so. The
+    # function scope keeps the override away from the caller's own setting.
+    function(nova_deck_add_moonlight_common_c source_dir binary_dir)
         set(BUILD_SHARED_LIBS OFF)
-    endif()
-    add_subdirectory("${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/moonlight-common-c")
+        add_subdirectory("${source_dir}" "${binary_dir}")
+    endfunction()
+    nova_deck_add_moonlight_common_c("${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/moonlight-common-c")
     target_link_libraries(nova_deck_core PUBLIC moonlight-common-c)
 else()
     message(FATAL_ERROR "moonlight-common-c is required for the Deck stream skeleton; expected ${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}/src/Limelight.h")
@@ -66,10 +68,12 @@ target_link_libraries(nova_deck_core
         Qt6::Quick
         Qt6::Network
 )
+include(GNUInstallDirs)
 target_compile_definitions(nova_deck_core
     PUBLIC
         NOVA_DECK_SAMPLE_GAME_FIXTURE=\"${CMAKE_CURRENT_SOURCE_DIR}/fixtures/sample_polaris_game.json\"
         NOVA_DECK_SAMPLE_LIBRARY_FIXTURE=\"${CMAKE_CURRENT_SOURCE_DIR}/fixtures/sample_polaris_library.json\"
+        NOVA_DECK_INSTALL_FIXTURE_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}/nova-deck/fixtures\"
 )
 
 include(CTest)
@@ -201,7 +205,6 @@ if(NOVA_DECK_BUILD_QT_SHELL)
                 Qt6::QuickControls2
         )
 
-        include(GNUInstallDirs)
         install(TARGETS nova-deck RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         install(FILES fixtures/sample_polaris_game.json fixtures/sample_polaris_library.json
             DESTINATION ${CMAKE_INSTALL_DATADIR}/nova-deck/fixtures)

--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -43,6 +43,12 @@ set(NOVA_DECK_MOONLIGHT_COMMON_C_DIR
     "Path to the checked-out moonlight-common-c source tree used by the Deck stream skeleton"
 )
 if(EXISTS "${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}/src/Limelight.h")
+    # moonlight-common-c defaults to a shared library when BUILD_SHARED_LIBS is
+    # unset; the Deck shell links it statically so an installed binary (the
+    # Flatpak, a Deck copy) carries it instead of hunting for the .so.
+    if(NOT DEFINED BUILD_SHARED_LIBS)
+        set(BUILD_SHARED_LIBS OFF)
+    endif()
     add_subdirectory("${NOVA_DECK_MOONLIGHT_COMMON_C_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/moonlight-common-c")
     target_link_libraries(nova_deck_core PUBLIC moonlight-common-c)
 else()

--- a/clients/deck/README.md
+++ b/clients/deck/README.md
@@ -84,6 +84,10 @@ Headless proof, with a real Moonlight or a recorder script:
 
 It prints the launch phase, how Moonlight ended, and a bounded tail of Moonlight's own output (backend-only: it can carry host addresses, so the shell never shows it). Exit codes: 0 launched and exited, 3 never launched, 4 still running when the wait ran out. Add `--handoff-windowed` to keep a real Moonlight in a window, for a proof on a desktop rather than a Deck.
 
+## Game Mode and packaging
+
+`packaging/flatpak/` builds the shell as the `com.papi_ux.Nova` Flatpak on `org.kde.Platform` 6.10, the runtime Moonlight-Qt already installs on a Steam Deck; see its README for the build, install and permission notes. `nova-deck --register-steam-shortcut` adds Nova to Steam as a non-Steam game so Game Mode can launch it: `src/runtime/deck_steam_shortcuts.*` parses and rewrites Steam's binary `shortcuts.vdf` byte for byte, registers or replaces one "Nova" entry, writes atomically, and refuses while Steam runs because Steam rewrites that file on exit. Inside the Flatpak the entry runs `flatpak run com.papi_ux.Nova --live`. Fixtures are found at runtime under `/app/share/nova-deck/fixtures` or next to the installed binary before the source tree is tried, and moonlight-common-c is linked statically so an installed binary carries it.
+
 ## Shared Polaris DTO boundary
 
 Native C++ cannot include Kotlin source directly. For this first slice, fixtures/sample_polaris_game.json is a generated/shared-contract sample using the same snake_case keys covered by the Kotlin shared DTO tests. src/polaris_game_fixture.h and src/polaris_game_fixture.cpp load that fixture into a tiny native projection so the Deck shell can exercise a real library-card shape while the actual native Polaris API/client bridge is still future work.

--- a/clients/deck/packaging/flatpak/README.md
+++ b/clients/deck/packaging/flatpak/README.md
@@ -1,0 +1,22 @@
+# Nova Flatpak (Deck and Linux desktops)
+
+`com.papi_ux.Nova` runs on `org.kde.Platform` 6.10, the runtime Moonlight-Qt already installs on a Steam Deck. It carries the Deck shell only; Moonlight-Qt stays its own Flatpak and does the streaming.
+
+Build a bundle from a checkout with its submodules initialised (moonlight-common-c is in-tree):
+
+    flatpak install --user flathub org.kde.Platform//6.10 org.kde.Sdk//6.10
+    flatpak-builder --user --force-clean --repo=build/flatpak-repo build/flatpak clients/deck/packaging/flatpak/com.papi_ux.Nova.json
+    flatpak build-bundle build/flatpak-repo build/Nova.flatpak com.papi_ux.Nova
+
+Install and run it (Desktop Mode on a Deck, or any desktop):
+
+    flatpak install --user build/Nova.flatpak
+    flatpak run com.papi_ux.Nova --print-live-state
+
+Permissions, and why: network for Polaris; wayland and dri for the shell; `input` for the Deck's controls; read-only access to Moonlight's config, which is where the pairing lives; `org.freedesktop.Flatpak` so the sandbox can ask the host to run `flatpak run com.moonlight_stream.Moonlight`; the Steam userdata directories so `--register-steam-shortcut` can add Nova to Game Mode.
+
+Register Nova with Steam from Desktop Mode, with Steam closed:
+
+    flatpak run com.papi_ux.Nova --register-steam-shortcut
+
+The shortcut runs `flatpak run com.papi_ux.Nova --live`; Steam shows it as "Nova" and Game Mode launches it like any other non-Steam game.

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.desktop
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Nova
+GenericName=Polaris game streaming client
+Comment=Your Polaris library on the Deck, streamed through Moonlight
+Exec=nova-deck --live
+Icon=com.papi_ux.Nova
+Terminal=false
+Categories=Game;
+Keywords=Polaris;Moonlight;streaming;Steam Deck;

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
@@ -1,0 +1,39 @@
+{
+  "app-id": "com.papi_ux.Nova",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "6.10",
+  "sdk": "org.kde.Sdk",
+  "command": "nova-deck",
+  "finish-args": [
+    "--share=network",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--share=ipc",
+    "--device=dri",
+    "--device=input",
+    "--filesystem=xdg-run/gamescope-0",
+    "--filesystem=~/.var/app/com.moonlight_stream.Moonlight/config:ro",
+    "--filesystem=~/.local/share/Steam/userdata:create",
+    "--filesystem=~/.steam/steam/userdata:create",
+    "--talk-name=org.freedesktop.Flatpak",
+    "--env=QT_QUICK_CONTROLS_STYLE=Material"
+  ],
+  "cleanup": ["/include", "*.a", "/lib/pkgconfig", "/share/nova-deck/cmake"],
+  "modules": [
+    {
+      "name": "nova-deck",
+      "buildsystem": "cmake-ninja",
+      "subdir": "clients/deck",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_TESTING=OFF"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../../../.."
+        }
+      ]
+    }
+  ]
+}

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
@@ -18,7 +18,7 @@
     "--talk-name=org.freedesktop.Flatpak",
     "--env=QT_QUICK_CONTROLS_STYLE=Material"
   ],
-  "cleanup": ["/include", "*.a", "/lib/pkgconfig", "/share/nova-deck/cmake"],
+  "cleanup": ["/include", "*.a", "/lib/static", "/lib/pkgconfig", "/share/nova-deck/cmake"],
   "modules": [
     {
       "name": "nova-deck",

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.json
@@ -13,8 +13,9 @@
     "--device=input",
     "--filesystem=xdg-run/gamescope-0",
     "--filesystem=~/.var/app/com.moonlight_stream.Moonlight/config:ro",
-    "--filesystem=~/.local/share/Steam/userdata:create",
-    "--filesystem=~/.steam/steam/userdata:create",
+    "--filesystem=~/.local/share/Steam/userdata",
+    "--filesystem=~/.steam/steam/userdata",
+    "--filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/Steam/userdata",
     "--talk-name=org.freedesktop.Flatpak",
     "--env=QT_QUICK_CONTROLS_STYLE=Material"
   ],

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.metainfo.xml
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.metainfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.papi_ux.Nova</id>
+  <name>Nova</name>
+  <summary>Your Polaris library on the Deck, streamed through Moonlight</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <description>
+    <p>Nova shows the games a paired Polaris host offers and opens the one you pick in Moonlight. It borrows the pairing Moonlight already made, so there is nothing to pair twice.</p>
+  </description>
+  <launchable type="desktop-id">com.papi_ux.Nova.desktop</launchable>
+  <url type="homepage">https://papi-ux.com/</url>
+  <provides>
+    <binary>nova-deck</binary>
+  </provides>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/clients/deck/packaging/flatpak/com.papi_ux.Nova.svg
+++ b/clients/deck/packaging/flatpak/com.papi_ux.Nova.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1B2140"/>
+      <stop offset="1" stop-color="#0B0E1D"/>
+    </linearGradient>
+    <linearGradient id="a" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#8AFFC1"/>
+      <stop offset="0.55" stop-color="#7DD3FF"/>
+      <stop offset="1" stop-color="#C39BFF"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#g)"/>
+  <path d="M128 40 L146 110 L216 128 L146 146 L128 216 L110 146 L40 128 L110 110 Z" fill="url(#a)"/>
+  <circle cx="128" cy="128" r="14" fill="#0B0E1D"/>
+</svg>

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -4,6 +4,7 @@
 #include "backend/deck_backend_interfaces.h"
 #include "backend/deck_live_read_only_state.h"
 #include "runtime/deck_moonlight_launcher.h"
+#include "runtime/deck_steam_shortcuts.h"
 #include "stream/deck_stream_media_adapters.h"
 
 #include <QClipboard>
@@ -14,6 +15,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -1196,6 +1198,45 @@ int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
 
     const QStringList appArguments = QCoreApplication::arguments();
+
+    // --register-steam-shortcut adds Nova to Steam as a non-Steam game so Game
+    // Mode can launch it. Steam rewrites shortcuts.vdf on exit, so this refuses
+    // to run while Steam is open. Exit codes: 0 registered, 5 refused.
+    if (appArguments.contains(QStringLiteral("--register-steam-shortcut"))) {
+        nova::deck::runtime::DeckSteamShortcut shortcut;
+        shortcut.appName = "Nova";
+        const bool insideFlatpak = std::filesystem::exists("/.flatpak-info");
+        const QString exeOverride = stringArgumentAfter(appArguments, QStringLiteral("--register-steam-exe"));
+        if (!exeOverride.isEmpty()) {
+            shortcut.exe = "\"" + exeOverride.toStdString() + "\"";
+            shortcut.launchOptions = stringArgumentAfter(appArguments, QStringLiteral("--register-steam-launch-options")).toStdString();
+        } else if (insideFlatpak) {
+            shortcut.exe = "\"/usr/bin/flatpak\"";
+            shortcut.launchOptions = "run com.papi_ux.Nova --live";
+        } else {
+            std::error_code ec;
+            const auto self = std::filesystem::read_symlink("/proc/self/exe", ec);
+            shortcut.exe = "\"" + (ec ? std::string{"nova-deck"} : self.string()) + "\"";
+            shortcut.launchOptions = "--live";
+        }
+        shortcut.startDir = "\"/usr/bin/\"";
+        shortcut.tags = {"Nova"};
+        std::vector<std::filesystem::path> files;
+        for (const auto& root : nova::deck::runtime::defaultSteamRoots()) {
+            for (auto& file : nova::deck::runtime::defaultShortcutFiles(root)) {
+                files.push_back(std::move(file));
+            }
+        }
+        const bool steamRunning = nova::deck::runtime::steamClientRunning("/proc", static_cast<unsigned>(::getuid()));
+        const auto result = nova::deck::runtime::writeShortcutForAccount(files, shortcut, steamRunning);
+        std::cout << "nova-deck steam shortcut: " << (result.ok ? "ok" : "refused") << " · " << result.detail;
+        if (result.ok) {
+            std::cout << " · appid=" << result.appId << " · files=" << result.written.size();
+        }
+        std::cout << std::endl;
+        return result.ok ? 0 : 5;
+    }
+
     const auto profile = nova::deck::defaultWindowProfile();
     const auto sampleLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
     const nova::deck::backend::DeckLaunchPreflightService readOnlyPreflightService;

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -1194,51 +1194,66 @@ void writeExpandedDiagnosticsFrameSmokeArtifact(QObject* rootObject, const QStri
 }
 } // namespace
 
+/**
+ * --register-steam-shortcut adds Nova to Steam as a non-Steam game so Game
+ * Mode can launch it. It runs before any window exists so it works from a
+ * terminal or over SSH, and refuses while Steam is open, because Steam
+ * rewrites shortcuts.vdf on exit. Exit codes: 0 registered, 5 refused.
+ */
+int registerSteamShortcutCommand(const QStringList& arguments) {
+    nova::deck::runtime::DeckSteamShortcut shortcut;
+    shortcut.appName = "Nova";
+    std::error_code ec;
+    const bool insideFlatpak = std::filesystem::exists("/.flatpak-info", ec);
+    const QString exeOverride = stringArgumentAfter(arguments, QStringLiteral("--register-steam-exe"));
+    if (!exeOverride.isEmpty()) {
+        shortcut.exe = "\"" + exeOverride.toStdString() + "\"";
+        shortcut.launchOptions = stringArgumentAfter(arguments, QStringLiteral("--register-steam-launch-options")).toStdString();
+    } else if (insideFlatpak) {
+        shortcut.exe = "\"/usr/bin/flatpak\"";
+        shortcut.launchOptions = "run com.papi_ux.Nova --live";
+    } else {
+        const auto self = std::filesystem::read_symlink("/proc/self/exe", ec);
+        shortcut.exe = "\"" + (ec ? std::string{"nova-deck"} : self.string()) + "\"";
+        shortcut.launchOptions = "--live";
+    }
+    shortcut.startDir = "\"/usr/bin/\"";
+    shortcut.tags = {"Nova"};
+
+    std::vector<std::filesystem::path> files;
+    for (const auto& root : nova::deck::runtime::defaultSteamRoots()) {
+        for (auto& file : nova::deck::runtime::defaultShortcutFiles(root)) {
+            files.push_back(std::move(file));
+        }
+    }
+    const auto steamRunning = nova::deck::runtime::steamClientRunningForAccount(insideFlatpak, static_cast<unsigned>(::getuid()));
+    nova::deck::runtime::DeckShortcutWriteResult result;
+    if (!steamRunning.has_value()) {
+        result.detail = "Could not tell whether Steam is running; close Steam and try again.";
+    } else {
+        result = nova::deck::runtime::writeShortcutForAccount(files, shortcut, *steamRunning);
+    }
+    std::cout << "nova-deck steam shortcut: " << (result.ok ? "ok" : "refused") << " · " << result.detail;
+    if (result.appId != 0) {
+        std::cout << " · appid=" << result.appId;
+    }
+    std::cout << " · files=" << result.written.size() << std::endl;
+    return result.ok ? 0 : 5;
+}
+
 int main(int argc, char *argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::string_view(argv[i]) == "--register-steam-shortcut") {
+            QCoreApplication app(argc, argv);
+            return registerSteamShortcutCommand(QCoreApplication::arguments());
+        }
+    }
+
     QGuiApplication app(argc, argv);
 
     const QStringList appArguments = QCoreApplication::arguments();
 
-    // --register-steam-shortcut adds Nova to Steam as a non-Steam game so Game
-    // Mode can launch it. Steam rewrites shortcuts.vdf on exit, so this refuses
-    // to run while Steam is open. Exit codes: 0 registered, 5 refused.
-    if (appArguments.contains(QStringLiteral("--register-steam-shortcut"))) {
-        nova::deck::runtime::DeckSteamShortcut shortcut;
-        shortcut.appName = "Nova";
-        const bool insideFlatpak = std::filesystem::exists("/.flatpak-info");
-        const QString exeOverride = stringArgumentAfter(appArguments, QStringLiteral("--register-steam-exe"));
-        if (!exeOverride.isEmpty()) {
-            shortcut.exe = "\"" + exeOverride.toStdString() + "\"";
-            shortcut.launchOptions = stringArgumentAfter(appArguments, QStringLiteral("--register-steam-launch-options")).toStdString();
-        } else if (insideFlatpak) {
-            shortcut.exe = "\"/usr/bin/flatpak\"";
-            shortcut.launchOptions = "run com.papi_ux.Nova --live";
-        } else {
-            std::error_code ec;
-            const auto self = std::filesystem::read_symlink("/proc/self/exe", ec);
-            shortcut.exe = "\"" + (ec ? std::string{"nova-deck"} : self.string()) + "\"";
-            shortcut.launchOptions = "--live";
-        }
-        shortcut.startDir = "\"/usr/bin/\"";
-        shortcut.tags = {"Nova"};
-        std::vector<std::filesystem::path> files;
-        for (const auto& root : nova::deck::runtime::defaultSteamRoots()) {
-            for (auto& file : nova::deck::runtime::defaultShortcutFiles(root)) {
-                files.push_back(std::move(file));
-            }
-        }
-        const bool steamRunning = nova::deck::runtime::steamClientRunning("/proc", static_cast<unsigned>(::getuid()));
-        const auto result = nova::deck::runtime::writeShortcutForAccount(files, shortcut, steamRunning);
-        std::cout << "nova-deck steam shortcut: " << (result.ok ? "ok" : "refused") << " · " << result.detail;
-        if (result.ok) {
-            std::cout << " · appid=" << result.appId << " · files=" << result.written.size();
-        }
-        std::cout << std::endl;
-        return result.ok ? 0 : 5;
-    }
-
     const auto profile = nova::deck::defaultWindowProfile();
-    const auto sampleLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
     const nova::deck::backend::DeckLaunchPreflightService readOnlyPreflightService;
 
     // --live reads the identity Moonlight-Qt already holds on this device and
@@ -1258,6 +1273,12 @@ int main(int argc, char *argv[]) {
         if (printLiveState) {
             return liveSnapshot->identityLoaded ? 0 : 2;
         }
+    }
+    // The sample library only matters off the live route; an installed binary
+    // without fixtures must still run --live.
+    nova::deck::PolarisGameLibraryFixture sampleLibrary;
+    if (!liveSnapshot) {
+        sampleLibrary = nova::deck::loadSamplePolarisGameLibraryFixture();
     }
     std::unique_ptr<nova::deck::backend::DeckReadOnlyStateProvider> readOnlyStateProviderOwner;
     if (liveSnapshot) {

--- a/clients/deck/src/polaris_game_fixture.cpp
+++ b/clients/deck/src/polaris_game_fixture.cpp
@@ -3,6 +3,8 @@
 #include <charconv>
 #include <cstdlib>
 #include <fstream>
+#include <vector>
+#include <system_error>
 #include <iterator>
 #include <stdexcept>
 #include <string_view>
@@ -297,22 +299,37 @@ PolarisGameFixture parsePolarisGameFixtureJson(const std::string& json) {
 
 } // namespace
 
-std::filesystem::path samplePolarisGameFixturePath() {
-    if (const auto* overridePath = std::getenv("NOVA_DECK_SAMPLE_GAME_FIXTURE_PATH")) {
-        if (overridePath[0] != char(0)) {
-            return std::filesystem::path(overridePath);
+namespace {
+
+// Installed copies win over the source tree the binary was built from, which
+// does not exist on a Deck or inside a Flatpak.
+std::filesystem::path resolveFixture(const char* fileName, const char* compileTimePath) {
+    std::vector<std::filesystem::path> candidates;
+    if (const char* dir = std::getenv("NOVA_DECK_FIXTURE_DIR"); dir != nullptr && *dir != '\0') {
+        candidates.emplace_back(std::filesystem::path(dir) / fileName);
+    }
+    candidates.emplace_back(std::filesystem::path("/app/share/nova-deck/fixtures") / fileName);
+    std::error_code ec;
+    if (const auto self = std::filesystem::read_symlink("/proc/self/exe", ec); !ec) {
+        candidates.emplace_back(self.parent_path().parent_path() / "share" / "nova-deck" / "fixtures" / fileName);
+    }
+    candidates.emplace_back(compileTimePath);
+    for (const auto& candidate : candidates) {
+        if (std::filesystem::is_regular_file(candidate, ec)) {
+            return candidate;
         }
     }
-    return std::filesystem::path(NOVA_DECK_SAMPLE_GAME_FIXTURE);
+    return candidates.back();
+}
+
+} // namespace
+
+std::filesystem::path samplePolarisGameFixturePath() {
+    return resolveFixture("sample_polaris_game.json", NOVA_DECK_SAMPLE_GAME_FIXTURE);
 }
 
 std::filesystem::path samplePolarisGameLibraryFixturePath() {
-    if (const auto* overridePath = std::getenv("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH")) {
-        if (overridePath[0] != char(0)) {
-            return std::filesystem::path(overridePath);
-        }
-    }
-    return std::filesystem::path(NOVA_DECK_SAMPLE_LIBRARY_FIXTURE);
+    return resolveFixture("sample_polaris_library.json", NOVA_DECK_SAMPLE_LIBRARY_FIXTURE);
 }
 
 PolarisGameFixture loadPolarisGameFixture(const std::filesystem::path& path) {

--- a/clients/deck/src/polaris_game_fixture.cpp
+++ b/clients/deck/src/polaris_game_fixture.cpp
@@ -301,13 +301,24 @@ PolarisGameFixture parsePolarisGameFixtureJson(const std::string& json) {
 
 namespace {
 
-// Installed copies win over the source tree the binary was built from, which
-// does not exist on a Deck or inside a Flatpak.
-std::filesystem::path resolveFixture(const char* fileName, const char* compileTimePath) {
-    std::vector<std::filesystem::path> candidates;
-    if (const char* dir = std::getenv("NOVA_DECK_FIXTURE_DIR"); dir != nullptr && *dir != '\0') {
-        candidates.emplace_back(std::filesystem::path(dir) / fileName);
+/**
+ * Where a fixture lives, in order: an explicit per-file override, an explicit
+ * fixture directory (both returned as given, so a typo surfaces as an open
+ * error instead of a silent fallback), the installed copies (the configured
+ * datadir, the Flatpak prefix, next to the binary), and last the source tree
+ * the binary was built from, which does not exist on a Deck.
+ */
+std::filesystem::path resolveFixture(const char* fileOverrideVariable, const char* fileName, const char* compileTimePath) {
+    if (const char* file = std::getenv(fileOverrideVariable); file != nullptr && *file != '\0') {
+        return std::filesystem::path(file);
     }
+    if (const char* dir = std::getenv("NOVA_DECK_FIXTURE_DIR"); dir != nullptr && *dir != '\0') {
+        return std::filesystem::path(dir) / fileName;
+    }
+    std::vector<std::filesystem::path> candidates;
+#ifdef NOVA_DECK_INSTALL_FIXTURE_DIR
+    candidates.emplace_back(std::filesystem::path(NOVA_DECK_INSTALL_FIXTURE_DIR) / fileName);
+#endif
     candidates.emplace_back(std::filesystem::path("/app/share/nova-deck/fixtures") / fileName);
     std::error_code ec;
     if (const auto self = std::filesystem::read_symlink("/proc/self/exe", ec); !ec) {
@@ -325,11 +336,11 @@ std::filesystem::path resolveFixture(const char* fileName, const char* compileTi
 } // namespace
 
 std::filesystem::path samplePolarisGameFixturePath() {
-    return resolveFixture("sample_polaris_game.json", NOVA_DECK_SAMPLE_GAME_FIXTURE);
+    return resolveFixture("NOVA_DECK_SAMPLE_GAME_FIXTURE_PATH", "sample_polaris_game.json", NOVA_DECK_SAMPLE_GAME_FIXTURE);
 }
 
 std::filesystem::path samplePolarisGameLibraryFixturePath() {
-    return resolveFixture("sample_polaris_library.json", NOVA_DECK_SAMPLE_LIBRARY_FIXTURE);
+    return resolveFixture("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH", "sample_polaris_library.json", NOVA_DECK_SAMPLE_LIBRARY_FIXTURE);
 }
 
 PolarisGameFixture loadPolarisGameFixture(const std::filesystem::path& path) {

--- a/clients/deck/src/runtime/deck_steam_shortcuts.cpp
+++ b/clients/deck/src/runtime/deck_steam_shortcuts.cpp
@@ -202,12 +202,10 @@ DeckVdfObject shortcutEntry(const DeckSteamShortcut& shortcut, const std::uint32
 
 std::optional<DeckVdfObject> parseBinaryVdf(const std::string_view bytes) {
     Reader reader{bytes};
+    // The document is one object: the end marker that closes it is the last
+    // byte of the file. Anything after it means the file is not what Steam writes.
     auto root = parseObject(reader);
-    if (!root) {
-        return std::nullopt;
-    }
-    // Steam terminates the document with a second end marker.
-    if (const auto trailer = reader.byte(); !trailer || *trailer != kEndObject || !reader.done()) {
+    if (!root || !reader.done()) {
         return std::nullopt;
     }
     return root;
@@ -216,7 +214,6 @@ std::optional<DeckVdfObject> parseBinaryVdf(const std::string_view bytes) {
 std::string serializeBinaryVdf(const DeckVdfObject& root) {
     std::string out;
     serializeObject(root, out);
-    out.push_back(kEndObject);
     return out;
 }
 

--- a/clients/deck/src/runtime/deck_steam_shortcuts.cpp
+++ b/clients/deck/src/runtime/deck_steam_shortcuts.cpp
@@ -1,6 +1,14 @@
 #include "runtime/deck_steam_shortcuts.h"
 
+#include <QByteArray>
+#include <QProcess>
+#include <QSaveFile>
+#include <QString>
+#include <QStringList>
+
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -14,6 +22,18 @@ constexpr char kTypeObject = '\x00';
 constexpr char kTypeString = '\x01';
 constexpr char kTypeInt32 = '\x02';
 constexpr char kEndObject = '\x08';
+
+bool sameKey(const std::string_view a, const std::string_view b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
 
 struct Reader {
     std::string_view bytes;
@@ -161,16 +181,37 @@ DeckVdfValue intValue(const std::int32_t number) {
     return value;
 }
 
-const DeckVdfValue* find(const DeckVdfObject& object, const std::string_view key) {
-    for (const auto& [k, v] : object) {
-        if (k == key) {
-            return &v;
-        }
+/// Set a key, keeping the spelling already in the object when it exists.
+void setString(DeckVdfObject& object, const std::string_view key, std::string text) {
+    if (auto* existing = findKey(object, key); existing != nullptr && existing->kind == DeckVdfValue::Kind::String) {
+        existing->text = std::move(text);
+        return;
     }
-    return nullptr;
+    object.emplace_back(std::string(key), stringValue(std::move(text)));
 }
 
-DeckVdfObject shortcutEntry(const DeckSteamShortcut& shortcut, const std::uint32_t appId) {
+bool stringContains(const DeckVdfObject& object, const std::string_view key, const std::string_view needle) {
+    const auto* value = findKey(object, key);
+    return value != nullptr && value->kind == DeckVdfValue::Kind::String && value->text.find(needle) != std::string::npos;
+}
+
+bool isNovaEntry(const DeckVdfObject& entry, const DeckSteamShortcut& shortcut) {
+    const auto* name = findKey(entry, "AppName");
+    if (name == nullptr || name->kind != DeckVdfValue::Kind::String || !sameKey(name->text, shortcut.appName)) {
+        return false;
+    }
+    if (const auto* exe = findKey(entry, "Exe"); exe != nullptr && exe->kind == DeckVdfValue::Kind::String && exe->text == shortcut.exe) {
+        return true;
+    }
+    for (const auto& marker : shortcut.identityMarkers) {
+        if (stringContains(entry, "Exe", marker) || stringContains(entry, "LaunchOptions", marker)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+DeckVdfObject newEntry(const DeckSteamShortcut& shortcut, const std::uint32_t appId) {
     DeckVdfObject entry;
     entry.emplace_back("appid", intValue(static_cast<std::int32_t>(appId)));
     entry.emplace_back("AppName", stringValue(shortcut.appName));
@@ -198,6 +239,41 @@ DeckVdfObject shortcutEntry(const DeckSteamShortcut& shortcut, const std::uint32
     return entry;
 }
 
+/// Update only what Nova owns on an entry that is already Nova's.
+void mergeEntry(DeckVdfObject& entry, const DeckSteamShortcut& shortcut) {
+    setString(entry, "AppName", shortcut.appName);
+    setString(entry, "Exe", shortcut.exe);
+    setString(entry, "StartDir", shortcut.startDir);
+    setString(entry, "LaunchOptions", shortcut.launchOptions);
+    if (!shortcut.icon.empty()) {
+        setString(entry, "icon", shortcut.icon);
+    }
+    auto* tags = findKey(entry, "tags");
+    if (tags == nullptr || tags->kind != DeckVdfValue::Kind::Object) {
+        DeckVdfValue container;
+        container.kind = DeckVdfValue::Kind::Object;
+        entry.emplace_back("tags", std::move(container));
+        tags = &entry.back().second;
+    }
+    for (const auto& tag : shortcut.tags) {
+        bool present = false;
+        for (const auto& [key, value] : tags->children) {
+            present = present || (value.kind == DeckVdfValue::Kind::String && value.text == tag);
+        }
+        if (!present) {
+            int next = 0;
+            for (const auto& [key, value] : tags->children) {
+                char* end = nullptr;
+                const long parsed = std::strtol(key.c_str(), &end, 10);
+                if (end != nullptr && *end == '\0' && parsed >= next) {
+                    next = static_cast<int>(parsed) + 1;
+                }
+            }
+            tags->children.emplace_back(std::to_string(next), stringValue(tag));
+        }
+    }
+}
+
 } // namespace
 
 std::optional<DeckVdfObject> parseBinaryVdf(const std::string_view bytes) {
@@ -217,6 +293,24 @@ std::string serializeBinaryVdf(const DeckVdfObject& root) {
     return out;
 }
 
+const DeckVdfValue* findKey(const DeckVdfObject& object, const std::string_view key) {
+    for (const auto& [k, v] : object) {
+        if (sameKey(k, key)) {
+            return &v;
+        }
+    }
+    return nullptr;
+}
+
+DeckVdfValue* findKey(DeckVdfObject& object, const std::string_view key) {
+    for (auto& [k, v] : object) {
+        if (sameKey(k, key)) {
+            return &v;
+        }
+    }
+    return nullptr;
+}
+
 std::uint32_t steamShortcutAppId(const std::string_view exe, const std::string_view appName) {
     std::string seed(exe);
     seed += appName;
@@ -226,47 +320,45 @@ std::uint32_t steamShortcutAppId(const std::string_view exe, const std::string_v
 DeckShortcutRegistration registerShortcut(const DeckVdfObject& document, const DeckSteamShortcut& shortcut) {
     DeckShortcutRegistration registration;
     registration.document = document;
-    registration.appId = steamShortcutAppId(shortcut.exe, shortcut.appName);
 
-    DeckVdfObject* shortcuts = nullptr;
-    for (auto& [key, value] : registration.document) {
-        if (key == "shortcuts" && value.kind == DeckVdfValue::Kind::Object) {
-            shortcuts = &value.children;
-        }
-    }
-    if (shortcuts == nullptr) {
+    auto* shortcuts = findKey(registration.document, "shortcuts");
+    if (shortcuts == nullptr || shortcuts->kind != DeckVdfValue::Kind::Object) {
         DeckVdfValue container;
         container.kind = DeckVdfValue::Kind::Object;
         registration.document.emplace_back("shortcuts", std::move(container));
-        shortcuts = &registration.document.back().second.children;
+        shortcuts = &registration.document.back().second;
     }
 
-    for (auto& [key, value] : *shortcuts) {
-        if (value.kind != DeckVdfValue::Kind::Object) {
+    for (auto& [key, value] : shortcuts->children) {
+        if (value.kind != DeckVdfValue::Kind::Object || !isNovaEntry(value.children, shortcut)) {
             continue;
         }
-        const auto* name = find(value.children, "AppName");
-        if (name != nullptr && name->kind == DeckVdfValue::Kind::String && name->text == shortcut.appName) {
-            value.children = shortcutEntry(shortcut, registration.appId);
-            registration.replaced = true;
-            registration.entryKey = key;
-            return registration;
+        mergeEntry(value.children, shortcut);
+        registration.replaced = true;
+        registration.entryKey = key;
+        if (const auto* appId = findKey(value.children, "appid"); appId != nullptr && appId->kind == DeckVdfValue::Kind::Int32) {
+            registration.appId = static_cast<std::uint32_t>(appId->number);
+        } else {
+            registration.appId = steamShortcutAppId(shortcut.exe, shortcut.appName);
+            value.children.insert(value.children.begin(), {"appid", intValue(static_cast<std::int32_t>(registration.appId))});
         }
+        return registration;
     }
 
     int next = 0;
-    for (const auto& [key, value] : *shortcuts) {
+    for (const auto& [key, value] : shortcuts->children) {
         char* end = nullptr;
         const long parsed = std::strtol(key.c_str(), &end, 10);
         if (end != nullptr && *end == '\0' && parsed >= next) {
             next = static_cast<int>(parsed) + 1;
         }
     }
+    registration.appId = steamShortcutAppId(shortcut.exe, shortcut.appName);
     DeckVdfValue entry;
     entry.kind = DeckVdfValue::Kind::Object;
-    entry.children = shortcutEntry(shortcut, registration.appId);
+    entry.children = newEntry(shortcut, registration.appId);
     registration.entryKey = std::to_string(next);
-    shortcuts->emplace_back(registration.entryKey, std::move(entry));
+    shortcuts->children.emplace_back(registration.entryKey, std::move(entry));
     return registration;
 }
 
@@ -285,6 +377,7 @@ std::vector<std::filesystem::path> defaultShortcutFiles(const std::filesystem::p
             files.push_back(it->path() / "config" / "shortcuts.vdf");
         }
     }
+    std::sort(files.begin(), files.end());
     return files;
 }
 
@@ -300,19 +393,16 @@ std::vector<std::filesystem::path> defaultSteamRoots() {
         return roots;
     }
     const std::filesystem::path base(home);
-    // The SteamOS layout first; the two are usually the same directory through a symlink.
+    // SteamOS and native Steam share one directory through a symlink; Flatpak Steam keeps its own.
     for (const auto& candidate : {base / ".local" / "share" / "Steam", base / ".steam" / "steam", base / ".var" / "app" / "com.valvesoftware.Steam" / ".local" / "share" / "Steam"}) {
         std::error_code ec;
-        if (std::filesystem::is_directory(candidate / "userdata", ec)) {
-            const auto canonical = std::filesystem::canonical(candidate, ec);
-            const auto path = ec ? candidate : canonical;
-            bool seen = false;
-            for (const auto& existing : roots) {
-                seen = seen || existing == path;
-            }
-            if (!seen) {
-                roots.push_back(path);
-            }
+        if (!std::filesystem::is_directory(candidate / "userdata", ec)) {
+            continue;
+        }
+        const auto canonical = std::filesystem::canonical(candidate, ec);
+        const auto path = ec ? candidate : canonical;
+        if (std::find(roots.begin(), roots.end(), path) == roots.end()) {
+            roots.push_back(path);
         }
     }
     return roots;
@@ -346,6 +436,30 @@ bool steamClientRunning(const std::filesystem::path& procRoot, const unsigned ui
     return false;
 }
 
+std::optional<bool> steamClientRunningForAccount(const bool insideFlatpak, const unsigned uid) {
+    if (!insideFlatpak) {
+        return steamClientRunning("/proc", uid);
+    }
+    // The sandbox has its own PID namespace; ask the host session instead.
+    QProcess probe;
+    probe.setProgram(QStringLiteral("flatpak-spawn"));
+    probe.setArguments({QStringLiteral("--host"), QStringLiteral("pgrep"), QStringLiteral("-x"), QStringLiteral("-u"), QString::number(uid), QStringLiteral("steam")});
+    probe.setStandardOutputFile(QProcess::nullDevice());
+    probe.setStandardErrorFile(QProcess::nullDevice());
+    probe.start();
+    if (!probe.waitForStarted(5000) || !probe.waitForFinished(10000) || probe.exitStatus() != QProcess::NormalExit) {
+        return std::nullopt;
+    }
+    // pgrep: 0 = at least one match, 1 = none; anything else is an error.
+    if (probe.exitCode() == 0) {
+        return true;
+    }
+    if (probe.exitCode() == 1) {
+        return false;
+    }
+    return std::nullopt;
+}
+
 DeckShortcutWriteResult writeShortcutForAccount(
     const std::vector<std::filesystem::path>& shortcutFiles,
     const DeckSteamShortcut& shortcut,
@@ -359,6 +473,10 @@ DeckShortcutWriteResult writeShortcutForAccount(
         result.detail = "No Steam user data directory was found for this account.";
         return result;
     }
+
+    // Prepare every file before touching any, so one bad profile refuses the
+    // whole run instead of leaving the others half done.
+    std::vector<std::pair<std::filesystem::path, std::string>> prepared;
     for (const auto& file : shortcutFiles) {
         DeckVdfObject document;
         std::error_code ec;
@@ -367,26 +485,25 @@ DeckShortcutWriteResult writeShortcutForAccount(
             std::string bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
             auto parsed = parseBinaryVdf(bytes);
             if (!parsed) {
-                result.detail = "Could not read the existing shortcuts file: " + file.filename().string();
+                result.detail = "Could not read the existing shortcuts file for profile " + file.parent_path().parent_path().filename().string() + "; nothing was changed.";
                 return result;
             }
             document = std::move(*parsed);
         }
         const auto registration = registerShortcut(document, shortcut);
         result.appId = registration.appId;
-        const auto serialized = serializeBinaryVdf(registration.document);
-        const auto temp = file.string() + ".nova-tmp";
-        {
-            std::ofstream out(temp, std::ios::binary | std::ios::trunc);
-            if (!out) {
-                result.detail = "Could not write next to the shortcuts file.";
-                return result;
-            }
-            out.write(serialized.data(), static_cast<std::streamsize>(serialized.size()));
+        prepared.emplace_back(file, serializeBinaryVdf(registration.document));
+    }
+
+    for (const auto& [file, bytes] : prepared) {
+        QSaveFile out(QString::fromStdString(file.string()));
+        if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            result.detail = "Could not write the shortcuts file for profile " + file.parent_path().parent_path().filename().string() + ".";
+            return result;
         }
-        std::filesystem::rename(temp, file, ec);
-        if (ec) {
-            result.detail = "Could not replace the shortcuts file: " + ec.message();
+        const auto written = out.write(bytes.data(), static_cast<qint64>(bytes.size()));
+        if (written != static_cast<qint64>(bytes.size()) || !out.commit()) {
+            result.detail = "Could not finish writing the shortcuts file for profile " + file.parent_path().parent_path().filename().string() + ".";
             return result;
         }
         result.written.push_back(file);

--- a/clients/deck/src/runtime/deck_steam_shortcuts.cpp
+++ b/clients/deck/src/runtime/deck_steam_shortcuts.cpp
@@ -1,0 +1,404 @@
+#include "runtime/deck_steam_shortcuts.h"
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <system_error>
+
+namespace nova::deck::runtime {
+
+namespace {
+
+constexpr char kTypeObject = '\x00';
+constexpr char kTypeString = '\x01';
+constexpr char kTypeInt32 = '\x02';
+constexpr char kEndObject = '\x08';
+
+struct Reader {
+    std::string_view bytes;
+    std::size_t pos = 0;
+
+    bool done() const {
+        return pos >= bytes.size();
+    }
+
+    std::optional<char> byte() {
+        if (done()) {
+            return std::nullopt;
+        }
+        return bytes[pos++];
+    }
+
+    std::optional<std::string> cstring() {
+        const auto end = bytes.find('\0', pos);
+        if (end == std::string_view::npos) {
+            return std::nullopt;
+        }
+        std::string value(bytes.substr(pos, end - pos));
+        pos = end + 1;
+        return value;
+    }
+
+    std::optional<std::int32_t> int32() {
+        if (pos + 4 > bytes.size()) {
+            return std::nullopt;
+        }
+        std::uint32_t raw = 0;
+        for (int i = 3; i >= 0; --i) {
+            raw = (raw << 8) | static_cast<unsigned char>(bytes[pos + static_cast<std::size_t>(i)]);
+        }
+        pos += 4;
+        return static_cast<std::int32_t>(raw);
+    }
+};
+
+std::optional<DeckVdfObject> parseObject(Reader& reader) {
+    DeckVdfObject object;
+    for (;;) {
+        const auto type = reader.byte();
+        if (!type) {
+            return std::nullopt;
+        }
+        if (*type == kEndObject) {
+            return object;
+        }
+        auto key = reader.cstring();
+        if (!key) {
+            return std::nullopt;
+        }
+        DeckVdfValue value;
+        if (*type == kTypeObject) {
+            value.kind = DeckVdfValue::Kind::Object;
+            auto children = parseObject(reader);
+            if (!children) {
+                return std::nullopt;
+            }
+            value.children = std::move(*children);
+        } else if (*type == kTypeString) {
+            value.kind = DeckVdfValue::Kind::String;
+            auto text = reader.cstring();
+            if (!text) {
+                return std::nullopt;
+            }
+            value.text = std::move(*text);
+        } else if (*type == kTypeInt32) {
+            value.kind = DeckVdfValue::Kind::Int32;
+            auto number = reader.int32();
+            if (!number) {
+                return std::nullopt;
+            }
+            value.number = *number;
+        } else {
+            return std::nullopt;
+        }
+        object.emplace_back(std::move(*key), std::move(value));
+    }
+}
+
+void serializeObject(const DeckVdfObject& object, std::string& out) {
+    for (const auto& [key, value] : object) {
+        switch (value.kind) {
+        case DeckVdfValue::Kind::Object:
+            out.push_back(kTypeObject);
+            out += key;
+            out.push_back('\0');
+            serializeObject(value.children, out);
+            break;
+        case DeckVdfValue::Kind::String:
+            out.push_back(kTypeString);
+            out += key;
+            out.push_back('\0');
+            out += value.text;
+            out.push_back('\0');
+            break;
+        case DeckVdfValue::Kind::Int32: {
+            out.push_back(kTypeInt32);
+            out += key;
+            out.push_back('\0');
+            auto raw = static_cast<std::uint32_t>(value.number);
+            for (int i = 0; i < 4; ++i) {
+                out.push_back(static_cast<char>(raw & 0xff));
+                raw >>= 8;
+            }
+            break;
+        }
+        }
+    }
+    out.push_back(kEndObject);
+}
+
+std::uint32_t crc32(std::string_view data) {
+    static const auto table = [] {
+        std::array<std::uint32_t, 256> t{};
+        for (std::uint32_t i = 0; i < 256; ++i) {
+            std::uint32_t c = i;
+            for (int k = 0; k < 8; ++k) {
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            }
+            t[i] = c;
+        }
+        return t;
+    }();
+    std::uint32_t crc = 0xFFFFFFFFu;
+    for (const unsigned char ch : data) {
+        crc = table[(crc ^ ch) & 0xff] ^ (crc >> 8);
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+DeckVdfValue stringValue(std::string text) {
+    DeckVdfValue value;
+    value.kind = DeckVdfValue::Kind::String;
+    value.text = std::move(text);
+    return value;
+}
+
+DeckVdfValue intValue(const std::int32_t number) {
+    DeckVdfValue value;
+    value.kind = DeckVdfValue::Kind::Int32;
+    value.number = number;
+    return value;
+}
+
+const DeckVdfValue* find(const DeckVdfObject& object, const std::string_view key) {
+    for (const auto& [k, v] : object) {
+        if (k == key) {
+            return &v;
+        }
+    }
+    return nullptr;
+}
+
+DeckVdfObject shortcutEntry(const DeckSteamShortcut& shortcut, const std::uint32_t appId) {
+    DeckVdfObject entry;
+    entry.emplace_back("appid", intValue(static_cast<std::int32_t>(appId)));
+    entry.emplace_back("AppName", stringValue(shortcut.appName));
+    entry.emplace_back("Exe", stringValue(shortcut.exe));
+    entry.emplace_back("StartDir", stringValue(shortcut.startDir));
+    entry.emplace_back("icon", stringValue(shortcut.icon));
+    entry.emplace_back("ShortcutPath", stringValue(""));
+    entry.emplace_back("LaunchOptions", stringValue(shortcut.launchOptions));
+    entry.emplace_back("IsHidden", intValue(0));
+    entry.emplace_back("AllowDesktopConfig", intValue(1));
+    entry.emplace_back("AllowOverlay", intValue(1));
+    entry.emplace_back("OpenVR", intValue(0));
+    entry.emplace_back("Devkit", intValue(0));
+    entry.emplace_back("DevkitGameID", stringValue(""));
+    entry.emplace_back("DevkitOverrideAppID", intValue(0));
+    entry.emplace_back("LastPlayTime", intValue(0));
+    entry.emplace_back("FlatpakAppID", stringValue(""));
+    DeckVdfValue tags;
+    tags.kind = DeckVdfValue::Kind::Object;
+    int index = 0;
+    for (const auto& tag : shortcut.tags) {
+        tags.children.emplace_back(std::to_string(index++), stringValue(tag));
+    }
+    entry.emplace_back("tags", std::move(tags));
+    return entry;
+}
+
+} // namespace
+
+std::optional<DeckVdfObject> parseBinaryVdf(const std::string_view bytes) {
+    Reader reader{bytes};
+    auto root = parseObject(reader);
+    if (!root) {
+        return std::nullopt;
+    }
+    // Steam terminates the document with a second end marker.
+    if (const auto trailer = reader.byte(); !trailer || *trailer != kEndObject || !reader.done()) {
+        return std::nullopt;
+    }
+    return root;
+}
+
+std::string serializeBinaryVdf(const DeckVdfObject& root) {
+    std::string out;
+    serializeObject(root, out);
+    out.push_back(kEndObject);
+    return out;
+}
+
+std::uint32_t steamShortcutAppId(const std::string_view exe, const std::string_view appName) {
+    std::string seed(exe);
+    seed += appName;
+    return crc32(seed) | 0x80000000u;
+}
+
+DeckShortcutRegistration registerShortcut(const DeckVdfObject& document, const DeckSteamShortcut& shortcut) {
+    DeckShortcutRegistration registration;
+    registration.document = document;
+    registration.appId = steamShortcutAppId(shortcut.exe, shortcut.appName);
+
+    DeckVdfObject* shortcuts = nullptr;
+    for (auto& [key, value] : registration.document) {
+        if (key == "shortcuts" && value.kind == DeckVdfValue::Kind::Object) {
+            shortcuts = &value.children;
+        }
+    }
+    if (shortcuts == nullptr) {
+        DeckVdfValue container;
+        container.kind = DeckVdfValue::Kind::Object;
+        registration.document.emplace_back("shortcuts", std::move(container));
+        shortcuts = &registration.document.back().second.children;
+    }
+
+    for (auto& [key, value] : *shortcuts) {
+        if (value.kind != DeckVdfValue::Kind::Object) {
+            continue;
+        }
+        const auto* name = find(value.children, "AppName");
+        if (name != nullptr && name->kind == DeckVdfValue::Kind::String && name->text == shortcut.appName) {
+            value.children = shortcutEntry(shortcut, registration.appId);
+            registration.replaced = true;
+            registration.entryKey = key;
+            return registration;
+        }
+    }
+
+    int next = 0;
+    for (const auto& [key, value] : *shortcuts) {
+        char* end = nullptr;
+        const long parsed = std::strtol(key.c_str(), &end, 10);
+        if (end != nullptr && *end == '\0' && parsed >= next) {
+            next = static_cast<int>(parsed) + 1;
+        }
+    }
+    DeckVdfValue entry;
+    entry.kind = DeckVdfValue::Kind::Object;
+    entry.children = shortcutEntry(shortcut, registration.appId);
+    registration.entryKey = std::to_string(next);
+    shortcuts->emplace_back(registration.entryKey, std::move(entry));
+    return registration;
+}
+
+std::vector<std::filesystem::path> defaultShortcutFiles(const std::filesystem::path& steamRoot) {
+    std::vector<std::filesystem::path> files;
+    std::error_code ec;
+    const auto userdata = steamRoot / "userdata";
+    std::filesystem::directory_iterator it(userdata, ec);
+    const std::filesystem::directory_iterator end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const auto name = it->path().filename().string();
+        if (name.empty() || name == "0" || name.find_first_not_of("0123456789") != std::string::npos) {
+            continue;
+        }
+        if (std::filesystem::is_directory(it->path() / "config", ec)) {
+            files.push_back(it->path() / "config" / "shortcuts.vdf");
+        }
+    }
+    return files;
+}
+
+std::vector<std::filesystem::path> defaultSteamRoots() {
+    std::vector<std::filesystem::path> roots;
+    // NOVA_DECK_STEAM_ROOT points a proof at a scratch Steam directory instead of the real one.
+    if (const char* override = std::getenv("NOVA_DECK_STEAM_ROOT"); override != nullptr && *override != '\0') {
+        roots.emplace_back(override);
+        return roots;
+    }
+    const char* home = std::getenv("HOME");
+    if (home == nullptr || *home == '\0') {
+        return roots;
+    }
+    const std::filesystem::path base(home);
+    // The SteamOS layout first; the two are usually the same directory through a symlink.
+    for (const auto& candidate : {base / ".local" / "share" / "Steam", base / ".steam" / "steam", base / ".var" / "app" / "com.valvesoftware.Steam" / ".local" / "share" / "Steam"}) {
+        std::error_code ec;
+        if (std::filesystem::is_directory(candidate / "userdata", ec)) {
+            const auto canonical = std::filesystem::canonical(candidate, ec);
+            const auto path = ec ? candidate : canonical;
+            bool seen = false;
+            for (const auto& existing : roots) {
+                seen = seen || existing == path;
+            }
+            if (!seen) {
+                roots.push_back(path);
+            }
+        }
+    }
+    return roots;
+}
+
+bool steamClientRunning(const std::filesystem::path& procRoot, const unsigned uid) {
+    std::error_code ec;
+    std::filesystem::directory_iterator it(procRoot, ec);
+    const std::filesystem::directory_iterator end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const auto name = it->path().filename().string();
+        if (name.empty() || name.find_first_not_of("0123456789") != std::string::npos) {
+            continue;
+        }
+        std::ifstream comm(it->path() / "comm");
+        std::string process;
+        if (!std::getline(comm, process) || process != "steam") {
+            continue;
+        }
+        std::ifstream status(it->path() / "status");
+        std::string line;
+        while (std::getline(status, line)) {
+            if (line.rfind("Uid:", 0) == 0) {
+                if (std::strtoul(line.c_str() + 4, nullptr, 10) == uid) {
+                    return true;
+                }
+                break;
+            }
+        }
+    }
+    return false;
+}
+
+DeckShortcutWriteResult writeShortcutForAccount(
+    const std::vector<std::filesystem::path>& shortcutFiles,
+    const DeckSteamShortcut& shortcut,
+    const bool steamRunning) {
+    DeckShortcutWriteResult result;
+    if (steamRunning) {
+        result.detail = "Steam is running; it rewrites shortcuts.vdf on exit, so close Steam first.";
+        return result;
+    }
+    if (shortcutFiles.empty()) {
+        result.detail = "No Steam user data directory was found for this account.";
+        return result;
+    }
+    for (const auto& file : shortcutFiles) {
+        DeckVdfObject document;
+        std::error_code ec;
+        if (std::filesystem::exists(file, ec)) {
+            std::ifstream in(file, std::ios::binary);
+            std::string bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+            auto parsed = parseBinaryVdf(bytes);
+            if (!parsed) {
+                result.detail = "Could not read the existing shortcuts file: " + file.filename().string();
+                return result;
+            }
+            document = std::move(*parsed);
+        }
+        const auto registration = registerShortcut(document, shortcut);
+        result.appId = registration.appId;
+        const auto serialized = serializeBinaryVdf(registration.document);
+        const auto temp = file.string() + ".nova-tmp";
+        {
+            std::ofstream out(temp, std::ios::binary | std::ios::trunc);
+            if (!out) {
+                result.detail = "Could not write next to the shortcuts file.";
+                return result;
+            }
+            out.write(serialized.data(), static_cast<std::streamsize>(serialized.size()));
+        }
+        std::filesystem::rename(temp, file, ec);
+        if (ec) {
+            result.detail = "Could not replace the shortcuts file: " + ec.message();
+            return result;
+        }
+        result.written.push_back(file);
+    }
+    result.ok = true;
+    result.detail = result.written.size() == 1
+        ? "Registered in one Steam profile. Restart Steam to see it."
+        : "Registered in " + std::to_string(result.written.size()) + " Steam profiles. Restart Steam to see it.";
+    return result;
+}
+
+} // namespace nova::deck::runtime

--- a/clients/deck/src/runtime/deck_steam_shortcuts.h
+++ b/clients/deck/src/runtime/deck_steam_shortcuts.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <filesystem>
-#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -12,10 +11,10 @@
 // userdata/<id>/config/shortcuts.vdf. Registering Nova there is what makes it
 // launchable from Game Mode. The file is rewritten by Steam on exit, so edits
 // only stick while Steam is closed, and every other entry must survive the
-// round trip byte for byte.
+// round trip byte for byte. KeyValues keys are case-insensitive; Steam and
+// third-party tools spell them differently, so lookups never assume a case.
 namespace nova::deck::runtime {
 
-/// One value in a binary KeyValues object, in file order.
 struct DeckVdfValue;
 using DeckVdfObject = std::vector<std::pair<std::string, DeckVdfValue>>;
 
@@ -31,27 +30,38 @@ struct DeckVdfValue {
     DeckVdfObject children;
 };
 
-/// Parse a whole binary KeyValues document (the root object, `shortcuts` for this file). nullopt on malformed input.
+/// Parse a whole binary KeyValues document. nullopt on malformed input or trailing bytes.
 std::optional<DeckVdfObject> parseBinaryVdf(std::string_view bytes);
 
 /// Serialize back to the exact bytes Steam writes.
 std::string serializeBinaryVdf(const DeckVdfObject& root);
 
+/// Case-insensitive key lookup, the way Steam reads KeyValues.
+const DeckVdfValue* findKey(const DeckVdfObject& object, std::string_view key);
+DeckVdfValue* findKey(DeckVdfObject& object, std::string_view key);
+
 struct DeckSteamShortcut {
     std::string appName;
     std::string exe;  ///< quoted the way Steam stores it, e.g. "/usr/bin/flatpak"
     std::string startDir;  ///< quoted, e.g. "/usr/bin/"
-    std::string icon;
+    std::string icon;  ///< left alone on replace when empty
     std::string launchOptions;
     std::vector<std::string> tags;
+    /// Substrings that mark an entry as Nova's own (in Exe or LaunchOptions), so an
+    /// unrelated shortcut that happens to share the name is never touched.
+    std::vector<std::string> identityMarkers = {"com.papi_ux.Nova", "nova-deck"};
 };
 
 /// Steam's id for a non-Steam shortcut: crc32(exe + appName) with the top bit set.
 std::uint32_t steamShortcutAppId(std::string_view exe, std::string_view appName);
 
 /**
- * @brief Add or replace the shortcut whose AppName matches, leaving every other entry untouched.
- * @return the new document and whether an existing entry was replaced.
+ * @brief Add Nova's entry, or update the fields Nova owns on the entry that is already Nova's.
+ *
+ * A replace keeps the entry's appid (grid art and controller layouts hang off
+ * it), its play time, hidden and overlay flags, and every key Nova does not
+ * own; only AppName, Exe, StartDir, LaunchOptions, a non-empty icon and the
+ * presence of Nova's tags change.
  */
 struct DeckShortcutRegistration {
     DeckVdfObject document;
@@ -65,8 +75,17 @@ DeckShortcutRegistration registerShortcut(const DeckVdfObject& document, const D
 std::vector<std::filesystem::path> defaultShortcutFiles(const std::filesystem::path& steamRoot);
 std::vector<std::filesystem::path> defaultSteamRoots();
 
-/// True when a Steam client process runs for this account; shortcuts.vdf edits are lost while it does.
+/// True when a `steam` process runs for @p uid, read from a procfs root.
 bool steamClientRunning(const std::filesystem::path& procRoot, unsigned uid);
+
+/**
+ * @brief Whether Steam runs for this account, seen from where Nova runs.
+ *
+ * Inside a Flatpak the sandbox has its own PID namespace and never sees the
+ * host's Steam, so the question goes to the host through flatpak-spawn.
+ * nullopt means the answer could not be obtained; callers refuse in that case.
+ */
+std::optional<bool> steamClientRunningForAccount(bool insideFlatpak, unsigned uid);
 
 struct DeckShortcutWriteResult {
     bool ok = false;
@@ -75,7 +94,13 @@ struct DeckShortcutWriteResult {
     std::uint32_t appId = 0;
 };
 
-/// Register the shortcut in every candidate file (creating the first when none exists). Refuses while Steam runs.
+/**
+ * @brief Register the shortcut in every candidate file, creating the first when none exists.
+ *
+ * Every file is parsed and serialized before any is written, so a bad file
+ * refuses the whole run instead of leaving profiles half done; each write is
+ * atomic (temp file, flush, rename). Refuses while Steam runs.
+ */
 DeckShortcutWriteResult writeShortcutForAccount(
     const std::vector<std::filesystem::path>& shortcutFiles,
     const DeckSteamShortcut& shortcut,

--- a/clients/deck/src/runtime/deck_steam_shortcuts.h
+++ b/clients/deck/src/runtime/deck_steam_shortcuts.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Steam keeps non-Steam shortcuts in a binary KeyValues file,
+// userdata/<id>/config/shortcuts.vdf. Registering Nova there is what makes it
+// launchable from Game Mode. The file is rewritten by Steam on exit, so edits
+// only stick while Steam is closed, and every other entry must survive the
+// round trip byte for byte.
+namespace nova::deck::runtime {
+
+/// One value in a binary KeyValues object, in file order.
+struct DeckVdfValue;
+using DeckVdfObject = std::vector<std::pair<std::string, DeckVdfValue>>;
+
+struct DeckVdfValue {
+    enum class Kind {
+        Object,
+        String,
+        Int32,
+    };
+    Kind kind = Kind::String;
+    std::string text;
+    std::int32_t number = 0;
+    DeckVdfObject children;
+};
+
+/// Parse a whole binary KeyValues document (the root object, `shortcuts` for this file). nullopt on malformed input.
+std::optional<DeckVdfObject> parseBinaryVdf(std::string_view bytes);
+
+/// Serialize back to the exact bytes Steam writes.
+std::string serializeBinaryVdf(const DeckVdfObject& root);
+
+struct DeckSteamShortcut {
+    std::string appName;
+    std::string exe;  ///< quoted the way Steam stores it, e.g. "/usr/bin/flatpak"
+    std::string startDir;  ///< quoted, e.g. "/usr/bin/"
+    std::string icon;
+    std::string launchOptions;
+    std::vector<std::string> tags;
+};
+
+/// Steam's id for a non-Steam shortcut: crc32(exe + appName) with the top bit set.
+std::uint32_t steamShortcutAppId(std::string_view exe, std::string_view appName);
+
+/**
+ * @brief Add or replace the shortcut whose AppName matches, leaving every other entry untouched.
+ * @return the new document and whether an existing entry was replaced.
+ */
+struct DeckShortcutRegistration {
+    DeckVdfObject document;
+    bool replaced = false;
+    std::uint32_t appId = 0;
+    std::string entryKey;
+};
+DeckShortcutRegistration registerShortcut(const DeckVdfObject& document, const DeckSteamShortcut& shortcut);
+
+/// Candidate shortcuts.vdf files for the current account: one per Steam user id under userdata.
+std::vector<std::filesystem::path> defaultShortcutFiles(const std::filesystem::path& steamRoot);
+std::vector<std::filesystem::path> defaultSteamRoots();
+
+/// True when a Steam client process runs for this account; shortcuts.vdf edits are lost while it does.
+bool steamClientRunning(const std::filesystem::path& procRoot, unsigned uid);
+
+struct DeckShortcutWriteResult {
+    bool ok = false;
+    std::string detail;
+    std::vector<std::filesystem::path> written;
+    std::uint32_t appId = 0;
+};
+
+/// Register the shortcut in every candidate file (creating the first when none exists). Refuses while Steam runs.
+DeckShortcutWriteResult writeShortcutForAccount(
+    const std::vector<std::filesystem::path>& shortcutFiles,
+    const DeckSteamShortcut& shortcut,
+    bool steamRunning);
+
+} // namespace nova::deck::runtime

--- a/clients/deck/tests/deck_layout_test.cpp
+++ b/clients/deck/tests/deck_layout_test.cpp
@@ -3,6 +3,8 @@
 #include "polaris_game_fixture.h"
 
 #include <cassert>
+#include <unistd.h>
+#include <filesystem>
 #include <cctype>
 #include <cstdlib>
 #include <fstream>
@@ -594,6 +596,28 @@ int main() {
     assert(!libraryFixturePath.empty());
     setenv("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH", libraryFixturePath.c_str(), 1);
     assert(nova::deck::samplePolarisGameLibraryFixturePath() == libraryFixturePath);
+
+    // A fixture directory override wins over every installed location, and a
+    // directory that does not exist surfaces as the path it named, so a typo
+    // fails to open instead of silently loading the checked-in copy.
+    {
+        const auto scratch = std::filesystem::temp_directory_path() / ("nova-deck-fixtures-" + std::to_string(::getpid()));
+        std::filesystem::create_directories(scratch);
+        std::filesystem::copy_file(compiledFixturePath, scratch / "sample_polaris_game.json", std::filesystem::copy_options::overwrite_existing);
+        std::filesystem::copy_file(libraryFixturePath, scratch / "sample_polaris_library.json", std::filesystem::copy_options::overwrite_existing);
+        unsetenv("NOVA_DECK_SAMPLE_GAME_FIXTURE_PATH");
+        unsetenv("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH");
+        setenv("NOVA_DECK_FIXTURE_DIR", scratch.c_str(), 1);
+        assert(nova::deck::samplePolarisGameFixturePath() == scratch / "sample_polaris_game.json");
+        assert(nova::deck::samplePolarisGameLibraryFixturePath() == scratch / "sample_polaris_library.json");
+        assert(nova::deck::loadSamplePolarisGameFixture().name == "Portal 2");
+        setenv("NOVA_DECK_FIXTURE_DIR", "/nonexistent/nova-deck-typo", 1);
+        assert(nova::deck::samplePolarisGameFixturePath() == std::filesystem::path("/nonexistent/nova-deck-typo/sample_polaris_game.json"));
+        unsetenv("NOVA_DECK_FIXTURE_DIR");
+        setenv("NOVA_DECK_SAMPLE_GAME_FIXTURE_PATH", compiledFixturePath.c_str(), 1);
+        setenv("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH", libraryFixturePath.c_str(), 1);
+        std::filesystem::remove_all(scratch);
+    }
 
     const auto library = nova::deck::loadSamplePolarisGameLibraryFixture();
     unsetenv("NOVA_DECK_SAMPLE_LIBRARY_FIXTURE_PATH");

--- a/clients/deck/tests/deck_steam_shortcuts_test.cpp
+++ b/clients/deck/tests/deck_steam_shortcuts_test.cpp
@@ -118,7 +118,7 @@ void testRegistrationAppendsThenReplaces() {
     const auto originalAppId = find(novaEntry, "appid")->number;
     for (auto& [key, value] : novaEntry) {
         if (key == "LastPlayTime") value.number = 1725760000;
-        if (key == "icon") value.text = "/home/deck/.local/share/icons/nova.png";
+        if (key == "icon") value.text = "/srv/icons/nova.png";
         if (key == "IsHidden") value.number = 1;
         if (key == "tags") { DeckVdfValue extra; extra.kind = DeckVdfValue::Kind::String; extra.text = "Favorites"; value.children.emplace_back("1", extra); }
     }
@@ -136,7 +136,7 @@ void testRegistrationAppendsThenReplaces() {
     assert(find(merged, "appid")->number == originalAppId && "a replace keeps the app id grid art hangs off");
     assert(second.appId == static_cast<std::uint32_t>(originalAppId));
     assert(find(merged, "LastPlayTime")->number == 1725760000);
-    assert(find(merged, "icon")->text == "/home/deck/.local/share/icons/nova.png" && "an empty icon in the request leaves the player's icon alone");
+    assert(find(merged, "icon")->text == "/srv/icons/nova.png" && "an empty icon in the request leaves the player's icon alone");
     assert(find(merged, "IsHidden")->number == 1);
     assert(find(merged, "SomeFutureSteamKey")->text == "keep me");
     assert(find(merged, "tags")->children.size() == 2 && "existing tags stay, Nova's tag is not duplicated");

--- a/clients/deck/tests/deck_steam_shortcuts_test.cpp
+++ b/clients/deck/tests/deck_steam_shortcuts_test.cpp
@@ -44,7 +44,7 @@ std::string syntheticFile() {
     bytes += std::string("\x00" "tags" "\x00", 6) + std::string("\x08", 1);
     bytes += std::string("\x08", 1);  // end entry 0
     bytes += std::string("\x08", 1);  // end shortcuts
-    bytes += std::string("\x08", 1);  // end document
+    bytes += std::string("\x08", 1);  // end of the root object, the last byte Steam writes
     return bytes;
 }
 

--- a/clients/deck/tests/deck_steam_shortcuts_test.cpp
+++ b/clients/deck/tests/deck_steam_shortcuts_test.cpp
@@ -1,0 +1,191 @@
+// Tests for the Steam shortcuts writer: binary KeyValues fidelity, the
+// non-Steam app id, idempotent registration, and the refusal to write while
+// Steam runs. NOVA_DECK_STEAM_SHORTCUTS_FIXTURE can point at a real
+// shortcuts.vdf copy for a byte-for-byte round trip.
+#include "runtime/deck_steam_shortcuts.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <unistd.h>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+namespace {
+
+using namespace nova::deck::runtime;
+namespace fs = std::filesystem;
+
+std::string readAll(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+const DeckVdfValue* find(const DeckVdfObject& object, const std::string& key) {
+    for (const auto& [k, v] : object) {
+        if (k == key) {
+            return &v;
+        }
+    }
+    return nullptr;
+}
+
+std::string syntheticFile() {
+    // One existing entry the way Steam writes it, then the closing pair of end markers.
+    std::string bytes;
+    bytes += std::string("\x00shortcuts\x00", 11);
+    bytes += std::string("\x00" "0" "\x00", 3);
+    bytes += std::string("\x02" "appid" "\x00", 7) + std::string("\x01\x02\x03\x84", 4);
+    bytes += std::string("\x01" "AppName" "\x00" "Lutris" "\x00", 16);
+    bytes += std::string("\x01" "Exe" "\x00" "\"/usr/bin/lutris\"" "\x00", 23);
+    bytes += std::string("\x01" "StartDir" "\x00" "\"/usr/bin/\"" "\x00", 22);
+    bytes += std::string("\x02" "IsHidden" "\x00", 10) + std::string("\x00\x00\x00\x00", 4);
+    bytes += std::string("\x00" "tags" "\x00", 6) + std::string("\x08", 1);
+    bytes += std::string("\x08", 1);  // end entry 0
+    bytes += std::string("\x08", 1);  // end shortcuts
+    bytes += std::string("\x08", 1);  // end document
+    return bytes;
+}
+
+void testRoundTripsSyntheticFile() {
+    const auto bytes = syntheticFile();
+    const auto parsed = parseBinaryVdf(bytes);
+    assert(parsed.has_value());
+    assert(parsed->size() == 1 && parsed->front().first == "shortcuts");
+    const auto& shortcuts = parsed->front().second.children;
+    assert(shortcuts.size() == 1 && shortcuts.front().first == "0");
+    const auto& entry = shortcuts.front().second.children;
+    assert(find(entry, "AppName")->text == "Lutris");
+    assert(find(entry, "appid")->kind == DeckVdfValue::Kind::Int32);
+    assert(static_cast<std::uint32_t>(find(entry, "appid")->number) == 0x84030201u);
+    assert(serializeBinaryVdf(*parsed) == bytes);
+
+    assert(!parseBinaryVdf("").has_value());
+    assert(!parseBinaryVdf(bytes.substr(0, bytes.size() - 1)).has_value() && "missing document terminator");
+    assert(!parseBinaryVdf(bytes + "x").has_value() && "trailing bytes");
+}
+
+void testRoundTripsARealFileWhenProvided() {
+    const char* fixture = std::getenv("NOVA_DECK_STEAM_SHORTCUTS_FIXTURE");
+    if (fixture == nullptr || *fixture == '\0') {
+        return;
+    }
+    const auto bytes = readAll(fixture);
+    assert(!bytes.empty());
+    const auto parsed = parseBinaryVdf(bytes);
+    assert(parsed.has_value() && "a real Steam shortcuts.vdf must parse");
+    assert(serializeBinaryVdf(*parsed) == bytes && "a real Steam shortcuts.vdf must round-trip byte for byte");
+}
+
+void testAppIdMatchesSteam() {
+    // crc32("\"/usr/bin/flatpak\"Nova") with the top bit set; the seed is exe then name.
+    const auto id = steamShortcutAppId("\"/usr/bin/flatpak\"", "Nova");
+    assert((id & 0x80000000u) != 0);
+    assert(id == steamShortcutAppId("\"/usr/bin/flatpak\"", "Nova"));
+    assert(id != steamShortcutAppId("\"/usr/bin/flatpak\"", "Nova 2"));
+    assert(steamShortcutAppId("", "") == (0x00000000u | 0x80000000u));
+}
+
+void testRegistrationAppendsThenReplaces() {
+    const auto parsed = parseBinaryVdf(syntheticFile());
+    assert(parsed.has_value());
+    DeckSteamShortcut nova;
+    nova.appName = "Nova";
+    nova.exe = "\"/usr/bin/flatpak\"";
+    nova.startDir = "\"/usr/bin/\"";
+    nova.launchOptions = "run com.papi_ux.Nova";
+    nova.tags = {"Nova"};
+
+    const auto first = registerShortcut(*parsed, nova);
+    assert(!first.replaced);
+    assert(first.entryKey == "1");
+    const auto& shortcuts = first.document.front().second.children;
+    assert(shortcuts.size() == 2);
+    const auto& entry = shortcuts.back().second.children;
+    assert(find(entry, "AppName")->text == "Nova");
+    assert(find(entry, "Exe")->text == "\"/usr/bin/flatpak\"");
+    assert(find(entry, "LaunchOptions")->text == "run com.papi_ux.Nova");
+    assert(find(entry, "AllowOverlay")->number == 1);
+    assert(find(entry, "tags")->children.size() == 1 && find(entry, "tags")->children.front().second.text == "Nova");
+    assert(static_cast<std::uint32_t>(find(entry, "appid")->number) == first.appId);
+    // The original entry is byte-identical after the append.
+    assert(serializeBinaryVdf(first.document).find(syntheticFile().substr(11, 80)) != std::string::npos);
+
+    nova.launchOptions = "run com.papi_ux.Nova --live";
+    const auto second = registerShortcut(first.document, nova);
+    assert(second.replaced);
+    assert(second.entryKey == "1");
+    assert(second.document.front().second.children.size() == 2);
+    assert(find(second.document.front().second.children.back().second.children, "LaunchOptions")->text == "run com.papi_ux.Nova --live");
+
+    const auto fromEmpty = registerShortcut(DeckVdfObject{}, nova);
+    assert(!fromEmpty.replaced && fromEmpty.entryKey == "0");
+    assert(parseBinaryVdf(serializeBinaryVdf(fromEmpty.document)).has_value());
+}
+
+void testWritesFilesAtomicallyAndRefusesWhileSteamRuns() {
+    const auto root = fs::temp_directory_path() / ("nova-deck-shortcuts-" + std::to_string(::getpid()));
+    fs::create_directories(root / "userdata" / "11324806" / "config");
+    fs::create_directories(root / "userdata" / "0" / "config");
+    fs::create_directories(root / "userdata" / "anonymous" / "config");
+    const auto files = defaultShortcutFiles(root);
+    assert(files.size() == 1 && files.front().parent_path().parent_path().filename() == "11324806");
+
+    {
+        std::ofstream out(files.front(), std::ios::binary);
+        const auto bytes = syntheticFile();
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    }
+    DeckSteamShortcut nova;
+    nova.appName = "Nova";
+    nova.exe = "\"/usr/bin/flatpak\"";
+    nova.startDir = "\"/usr/bin/\"";
+    nova.launchOptions = "run com.papi_ux.Nova";
+
+    const auto refused = writeShortcutForAccount(files, nova, true);
+    assert(!refused.ok && refused.detail.find("close Steam") != std::string::npos);
+    assert(readAll(files.front()) == syntheticFile() && "nothing written while Steam runs");
+
+    const auto written = writeShortcutForAccount(files, nova, false);
+    assert(written.ok);
+    assert(written.written.size() == 1);
+    const auto after = parseBinaryVdf(readAll(files.front()));
+    assert(after.has_value() && after->front().second.children.size() == 2);
+    assert(!fs::exists(files.front().string() + ".nova-tmp"));
+
+    const auto again = writeShortcutForAccount(files, nova, false);
+    assert(again.ok);
+    assert(parseBinaryVdf(readAll(files.front()))->front().second.children.size() == 2 && "re-registering replaces, never duplicates");
+
+    const auto none = writeShortcutForAccount({}, nova, false);
+    assert(!none.ok);
+
+    fs::remove_all(root);
+}
+
+void testSteamDetectionReadsProc() {
+    const auto root = fs::temp_directory_path() / ("nova-deck-proc-" + std::to_string(::getpid()));
+    fs::create_directories(root / "4242");
+    fs::create_directories(root / "4243");
+    fs::create_directories(root / "notapid");
+    { std::ofstream(root / "4242" / "comm") << "steam\n"; std::ofstream(root / "4242" / "status") << "Name:\tsteam\nUid:\t1000\t1000\t1000\t1000\n"; }
+    { std::ofstream(root / "4243" / "comm") << "steamwebhelper\n"; std::ofstream(root / "4243" / "status") << "Name:\tsteamwebhelper\nUid:\t1000\t1000\t1000\t1000\n"; }
+    assert(steamClientRunning(root, 1000));
+    assert(!steamClientRunning(root, 1001));
+    fs::remove(root / "4242" / "comm");
+    assert(!steamClientRunning(root, 1000));
+    fs::remove_all(root);
+}
+
+} // namespace
+
+int main() {
+    testRoundTripsSyntheticFile();
+    testRoundTripsARealFileWhenProvided();
+    testAppIdMatchesSteam();
+    testRegistrationAppendsThenReplaces();
+    testWritesFilesAtomicallyAndRefusesWhileSteamRuns();
+    testSteamDetectionReadsProc();
+    return 0;
+}

--- a/clients/deck/tests/deck_steam_shortcuts_test.cpp
+++ b/clients/deck/tests/deck_steam_shortcuts_test.cpp
@@ -23,12 +23,11 @@ std::string readAll(const fs::path& path) {
 }
 
 const DeckVdfValue* find(const DeckVdfObject& object, const std::string& key) {
-    for (const auto& [k, v] : object) {
-        if (k == key) {
-            return &v;
-        }
-    }
-    return nullptr;
+    return findKey(object, key);
+}
+
+std::string entryBytes(const DeckSteamShortcut& shortcut, std::uint32_t appId) {
+    return serializeBinaryVdf(registerShortcut(DeckVdfObject{}, shortcut).document);
 }
 
 std::string syntheticFile() {
@@ -112,16 +111,116 @@ void testRegistrationAppendsThenReplaces() {
     // The original entry is byte-identical after the append.
     assert(serializeBinaryVdf(first.document).find(syntheticFile().substr(11, 80)) != std::string::npos);
 
+    // Steam and the player touch the entry between runs: play time, a custom
+    // icon, a hidden flag, a collection tag and a key Nova has never heard of.
+    auto touched = first.document;
+    auto& novaEntry = touched.front().second.children.back().second.children;
+    const auto originalAppId = find(novaEntry, "appid")->number;
+    for (auto& [key, value] : novaEntry) {
+        if (key == "LastPlayTime") value.number = 1725760000;
+        if (key == "icon") value.text = "/home/deck/.local/share/icons/nova.png";
+        if (key == "IsHidden") value.number = 1;
+        if (key == "tags") { DeckVdfValue extra; extra.kind = DeckVdfValue::Kind::String; extra.text = "Favorites"; value.children.emplace_back("1", extra); }
+    }
+    DeckVdfValue unknown; unknown.kind = DeckVdfValue::Kind::String; unknown.text = "keep me";
+    novaEntry.emplace_back("SomeFutureSteamKey", unknown);
+
+    nova.exe = "\"/usr/bin/flatpak\"";
     nova.launchOptions = "run com.papi_ux.Nova --live";
-    const auto second = registerShortcut(first.document, nova);
+    const auto second = registerShortcut(touched, nova);
     assert(second.replaced);
     assert(second.entryKey == "1");
     assert(second.document.front().second.children.size() == 2);
-    assert(find(second.document.front().second.children.back().second.children, "LaunchOptions")->text == "run com.papi_ux.Nova --live");
+    const auto& merged = second.document.front().second.children.back().second.children;
+    assert(find(merged, "LaunchOptions")->text == "run com.papi_ux.Nova --live");
+    assert(find(merged, "appid")->number == originalAppId && "a replace keeps the app id grid art hangs off");
+    assert(second.appId == static_cast<std::uint32_t>(originalAppId));
+    assert(find(merged, "LastPlayTime")->number == 1725760000);
+    assert(find(merged, "icon")->text == "/home/deck/.local/share/icons/nova.png" && "an empty icon in the request leaves the player's icon alone");
+    assert(find(merged, "IsHidden")->number == 1);
+    assert(find(merged, "SomeFutureSteamKey")->text == "keep me");
+    assert(find(merged, "tags")->children.size() == 2 && "existing tags stay, Nova's tag is not duplicated");
 
     const auto fromEmpty = registerShortcut(DeckVdfObject{}, nova);
     assert(!fromEmpty.replaced && fromEmpty.entryKey == "0");
     assert(parseBinaryVdf(serializeBinaryVdf(fromEmpty.document)).has_value());
+}
+
+void testLowercaseKeysAreFoundAndSpellingIsKept() {
+    // Older clients and third-party tools write lowercase keys; Steam reads them case-insensitively.
+    std::string bytes;
+    bytes += std::string("\x00shortcuts\x00", 11);
+    bytes += std::string("\x00" "0" "\x00", 3);
+    bytes += std::string("\x02" "appid" "\x00", 7) + std::string("\x01\x02\x03\x84", 4);
+    bytes += std::string("\x01" "appname" "\x00" "Nova" "\x00", 14);
+    bytes += std::string("\x01" "exe" "\x00" "\"/usr/bin/flatpak\"" "\x00", 24);
+    bytes += std::string("\x01" "launchoptions" "\x00" "run com.papi_ux.Nova" "\x00", 36);
+    bytes += std::string("\x08", 1) + std::string("\x08", 1) + std::string("\x08", 1);
+    const auto parsed = parseBinaryVdf(bytes);
+    assert(parsed.has_value());
+    DeckSteamShortcut nova;
+    nova.appName = "Nova";
+    nova.exe = "\"/usr/bin/flatpak\"";
+    nova.startDir = "\"/usr/bin/\"";
+    nova.launchOptions = "run com.papi_ux.Nova --live";
+    const auto registration = registerShortcut(*parsed, nova);
+    assert(registration.replaced && "the lowercase entry is Nova's and is updated, not duplicated");
+    const auto& shortcuts = registration.document.front().second.children;
+    assert(shortcuts.size() == 1);
+    const auto& entry = shortcuts.front().second.children;
+    bool sawLowercase = false;
+    for (const auto& [key, value] : entry) {
+        if (key == "launchoptions") { sawLowercase = true; assert(value.text == "run com.papi_ux.Nova --live"); }
+        assert(key != "LaunchOptions" && "no second spelling is added");
+    }
+    assert(sawLowercase);
+    assert(find(entry, "StartDir") != nullptr && "a key Nova owns that was missing is added");
+}
+
+void testUnrelatedShortcutNamedNovaIsLeftAlone() {
+    const auto parsed = parseBinaryVdf(syntheticFile());
+    assert(parsed.has_value());
+    DeckSteamShortcut other;
+    other.appName = "Nova";
+    other.exe = "\"/opt/some-other-tool/nova\"";
+    other.startDir = "\"/opt/some-other-tool/\"";
+    other.launchOptions = "--fancy";
+    other.identityMarkers = {"some-other-tool"};
+    const auto withOther = registerShortcut(*parsed, other);
+    assert(!withOther.replaced);
+
+    DeckSteamShortcut nova;
+    nova.appName = "Nova";
+    nova.exe = "\"/usr/bin/flatpak\"";
+    nova.startDir = "\"/usr/bin/\"";
+    nova.launchOptions = "run com.papi_ux.Nova --live";
+    const auto ours = registerShortcut(withOther.document, nova);
+    assert(!ours.replaced && "same name, not ours: appended, never overwritten");
+    const auto& shortcuts = ours.document.front().second.children;
+    assert(shortcuts.size() == 3);
+    assert(find(shortcuts[1].second.children, "Exe")->text == "\"/opt/some-other-tool/nova\"");
+    assert(find(shortcuts[2].second.children, "LaunchOptions")->text == "run com.papi_ux.Nova --live");
+}
+
+void testOneBadProfileRefusesTheWholeRun() {
+    const auto root = fs::temp_directory_path() / ("nova-deck-profiles-" + std::to_string(::getpid()));
+    fs::create_directories(root / "userdata" / "111" / "config");
+    fs::create_directories(root / "userdata" / "222" / "config");
+    const auto files = defaultShortcutFiles(root);
+    assert(files.size() == 2);
+    { std::ofstream out(files[0], std::ios::binary); const auto b = syntheticFile(); out.write(b.data(), static_cast<std::streamsize>(b.size())); }
+    { std::ofstream out(files[1], std::ios::binary); out << "definitely not a KeyValues file"; }
+    DeckSteamShortcut nova;
+    nova.appName = "Nova";
+    nova.exe = "\"/usr/bin/flatpak\"";
+    nova.startDir = "\"/usr/bin/\"";
+    nova.launchOptions = "run com.papi_ux.Nova --live";
+    const auto result = writeShortcutForAccount(files, nova, false);
+    assert(!result.ok);
+    assert(result.written.empty() && "nothing is written when a later profile cannot be read");
+    assert(result.detail.find("222") != std::string::npos);
+    assert(readAll(files[0]) == syntheticFile() && "the good profile is untouched");
+    fs::remove_all(root);
 }
 
 void testWritesFilesAtomicallyAndRefusesWhileSteamRuns() {
@@ -185,6 +284,9 @@ int main() {
     testRoundTripsARealFileWhenProvided();
     testAppIdMatchesSteam();
     testRegistrationAppendsThenReplaces();
+    testLowercaseKeysAreFoundAndSpellingIsKept();
+    testUnrelatedShortcutNamedNovaIsLeftAlone();
+    testOneBadProfileRefusesTheWholeRun();
     testWritesFilesAtomicallyAndRefusesWhileSteamRuns();
     testSteamDetectionReadsProc();
     return 0;

--- a/docs/steam_deck_native_port_study.md
+++ b/docs/steam_deck_native_port_study.md
@@ -300,8 +300,13 @@ shell.
 Slice 1 of arc 1 is the live read-only route in `clients/deck/README.md`: real hosts
 and library, no execution (shipped as nova#287 and proven on pc-papi against its own
 Polaris through a Moonlight-Qt Flatpak pairing). Slice 2 executes the handoff through
-`clients/deck/src/runtime/deck_moonlight_launcher.*` and returns focus. Slice 3 is
-Game Mode integration (Steam shortcut) and Flatpak packaging on `org.kde.Platform`.
+`clients/deck/src/runtime/deck_moonlight_launcher.*` and returns focus (nova#288,
+proven with a real Moonlight-Qt on pc-papi). Slice 3 packages the shell as the
+`com.papi_ux.Nova` Flatpak on `org.kde.Platform` 6.10 and registers it with Steam
+through `clients/deck/src/runtime/deck_steam_shortcuts.*`, so Game Mode launches it;
+proven on pc-papi from inside the sandbox, including the handoff through the Flatpak
+portal. The remaining physical step is the Deck itself: install the bundle, register
+from Desktop Mode with Steam closed, launch from Game Mode.
 
 ## Deck-T4 streaming backend decision
 


### PR DESCRIPTION
## Summary

Slice 3 of the Steam Deck / Linux handoff arc: the shell ships as a Flatpak and registers itself with Steam so Game Mode can launch it. Proven from inside the sandbox on pc-papi: the live route reads the Polaris library, `--register-steam-shortcut` writes the `flatpak run com.papi_ux.Nova --live` entry, and the Moonlight handoff reaches the real Moonlight-Qt through the Flatpak portal with Polaris logging the session.

- `clients/deck/packaging/flatpak/`: manifest for `com.papi_ux.Nova` on `org.kde.Platform` 6.10 (the runtime Moonlight-Qt already installs on a Deck; the 6.10 SDK carries every native dependency the client needs, so it is a single module), desktop entry, icon, AppStream metadata, and a README with the build, install and permission notes. Permissions: network, wayland, dri, input, read-only Moonlight config, the Steam userdata directories, and `org.freedesktop.Flatpak` for `flatpak-spawn --host`.
- CMake: install rules for the binary, the sample fixtures, the desktop entry, icon and metainfo; moonlight-common-c is now linked statically (its CMake defaults to a shared library that never gets installed, which made the first Flatpak die with exit 127).
- `src/polaris_game_fixture.cpp`: fixtures are resolved at runtime from `NOVA_DECK_FIXTURE_DIR`, `/app/share/nova-deck/fixtures`, or `../share/nova-deck/fixtures` next to the binary before the compile-time source path, which does not exist on a Deck.
- `src/runtime/deck_steam_shortcuts.*`: binary KeyValues parser and serializer for Steam's `shortcuts.vdf` (byte-for-byte round trip of a real file is a test), Steam's non-Steam app id (`crc32(exe + name) | 0x80000000`), idempotent register-or-replace of one "Nova" entry that leaves every other entry untouched, atomic write, refusal while a `steam` process runs for the account (Steam rewrites the file on exit), and `NOVA_DECK_STEAM_ROOT` for proofs against a scratch root.
- `nova-deck --register-steam-shortcut`: inside a Flatpak the entry is `"/usr/bin/flatpak"` with `run com.papi_ux.Nova --live`; natively it is the running binary with `--live`. Exit 5 when refused.
- README and the port study document the slice.

Not in this PR: the physical Deck run (install the bundle, register from Desktop Mode with Steam closed, launch from Game Mode). The Deck has been asleep all night; a watcher installs the bundle and runs the live probe there the moment it answers.

## Exact candidate

- `Commit:` `2693d7ae99edea928b979322528d780f03921fe0`
- `Tree:` `10b10ae603ca959fa933860517a201df06ec9dbf`
- `Parent:` `2caf58595da518e70434128e8035f61f47cbe54c`
- `Base:` `4ccaadc44ad4a9daed889bf568f427a63f6b7717` (master)

## Testing

On pc-papi (Fedora 44, Qt 6.11.2 natively; org.kde.Sdk 6.10 for the Flatpak):

- [x] Native `ninja` + `ctest`: 18/18, including `nova_deck_steam_shortcuts_test` with `NOVA_DECK_STEAM_SHORTCUTS_FIXTURE` pointing at a copy of pc-papi's real `shortcuts.vdf` (seven entries) for the byte-for-byte round trip; `ldd` shows no shared moonlight library
- [x] `nova-deck --register-steam-shortcut` against a scratch Steam root seeded with that real file, with no display environment: appends Nova, a second run updates it in place (one entry), the seven original entries are preserved verbatim
- [x] `cmake --install` to a scratch prefix: binary, fixtures, desktop entry, icon, metainfo land where the manifest expects them
- [x] `flatpak-builder` on org.kde.Sdk//6.10: clean build, 500 KB bundle, installs as a user app
- [x] Inside the sandbox: `--print-live-state` reports `status=ok library=polaris-live games=24`; `--register-steam-shortcut` into a scratch root, with no display environment and the host Steam check answered through `flatpak-spawn`, writes `Exe "/usr/bin/flatpak"` and `LaunchOptions run com.papi_ux.Nova --live`; `--live --handoff-game Desktop --handoff-windowed` reaches the real Moonlight-Qt through `flatpak-spawn --host` (Polaris journal: `Session started` / `Session ended` for the paired client, Nova's poll read `streaming Desktop · owned by this device`)
- [x] Both source guards pass; `scripts/check-public-surface.sh` clean (the first push tripped it on a `/home/deck` literal in a test fixture, replaced by a neutral path)
- [x] Code-review pass on the branch; all ten findings fixed in the head commit: the Steam-running check goes through `flatpak-spawn --host` when sandboxed (the sandbox never sees the host's Steam), registration runs before any window so it works over SSH (proven with DISPLAY and WAYLAND_DISPLAY unset, natively and in the sandbox), KeyValues keys are matched case-insensitively with their spelling kept, only an entry carrying Nova's markers is treated as Nova's, a replace keeps the app id, play time, icon, flags and unknown keys, every profile is prepared before any is written and each write goes through QSaveFile, the per-file fixture overrides are honoured again with a set fixture directory treated as authoritative, the sample library loads only off the live route, the core library is explicitly static with the shared-library override scoped to the submodule, and the manifest no longer creates `~/.steam/steam` on the host and covers Flatpak Steam
- [ ] On the Steam Deck: pending the Deck waking up
- [ ] Android untouched (`app/` has no diff); `clients/deck` is not in CI

## Notes

Process execution stays in `deck_moonlight_launcher.cpp`; the shortcuts writer only touches files. Certificate handling and pairing: unchanged. Steam config: the writer only ever adds or replaces the single entry named "Nova", and refuses to run while Steam is open.
