### PR TITLE
fix(launch): identify the host from serverinfo state, not a Polaris-only probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Launching on a Sunshine host works again. Since 1.4.0 the launch gate identified the host by probing a Polaris-only route and treating anything it could not read as a reason to refuse with "Update Polaris before launching". Sunshine answers an unknown route with a malformed reply that Android reads as a protocol error, so every Sunshine host was blocked. Nova now reads the host family from GameStream serverinfo, the route every host answers the same way, and launches a stock host with local settings. Polaris hosts are identified exactly as before. (#291)
+
 ## 1.4.4 - 2026-09-06
 
 Matched client for Polaris 1.4.4: Wake Host, a Command Center that leads with the verdict's explanation, a MangoHud-style Slim HUD, decode time and a network row in Debug, and labels that say what they do.

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -9,6 +9,7 @@ import com.papi.nova.LimeLog
 import com.papi.nova.R
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.nvstream.http.LimelightCryptoProvider
+import com.papi.nova.nvstream.http.NvHTTP
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -120,6 +121,18 @@ enum class PolarisLaunchHostKind {
 }
 
 /**
+ * Host family read from GameStream serverinfo's <state> field, the one signal
+ * every reachable GameStream host reports the same way. POLARIS_SERVER_* is
+ * Polaris; SUNSHINE_SERVER_*, MJOLNIR (GeForce Experience) and every other
+ * value is a stock host; absent or unreadable is ambiguous.
+ */
+enum class PolarisServerFamily {
+    POLARIS,
+    STOCK,
+    UNKNOWN
+}
+
+/**
  * HTTP client for Polaris REST API on the nvhttp port (47984).
  * Uses the same client certificate as Moonlight pairing.
  */
@@ -148,6 +161,9 @@ class PolarisApiClient @JvmOverloads constructor(
 
     companion object {
         const val WEB_UI_HTTPS_PORT = 47990
+        private const val SERVERINFO_IDENTITY_TIMEOUT_SECONDS = 3L
+        // GameStream serves HTTP five ports above its HTTPS port (47989 vs 47984).
+        private const val GAMESTREAM_HTTP_HTTPS_PORT_OFFSET = 5
         private const val CLIENT_CERT_ALIAS = "Limelight-RSA"
         // Poster-shaped bucket; also the fallback for studio preview cells.
         private const val PREVIEW_TARGET_WIDTH = 512
@@ -1093,6 +1109,23 @@ class PolarisApiClient @JvmOverloads constructor(
         fun supportsDeterministicLaunchContract(capabilities: PolarisCapabilities): Boolean =
             capabilities.features.resolvedProfileProvenance &&
                 capabilities.features.expectedTopologyAssertion
+
+        /**
+         * Map a serverinfo <state> value to a host family. Polaris reports
+         * POLARIS_SERVER_FREE / POLARIS_SERVER_BUSY; a stock GameStream host
+         * reports SUNSHINE_SERVER_*, MJOLNIR* or similar. A blank or missing
+         * value is ambiguous and must not identify a host either way.
+         */
+        @JvmStatic
+        fun launchHostFamilyFromServerState(state: String?): PolarisServerFamily {
+            val trimmed = state?.trim().orEmpty()
+            if (trimmed.isEmpty()) return PolarisServerFamily.UNKNOWN
+            return if (trimmed.startsWith("POLARIS_SERVER", ignoreCase = true)) {
+                PolarisServerFamily.POLARIS
+            } else {
+                PolarisServerFamily.STOCK
+            }
+        }
 
         private fun parseDoctorStatus(
             doctor: JSONObject?,
@@ -2141,50 +2174,102 @@ class PolarisApiClient @JvmOverloads constructor(
 
     /**
      * Resolve host identity for a new launch without publishing process-global
-     * feature state. Network/protocol ambiguity is UNKNOWN and must fail closed;
-     * only explicit 404s from both Polaris routes identify a stock host.
+     * feature state. Identity comes from GameStream serverinfo's <state> field,
+     * which every reachable host answers the same well-formed way, so a stock
+     * host is recognized without depending on how its fork answers an unknown
+     * /polaris/v1 route. Sunshine's not-found handler writes a malformed
+     * 200-then-404 that some HTTP clients read as a protocol error (#291), so a
+     * probe of a Polaris-only route can never be a reliable stock-host signal.
+     * A Polaris host is then split into current or legacy by whether it serves
+     * the deterministic launch contract. Anything ambiguous is UNKNOWN and must
+     * fail closed.
      */
     fun identifyLaunchHost(): PolarisLaunchHostKind {
+        val state = readServerStateForIdentity()
+        return when (launchHostFamilyFromServerState(state)) {
+            PolarisServerFamily.UNKNOWN -> PolarisLaunchHostKind.UNKNOWN
+            PolarisServerFamily.STOCK -> PolarisLaunchHostKind.NON_POLARIS
+            PolarisServerFamily.POLARIS -> probePolarisLaunchContract()
+        }
+    }
+
+    /**
+     * Read the GameStream serverinfo <state> for launch identity. Tries HTTPS
+     * with the paired client certificate first, then falls back to plain HTTP
+     * the way NvHTTP already does. The fallback triggers whenever a readable
+     * state does not come back, not only when the HTTP layer fails: a stock
+     * Sunshine host drops the first cold HTTPS connection in a way Android reads
+     * as a protocol error, and an unpaired or cert-rejected HTTPS serverinfo
+     * answers HTTP 200 with an XML root whose status_code is 401, which is not a
+     * readable state either. Its HTTP serverinfo answers cleanly, and the
+     * <state> field is the same over either transport. Returns null only when
+     * neither transport yields a state, which fails the launch closed.
+     */
+    private fun readServerStateForIdentity(): String? {
+        readServerStateOnce(clientForCall(), "https://$serverAddress:$resolvedHttpsPort/serverinfo", "https")?.let { return it }
+        val httpPort = resolvedHttpsPort + GAMESTREAM_HTTP_HTTPS_PORT_OFFSET
+        return readServerStateOnce(client, "http://$serverAddress:$httpPort/serverinfo", "http")
+    }
+
+    private fun readServerStateOnce(httpClient: OkHttpClient, url: String, transport: String): String? {
+        val probeClient = httpClient.newBuilder()
+            .connectTimeout(SERVERINFO_IDENTITY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(SERVERINFO_IDENTITY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(false)
+            .build()
+        val request = Request.Builder().url(url).header("Connection", "close").build()
+        return try {
+            probeClient.newCall(request).execute().use { response ->
+                if (response.code != 200) return null
+                val body = response.body?.string() ?: return null
+                // getXmlString validates the XML root status_code, so a 401 or
+                // malformed serverinfo throws here and the HTTP fallback is tried.
+                NvHTTP.getXmlString(body, "state", false)?.takeIf { it.isNotBlank() }
+            }
+        } catch (e: Exception) {
+            LimeLog.warning("Nova: Launch host identity serverinfo over $transport failed: ${errorMessage(e)}")
+            null
+        }
+    }
+
+    /**
+     * The host is known to be Polaris from its serverinfo state; decide whether
+     * it serves the deterministic launch contract. A Polaris host answers
+     * /polaris/v1/capabilities with clean JSON, so a failure here is a Polaris
+     * host that cannot prove the contract, which fails closed.
+     */
+    private fun probePolarisLaunchContract(): PolarisLaunchHostKind {
         val probeClient = clientForCall().newBuilder()
             .connectTimeout(2, TimeUnit.SECONDS)
             .readTimeout(2, TimeUnit.SECONDS)
             .retryOnConnectionFailure(false)
             .build()
-        fun executeProbe(path: String) = probeClient.newCall(
-            Request.Builder()
-                .url("$baseUrl$path")
-                .header("Connection", "close")
-                .build()
-        ).execute()
-
         return try {
-            executeProbe("/capabilities").use { response ->
-                when (response.code) {
-                    200 -> {
-                        val body = response.body?.string() ?: return PolarisLaunchHostKind.UNKNOWN
-                        val capabilities = runCatching {
-                            parseCapabilitiesResponse(JSONObject(body))
-                        }.getOrNull() ?: return PolarisLaunchHostKind.UNKNOWN
-                        if (!capabilities.server.equals("polaris", ignoreCase = true)) {
-                            PolarisLaunchHostKind.UNKNOWN
-                        } else if (supportsDeterministicLaunchContract(capabilities)) {
-                            PolarisLaunchHostKind.CURRENT_POLARIS
-                        } else {
-                            PolarisLaunchHostKind.LEGACY_POLARIS
-                        }
-                    }
-                    404 -> executeProbe("/session/status").use { fallback ->
-                        when (fallback.code) {
-                            200 -> PolarisLaunchHostKind.LEGACY_POLARIS
-                            404 -> PolarisLaunchHostKind.NON_POLARIS
-                            else -> PolarisLaunchHostKind.UNKNOWN
-                        }
-                    }
-                    else -> PolarisLaunchHostKind.UNKNOWN
+            probeClient.newCall(
+                Request.Builder()
+                    .url("$baseUrl/capabilities")
+                    .header("Connection", "close")
+                    .build()
+            ).execute().use { response ->
+                if (response.code != 200) return PolarisLaunchHostKind.UNKNOWN
+                val body = response.body?.string() ?: return PolarisLaunchHostKind.UNKNOWN
+                val capabilities = runCatching {
+                    parseCapabilitiesResponse(JSONObject(body))
+                }.getOrNull() ?: return PolarisLaunchHostKind.UNKNOWN
+                // The serverinfo state said Polaris; a capabilities document that
+                // does not agree is contradictory, so fail closed rather than
+                // trust a foreign body.
+                if (!capabilities.server.equals("polaris", ignoreCase = true)) {
+                    return PolarisLaunchHostKind.UNKNOWN
+                }
+                if (supportsDeterministicLaunchContract(capabilities)) {
+                    PolarisLaunchHostKind.CURRENT_POLARIS
+                } else {
+                    PolarisLaunchHostKind.LEGACY_POLARIS
                 }
             }
         } catch (e: Exception) {
-            LimeLog.warning("Nova: Launch host identity probe failed: ${errorMessage(e)}")
+            LimeLog.warning("Nova: Polaris launch contract probe failed: ${errorMessage(e)}")
             PolarisLaunchHostKind.UNKNOWN
         }
     }

--- a/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisApiClientParsingTest.kt
@@ -883,6 +883,27 @@ class PolarisApiClientParsingTest {
     }
 
     @Test
+    fun launchHostFamilyReadsTheServerinfoState() {
+        // The real serverinfo state strings, captured from paired hosts.
+        assertEquals(PolarisServerFamily.POLARIS, PolarisApiClient.launchHostFamilyFromServerState("POLARIS_SERVER_FREE"))
+        assertEquals(PolarisServerFamily.POLARIS, PolarisApiClient.launchHostFamilyFromServerState("POLARIS_SERVER_BUSY"))
+        assertEquals(PolarisServerFamily.POLARIS, PolarisApiClient.launchHostFamilyFromServerState("  polaris_server_free  "))
+
+        // Every stock GameStream host is a stock host, identified without its
+        // /polaris/v1 answer. This is the #291 fix: Sunshine no longer needs to
+        // return a readable 404 to be recognized.
+        assertEquals(PolarisServerFamily.STOCK, PolarisApiClient.launchHostFamilyFromServerState("SUNSHINE_SERVER_FREE"))
+        assertEquals(PolarisServerFamily.STOCK, PolarisApiClient.launchHostFamilyFromServerState("SUNSHINE_SERVER_BUSY"))
+        assertEquals(PolarisServerFamily.STOCK, PolarisApiClient.launchHostFamilyFromServerState("MJOLNIR_SERVER_FREE"))
+        assertEquals(PolarisServerFamily.STOCK, PolarisApiClient.launchHostFamilyFromServerState("APOLLO_SERVER_FREE"))
+
+        // A blank or missing state is ambiguous and identifies nothing.
+        assertEquals(PolarisServerFamily.UNKNOWN, PolarisApiClient.launchHostFamilyFromServerState(null))
+        assertEquals(PolarisServerFamily.UNKNOWN, PolarisApiClient.launchHostFamilyFromServerState(""))
+        assertEquals(PolarisServerFamily.UNKNOWN, PolarisApiClient.launchHostFamilyFromServerState("   "))
+    }
+
+    @Test
     fun parseSessionStatusResponse_includesHdrDowngradeTruth() {
         val health = JSONObject()
             .put("primary_issue", "hdr_downgraded")


### PR DESCRIPTION
## Summary

Fixes #291. Since 1.4.0 the launch gate identifies the host before every launch and fails closed on anything it cannot read. It probed `/polaris/v1/capabilities` and `/polaris/v1/session/status` and accepted only an HTTP 404 from both as proof of a stock GameStream host. Sunshine never sends that: its not_found handler writes the GameStream XML through the default response path, producing a malformed reply (HTTP 200 with a second raw 404 appended, bare-newline framing) that Android's HTTP client reads as an SSL protocol error. The probe threw, the host was called unknown, and the launch was refused with "Update Polaris before launching". Every Sunshine host has been blocked since 1.4.0.

Identity now comes from GameStream serverinfo, the route every reachable host answers the same well-formed way. Its `<state>` field is `POLARIS_SERVER_*` on Polaris and `SUNSHINE_SERVER_*` / `MJOLNIR` / similar on a stock host, parsed with the existing `NvHTTP.getXmlString`. A stock host launches with local settings; a Polaris host is split into current or legacy by whether `/polaris/v1/capabilities` reports the deterministic contract, a route Polaris answers cleanly. This is a positive identity for both families, so no released Polaris host can be misread as stock, and it does not depend on how any fork answers an unknown route.

The serverinfo fetch tries HTTPS with the pinned client certificate, then falls back to plain HTTP exactly as `NvHTTP` does, because a stock Sunshine host drops the first cold HTTPS connection in the same protocol-error way, while its HTTP serverinfo answers cleanly and carries the same `<state>`. Anything ambiguous is still `UNKNOWN` and fails the launch closed.

## Exact candidate

- `Commit:` `c39c9ff24778f16ed043fe8aad180e67d23ea5f7`
- `Tree:` `111a63748ac09c6fc2bbbe4a310b66968fbb38a6`
- `Base:` `a06b13837f03d0c19321de4bf5c18044330fbb16` (master)

## Testing

- [x] `testNonRoot_gameDebugUnitTest` on pc-papi: PolarisApiClientParsingTest green, including the new state-to-family mapping test against the real serverinfo strings
- [x] Wire capture: real Sunshine 2025.922 (Docker on Unraid) answers an unknown `/polaris/v1` route with a malformed two-response body; its `/serverinfo` answers cleanly over both HTTPS and HTTP with `<state>SUNSHINE_SERVER_FREE</state>`; pc-papi Polaris answers `<state>POLARIS_SERVER_FREE</state>`
- [x] **Device, the #291 case:** Retroid Pocket 6, `com.papi.nova.debug` paired to that Sunshine. The current release refuses with the toast; this build passes identity and issues the real GameStream launch (the host returns 503 only because the headless container has no display to capture). Reliable across cold starts (3/3), which the earlier HTTPS-only cut failed
- [x] **Device, Polaris regression:** the same build launching a pc-papi Polaris game takes the deterministic path (`/polaris/v1/optimize` HTTP 200, `source=deterministic_preset_v1`, `state=deterministic`), never "Stock host" or "Legacy or unknown"

## Notes

Reporter is on an AYN Thor with Sunshine on CachyOS through Obtainium. No Polaris-side change is needed. An HTTPS client cert that a host rejects (401) now falls back to HTTP serverinfo and still identifies the host, rather than reporting "Update Polaris" for an authorization problem.
