### PR TITLE
Sync Live Tuning across Command Center and NovaHUD

### DIFF
--- a/app/src/main/java/com/papi/nova/Game.kt
+++ b/app/src/main/java/com/papi/nova/Game.kt
@@ -6270,6 +6270,8 @@ internal fun launchRuntimeIo(name:String, block:suspend kotlinx.coroutines.Corou
 runtimeTasks.launchIo(name, block)
 }
 
+internal fun cancelRuntimeTask(name:String) { runtimeTasks.cancel(name) }
+
 internal fun launchReplacingRuntimeIo(name:String, block:suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {
 runtimeTasks.launchIoReplacing(name, block)
 }
@@ -6336,58 +6338,60 @@ if (!connected && !isStreamActive)
 {
 novaProgressOverlay?.show()
 }
-novaEventSource = com.papi.nova.api.PolarisEventSource(host ?: "",
-object : com.papi.nova.api.PolarisEventSource.EventListener {
-override fun onSessionEvent(event:String, state:String, message:String) {
-LimeLog.info("Nova SSE: " + event + " [" + state + "] " + message)
-if (PolarisSessionEvents.isCurrentSessionEvent(event, state))
-{
-polarisSseSawCurrentSessionEvent = true
+val sourceClient = novaApiClient ?: return
+val eventsEndpoint = sourceClient.sessionEventsUrl ?: return
+lateinit var source: com.papi.nova.api.PolarisEventSource
+var previousSessionState = ""
+fun deliverToCurrentSession(action: () -> Unit) {
+runOnUiThread {
+if (novaEventSource === source && novaApiClient === sourceClient && source.isRunning &&
+    !isFinishing && !isDestroyed) action()
 }
-novaProgressOverlay!!.updateState(state, message)
-if (PolarisSessionEvents.shouldFinishGameActivity(event, state, polarisSseSawCurrentSessionEvent))
-{
+}
+source = com.papi.nova.api.PolarisEventSource(eventsEndpoint,
+object : com.papi.nova.api.PolarisEventSource.EventListener {
+override fun onSessionEvent(event:String, state:String, message:String) = deliverToCurrentSession {
+if (PolarisSessionEvents.isCurrentSessionEvent(event, state)) polarisSseSawCurrentSessionEvent = true
+novaProgressOverlay?.updateState(state, message)
+if (PolarisSessionEvents.shouldFinishGameActivity(event, state, polarisSseSawCurrentSessionEvent)) {
 handlePolarisHostSessionEnded()
 }
 }
-override fun onStateUpdate(sessionState:String, cageRunning:Boolean, screenLocked:Boolean) {
-if (PolarisSessionEvents.isCurrentSessionEvent("", sessionState))
-{
-polarisSseSawCurrentSessionEvent = true
+override fun onStateUpdate(sessionState:String, cageRunning:Boolean, screenLocked:Boolean) = deliverToCurrentSession {
+if (PolarisSessionEvents.isCurrentSessionEvent("", sessionState)) polarisSseSawCurrentSessionEvent = true
+novaProgressOverlay?.updateState(sessionState, "")
+// State heartbeats already carry tuning. Refresh full status on transitions only.
+if (sessionState == "streaming" && previousSessionState != sessionState) {
+schedulePolarisLiveSessionStatusRefresh(true)
+} else if (PolarisSessionEvents.shouldFinishGameActivity("", sessionState, polarisSseSawCurrentSessionEvent)) {
+handlePolarisHostSessionEnded()
 }
-novaProgressOverlay!!.updateState(sessionState, "")
-if ("streaming".equals(sessionState))
-{
+previousSessionState = sessionState
+if (novaHasLockScreenControl()) {
+if (shouldShowPolarisLockOverlay(screenLocked, cageRunning)) novaLockScreenOverlay?.show()
+else novaLockScreenOverlay?.dismiss()
+}
+}
+override fun onConnectionLost() = deliverToCurrentSession {
 schedulePolarisLiveSessionStatusRefresh(true)
 }
-else if (PolarisSessionEvents.shouldFinishGameActivity("", sessionState, polarisSseSawCurrentSessionEvent))
-{
-handlePolarisHostSessionEnded()
+override fun onResyncNeeded() = deliverToCurrentSession { schedulePolarisLiveSessionStatusRefresh(true) }
+override fun onInvalidLiveTuning() = deliverToCurrentSession {
+sourceClient.invalidateLiveTuningEvent()
+lastPolarisSessionStatus = sourceClient.sessionStatusUpdates.value
+novaHud?.applySessionStatus(lastPolarisSessionStatus)
+schedulePolarisLiveSessionStatusRefresh(true)
 }
-if (novaHasLockScreenControl())
-{
-var shouldShowLockOverlay:Boolean = shouldShowPolarisLockOverlay(screenLocked, cageRunning)
-if (shouldShowLockOverlay && cageRunning)
-{
-LimeLog.info("Nova SSE: host lock flag received while stream compositor is running; showing unlock overlay")
+override fun onLiveTuning(state:com.papi.nova.api.LiveTuningStatus) = deliverToCurrentSession {
+sourceClient.acceptLiveTuningEvent(state)
+val current = sourceClient.sessionStatusUpdates.value
+lastPolarisSessionStatus = current
+novaHud?.applySessionStatus(current)
+updateCompanionCommandDeck()
 }
-if (shouldShowLockOverlay)
-{
-novaLockScreenOverlay!!.show()
-}
-else
-{
-novaLockScreenOverlay!!.dismiss()
-}
-}
-}
-override fun onConnectionLost() {
-LimeLog.warning("Nova SSE: Connection lost")
-}
-},
-novaApiClient!!.client
-)
-novaEventSource!!.start()
+}, sourceClient.client)
+novaEventSource = source
+source.start()
 }
 
 private fun schedulePolarisLiveSessionStatusRefresh(immediate:Boolean) {
@@ -6659,22 +6663,32 @@ if (novaApiClient == null || !polarisSessionStatusRefreshInFlight.compareAndSet(
 return
 }
 
+val statusClient = novaApiClient ?: return
 runtimeTasks.launchIo("NovaSessionStatus") { try
 {
-var status:com.papi.nova.api.PolarisSessionStatus? = novaApiClient!!.getSessionStatus()
+val status = statusClient.getSessionStatus()
 if (status != null)
 {
-lastPolarisSessionStatus = status
 runtimeTasks.runOnMainIfActive {
-if (isFinishing || isDestroyed)
+if (novaApiClient !== statusClient || isFinishing || isDestroyed)
 {
 return@runOnMainIfActive
 }
-novaHud?.applySessionStatus(status)
-maybeShowDisplayModeWarning(status)
+val current = statusClient.sessionStatusUpdates.value
+lastPolarisSessionStatus = current
+startNovaEventSourceIfSupported()
+novaHud?.applySessionStatus(current)
+current?.let { maybeShowDisplayModeWarning(it) }
 updateCompanionCommandDeck()
 }
 reportClientPresentationIfNeeded(status)
+} else {
+runtimeTasks.runOnMainIfActive {
+if (novaApiClient === statusClient) {
+lastPolarisSessionStatus = statusClient.sessionStatusUpdates.value
+novaHud?.applySessionStatus(lastPolarisSessionStatus)
+}
+}
 }
 }
 catch (e:kotlinx.coroutines.CancellationException) {

--- a/app/src/main/java/com/papi/nova/api/LiveTuningStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/LiveTuningStatus.kt
@@ -1,0 +1,58 @@
+package com.papi.nova.api
+
+import org.json.JSONObject
+
+/** Host-owned preference and encoder acknowledgement. AI readiness is independent. */
+data class LiveTuningStatus(
+    val enabled: Boolean,
+    val state: String,
+    val supported: Boolean,
+    val reason: String,
+    val qualityLimitKbps: Int,
+    val requestedBitrateKbps: Int,
+    val appliedBitrateKbps: Int,
+    val configurationRevision: String,
+    val hostInstance: String,
+    val sequence: Long,
+    val sessionGeneration: Long,
+    val appSessionId: String,
+) {
+    companion object {
+        private fun integer(json: JSONObject, key: String, min: Long, max: Long): Boolean {
+            val value = json.opt(key)
+            return (value is Int || value is Long) && (value as Number).toLong() in min..max
+        }
+        fun parse(json: JSONObject?): LiveTuningStatus? {
+            if (json == null || json.opt("version") != 1 || json.opt("enabled") !is Boolean ||
+                json.opt("supported") !is Boolean || json.optString("scope") != "host" ||
+                !json.optString("configuration_revision").matches(Regex("[a-fA-F0-9]{64}")) ||
+                json.opt("host_instance") !is String || json.optString("host_instance").isBlank() ||
+                !integer(json, "sequence", 1, 9007199254740991L) ||
+                !integer(json, "session_generation", 0, 9007199254740991L) ||
+                listOf("quality_limit_kbps", "requested_bitrate_kbps", "applied_bitrate_kbps").any { !integer(json, it, 0, Int.MAX_VALUE.toLong()) } ||
+                json.opt("app_session_id") !is String ||
+                json.optString("state") !in setOf("off", "waiting", "unavailable", "applying", "measuring", "adjusting", "stable")) return null
+            return LiveTuningStatus(
+                json.getBoolean("enabled"), json.getString("state"), json.getBoolean("supported"),
+                json.optString("reason"), json.optInt("quality_limit_kbps"),
+                json.optInt("requested_bitrate_kbps"), json.optInt("applied_bitrate_kbps"),
+                json.getString("configuration_revision"), json.getString("host_instance"),
+                json.getLong("sequence"), json.optLong("session_generation"), json.optString("app_session_id")
+            )
+        }
+    }
+}
+
+/** One reducer per pinned host client. Discard delayed observations and old host instances. */
+class LiveTuningReducer {
+    private var current: LiveTuningStatus? = null
+    private val retired = mutableSetOf<String>()
+    @Synchronized fun accept(next: LiveTuningStatus): LiveTuningStatus? {
+        if (next.hostInstance in retired) return null
+        val previous = current
+        if (previous?.hostInstance == next.hostInstance && next.sequence <= previous.sequence) return null
+        if (previous != null && previous.hostInstance != next.hostInstance) retired.add(previous.hostInstance)
+        current = next
+        return next
+    }
+}

--- a/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisApiClient.kt
@@ -151,7 +151,37 @@ class PolarisApiClient @JvmOverloads constructor(
     private var apiTrustManager: X509TrustManager? = null
     private val resolvedHttpsPort = if (httpsPort > 0) httpsPort else 47984
     private val baseUrl = "https://$serverAddress:$resolvedHttpsPort/polaris/v1"
-    private val webBaseUrl = "https://$serverAddress:$WEB_UI_HTTPS_PORT"
+    private val webBaseUrl = "https://$serverAddress:${resolvedHttpsPort + 6}"
+    @Volatile private var advertisedEventsPort: Int? = null
+    val sessionEventsUrl: String? get() = advertisedEventsPort?.let { port ->
+        okhttp3.HttpUrl.Builder().scheme("https").host(serverAddress.removeSurrounding("[", "]"))
+            .port(port).addPathSegments("api/polaris/events").build().toString()
+    }
+    // Read the immutable snapshot before invoking UI code; never hold the API monitor through a consumer.
+    fun <T> withCurrentSessionStatus(consumer: (PolarisSessionStatus?) -> T): T = consumer(mutableSessionStatus.value)
+    @Synchronized fun invalidateLiveTuningEvent() {
+        val current = mutableSessionStatus.value ?: return
+        if (current.liveTuningPresent) publishStatus(current.copy(liveTuning = null, liveTuningPresent = true))
+    }
+    @Synchronized fun acceptLiveTuningEvent(live: LiveTuningStatus) {
+        val current = mutableSessionStatus.value ?: return
+        if (current.liveTuning?.hostInstance == live.hostInstance &&
+            current.sessionGeneration == live.sessionGeneration && current.appSessionId == live.appSessionId) {
+            publishStatus(current.copy(liveTuning = live, liveTuningPresent = true))
+        }
+    }
+    // Status reads are authoritative resync boundaries. Serializing their I/O
+    // prevents a delayed, previously unseen old host from replacing a new one.
+    private val statusObservationLock = Any()
+    private val liveTuningReducer = LiveTuningReducer()
+    private val mutableSessionStatus = kotlinx.coroutines.flow.MutableStateFlow<PolarisSessionStatus?>(null)
+    val sessionStatusUpdates: kotlinx.coroutines.flow.StateFlow<PolarisSessionStatus?> = mutableSessionStatus
+    @Synchronized private fun publishStatus(status: PolarisSessionStatus?): PolarisSessionStatus? {
+        if (status == null) { mutableSessionStatus.value = null; return null }
+        if (status.liveTuning != null && liveTuningReducer.accept(status.liveTuning) == null) return mutableSessionStatus.value
+        mutableSessionStatus.value = status
+        return status
+    }
     private val artworkDiskCache = PolarisArtworkDiskCache(context.applicationContext, serverAddress, resolvedHttpsPort)
     private val artworkResolveOnce = ArtworkResolveOnce<PolarisGame.ArtworkManifest>()
     private val imageScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(3))
@@ -1724,6 +1754,8 @@ class PolarisApiClient @JvmOverloads constructor(
                 screenLocked = json.optBoolean("screen_locked", false),
                 cursorVisible = json.optBoolean("cursor_visible", false),
                 dynamicRange = json.optInt("dynamic_range", 0),
+                liveTuning = LiveTuningStatus.parse(json.optJSONObject("live_tuning")),
+                liveTuningPresent = json.has("live_tuning"),
                 adaptiveBitrateEnabled = json.optBoolean("adaptive_bitrate_enabled", false),
                 adaptiveTargetBitrateKbps = json.optInt("adaptive_target_bitrate_kbps", 0),
                 aiAutoQualityEnabled = json.optBoolean(
@@ -2278,16 +2310,19 @@ class PolarisApiClient @JvmOverloads constructor(
      * Query the current session state. Used by ConnectionResilienceManager
      * to determine if the server session is still alive after a stream drop.
      */
-    fun getSessionStatus(): PolarisSessionStatus? {
-        return try {
+    fun getSessionStatus(): PolarisSessionStatus? = synchronized(statusObservationLock) {
+        try {
             val request = Request.Builder().url("$baseUrl/session/status").build()
             executeGetWithRetry(request).use { response ->
-                if (response.code != 200) return null
-                parseSessionStatusResponse(JSONObject(response.body?.string() ?: return null))
+                if (response.code != 200) return publishStatus(null)
+                val json = JSONObject(response.body?.string() ?: return publishStatus(null))
+                val port = json.optInt("events_https_port", 0)
+                advertisedEventsPort = port.takeIf { it in 1..65535 }
+                publishStatus(parseSessionStatusResponse(json))
             }
         } catch (e: Exception) {
             LimeLog.warning("Nova: Session status query failed: ${errorMessage(e)}")
-            null
+            publishStatus(null)
         }
     }
 
@@ -2974,41 +3009,46 @@ class PolarisApiClient @JvmOverloads constructor(
     }
 
     /**
-     * Compatibility API for older Polaris hosts. Current Polaris maps this to AI Auto Quality.
+     * Compatibility name for Live Tuning; AI explanation readiness is independent.
      */
-    fun setAdaptiveBitrateEnabled(enabled: Boolean): Boolean {
+    fun setAdaptiveBitrateEnabled(enabled: Boolean): Boolean =
+        setLiveTuningEnabled(enabled, mutableSessionStatus.value ?: getSessionStatus())
+
+    fun setLiveTuningEnabled(enabled: Boolean, observed: PolarisSessionStatus?): Boolean = synchronized(statusObservationLock) {
+        val status = observed?.takeIf {
+            it.canAdjustHostTuning && it.appSessionId.isNotBlank() && it.sessionGeneration > 0L
+        } ?: return false
+        if (status.liveTuningPresent && status.liveTuning == null) return false
         return try {
-            val status = getSessionStatus()?.takeIf {
-                it.canAdjustHostTuning && it.appSessionId.isNotBlank() && it.sessionGeneration > 0L
-            } ?: return false
-            val body = org.json.JSONObject().apply {
+            val body = JSONObject().apply {
                 put("enabled", enabled)
                 put("app_session_id", status.appSessionId)
                 put("session_generation", status.sessionGeneration)
+                status.liveTuning?.let { put("configuration_revision", it.configurationRevision) }
             }
-            val request = Request.Builder()
-                .url("$baseUrl/session/adaptive-bitrate")
-                .post(okhttp3.RequestBody.create(
-                    "application/json".toMediaTypeOrNull(),
-                    body.toString()
-                ))
-                .build()
-            executeWithTransientRetry(request).use { response ->
-                response.code == 200
+            val request = Request.Builder().url("$baseUrl/session/adaptive-bitrate")
+                .post(okhttp3.RequestBody.create("application/json".toMediaTypeOrNull(), body.toString())).build()
+            // A lost response must refresh; never replay a stale operator decision.
+            executeNonRetryable(request).use { response ->
+                val result = JSONObject(response.body?.string().orEmpty())
+                val live = LiveTuningStatus.parse(result.optJSONObject("live_tuning"))
+                if (live != null && live.sessionGeneration == status.sessionGeneration && live.appSessionId == status.appSessionId) {
+                    acceptLiveTuningEvent(live)
+                }
+                response.code == 200 && result.optBoolean("status")
             }
         } catch (e: Exception) {
-            LimeLog.warning("Nova: Adaptive bitrate toggle failed: ${errorMessage(e)}")
+            LimeLog.warning("Nova: Live Tuning save failed: ${errorMessage(e)}")
+            publishStatus(null)
             false
         }
     }
 
     /**
-     * Toggle AI Auto Quality. Polaris maps this to optimizer decisions and adaptive bitrate.
+     * Legacy compatibility name for the host Live Tuning preference.
      */
     fun setAiAutoQualityEnabled(enabled: Boolean): Boolean {
-        val aiUpdated = setAiOptimizerEnabled(enabled)
-        val adaptiveUpdated = setAdaptiveBitrateEnabled(enabled)
-        return aiUpdated || adaptiveUpdated
+        return setAdaptiveBitrateEnabled(enabled)
     }
 
     /**

--- a/app/src/main/java/com/papi/nova/api/PolarisEventSource.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisEventSource.kt
@@ -1,133 +1,122 @@
 package com.papi.nova.api
 
 import com.papi.nova.LimeLog
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.Response
-import java.io.BufferedReader
-import java.io.InputStreamReader
+import org.json.JSONObject
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
-/**
- * Server-Sent Events (SSE) client for Polaris session lifecycle events.
- * Connects to /api/polaris/events and dispatches events to a listener.
- *
- * Runs on a background thread. Auto-reconnects on connection loss.
- */
+/** Session events from the selected host's authenticated, advertised endpoint. */
 class PolarisEventSource(
-    private val baseUrl: String,
+    private val endpoint: String,
     private val listener: EventListener,
-    sharedClient: OkHttpClient? = null
+    sharedClient: OkHttpClient
 ) {
     interface EventListener {
         fun onSessionEvent(event: String, state: String, message: String)
         fun onStateUpdate(sessionState: String, cageRunning: Boolean, screenLocked: Boolean)
         fun onConnectionLost()
+        fun onResyncNeeded() {}
+        fun onLiveTuning(state: LiveTuningStatus) {}
+        fun onInvalidLiveTuning() {}
     }
-
-    private val running = AtomicBoolean(false)
+    private val generation = AtomicLong(0)
     private var thread: Thread? = null
+    @Volatile private var activeCall: Call? = null
+    private val client = sharedClient.newBuilder().connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .followRedirects(false).followSslRedirects(false).build()
 
-    // Derive from shared client to reuse connection pool and TLS config,
-    // but override read timeout for SSE long-polling
-    private val client = (sharedClient?.newBuilder() ?: OkHttpClient.Builder())
-        .connectTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(0, TimeUnit.MILLISECONDS) // No read timeout for SSE
-        .build()
-
-    fun start() {
-        if (running.getAndSet(true)) return
-
+    @Synchronized fun start() {
+        if (thread != null) return
+        val epoch = generation.incrementAndGet()
         thread = Thread({
-            while (running.get()) {
-                try {
-                    connect()
-                } catch (e: Exception) {
-                    LimeLog.warning("Nova SSE: Connection error: ${e.message}")
-                }
-
-                if (running.get()) {
-                    listener.onConnectionLost()
-                    // Reconnect after 2 seconds
-                    try { Thread.sleep(2000) } catch (_: InterruptedException) { break }
-                }
+            var delay = 1000L
+            while (generation.get() == epoch) {
+                try { connect(epoch); delay = 1000L }
+                catch (e: Exception) { if (generation.get() == epoch) LimeLog.warning("Nova SSE: ${e.javaClass.simpleName}") }
+                if (generation.get() != epoch) break
+                deliver(epoch) { listener.onConnectionLost() }
+                try { Thread.sleep(delay) } catch (_: InterruptedException) { break }
+                delay = (delay * 2).coerceAtMost(15000L)
             }
         }, "nova-sse").apply { isDaemon = true; start() }
-
-        LimeLog.info("Nova SSE: Started")
     }
+    val isRunning: Boolean @Synchronized get() = thread != null
 
-    fun stop() {
-        running.set(false)
+    @Synchronized fun stop() {
+        generation.incrementAndGet()
+        activeCall?.cancel() // Interrupt a blocked socket read, not just the Java thread.
+        activeCall = null
         thread?.interrupt()
         thread = null
-        LimeLog.info("Nova SSE: Stopped")
     }
-
-    private fun connect() {
-        // Use the web UI port (47990) for SSE, not nvhttp
-        val url = "https://$baseUrl:${PolarisApiClient.WEB_UI_HTTPS_PORT}/api/polaris/events"
-        val request = Request.Builder()
-            .url(url)
-            .header("Accept", "text/event-stream")
-            .build()
-
-        val response: Response = client.newCall(request).execute()
-        if (response.code != 200) {
-            LimeLog.warning("Nova SSE: HTTP ${response.code}")
-            response.close()
-            return
+    private inline fun deliver(epoch: Long, callback: () -> Unit) = synchronized(this) {
+        if (generation.get() == epoch) callback()
+    }
+    private fun connect(epoch: Long) {
+        val call = client.newCall(Request.Builder().url(endpoint).header("Accept", "text/event-stream").build())
+        synchronized(this) {
+            if (generation.get() != epoch) return
+            activeCall = call
         }
-
-        LimeLog.info("Nova SSE: Connected to $url")
-        val reader = BufferedReader(InputStreamReader(response.body!!.byteStream()))
-
-        var eventType = ""
-        val dataBuffer = StringBuilder()
-
-        while (running.get()) {
-            val line = reader.readLine() ?: break
-
-            when {
-                line.startsWith("event: ") -> {
-                    eventType = line.substring(7).trim()
-                }
-                line.startsWith("data: ") -> {
-                    dataBuffer.append(line.substring(6))
-                }
-                line.isEmpty() -> {
-                    // End of event — dispatch
-                    if (dataBuffer.isNotEmpty()) {
-                        try {
-                            val json = org.json.JSONObject(dataBuffer.toString())
-                            when (eventType) {
-                                "session" -> {
-                                    listener.onSessionEvent(
-                                        json.optString("event", ""),
-                                        json.optString("state", ""),
-                                        json.optString("message", "")
-                                    )
+        try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) return
+                if (generation.get() != epoch) return
+                // The server sends snapshots, not a retained replay log.
+                deliver(epoch) { listener.onResyncNeeded() }
+                val source = response.body?.source() ?: return
+                var event = ""
+                var id = ""
+                var lastId = ""
+                val data = StringBuilder()
+                while (generation.get() == epoch && !source.exhausted()) {
+                    val line = source.readUtf8LineStrict(65536)
+                    if (generation.get() != epoch) break
+                    when {
+                        line.startsWith("event:") -> event = line.substring(6).trim()
+                        line.startsWith("id:") -> id = line.substring(3).trim()
+                        line.startsWith("data:") -> {
+                            if (data.length + line.length > 65536) throw java.io.IOException("SSE event too large")
+                            if (data.isNotEmpty()) data.append('\n')
+                            data.append(line.substring(5).removePrefix(" "))
+                        }
+                        line.isEmpty() -> {
+                            if (data.isNotEmpty()) {
+                                if (id.isNotEmpty() && lastId.isNotEmpty() && !consecutiveEventIds(lastId, id)) deliver(epoch) { listener.onResyncNeeded() }
+                                val json = JSONObject(data.toString())
+                                when (event) {
+                                    "session" -> deliver(epoch) { listener.onSessionEvent(json.optString("event"), json.optString("state"), json.optString("message")) }
+                                    "state" -> {
+                                        deliver(epoch) {
+                                            listener.onStateUpdate(json.optString("session_state", "idle"), json.optBoolean("cage_running"), json.optBoolean("screen_locked"))
+                                        }
+                                        val live = LiveTuningStatus.parse(json.optJSONObject("live_tuning"))
+                                        deliver(epoch) {
+                                            if (live != null) listener.onLiveTuning(live)
+                                            else listener.onInvalidLiveTuning()
+                                        }
+                                    }
                                 }
-                                "state" -> {
-                                    listener.onStateUpdate(
-                                        json.optString("session_state", "idle"),
-                                        json.optBoolean("cage_running", false),
-                                        json.optBoolean("screen_locked", false)
-                                    )
-                                }
+                                if (id.isNotEmpty()) lastId = id
                             }
-                        } catch (e: Exception) {
-                            LimeLog.warning("Nova SSE: Parse error: ${e.message}")
+                            event = ""; id = ""; data.clear()
                         }
                     }
-                    eventType = ""
-                    dataBuffer.clear()
                 }
             }
+        } finally { synchronized(this) { if (activeCall === call) activeCall = null } }
+    }
+    companion object {
+        fun consecutiveEventIds(previous: String, next: String): Boolean {
+            val a = previous.substringBeforeLast(':', "")
+            val b = next.substringBeforeLast(':', "")
+            val x = previous.substringAfterLast(':').toLongOrNull()
+            val y = next.substringAfterLast(':').toLongOrNull()
+            return a.isNotEmpty() && a == b && x != null && x < Long.MAX_VALUE && y == x + 1
         }
-
-        reader.close()
-        response.close()
     }
 }

--- a/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
+++ b/app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt
@@ -23,6 +23,8 @@ data class PolarisSessionStatus(
     val screenLocked: Boolean = false,
     val cursorVisible: Boolean = false,
     val dynamicRange: Int = 0,
+    val liveTuning: LiveTuningStatus? = null,
+    val liveTuningPresent: Boolean = false,
     val adaptiveBitrateEnabled: Boolean = false,
     val adaptiveTargetBitrateKbps: Int = 0,
     val aiAutoQualityEnabled: Boolean = false,

--- a/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/AutoQualityUiState.kt
@@ -1,8 +1,8 @@
 package com.papi.nova.ui
 
 import com.papi.nova.api.PolarisSessionStatus
-import kotlin.math.roundToInt
 
+// Keep the source name for existing HUD consumers; this models only Live Tuning.
 data class AutoQualityUiState(
     val state: State,
     val label: String,
@@ -14,391 +14,47 @@ data class AutoQualityUiState(
     val recovering: Boolean = false,
     val manualOverride: Boolean = false
 ) {
-    enum class State {
-        OFF,
-        WATCHING,
-        OPTIMIZING,
-        STABLE,
-        RECOVERING,
-        BLOCKED,
-        UPGRADE_AVAILABLE,
-        MANUAL_OVERRIDE,
-        NEEDS_ATTENTION
-    }
-
-    enum class Tone {
-        MUTED,
-        INFO,
-        STABLE,
-        WARNING,
-        DANGER
-    }
-
+    enum class State { OFF, WATCHING, OPTIMIZING, STABLE, RECOVERING, BLOCKED,
+        UPGRADE_AVAILABLE, MANUAL_OVERRIDE, NEEDS_ATTENTION }
+    enum class Tone { MUTED, INFO, STABLE, WARNING, DANGER }
     companion object {
-        @JvmStatic
-        fun from(
-            status: PolarisSessionStatus?,
-            fallbackTargetFps: Double = 0.0
-        ): AutoQualityUiState {
-            if (status == null) {
-                return AutoQualityUiState(
-                    state = State.WATCHING,
-                    label = "Checking Stream",
-                    compactLabel = "CHECK",
-                    detail = "Waiting for Polaris session status",
-                    targetSummary = "",
-                    tone = Tone.MUTED,
-                    enabled = true
-                )
+        @JvmStatic fun from(status: PolarisSessionStatus?, fallbackTargetFps: Double = 0.0): AutoQualityUiState {
+            val policy = StreamPolicyUiState.from(status, fallbackTargetFps = fallbackTargetFps)
+            val live = status?.liveTuning
+            val unknown = status == null || (status.liveTuningPresent && live == null)
+            if (unknown) return AutoQualityUiState(State.WATCHING, "Live Tuning: Unknown", "Tuning: Unknown",
+                "Waiting for the host to confirm the setting", policy.targetSummary, Tone.MUTED, false)
+            val enabled = live?.enabled ?: (status!!.tuning.adaptiveBitrateEnabled || status.adaptiveBitrateEnabled)
+            if (!enabled) return AutoQualityUiState(State.OFF, "Live Tuning Off", "Tuning Off",
+                "Automatic bitrate adjustment is off", policy.targetSummary, Tone.MUTED, false)
+            // Older hosts expose preference and target only. Never claim encoder acknowledgement.
+            if (live == null) return AutoQualityUiState(State.WATCHING, "Live Tuning On", "Tuning: On",
+                "Enabled on this host; encoder acknowledgement is unavailable", policy.targetSummary, Tone.INFO, true)
+            val label = when (live.state) {
+                "waiting" -> "Live Tuning On — waiting for a stream"
+                "unavailable" -> "Live Tuning On — unavailable for this stream"
+                "applying" -> "Live Tuning On — applying bitrate"
+                "measuring" -> "Live Tuning On — measuring"
+                "adjusting" -> "Live Tuning On — adjusting"
+                else -> "Live Tuning On — stable"
             }
-
-            val adaptiveEnabled = status.tuning.adaptiveBitrateEnabled || status.adaptiveBitrateEnabled
-            val aiEnabled = status.tuning.aiOptimizerEnabled || status.aiOptimizerEnabled
-            val autoEnabled = adaptiveEnabled || aiEnabled
-            val syncState = status.syncStatus.state.lowercase()
-            val presentationStatus = status.clientPresentation.status.lowercase()
-            val targetFps = listOf(
-                status.encoder.sessionTargetFps,
-                status.encoder.encodeTargetFps,
-                status.encoder.requestedClientFps,
-                fallbackTargetFps
-            ).firstOrNull { it > 0.0 } ?: 0.0
-            val streamPolicy = StreamPolicyUiState.from(status, fallbackTargetFps = fallbackTargetFps)
-            val autoPolicy = status.autoQuality
-            val adaptiveTarget = streamPolicy.adaptiveTargetBitrateKbps
-            val adaptiveLowered = streamPolicy.hasAdaptiveCap ||
-                (
-                    adaptiveEnabled &&
-                        adaptiveTarget > 0 &&
-                        streamPolicy.adaptiveBaseBitrateKbps > 0 &&
-                        adaptiveTarget < streamPolicy.adaptiveBaseBitrateKbps
-                    )
-            val authoritativeDoctor = status.hasAuthoritativeDoctorResult
-            val legacyHealthSummary = status.health.summary.takeIf {
-                !authoritativeDoctor && it.isNotBlank()
+            val compact = when (live.state) {
+                "waiting" -> "Tuning: Waiting"
+                "unavailable" -> "Tuning: Unavailable"
+                "applying" -> "Tuning: Applying"
+                "measuring" -> "Tuning: Measuring"
+                "adjusting" -> "Auto: ${live.appliedBitrateKbps / 1000} / ${live.qualityLimitKbps / 1000}M"
+                else -> "Tuning: On"
             }
-            val healthGrade = if (authoritativeDoctor) "stable" else status.health.grade.lowercase()
-            val healthAutoAction = if (authoritativeDoctor) "" else status.health.autoAction.lowercase()
-            val healthSuggestsRecovery = status.hasHealthConcerns ||
-                (!authoritativeDoctor && status.health.recoveryProfile.isNotBlank()) ||
-                (!authoritativeDoctor && status.health.relaunchRecommended) ||
-                healthAutoAction == "lower_bitrate" ||
-                healthAutoAction == "lower_render_profile" ||
-                healthAutoAction == "apply_recovery" ||
-                healthAutoAction == "suggest_recovery"
-            val hostRenderLimited = status.isHostRenderLimited
-            val currentBitrate = streamPolicy.effectiveBitrateKbps
-            val safeBitrateApplied = !authoritativeDoctor && healthSuggestsRecovery &&
-                status.health.safeBitrateKbps > 0 &&
-                currentBitrate > 0 &&
-                status.health.safeBitrateKbps < currentBitrate
-            val safeFpsApplied = !authoritativeDoctor && status.health.safeTargetFps > 0.0 &&
-                targetFps > 0.0 &&
-                status.health.safeTargetFps < targetFps
-            val hostRenderRecoveryQueued = hostRenderLimited &&
-                (
-                    (!authoritativeDoctor && autoPolicy.isRecoveryQueued) ||
-                    (!authoritativeDoctor && status.health.relaunchRecommended) ||
-                        safeFpsApplied
-                    )
-            val safeProfileApplied = safeFpsApplied ||
-                safeBitrateApplied ||
-                (!authoritativeDoctor && healthSuggestsRecovery && status.health.safeDisplayMode.isNotBlank()) ||
-                (!authoritativeDoctor && status.health.recoveryProfile.isNotBlank())
-            val syncFailed = status.syncStatus.isFailed ||
-                presentationStatus == "blocked"
-            val severeHealth = healthGrade == "degraded" ||
-                (!authoritativeDoctor && status.health.decoderRisk.equals("elevated", ignoreCase = true))
-            val manualOverride = status.syncStatus.isManualOverride ||
-                syncState == "manual_override"
-            val cleanAdaptiveRecovery = authoritativeDoctor &&
-                adaptiveLowered &&
-                !status.hasHealthConcerns
-
-            if (status.isHdrDowngraded) {
-                return AutoQualityUiState(
-                    state = State.NEEDS_ATTENTION,
-                    label = "HDR Downgraded",
-                    compactLabel = "HDR",
-                    detail = "Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = true
-                )
-            }
-            if (!autoEnabled && !manualOverride) {
-                return AutoQualityUiState(
-                    state = State.OFF,
-                    label = "Live Tuning Off",
-                    compactLabel = "OFF",
-                    detail = "Manual stream tuning is active",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.MUTED,
-                    enabled = false
-                )
-            }
-
-            val manualNeedsAttention = manualOverride && (
-                syncFailed ||
-                    severeHealth
-                )
-
-            if (manualOverride && manualNeedsAttention) {
-                return AutoQualityUiState(
-                    state = State.NEEDS_ATTENTION,
-                    label = "Sync Attention",
-                    compactLabel = "MAN",
-                    detail = status.syncStatus.message.takeIf { it.isNotBlank() }
-                        ?: legacyHealthSummary
-                        ?: "Nova and Polaris need a settings check",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = autoEnabled,
-                    manualOverride = true
-                )
-            }
-
-            if (hostRenderRecoveryQueued) {
-                val safeTarget = status.health.safeTargetFps
-                    .takeIf { it > 0.0 }
-                    ?: autoPolicy.suggestedTargetFps
-                val detail = when {
-                    safeTarget > 0.0 -> "Observed host pacing pressure near ${safeTarget.roundToInt()} FPS; launch settings are unchanged"
-                    !authoritativeDoctor && autoPolicy.summary.isNotBlank() -> autoPolicy.summary
-                    legacyHealthSummary != null -> legacyHealthSummary
-                    else -> "Host render evidence needs a read-only pacing recheck"
-                }
-                return AutoQualityUiState(
-                    state = State.NEEDS_ATTENTION,
-                    label = "Frame Pacing Watch",
-                    compactLabel = "HOST",
-                    detail = detail,
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = true,
-                    recovering = false,
-                    manualOverride = manualOverride
-                )
-            }
-
-            if (!authoritativeDoctor && autoPolicy.isBlocked) {
-                val hostBlocked = autoPolicy.normalizedBlockedReason == "host_render_limited" ||
-                    hostRenderLimited
-                val label = when {
-                    hostBlocked -> "Host render limited"
-                    autoPolicy.normalizedBlockedReason == "network" -> "Network limited"
-                    autoPolicy.normalizedBlockedReason == "encoder" -> "Encoder limited"
-                    autoPolicy.normalizedBlockedReason == "decoder" -> "Decoder limited"
-                    else -> "Live tuning holding"
-                }
-                return AutoQualityUiState(
-                    state = State.BLOCKED,
-                    label = label,
-                    compactLabel = when {
-                        hostBlocked -> "HOST"
-                        autoPolicy.normalizedBlockedReason == "network" -> "NET"
-                        autoPolicy.normalizedBlockedReason == "encoder" -> "ENC"
-                        autoPolicy.normalizedBlockedReason == "decoder" -> "DEC"
-                        else -> "HOLD"
-                    },
-                    detail = autoPolicy.summary.takeIf { it.isNotBlank() }
-                        ?: legacyHealthSummary
-                        ?: "Holding quality until the stream is stable",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = true,
-                    recovering = false,
-                    manualOverride = manualOverride
-                )
-            }
-
-            if (hostRenderLimited) {
-                return AutoQualityUiState(
-                    state = State.BLOCKED,
-                    label = "Host Render Limited",
-                    compactLabel = "HOST",
-                    detail = status.doctor.likelyCause.takeIf {
-                        authoritativeDoctor && it.isNotBlank()
-                    } ?: legacyHealthSummary
-                        ?: "Holding quality until the host render path reaches the stream FPS target",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = true,
-                    recovering = false,
-                    manualOverride = manualOverride
-                )
-            }
-
-            if (syncFailed || severeHealth) {
-                val label = when {
-                    status.health.decoderRisk.equals("elevated", ignoreCase = true) -> "Decoder pressure"
-                    syncFailed -> "Sync attention"
-                    else -> "Needs Attention"
-                }
-                return AutoQualityUiState(
-                    state = State.NEEDS_ATTENTION,
-                    label = label,
-                    compactLabel = "ATTN",
-                    detail = legacyHealthSummary
-                        ?: status.syncStatus.message.takeIf { it.isNotBlank() }
-                        ?: "Doctor needs a stream setting check",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.DANGER,
-                    enabled = true
-                )
-            }
-
-            if (autoPolicy.isRecoveringBitrate || cleanAdaptiveRecovery) {
-                return AutoQualityUiState(
-                    state = State.RECOVERING,
-                    label = "Recovering Bitrate",
-                    compactLabel = streamPolicy.adaptiveTargetLabel
-                        .takeIf { it.isNotBlank() }
-                        ?.replace(" Mbps", "M")
-                        ?: "SAFE",
-                    detail = autoPolicy.summary.takeIf { it.isNotBlank() }
-                        ?: if (status.tuning.adaptiveBitrateState.equals("recovering", ignoreCase = true)) {
-                            "Auto Safe is recovering toward the launch quality ceiling"
-                        } else {
-                            "Auto Safe is holding a lower live target while the stream remains healthy"
-                        },
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.INFO,
-                    enabled = true,
-                    recovering = true,
-                    manualOverride = manualOverride
-                )
-            }
-
-            if (!authoritativeDoctor && autoPolicy.isUpgradeAvailable) {
-                return AutoQualityUiState(
-                    state = State.UPGRADE_AVAILABLE,
-                    label = "Higher Quality Ready",
-                    compactLabel = "UP",
-                    detail = autoPolicy.summary.takeIf { it.isNotBlank() }
-                        ?: if (autoPolicy.relaunchRequired) {
-                            "Relaunch for higher quality"
-                        } else {
-                            "Higher quality is available on the next launch"
-                        },
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.INFO,
-                    enabled = true,
-                    recovering = false,
-                    manualOverride = manualOverride
-                )
-            }
-
-            val sessionState = status.state.lowercase()
-            if (sessionState == "initializing" ||
-                sessionState == "cage_starting" ||
-                sessionState == "game_launching" ||
-                status.encoder.optimizationCacheStatus.equals("miss", ignoreCase = true) ||
-                syncState == "applying"
-            ) {
-                return AutoQualityUiState(
-                    state = State.OPTIMIZING,
-                    label = "Applying Launch Preset",
-                    compactLabel = "SETUP",
-                    detail = "Resolving the selected preset against host and client capabilities",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.INFO,
-                    enabled = true
-                )
-            }
-
-            if (healthSuggestsRecovery ||
-                adaptiveLowered ||
-                safeProfileApplied ||
-                (!authoritativeDoctor && status.health.relaunchRecommended) ||
-                healthAutoAction == "lower_bitrate" ||
-                healthAutoAction == "lower_render_profile" ||
-                healthAutoAction == "apply_recovery" ||
-                healthAutoAction == "suggest_recovery" ||
-                hostRenderLimited
-            ) {
-                val label = when {
-                    hostRenderLimited -> "Host render limited"
-                    status.healthToneLabel == "Frame pacing" -> "Frame pacing"
-                    healthGrade == "degraded" -> "Stream degraded"
-                    healthGrade == "watch" -> "Needs attention"
-                    adaptiveLowered -> "Live bitrate adjusted"
-                    else -> "Doctor observation"
-                }
-                val detail = (if (authoritativeDoctor) {
-                    status.doctor.likelyCause
-                } else {
-                    legacyHealthSummary.orEmpty()
-                }).takeIf {
-                    it.isNotBlank() && !it.trim().trimEnd('.', '!').equals("Stable", ignoreCase = true)
-                }
-                    ?: when {
-                        status.hasHealthConcerns -> status.healthToneLabel
-                        adaptiveLowered -> streamPolicy.statusCaption
-                        safeFpsApplied -> "Historical FPS guidance is observational; launch settings are unchanged"
-                        hostRenderLimited -> "Host render path is missing the target frame rate"
-                        else -> "Recheck the measured evidence or review manual guidance"
-                    }
-                return AutoQualityUiState(
-                    state = State.NEEDS_ATTENTION,
-                    label = label,
-                    compactLabel = when {
-                        hostRenderLimited -> "HOST"
-                        adaptiveLowered -> streamPolicy.adaptiveTargetLabel.replace(" Mbps", "M")
-                        else -> "SAFE"
-                    },
-                    detail = detail,
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.WARNING,
-                    enabled = true,
-                    recovering = false,
-                    manualOverride = manualOverride
-                )
-            }
-
-            if (manualOverride) {
-                return AutoQualityUiState(
-                    state = State.STABLE,
-                    label = "Quality Preset",
-                    compactLabel = "QLTY",
-                    detail = status.syncStatus.message.takeIf { it.isNotBlank() }
-                        ?: streamPolicy.statusCaption,
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.STABLE,
-                    enabled = autoEnabled,
-                    manualOverride = true
-                )
-            }
-
-            if (!status.isStreaming) {
-                return AutoQualityUiState(
-                    state = State.WATCHING,
-                    label = "Launch Ready",
-                    compactLabel = "READY",
-                    detail = "Ready for the next stream",
-                    targetSummary = streamPolicy.targetSummary,
-                    tone = Tone.INFO,
-                    enabled = true
-                )
-            }
-
-            return AutoQualityUiState(
-                state = State.STABLE,
-                label = if (autoPolicy.isAtQualityCap) "Stream at Quality Cap" else "Stream Ready",
-                compactLabel = "OK",
-                detail = autoPolicy.summary.takeIf { !authoritativeDoctor && it.isNotBlank() }
-                    ?: status.doctor.likelyCause.takeIf {
-                        authoritativeDoctor &&
-                            it.isNotBlank() &&
-                            !it.equals("No confirmed issue", ignoreCase = true)
-                    }
-                    ?: legacyHealthSummary
-                    ?: "Stream target is holding steady",
-                targetSummary = streamPolicy.targetSummary,
-                tone = Tone.STABLE,
-                enabled = true
-            )
+            val detail = if (live.state == "unavailable") live.reason.replace('_', ' ') else
+                if (live.appliedBitrateKbps > 0) "${StreamPolicyUiState.formatMbps(live.appliedBitrateKbps)} applied / ${StreamPolicyUiState.formatMbps(live.qualityLimitKbps)} limit" else
+                    "Automatically adjust stream bitrate within your quality limit"
+            return AutoQualityUiState(when (live.state) {
+                "unavailable" -> State.BLOCKED
+                "applying", "adjusting" -> State.RECOVERING
+                "waiting", "measuring" -> State.WATCHING
+                else -> State.STABLE
+            }, label, compact, detail, policy.targetSummary, if (live.supported) Tone.STABLE else Tone.INFO, true)
         }
-
     }
 }

--- a/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt
@@ -72,6 +72,7 @@ data class NovaHudUiState(
     val autopilotLabel: String,
     val autopilotHudLabel: String,
     val autopilotCompactLabel: String,
+    val tuningTone: NovaHudTone = NovaHudTone.MUTED,
     val fpsTone: NovaHudTone,
     val latencyTone: NovaHudTone,
     val statusTone: NovaHudTone,
@@ -198,7 +199,8 @@ data class NovaHudUiState(
                 autopilotCompactLabel = autoQuality.compactLabel,
                 fpsTone = toneForFps(fps, status),
                 latencyTone = toneForLatency(latencyMs),
-                statusTone = if (healthReason.second == NovaHudTone.WARNING || healthReason.second == NovaHudTone.DANGER) healthReason.second else autoQuality.tone.toHudTone(),
+                statusTone = healthReason.second,
+                tuningTone = autoQuality.tone.toHudTone(),
                 healthReasonLabel = healthReason.first,
                 healthReasonTone = healthReason.second,
                 streamTruthLabel = buildStreamTruth(status, targetFps, codec, height),
@@ -554,40 +556,7 @@ data class NovaHudUiState(
         private fun buildSessionModeShortLabel(status: PolarisSessionStatus): String =
             status.sessionModeLabel.substringBefore(" (").trim()
 
-        private fun AutoQualityUiState.hudLabel(): String = when (state) {
-            AutoQualityUiState.State.OFF -> "Live Tune Off"
-            AutoQualityUiState.State.WATCHING -> "Doctor Check"
-            AutoQualityUiState.State.OPTIMIZING -> "Launch Setup"
-            AutoQualityUiState.State.STABLE -> when {
-                manualOverride -> "Quality Preset"
-                label.contains("cap", ignoreCase = true) -> "At Quality Cap"
-                else -> "Stream Ready"
-            }
-            AutoQualityUiState.State.RECOVERING -> when {
-                compactLabel == "HOST" -> "Host Recovery"
-                label.contains("safe", ignoreCase = true) -> "Auto Safe"
-                label.contains("cap", ignoreCase = true) -> "Auto Safe"
-                label.contains("bitrate", ignoreCase = true) -> "Bitrate Recovery"
-                label.contains("FPS", ignoreCase = true) -> "FPS Recovery"
-                else -> "Recovering"
-            }
-            AutoQualityUiState.State.BLOCKED -> when {
-                label.contains("host", ignoreCase = true) -> "Host Limited"
-                label.contains("network", ignoreCase = true) -> "Network Limited"
-                label.contains("encoder", ignoreCase = true) -> "Encoder Limited"
-                label.contains("decoder", ignoreCase = true) -> "Decoder Limited"
-                else -> "Holding"
-            }
-            AutoQualityUiState.State.UPGRADE_AVAILABLE -> "Quality Ready"
-            AutoQualityUiState.State.MANUAL_OVERRIDE -> "Manual"
-            AutoQualityUiState.State.NEEDS_ATTENTION -> when {
-                label.contains("sync", ignoreCase = true) -> "Sync Attention"
-                label.contains("decoder", ignoreCase = true) -> "Decoder Pressure"
-                label.contains("pacing", ignoreCase = true) -> "Pacing Watch"
-                label.contains("bitrate", ignoreCase = true) -> "Bitrate Adjusted"
-                else -> "Attention"
-            }
-        }
+        private fun AutoQualityUiState.hudLabel(): String = compactLabel
 
         private fun AutoQualityUiState.Tone.toHudTone(): NovaHudTone = when (this) {
             AutoQualityUiState.Tone.MUTED -> NovaHudTone.MUTED

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenu.kt
@@ -107,6 +107,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             }
         }
         overlay.setOnDismissListener {
+            game.cancelRuntimeTask("NovaQuickMenuLiveTuning")
             if (doctorMenuRefreshRegistry.close(menuValidationGeneration)) {
                 synchronized(doctorActionLock) {
                     doctorReceiptValidatedScopeId = null
@@ -162,20 +163,15 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         var advancedTuningVisible = false
         var profileClearInProgress = false
         var hostStateUnavailable = false
+        var liveTuningPending = false
         lateinit var scheduleDoctorVerification: (DoctorActionReceipt?) -> Unit
 
         fun menuValidationIsCurrent(): Boolean =
             doctorMenuRefreshRegistry.isCurrent(menuValidationGeneration)
 
         fun syncSessionDerivedState() {
-            adaptiveEnabled = sessionStatus?.tuning?.adaptiveBitrateEnabled == true ||
-                sessionStatus?.adaptiveBitrateEnabled == true
-            aiEnabled = sessionStatus?.autoQuality?.enabled == true ||
-                sessionStatus?.tuning?.aiAutoQualityEnabled == true ||
-                sessionStatus?.aiAutoQualityEnabled == true ||
-                sessionStatus?.tuning?.aiOptimizerEnabled == true ||
-                sessionStatus?.aiOptimizerEnabled == true ||
-                adaptiveEnabled
+            adaptiveEnabled = sessionStatus?.liveTuning?.enabled ?: (sessionStatus?.tuning?.adaptiveBitrateEnabled == true || sessionStatus?.adaptiveBitrateEnabled == true)
+            aiEnabled = adaptiveEnabled
             mangoHudEnabled = sessionStatus?.tuning?.mangohudConfigured == true ||
                 sessionStatus?.mangohudConfigured == true
         }
@@ -226,14 +222,23 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
             }
         }
 
-        fun acceptRefreshedSessionStatus(refreshed: PolarisSessionStatus?): Boolean {
-            if (refreshed == null) return false
+        // All menu/receipt publication runs on Main. Async completions resolve
+        // the current store there, so an earlier GET cannot replay old state.
+        fun publishCurrentSessionStatus(): Boolean {
             return doctorMenuRefreshRegistry.runIfCurrent(menuValidationGeneration) {
-                sessionStatus = refreshed
-                syncSessionDerivedState()
-                syncDoctorReceiptScope()
-                true
+                apiClient?.withCurrentSessionStatus { current ->
+                    sessionStatus = current
+                    syncSessionDerivedState()
+                    syncDoctorReceiptScope()
+                    current != null
+                } ?: false
             } ?: false
+        }
+
+        suspend fun acceptRefreshedSessionStatus(@Suppress("UNUSED_PARAMETER") refreshed: PolarisSessionStatus?): Boolean {
+            var accepted = false
+            game.runOnMainIfRuntimeActive { accepted = publishCurrentSessionStatus() }
+            return accepted
         }
 
         fun canExecuteDoctorAction(
@@ -464,6 +469,7 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                 status = sessionStatus,
                 apiAvailable = apiClient != null,
                 hostStateUnavailable = hostStateUnavailable,
+                liveTuningPending = liveTuningPending,
                 adaptiveSupported = adaptiveSupported,
                 aiSupported = aiSupported,
                 adaptiveEnabled = adaptiveEnabled,
@@ -497,7 +503,13 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
 
         var uiState by mutableStateOf(buildState())
         fun refreshState() {
-            uiState = buildState()
+            if (apiClient != null) apiClient.withCurrentSessionStatus { current ->
+                sessionStatus = current
+                hostStateUnavailable = current == null
+                syncSessionDerivedState()
+                syncDoctorReceiptScope()
+                uiState = buildState()
+            } else uiState = buildState()
         }
 
         fun sendQuickKey(actionId: NovaQuickMenuActionId) {
@@ -850,7 +862,25 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     game.launchRuntimeIo("NovaQuickMenuSyncStatus") {
                         acceptRefreshedSessionStatus(apiClient.getSessionStatus())
                         game.runOnMainIfRuntimeActive {
-                            hostStateUnavailable = false
+                            refreshState()
+                        }
+                    }
+                }
+            },
+            onLiveTuning = {
+                val observed = sessionStatus
+                if (apiClient != null && observed?.canAdjustHostTuning == true && !hostStateUnavailable && !liveTuningPending) {
+                    val desired = !(observed.liveTuning?.enabled ?: adaptiveEnabled)
+                    liveTuningPending = true
+                    refreshState()
+                    game.launchRuntimeIo("NovaLiveTuningSave") {
+                        val success = apiClient.setLiveTuningEnabled(desired, observed)
+                        apiClient.getSessionStatus()
+                        game.runOnMainIfRuntimeActive {
+                            if (!menuValidationIsCurrent()) return@runOnMainIfRuntimeActive
+                            liveTuningPending = false
+                            hostStateUnavailable = !publishCurrentSessionStatus()
+                            if (!success) NovaSnackbar.showError(game, "Settings changed or could not be confirmed. Review Live Tuning and try again.", anchor = composeView)
                             refreshState()
                         }
                     }
@@ -1066,30 +1096,28 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
         }
 
         if (apiClient != null) {
+            game.launchReplacingRuntimeIo("NovaQuickMenuLiveTuning") {
+                apiClient.sessionStatusUpdates.collect {
+                    game.runOnMainIfRuntimeActive {
+                        if (!menuValidationIsCurrent()) return@runOnMainIfRuntimeActive
+                        hostStateUnavailable = !publishCurrentSessionStatus()
+                        refreshState()
+                    }
+                }
+            }
             game.launchReplacingRuntimeIo("NovaQuickMenuStateRefresh") {
                 try {
                     // Capabilities do not change inside a stream; one fetch per session,
                     // not one per open.
                     val refreshedCapabilities = capabilities ?: apiClient.getCapabilities()
-                    val refreshedSessionStatus = apiClient.getSessionStatus()
-                    val accepted = doctorMenuRefreshRegistry.runIfCurrent(menuValidationGeneration) {
-                        synchronized(doctorActionLock) {
-                            capabilities = refreshedCapabilities
-                            sessionStatus = refreshedSessionStatus
-                            val polarisSessionApiAvailable = sessionStatus != null
-                            adaptiveSupported = capabilities?.features?.adaptiveBitrateControl == true || polarisSessionApiAvailable
-                            aiSupported = capabilities?.features?.aiAutoQualityControl == true ||
-                                capabilities?.features?.aiOptimizerControl == true
-                            hostStateUnavailable = false
-                            syncSessionDerivedState()
-                            syncDoctorReceiptScope()
-                            true
-                        }
-                    } ?: false
-                    if (!accepted) return@launchReplacingRuntimeIo
-
+                    apiClient.getSessionStatus()
                     game.runOnMainIfRuntimeActive {
                         if (!menuValidationIsCurrent()) return@runOnMainIfRuntimeActive
+                        capabilities = refreshedCapabilities
+                        adaptiveSupported = capabilities?.features?.adaptiveBitrateControl == true
+                        aiSupported = capabilities?.features?.aiAutoQualityControl == true ||
+                            capabilities?.features?.aiOptimizerControl == true
+                        publishCurrentSessionStatus()
                         scheduleDoctorVerification(doctorReceipt)
                         refreshState()
                     }
@@ -1097,16 +1125,8 @@ class NovaQuickMenu(private val game: Game) : Game.GameMenuCallbacks {
                     throw e
                 } catch (e: Exception) {
                     LimeLog.warning("Nova: Quick menu state refresh failed: ${e.message}")
-                    val accepted = doctorMenuRefreshRegistry.runIfCurrent(menuValidationGeneration) {
-                        synchronized(doctorActionLock) {
-                            hostStateUnavailable = true
-                            true
-                        }
-                    } ?: false
-                    if (accepted) {
-                        game.runOnMainIfRuntimeActive {
-                            if (menuValidationIsCurrent()) refreshState()
-                        }
+                    game.runOnMainIfRuntimeActive {
+                        if (menuValidationIsCurrent()) refreshState()
                     }
                 }
             }

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuContent.kt
@@ -79,6 +79,7 @@ data class NovaQuickMenuCallbacks(
     val onDisconnect: () -> Unit = {},
     val onEndStream: () -> Unit = {},
     val onStability: () -> Unit = {},
+    val onLiveTuning: () -> Unit = {},
     val onSyncStatus: () -> Unit = {},
     val onToggleAdvanced: () -> Unit = {},
     val onClearGameProfile: () -> Unit = {},
@@ -98,6 +99,7 @@ data class NovaQuickMenuCallbacks(
             NovaQuickMenuActionId.DISCONNECT -> onDisconnect()
             NovaQuickMenuActionId.END_STREAM -> onEndStream()
             NovaQuickMenuActionId.STABILITY -> onStability()
+            NovaQuickMenuActionId.LIVE_TUNING -> onLiveTuning()
             NovaQuickMenuActionId.SYNC_STATUS -> onSyncStatus()
             NovaQuickMenuActionId.ADVANCED_TUNING -> onToggleAdvanced()
             NovaQuickMenuActionId.CLEAR_GAME_PROFILE -> onClearGameProfile()
@@ -332,6 +334,7 @@ fun NovaQuickMenuContent(
                 .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 18.dp)
         ) {
             NovaQuickMenuSessionStrip(state, initialFocusRequester)
+            NovaQuickMenuRow(state.liveTuningAction, callbacks)
             // The keys a handheld cannot press any other way stay one reach from the top;
             // the full keyboard grid lives further down with the rest of the panels.
             if (state.pinnedQuickKeys.isNotEmpty()) {

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -17,6 +17,7 @@ enum class NovaQuickMenuActionId {
     DISCONNECT,
     END_STREAM,
     STABILITY,
+    LIVE_TUNING,
     SYNC_STATUS,
     ADVANCED_TUNING,
     CLEAR_GAME_PROFILE,
@@ -142,6 +143,7 @@ data class NovaQuickMenuUiState(
     val disconnectAction: NovaQuickMenuAction,
     val endAction: NovaQuickMenuAction,
     val stability: NovaQuickMenuStabilityState,
+    val liveTuningAction: NovaQuickMenuAction = NovaQuickMenuAction(NovaQuickMenuActionId.LIVE_TUNING, "Live Tuning", enabled = false),
     val sync: NovaQuickMenuAction,
     val advancedToggle: NovaQuickMenuAction,
     val advancedExpanded: Boolean,
@@ -173,6 +175,7 @@ data class NovaQuickMenuUiState(
             status: PolarisSessionStatus?,
             apiAvailable: Boolean,
             hostStateUnavailable: Boolean = false,
+            liveTuningPending: Boolean = false,
             adaptiveSupported: Boolean,
             aiSupported: Boolean,
             adaptiveEnabled: Boolean,
@@ -208,16 +211,6 @@ data class NovaQuickMenuUiState(
             val ownerInputAllowed = !viewerSession
             val streamPolicy = StreamPolicyUiState.from(status, fallbackBitrateKbps, fallbackTargetFps)
             val autoQuality = AutoQualityUiState.from(status, fallbackTargetFps)
-            val effectiveAdaptiveEnabled = adaptiveEnabled ||
-                status?.tuning?.adaptiveBitrateEnabled == true ||
-                status?.adaptiveBitrateEnabled == true
-            val effectiveAiEnabled = aiEnabled ||
-                status?.autoQuality?.enabled == true ||
-                status?.tuning?.aiAutoQualityEnabled == true ||
-                status?.aiAutoQualityEnabled == true ||
-                status?.tuning?.aiOptimizerEnabled == true ||
-                status?.aiOptimizerEnabled == true ||
-                effectiveAdaptiveEnabled
             val currentGame = currentGameName?.takeIf { it.isNotBlank() }
             val currentUuid = currentGameUuid?.takeIf { it.isNotBlank() }
             val postSessionReport = NovaPostSessionReportUiState.from(status?.health ?: PolarisSessionStatus.HealthStatus())
@@ -267,30 +260,6 @@ data class NovaQuickMenuUiState(
                 else -> context.getString(R.string.nova_quick_menu_command_center_subtitle)
             }
 
-            val safeBitrate = status?.health?.safeBitrateKbps ?: 0
-            val liveBitrate = streamPolicy.effectiveBitrateKbps
-            val qualityBlocked = status?.autoQuality?.isBlocked == true || status?.isHostRenderLimited == true
-            val canLowerBitrate = !qualityBlocked && safeBitrate > 0 && liveBitrate > 0 && safeBitrate < liveBitrate
-            val canEnableAdaptive = !qualityBlocked && canAdjustHostTuning && !effectiveAiEnabled
-            val relaunchOnly = !qualityBlocked &&
-                (
-                    status?.autoQuality?.let { it.isUpgradeAvailable && it.relaunchRequired } == true ||
-                        status?.health?.relaunchRecommended == true
-                    ) &&
-                !canLowerBitrate &&
-                !canEnableAdaptive
-            val stabilityEnabled = canAdjustHostTuning && (canLowerBitrate || canEnableAdaptive || relaunchOnly)
-            val stabilityChip = when {
-                hostStateUnavailable -> chip(context.getString(R.string.nova_quick_menu_unavailable), NovaQuickMenuTone.MUTED)
-                !apiAvailable && status == null -> chip(context.getString(R.string.nova_quick_menu_not_available), NovaQuickMenuTone.MUTED)
-                status == null -> chip(context.getString(R.string.nova_quick_menu_loading), NovaQuickMenuTone.MUTED)
-                !stabilityEnabled && viewerSession -> chip(context.getString(R.string.nova_quick_menu_owner), NovaQuickMenuTone.MUTED)
-                !stabilityEnabled -> chip(autoQuality.label, autoQuality.tone.toQuickTone())
-                stabilityApplied -> chip(context.getString(R.string.nova_quick_menu_done), NovaQuickMenuTone.ACTIVE)
-                relaunchOnly -> chip("Relaunch", NovaQuickMenuTone.WARNING)
-                else -> chip(autoQuality.label, autoQuality.tone.toQuickTone())
-            }
-
             val profileButtonsEnabled = currentGame != null
             val normalizedPreference = AutoQualityProfilePreferences.normalize(profilePreference)
             val profileOptions = listOf(
@@ -310,20 +279,12 @@ data class NovaQuickMenuUiState(
             val diagnosis = diagnosisState(status)
             val stability = NovaQuickMenuStabilityState(
                 title = context.getString(R.string.nova_quick_menu_stream_card),
-                caption = when {
-                    hostStateUnavailable -> context.getString(R.string.nova_quick_menu_host_state_unavailable)
-                    !apiAvailable && status == null -> context.getString(R.string.nova_quick_menu_not_polaris_session)
-                    status == null -> context.getString(R.string.nova_quick_menu_health_checking)
-                    // The session strip and the Doctor card already say this sentence; the
-                    // Stream card repeats it only when it adds something.
-                    autoQuality.detail.sameSentenceAs(healthSummary) ||
-                        autoQuality.detail.sameSentenceAs(diagnosis.likelyCause) -> ""
-                    else -> autoQuality.detail
-                },
+                caption = if (hostStateUnavailable) context.getString(R.string.nova_quick_menu_host_state_unavailable) else "",
                 targetSummary = streamPolicy.targetSummary.takeIf { it.isNotBlank() }
                     ?: context.getString(R.string.nova_quick_menu_target_checking),
-                chip = stabilityChip,
-                enabled = stabilityEnabled,
+                chip = if (viewerSession) chip(context.getString(R.string.nova_quick_menu_owner), NovaQuickMenuTone.MUTED) else
+                    chip(profileOptions.first { it.selected }.label, NovaQuickMenuTone.INFO),
+                enabled = false,
                 profileTitle = context.getString(R.string.nova_quick_menu_profile_preference),
                 profileCaption = when {
                     currentGame == null -> context.getString(R.string.nova_quick_menu_profile_preference_checking)
@@ -469,6 +430,14 @@ data class NovaQuickMenuUiState(
             )
 
             return NovaQuickMenuUiState(
+                liveTuningAction = NovaQuickMenuAction(
+                    NovaQuickMenuActionId.LIVE_TUNING, "Live Tuning",
+                    caption = if (liveTuningPending) "Saving…" else if (hostStateUnavailable) "Reconnecting — state not confirmed" else
+                        "${autoQuality.label}. Host setting. ${autoQuality.detail}",
+                    chip = NovaQuickMenuChip(if (hostStateUnavailable || status == null || (status.liveTuningPresent && status.liveTuning == null)) "Unknown" else if (autoQuality.enabled) "On" else "Off", if (autoQuality.enabled) NovaQuickMenuTone.ACTIVE else NovaQuickMenuTone.INACTIVE),
+                    enabled = !liveTuningPending && !hostStateUnavailable && canAdjustHostTuning &&
+                        (status?.liveTuning != null || (status?.liveTuningPresent != true && adaptiveSupported))
+                ),
                 title = context.getString(R.string.nova_quick_menu_command_center_title),
                 subtitle = subtitle,
                 sessionMode = sessionMode,

--- a/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaStreamHudContent.kt
@@ -115,7 +115,7 @@ private fun NovaStreamHudDebug(state: NovaHudUiState, modifier: Modifier) {
             ) {
                 Text(
                     text = state.autopilotHudLabel,
-                    color = state.statusTone.hudColor(),
+                    color = state.tuningTone.hudColor(),
                     fontSize = 10.sp,
                     lineHeight = 12.sp,
                     fontWeight = FontWeight.SemiBold,
@@ -221,7 +221,7 @@ private fun HudPerformancePrimaryRow(state: NovaHudUiState) {
         HudStatusDot(state.statusTone, height = 20.dp)
         Text(
             text = state.autopilotCompactLabel,
-            color = state.statusTone.hudColor(),
+            color = state.tuningTone.hudColor(),
             fontSize = 9.sp,
             lineHeight = 11.sp,
             fontWeight = FontWeight.SemiBold,
@@ -334,7 +334,7 @@ private fun NovaStreamHudMinimal(state: NovaHudUiState, modifier: Modifier) {
                 HudCompactText(state.latencyLabel, state.latencyTone, minWidth = 34.dp)
                 Text(
                     text = state.autopilotCompactLabel,
-                    color = state.statusTone.hudColor(),
+                    color = state.tuningTone.hudColor(),
                     fontSize = 8.sp,
                     lineHeight = 10.sp,
                     fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/com/papi/nova/ui/StreamPolicyUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/StreamPolicyUiState.kt
@@ -14,7 +14,7 @@ data class StreamPolicyUiState(
     val displayLabel: String,
     val hostCaptureLabel: String = ""
 ) {
-    val autoQualityEnabled get() = adaptiveEnabled || aiEnabled
+    val autoQualityEnabled get() = adaptiveEnabled
     val hasAdaptiveCap get() = adaptiveEnabled &&
         adaptiveTargetBitrateKbps > 0 &&
         qualityLimitBitrateKbps > 0 &&
@@ -51,26 +51,28 @@ data class StreamPolicyUiState(
             fallbackBitrateKbps: Int = 0,
             fallbackTargetFps: Double = 0.0
         ): StreamPolicyUiState {
-            val adaptiveEnabled = status?.tuning?.adaptiveBitrateEnabled == true ||
-                status?.adaptiveBitrateEnabled == true
+            val live = status?.liveTuning
+            val invalid = status?.liveTuningPresent == true && live == null
+            val adaptiveEnabled = !invalid && (live?.enabled ?: (status?.tuning?.adaptiveBitrateEnabled == true ||
+                status?.adaptiveBitrateEnabled == true))
             val aiEnabled = status?.tuning?.aiOptimizerEnabled == true ||
                 status?.aiOptimizerEnabled == true
             val autoPolicy = status?.autoQuality
-            val adaptiveTarget = firstPositive(
+            val adaptiveTarget = if (invalid) 0 else live?.appliedBitrateKbps ?: firstPositive(
                 autoPolicy?.liveBitrateKbps,
                 status?.syncStatus?.effective?.adaptiveTargetBitrateKbps,
                 status?.syncStatus?.applied?.adaptiveTargetBitrateKbps,
                 status?.tuning?.adaptiveTargetBitrateKbps,
                 status?.adaptiveTargetBitrateKbps
             )
-            val qualityLimit = firstPositive(
+            val qualityLimit = live?.qualityLimitKbps ?: firstPositive(
                 autoPolicy?.qualityCapKbps,
                 status?.syncStatus?.effective?.targetBitrateKbps,
                 status?.syncStatus?.applied?.targetBitrateKbps,
                 status?.encoder?.bitrateKbps,
                 fallbackBitrateKbps
             )
-            val effectiveBitrate = when {
+            val effectiveBitrate = if (invalid) 0 else live?.appliedBitrateKbps ?: when {
                 adaptiveEnabled &&
                     adaptiveTarget > 0 &&
                     (qualityLimit <= 0 || adaptiveTarget <= qualityLimit) -> adaptiveTarget
@@ -99,7 +101,7 @@ data class StreamPolicyUiState(
                 effectiveBitrateKbps = effectiveBitrate,
                 qualityLimitBitrateKbps = qualityLimit,
                 adaptiveTargetBitrateKbps = adaptiveTarget,
-                adaptiveBaseBitrateKbps = status?.tuning?.adaptiveBaseBitrateKbps ?: 0,
+                adaptiveBaseBitrateKbps = live?.qualityLimitKbps ?: status?.tuning?.adaptiveBaseBitrateKbps ?: 0,
                 adaptiveEnabled = adaptiveEnabled,
                 aiEnabled = aiEnabled,
                 codecLabel = normalizeCodec(status?.encoder?.codec.orEmpty()),

--- a/app/src/test/java/com/papi/nova/api/LiveTuningStatusTest.kt
+++ b/app/src/test/java/com/papi/nova/api/LiveTuningStatusTest.kt
@@ -1,0 +1,131 @@
+package com.papi.nova.api
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LiveTuningStatusTest {
+    private fun fixtures() = JSONArray(javaClass.getResource("/live-tuning-v1.json")!!.readText())
+    private fun value() = fixtures().getJSONObject(0).getJSONObject("live_tuning")
+    @Test fun sharedFixturesParseWithoutAiCredentials() {
+        val cases = fixtures()
+        for (index in 0 until cases.length()) {
+            val row = cases.getJSONObject(index)
+            val parsed = LiveTuningStatus.parse(row.getJSONObject("live_tuning"))!!
+            assertEquals(row.getString("name"), parsed.state)
+        }
+    }
+    @Test fun malformedPreferenceAndRevisionAreUnknown() {
+        assertNull(LiveTuningStatus.parse(value().put("enabled", "false")))
+        assertNull(LiveTuningStatus.parse(value().put("configuration_revision", "")))
+        assertNull(LiveTuningStatus.parse(value().put("version", 2)))
+        for (key in listOf("sequence", "session_generation", "quality_limit_kbps", "requested_bitrate_kbps", "applied_bitrate_kbps")) {
+            assertNull(LiveTuningStatus.parse(value().put(key, "42")))
+            assertNull(LiveTuningStatus.parse(value().put(key, -1)))
+            assertNull(LiveTuningStatus.parse(value().put(key, 1.5)))
+        }
+        val status = PolarisApiClient.parseSessionStatusResponse(JSONObject().put("live_tuning", value().put("version", 2)))
+        assertTrue(status.liveTuningPresent)
+        assertNull(status.liveTuning)
+    }
+    @Test fun reducerRejectsDelayedResponsesAcrossRestart() {
+        val reducer = LiveTuningReducer()
+        val first = LiveTuningStatus.parse(value())!!
+        assertNotNull(reducer.accept(first.copy(sequence = 5)))
+        assertNull(reducer.accept(first.copy(sequence = 4)))
+        assertNotNull(reducer.accept(first.copy(hostInstance = "restarted", sequence = 1)))
+        assertNull(reducer.accept(first.copy(sequence = 100)))
+    }
+    @Test fun sseIdsDetectGapsAndRestart() {
+        assertTrue(PolarisEventSource.consecutiveEventIds("connection:2", "connection:3"))
+        assertFalse(PolarisEventSource.consecutiveEventIds("connection:2", "connection:4"))
+        assertFalse(PolarisEventSource.consecutiveEventIds("connection:2", "restarted:3"))
+        assertFalse(PolarisEventSource.consecutiveEventIds("connection:2", "connection:2"))
+    }
+    @Test fun delayedMenuDeliveryUsesTheCurrentOwnerSessionAndClearedState() {
+        val client = PolarisApiClient(androidx.test.core.app.ApplicationProvider.getApplicationContext(), "127.0.0.1", 47984)
+        val publish = PolarisApiClient::class.java.getDeclaredMethod("publishStatus", PolarisSessionStatus::class.java).apply { isAccessible = true }
+        val first = PolarisApiClient.parseSessionStatusResponse(JSONObject().put("live_tuning", value()))
+        publish.invoke(client, first)
+        val captured = client.sessionStatusUpdates.value
+        var delivered: PolarisSessionStatus? = null
+        val queuedDelivery = { client.withCurrentSessionStatus { delivered = it } }
+        val second = first.copy(appSessionId = "new-owner-session", sessionGeneration = 99,
+            liveTuning = first.liveTuning!!.copy(sequence = first.liveTuning.sequence + 1, appSessionId = "new-owner-session", sessionGeneration = 99))
+        publish.invoke(client, second)
+        queuedDelivery()
+        assertNotSame(captured, delivered)
+        assertEquals("new-owner-session", delivered!!.appSessionId)
+        assertEquals(99L, delivered!!.sessionGeneration)
+        publish.invoke(client, null)
+        queuedDelivery()
+        assertNull(delivered)
+    }
+    @Test fun invalidEventRemovesConfirmedTuningWithoutRevivingLegacyState() {
+        val client = PolarisApiClient(androidx.test.core.app.ApplicationProvider.getApplicationContext(), "127.0.0.1", 47984)
+        val publish = PolarisApiClient::class.java.getDeclaredMethod("publishStatus", PolarisSessionStatus::class.java).apply { isAccessible = true }
+        publish.invoke(client, PolarisApiClient.parseSessionStatusResponse(JSONObject().put("live_tuning", value())))
+        client.invalidateLiveTuningEvent()
+        assertTrue(client.sessionStatusUpdates.value!!.liveTuningPresent)
+        assertNull(client.sessionStatusUpdates.value!!.liveTuning)
+        assertEquals("Live Tuning: Unknown", com.papi.nova.ui.AutoQualityUiState.from(client.sessionStatusUpdates.value).label)
+    }
+
+    @Test fun statusReadAndMutationSerializeTheirActualHttpDispatch() {
+        val client = PolarisApiClient(androidx.test.core.app.ApplicationProvider.getApplicationContext(), "127.0.0.1", 47984)
+        val entered = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+        val posted = java.util.concurrent.CountDownLatch(1)
+        val methods = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val intercepted = okhttp3.OkHttpClient.Builder().addInterceptor { chain ->
+            val request = chain.request()
+            methods.add(request.method)
+            if (request.method == "GET") {
+                entered.countDown()
+                check(release.await(5, java.util.concurrent.TimeUnit.SECONDS))
+            } else posted.countDown()
+            okhttp3.Response.Builder().request(request).protocol(okhttp3.Protocol.HTTP_1_1).code(200).message("OK")
+                .body(okhttp3.ResponseBody.create(null, "{\"status\":true}")).build()
+        }.build()
+        PolarisApiClient::class.java.getDeclaredField("client").apply { isAccessible = true }.set(client, intercepted)
+        val status = PolarisSessionStatus(state = "streaming", ownedByClient = true, appSessionId = "owner", sessionGeneration = 1)
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(2)
+        try {
+            val get = pool.submit<PolarisSessionStatus?> { client.getSessionStatus() }
+            assertTrue(entered.await(5, java.util.concurrent.TimeUnit.SECONDS))
+            val save = pool.submit<Boolean> { client.setLiveTuningEnabled(true, status) }
+            assertFalse("POST must wait for the in-flight GET", posted.await(100, java.util.concurrent.TimeUnit.MILLISECONDS))
+            release.countDown()
+            get.get(5, java.util.concurrent.TimeUnit.SECONDS)
+            assertTrue(save.get(5, java.util.concurrent.TimeUnit.SECONDS))
+            assertEquals(listOf("GET", "POST"), methods.toList())
+        } finally { release.countDown(); pool.shutdownNow() }
+    }
+
+    @Test fun menuConsumerDoesNotHoldTheApiMonitorWhileWaitingForDoctorState() {
+        val client = PolarisApiClient(androidx.test.core.app.ApplicationProvider.getApplicationContext(), "127.0.0.1", 47984)
+        val publish = PolarisApiClient::class.java.getDeclaredMethod("publishStatus", PolarisSessionStatus::class.java).apply { isAccessible = true }
+        val consumerEntered = java.util.concurrent.CountDownLatch(1)
+        val published = java.util.concurrent.CountDownLatch(1)
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(2)
+        try {
+            val ui = pool.submit<Boolean> {
+                client.withCurrentSessionStatus {
+                    consumerEntered.countDown()
+                    published.await(3, java.util.concurrent.TimeUnit.SECONDS)
+                }
+            }
+            assertTrue(consumerEntered.await(3, java.util.concurrent.TimeUnit.SECONDS))
+            val io = pool.submit { publish.invoke(client, null); published.countDown() }
+            assertTrue("UI consumers must release the API monitor before other locks", ui.get(5, java.util.concurrent.TimeUnit.SECONDS))
+            io.get(5, java.util.concurrent.TimeUnit.SECONDS)
+        } finally { published.countDown(); pool.shutdownNow() }
+    }
+
+}

--- a/app/src/test/java/com/papi/nova/api/PolarisEventSourceTest.kt
+++ b/app/src/test/java/com/papi/nova/api/PolarisEventSourceTest.kt
@@ -1,0 +1,117 @@
+package com.papi.nova.api
+
+import okhttp3.OkHttpClient
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PolarisEventSourceTest {
+    private open class Listener : PolarisEventSource.EventListener {
+        override fun onSessionEvent(event: String, state: String, message: String) {}
+        override fun onStateUpdate(sessionState: String, cageRunning: Boolean, screenLocked: Boolean) {}
+        override fun onConnectionLost() {}
+    }
+    @Test fun stopCancelsABlockedReadWithoutDeliveringLateCallbacks() {
+        ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress()).use { server ->
+            server.soTimeout = 5000
+            val connected = CountDownLatch(1)
+            val eof = CountDownLatch(1)
+            val callbacks = AtomicInteger()
+            val worker = Thread {
+                server.accept().use { socket ->
+                    socket.soTimeout = 5000
+                    val input = socket.getInputStream().bufferedReader()
+                    while (!input.readLine().isNullOrEmpty()) { }
+                    socket.getOutputStream().write("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n".toByteArray())
+                    socket.getOutputStream().flush()
+                    if (input.read() == -1) eof.countDown()
+                }
+            }.apply { isDaemon = true; start() }
+            val source = PolarisEventSource("http://127.0.0.1:${server.localPort}/events", object : Listener() {
+                override fun onResyncNeeded() { callbacks.incrementAndGet(); connected.countDown() }
+                override fun onConnectionLost() { callbacks.incrementAndGet() }
+            }, OkHttpClient())
+            try {
+                source.start()
+                assertTrue(connected.await(5, TimeUnit.SECONDS))
+                source.stop()
+                val stoppedCount = callbacks.get()
+                assertFalse(source.isRunning)
+                assertTrue("stop must close the blocked socket", eof.await(5, TimeUnit.SECONDS))
+                worker.join(1000)
+                assertEquals(stoppedCount, callbacks.get())
+            } finally { source.stop() }
+        }
+    }
+    @Test fun redirectCannotSendThePinnedClientToAnotherEndpoint() {
+        ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress()).use { target ->
+            target.soTimeout = 500
+            ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress()).use { origin ->
+                origin.soTimeout = 5000
+                val lost = CountDownLatch(1)
+                val worker = Thread {
+                    origin.accept().use { socket ->
+                        val input = socket.getInputStream().bufferedReader()
+                        while (!input.readLine().isNullOrEmpty()) { }
+                        socket.getOutputStream().write("HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:${target.localPort}/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                        socket.getOutputStream().flush()
+                    }
+                }.apply { isDaemon = true; start() }
+                val source = PolarisEventSource("http://127.0.0.1:${origin.localPort}/events", object : Listener() {
+                    override fun onConnectionLost() { lost.countDown() }
+                }, OkHttpClient())
+                try {
+                    source.start()
+                    assertTrue(lost.await(5, TimeUnit.SECONDS))
+                    source.stop()
+                    try { target.accept().use { fail("redirect was followed") } }
+                    catch (_: SocketTimeoutException) { /* No redirected connection. */ }
+                    worker.join(1000)
+                } finally { source.stop() }
+            }
+        }
+    }
+    @Test fun unchangedStreamingHeartbeatReportsMissingAndInvalidTuning() {
+        ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress()).use { server ->
+            server.soTimeout = 5000
+            val received = CountDownLatch(3)
+            val events = java.util.Collections.synchronizedList(mutableListOf<String>())
+            val fixture = org.json.JSONArray(javaClass.getResource("/live-tuning-v1.json")!!.readText()).getJSONObject(0).getJSONObject("live_tuning")
+            val worker = Thread {
+                server.accept().use { socket ->
+                    socket.soTimeout = 5000
+                    val input = socket.getInputStream().bufferedReader()
+                    while (!input.readLine().isNullOrEmpty()) { }
+                    val output = socket.getOutputStream().bufferedWriter()
+                    output.write("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n")
+                    for (live in listOf(fixture, null, org.json.JSONObject(fixture.toString()).put("version", 99))) {
+                        val payload = org.json.JSONObject().put("session_state", "streaming")
+                        if (live != null) payload.put("live_tuning", live)
+                        output.write("event: state\ndata: $payload\n\n")
+                    }
+                    output.flush()
+                    input.read()
+                }
+            }.apply { isDaemon = true; start() }
+            val source = PolarisEventSource("http://127.0.0.1:${server.localPort}/events", object : Listener() {
+                override fun onLiveTuning(state: LiveTuningStatus) { events.add("valid"); received.countDown() }
+                override fun onInvalidLiveTuning() { events.add("invalid"); received.countDown() }
+            }, OkHttpClient())
+            try {
+                source.start()
+                assertTrue(received.await(5, TimeUnit.SECONDS))
+                assertEquals(listOf("valid", "invalid", "invalid"), events.toList())
+            } finally { source.stop(); worker.join(1000) }
+        }
+    }
+
+}

--- a/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/AutoQualityUiStateTest.kt
@@ -1,9 +1,9 @@
 package com.papi.nova.ui
 
 import com.papi.nova.api.PolarisSessionStatus
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import com.papi.nova.api.LiveTuningStatus
+import org.json.JSONArray
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -12,259 +12,36 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class AutoQualityUiStateTest {
-    @Test
-    fun stableQualityRunShowsStable() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "good",
-                    safeBitrateKbps = 30000,
-                    safeDisplayMode = "headless"
-                ),
-                encoder = encoder(fps = 118.0),
-                capture = capture()
-            ),
-            fallbackTargetFps = 120.0
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals("Stream Ready", state.label)
-        assertEquals("Stream target is holding steady", state.detail)
-        assertFalse(state.detail.contains("Network", ignoreCase = true))
-        assertFalse(state.detail.contains("frame pacing", ignoreCase = true))
-        assertTrue(state.targetSummary.contains("HEVC"))
+    @Test fun sharedStatesDescribeAcknowledgedIntentAndRate() {
+        val fixtures = JSONArray(javaClass.getResource("/live-tuning-v1.json")!!.readText())
+        for (i in 0 until fixtures.length()) {
+            val live = LiveTuningStatus.parse(fixtures.getJSONObject(i).getJSONObject("live_tuning"))!!
+            val status = status().copy(liveTuning = live, liveTuningPresent = true)
+            val ui = AutoQualityUiState.from(status)
+            assertEquals(live.enabled, ui.enabled)
+            assertTrue(ui.label.startsWith("Live Tuning"))
+            assertEquals(live.appliedBitrateKbps, StreamPolicyUiState.from(status).effectiveBitrateKbps)
+        }
     }
-
-    @Test
-    fun greenDoctorControlObservationKeepsCapabilityWatchInformational() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                doctor = PolarisSessionStatus.DoctorStatus(
-                    available = true,
-                    version = 2,
-                    resultId = "doctor-control-observation",
-                    status = "ok",
-                    severity = "info",
-                    trafficLight = "green",
-                    primaryIssue = "control_channel_observation",
-                    likelyCause = "Control-channel retries were observed, but video packet loss is not confirmed.",
-                    evidenceItems = listOf(
-                        PolarisSessionStatus.DoctorStatus.EvidenceItem(
-                            id = "live_bitrate_control",
-                            status = "watch",
-                            source = "encoder_capability"
-                        )
-                    )
-                )
-            ),
-            fallbackTargetFps = 120.0
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals(AutoQualityUiState.Tone.STABLE, state.tone)
-        assertEquals("OK", state.compactLabel)
-        assertEquals("Stream Ready", state.label)
+    @Test fun aiReadinessCannotEnableLiveTuning() {
+        val ui = AutoQualityUiState.from(status(adaptiveBitrateEnabled = false, aiOptimizerEnabled = true))
+        assertFalse(ui.enabled)
+        assertEquals("Live Tuning Off", ui.label)
     }
-
-    @Test
-    fun greenDoctorEnvelopeCannotHideConfirmedMediaLoss() {
-        val status = status(
-            doctor = PolarisSessionStatus.DoctorStatus(
-                available = true,
-                version = 2,
-                resultId = "doctor-green-contradiction",
-                status = "ok",
-                severity = "info",
-                trafficLight = "green",
-                primaryIssue = "control_channel_observation",
-                evidenceItems = listOf(
-                    PolarisSessionStatus.DoctorStatus.EvidenceItem(
-                        id = "packet_loss",
-                        status = "fail",
-                        source = "media_transport",
-                        value = 3.2
-                    )
-                )
-            )
-        )
-        val state = AutoQualityUiState.from(
-            status = status,
-            fallbackTargetFps = 120.0
-        )
-
-        assertTrue(status.hasHealthConcerns)
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals(AutoQualityUiState.Tone.WARNING, state.tone)
-        // "REC" read as recording on the HUD; the compact recovery label says what it does.
-        assertEquals("SAFE", state.compactLabel)
+    @Test fun healthWarningsCannotEraseEnabledState() {
+        val unhealthy = status(health = PolarisSessionStatus.HealthStatus(grade = "degraded", summary = "Network pressure"))
+        val ui = AutoQualityUiState.from(unhealthy)
+        assertTrue(ui.enabled)
+        assertEquals("Live Tuning On", ui.label)
+        assertEquals("Network pressure", unhealthy.health.summary)
     }
-
-    @Test
-    fun lowRenderedFpsWithoutHostCadenceEvidenceRemainsObservational() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "good",
-                    primaryIssue = "none"
-                ),
-                encoder = encoder(fps = 30.0),
-                capture = capture()
-            ),
-            fallbackTargetFps = 120.0
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals("Stream Ready", state.label)
+    @Test fun missingOrUnsupportedSchemaIsUnknown() {
+        assertEquals("Tuning: Unknown", AutoQualityUiState.from(null).compactLabel)
+        assertEquals("Tuning: Unknown", AutoQualityUiState.from(status().copy(liveTuningPresent = true)).compactLabel)
     }
-
-    @Test
-    fun warningOnlyFramePacingEvidenceNeverShowsStable() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "watch",
-                    summary = "Stable",
-                    primaryIssue = "frame_pacing",
-                    issues = listOf("frame_pacing")
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals("Frame pacing", state.label)
-        assertEquals(AutoQualityUiState.Tone.WARNING, state.tone)
-        assertEquals("Frame pacing", state.detail)
-    }
-
-    @Test
-    fun adaptiveTargetBelowBaseShowsAutoSafeCap() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                tuning = PolarisSessionStatus.TuningStatus(
-                    adaptiveBitrateEnabled = true,
-                    adaptiveTargetBitrateKbps = 12000,
-                    adaptiveBaseBitrateKbps = 30000,
-                    aiOptimizerEnabled = true
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals("Live bitrate adjusted", state.label)
-        assertTrue(state.targetSummary.contains("12 Mbps live / 30 Mbps limit"))
-    }
-
-    @Test
-    fun greenDoctorMakesCleanAutoSafeRecoveryInformational() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                tuning = PolarisSessionStatus.TuningStatus(
-                    adaptiveBitrateEnabled = true,
-                    adaptiveTargetBitrateKbps = 12000,
-                    adaptiveBaseBitrateKbps = 30000,
-                    adaptiveBitrateState = "recovering",
-                    adaptiveBitrateReason = "healthy_window",
-                    aiOptimizerEnabled = false
-                ),
-                doctor = PolarisSessionStatus.DoctorStatus(
-                    available = true,
-                    version = 2,
-                    resultId = "doctor-clean-auto-safe-recovery",
-                    status = "ok",
-                    severity = "info",
-                    trafficLight = "green",
-                    primaryIssue = "none",
-                    evidenceItems = listOf(
-                        PolarisSessionStatus.DoctorStatus.EvidenceItem(
-                            id = "effective_quality_ceiling",
-                            status = "watch",
-                            source = "launch_policy",
-                            value = 30000.0
-                        )
-                    )
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.RECOVERING, state.state)
-        assertEquals(AutoQualityUiState.Tone.INFO, state.tone)
-        assertEquals("Recovering Bitrate", state.label)
-        assertEquals("12M", state.compactLabel)
-        assertTrue(state.recovering)
-    }
-
-    @Test
-    fun hostRenderRecoveryHistoryShowsObservationalPacingWatch() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "watch",
-                    primaryIssue = "host_render_limited",
-                    hostRenderLimited = true,
-                    safeTargetFps = 60.0,
-                    recoveryProfile = "host_render_limited",
-                    relaunchRecommended = true
-                ),
-                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
-                    state = "recovery_queued",
-                    relaunchRequired = true,
-                    suggestedTargetFps = 60.0
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals("Frame Pacing Watch", state.label)
-        assertEquals("HOST", state.compactLabel)
-        assertEquals(false, state.recovering)
-    }
-
-    @Test
-    fun healthyManualQualityPresetShowsStable() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                sync = PolarisSessionStatus.SyncStatus(
-                    available = true,
-                    state = "manual_override",
-                    manualOverride = true
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals("Quality Preset", state.label)
-        assertTrue(state.manualOverride)
-    }
-
-    @Test
-    fun manualQualityDoesNotHideHostRenderRecovery() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "watch",
-                    summary = "Host render path is missing the target frame rate",
-                    primaryIssue = "host_render_limited",
-                    hostRenderLimited = true,
-                    safeTargetFps = 60.0,
-                    recoveryProfile = "host_render_limited",
-                    relaunchRecommended = true
-                ),
-                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
-                    state = "recovery_queued",
-                    relaunchRequired = true,
-                    suggestedTargetFps = 60.0
-                ),
-                sync = PolarisSessionStatus.SyncStatus(
-                    available = true,
-                    state = "manual_override",
-                    manualOverride = true
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.NEEDS_ATTENTION, state.state)
-        assertEquals("Frame Pacing Watch", state.label)
-        assertTrue(state.manualOverride)
+    @Test fun legacyTargetDoesNotClaimEncoderAcknowledgement() {
+        val ui = AutoQualityUiState.from(status())
+        assertTrue(ui.detail.contains("acknowledgement is unavailable"))
     }
 
     @Test
@@ -331,111 +108,6 @@ class AutoQualityUiStateTest {
 
         assertEquals("VAAPI + SHM fallback", policy.hostCaptureLabel)
         assertTrue(policy.targetSummary.contains("VAAPI + SHM fallback"))
-    }
-
-    @Test
-    fun autoQualityPolicyShowsBitrateRecovery() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
-                    state = "recovering_bitrate",
-                    liveBitrateKbps = 12000,
-                    qualityCapKbps = 30000,
-                    canRecoverLive = true,
-                    summary = "Recovering bitrate toward the quality cap."
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.RECOVERING, state.state)
-        assertEquals("Recovering Bitrate", state.label)
-        assertTrue(state.recovering)
-        assertTrue(state.targetSummary.contains("12 Mbps live / 30 Mbps limit"))
-    }
-
-    @Test
-    fun autoQualityPolicyShowsUpgradeAvailable() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
-                    state = "upgrade_available",
-                    relaunchRequired = true,
-                    summary = "Higher quality is available on the next launch."
-                )
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.UPGRADE_AVAILABLE, state.state)
-        assertEquals("Higher Quality Ready", state.label)
-        assertEquals("UP", state.compactLabel)
-    }
-
-    @Test
-    fun healthyCpuCaptureStaysStable() {
-        val state = AutoQualityUiState.from(
-            status = status(capture = capture(transport = "shm", residency = "cpu"))
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals(AutoQualityUiState.Tone.STABLE, state.tone)
-        assertEquals("Stream Ready", state.label)
-        assertEquals("OK", state.compactLabel)
-    }
-
-    @Test
-    fun disabledAutoQualityReportsOff() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                tuning = PolarisSessionStatus.TuningStatus(
-                    adaptiveBitrateEnabled = false,
-                    aiOptimizerEnabled = false
-                ),
-                adaptiveBitrateEnabled = false,
-                aiOptimizerEnabled = false
-            )
-        )
-
-        assertEquals(AutoQualityUiState.State.OFF, state.state)
-        assertEquals("Live Tuning Off", state.label)
-    }
-
-    @Test
-    fun authoritativeDoctorNoneIgnoresStaleHealthRecoveryAndPacingHistory() {
-        val state = AutoQualityUiState.from(
-            status = status(
-                health = PolarisSessionStatus.HealthStatus(
-                    grade = "watch",
-                    summary = "Network jitter and frame pacing were previously observed.",
-                    primaryIssue = "frame_pacing",
-                    issues = listOf("frame_pacing", "network_jitter"),
-                    networkRisk = "elevated",
-                    recoveryProfile = "host_render_limited",
-                    relaunchRecommended = true,
-                    safeTargetFps = 30.0,
-                    safeBitrateKbps = 12000
-                ),
-                doctor = PolarisSessionStatus.DoctorStatus(
-                    available = true,
-                    version = 2,
-                    resultId = "doctor-current-none",
-                    primaryIssue = "none"
-                ),
-                autoQuality = PolarisSessionStatus.AutoQualityPolicy(
-                    enabled = true,
-                    state = "blocked",
-                    blockedReason = "network",
-                    relaunchRequired = true,
-                    summary = "Holding quality while network pressure clears."
-                )
-            ),
-            fallbackTargetFps = 120.0
-        )
-
-        assertEquals(AutoQualityUiState.State.STABLE, state.state)
-        assertEquals("Stream Ready", state.label)
-        assertEquals("Stream target is holding steady", state.detail)
-        assertFalse(state.detail.contains("Network", ignoreCase = true))
-        assertFalse(state.detail.contains("frame pacing", ignoreCase = true))
     }
 
     private fun status(

--- a/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaHudUiStateTest.kt
@@ -36,9 +36,9 @@ class NovaHudUiStateTest {
         assertEquals("24 Mbps", state.bitrateLabel)
         assertEquals("1920×1080", state.resolutionLabel)
         assertEquals("HEVC", state.codecLabel)
-        assertEquals("Stream Ready", state.autopilotLabel)
-        assertEquals("Stream Ready", state.autopilotHudLabel)
-        assertEquals("OK", state.autopilotCompactLabel)
+        assertEquals("Live Tuning On", state.autopilotLabel)
+        assertEquals("Tuning: On", state.autopilotHudLabel)
+        assertEquals("Tuning: On", state.autopilotCompactLabel)
         assertEquals(NovaHudTone.STABLE, state.fpsTone)
         assertEquals(NovaHudTone.STABLE, state.latencyTone)
         assertEquals(NovaHudTone.STABLE, state.statusTone)
@@ -352,9 +352,9 @@ class NovaHudUiStateTest {
             sparklineSamples = listOf(42f)
         )
 
-        assertEquals("Frame Pacing Watch", state.autopilotLabel)
-        assertEquals("Pacing Watch", state.autopilotHudLabel)
-        assertEquals("HOST", state.autopilotCompactLabel)
+        assertEquals("Live Tuning On", state.autopilotLabel)
+        assertEquals("Tuning: On", state.autopilotHudLabel)
+        assertEquals("Tuning: On", state.autopilotCompactLabel)
         assertEquals(NovaHudTone.WARNING, state.statusTone)
         assertEquals(NovaHudTone.WARNING, state.fpsTone)
     }
@@ -392,9 +392,9 @@ class NovaHudUiStateTest {
             sparklineSamples = listOf(118f)
         )
 
-        assertEquals("Live bitrate adjusted", state.autopilotLabel)
-        assertEquals("Bitrate Adjusted", state.autopilotHudLabel)
-        assertEquals(NovaHudTone.WARNING, state.statusTone)
+        assertEquals("Live Tuning On", state.autopilotLabel)
+        assertEquals("Tuning: On", state.autopilotHudLabel)
+        assertEquals(NovaHudTone.STABLE, state.statusTone)
     }
 
     @Test
@@ -448,8 +448,8 @@ class NovaHudUiStateTest {
         )
 
         assertEquals("Stable", state.healthReasonLabel)
-        assertEquals("Recovering Bitrate", state.autopilotLabel)
-        assertEquals(NovaHudTone.INFO, state.statusTone)
+        assertEquals("Live Tuning On", state.autopilotLabel)
+        assertEquals(NovaHudTone.STABLE, state.statusTone)
     }
 
     @Test
@@ -500,9 +500,9 @@ class NovaHudUiStateTest {
             sparklineSamples = emptyList()
         )
 
-        assertEquals("Stream Ready", stable.autopilotHudLabel)
-        assertEquals("Quality Ready", upgrade.autopilotHudLabel)
-        assertEquals("Attention", attention.autopilotHudLabel)
+        assertEquals("Tuning: On", stable.autopilotHudLabel)
+        assertEquals("Tuning: On", upgrade.autopilotHudLabel)
+        assertEquals("Tuning: On", attention.autopilotHudLabel)
         assertTrue(
             listOf(stable, upgrade, attention).all {
                 it.autopilotHudLabel.length <= 16
@@ -1040,9 +1040,9 @@ class NovaHudUiStateTest {
             sparklineSamples = listOf(116f, 117f, 118f)
         )
 
-        assertEquals("OK", state.autopilotCompactLabel)
-        assertEquals("Stream Ready", state.autopilotHudLabel)
-        assertEquals(NovaHudTone.STABLE, state.statusTone)
+        assertEquals("Tuning: On", state.autopilotCompactLabel)
+        assertEquals("Tuning: On", state.autopilotHudLabel)
+        assertEquals(NovaHudTone.MUTED, state.statusTone)
         assertEquals("Link retries", state.healthReasonLabel)
         assertEquals(NovaHudTone.MUTED, state.healthReasonTone)
         assertTrue(state.streamModeLabel.contains("SHM/CPU capture"))

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -83,8 +83,10 @@ class NovaQuickMenuUiStateTest {
 
         assertEquals("Frame-pacing evidence needs a read-only recheck; launch settings are unchanged.", state.healthSummary)
         assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
-        assertEquals("Frame Pacing Watch", state.stability.chip.label)
-        assertEquals(NovaQuickMenuTone.WARNING, state.stability.chip.tone)
+        assertEquals("Quality", state.stability.chip.label)
+        assertEquals("Live Tuning", state.liveTuningAction.label)
+        assertEquals("Off", state.liveTuningAction.chip?.label)
+        assertEquals(NovaQuickMenuTone.INFO, state.stability.chip.tone)
     }
 
     @Test
@@ -129,7 +131,7 @@ class NovaQuickMenuUiStateTest {
 
         assertEquals("HDR requested, but Private Stream is 10-bit SDR.", state.healthSummary)
         assertEquals("Private Stream does not report HDR metadata. Polaris is sending 10-bit SDR; use an HDR-capable display path for true HDR.", state.healthDetail)
-        assertEquals("Polaris is sending 10-bit SDR, not HDR. Use an HDR-capable display path for true HDR.", state.stability.caption)
+        assertEquals("", state.stability.caption)
         assertEquals(NovaQuickMenuTone.WARNING, state.healthTone)
     }
 

--- a/app/src/test/resources/live-tuning-v1.json
+++ b/app/src/test/resources/live-tuning-v1.json
@@ -1,0 +1,156 @@
+[
+  {
+    "name": "off",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": false,
+      "scope": "host",
+      "state": "off",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": false,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 1
+    }
+  },
+  {
+    "name": "waiting",
+    "streaming": false,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "waiting",
+      "supported": false,
+      "reason": "no_stream",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 0,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 0,
+      "session_generation": 0,
+      "app_session_id": "",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 2
+    }
+  },
+  {
+    "name": "unavailable",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "unavailable",
+      "supported": false,
+      "reason": "encoder_runtime_update_unsupported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 0,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 3
+    }
+  },
+  {
+    "name": "applying",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "applying",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": true,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 14000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 4
+    }
+  },
+  {
+    "name": "measuring",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "measuring",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 20000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 5
+    }
+  },
+  {
+    "name": "adjusting",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "adjusting",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 14000,
+      "applied_bitrate_kbps": 14000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 6
+    }
+  },
+  {
+    "name": "stable",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "stable",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 20000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 7
+    }
+  }
+]

--- a/docs/live-tuning.md
+++ b/docs/live-tuning.md
@@ -1,0 +1,66 @@
+# Live Tuning
+
+Live Tuning is the host's adaptive bitrate preference. It does not require an AI
+provider or a subscription. Doctor explanations remain a separate feature.
+
+The switch in Quick Controls and Audio/Video settings saves immediately. Nova's
+Command Center uses the same preference. Its HUD shows tuning separately from
+stream health. A saved On preference can be waiting for a stream, measuring,
+adjusting, applying a bitrate, stable, or unavailable for the current encoder.
+Disconnected or invalid status is Unknown; it is not permission to change settings.
+
+The displayed applied bitrate comes from the encoder acknowledgement, not the
+requested target. Turning tuning off holds the last confirmed bitrate. Choosing
+an explicit fixed live bitrate also turns tuning off and supersedes a pending
+Doctor bitrate action. Auto, Quality, High FPS, and Stability launch presets still
+apply at the next explicit launch.
+
+## API contract
+
+`GET /api/live-tuning` requires web administrator authentication. Its response
+contains `status` and `live_tuning`. `POST /api/live-tuning` accepts exactly one
+boolean field, `enabled`, and requires the quoted `configuration_revision` in
+`If-Match`. Cookie-authenticated mutations require the normal CSRF token. A valid
+configured bearer credential or an authorized verified client certificate bypasses
+cookie CSRF validation; the endpoint still enforces its authentication checks.
+
+A stale or absent revision returns HTTP 412 without changing the controller.
+A failed durable commit returns an error without changing the preference. Refresh
+the state before asking the user to retry; do not automatically replay the save.
+`GET /api/config` returns contents and revision from one secure file snapshot.
+Configuration saves preserve the live preference when it is omitted.
+
+The existing paired `/polaris/v1/session/adaptive-bitrate` route accepts
+`configuration_revision` alongside the existing application session ID and
+generation. Its sole-owner, permission, revocation and session-generation checks
+remain mandatory. Legacy paired callers may omit the revision; new Nova sends it.
+
+The additive `live_tuning` version 1 object is shared by web statistics, paired
+session status and session events. It contains:
+
+- `enabled`, `scope` (`host`), `state`, `supported`, and `reason`;
+- `runtime_enabled`, `pending`, `quality_limit_kbps`, `requested_bitrate_kbps`,
+  and `applied_bitrate_kbps`;
+- `app_session_id`, `session_generation`, `configuration_revision`,
+  `host_instance`, and increasing `sequence`.
+
+A shared encoder or a mismatched session cannot claim a supported live actuator
+or another session's applied bitrate. Clients reject malformed values, old
+sequences and retired host instances. The shared conformance examples are in
+`tests/fixtures/live-tuning-v1.json` in Polaris and
+`app/src/test/resources/live-tuning-v1.json` in Nova.
+
+Session status advertises `events_https_port`. Nova uses that HTTPS endpoint with
+its existing pinned authenticated client, disables redirects, cancels blocked
+reads on teardown, and requests a fresh status after connection loss or an event
+sequence gap. Events are snapshots, not a replay log. Old connection callbacks
+cannot update a replacement session. Missing or invalid canonical tuning becomes
+Unknown until a successful resynchronization.
+
+## Validation boundary
+
+Unit and isolated transport tests cover conditional saves, failed persistence,
+configuration contention, encoder acknowledgement races, recreation followed by
+disable, owner/session attribution, shared fixtures, and stale UI delivery.
+Physical game streaming and device-specific encoder behavior remain separate
+acceptance checks. This change does not enable container multiseat production.


### PR DESCRIPTION
Command Center and NovaHUD now display Polaris's shared Live Tuning preference and encoder-confirmed bitrate. AI subscription/API readiness no longer controls the switch, and stream health remains a separate indication. Launch presets still apply at the next explicit launch.

The API client publishes one canonical status store, serializes status reads and mutations, and conditionally saves against the observed configuration revision and owner/session generation. It uses the host-advertised HTTPS event endpoint with the existing pinned client, disables redirects, cancels blocked reads on teardown, rejects stale connection callbacks, and marks missing/invalid tuning Unknown until resynchronization. Menu publication occurs on Main using the current immutable status, without holding the API monitor through UI/Doctor code.

Validation includes shared host/client fixtures, malformed and stale state, delayed menu delivery across owner changes, invalid SSE heartbeats, blocked socket cancellation, redirect containment, actual GET/mutation serialization, and a lock-inversion regression. The ARM64 debug APK build and full JVM tests pass in the isolated Android toolchain. Independent review cleared the committed source. The ARM64 debug APK has been retrieved and its checksum verified. Device installation and physical gameplay are separate acceptance steps.

The existing Steam/Deck integration is already on master through #287, #288, #289, and #290; this PR preserves that work.

Companion host implementation: papi-ux/polaris#641, based on papi-ux/polaris#639 and papi-ux/polaris#638. Steam/Deck discovery follow-up: #294.
