### PR TITLE
fix(detail): make the Launch button follow the chosen frame rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The Launch button on a game's page now reads the frame rate you chose in Play Setup, so a 120 FPS choice says 120 FPS before you press it. The A badge is gone from that button, and the focused button gets a clearer ring and fill so the controller highlight is easy to see.
 - Launching on a Sunshine host works again. Since 1.4.0 the launch gate identified the host by probing a Polaris-only route and treating anything it could not read as a reason to refuse with "Update Polaris before launching". Sunshine answers an unknown route with a malformed reply that Android reads as a protocol error, so every Sunshine host was blocked. Nova now reads the host family from GameStream serverinfo, the route every host answers the same way, and launches a stock host with local settings. Polaris hosts are identified exactly as before. (#291)
 
 ## 1.4.4 - 2026-09-06

--- a/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaGameDetailComposeTest.kt
@@ -10,6 +10,7 @@ import com.papi.nova.api.PolarisClientSettings
 import com.papi.nova.api.PolarisApiClient
 import com.papi.nova.shared.polaris.model.PolarisGame
 import com.papi.nova.ui.compose.NovaComposeTheme
+import com.papi.nova.utils.GameShortcutPinState
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -131,6 +132,9 @@ class NovaGameDetailComposeTest {
                         modePicker = null,
                         onPickMode = {},
                         onPickHostDefault = {},
+                        shortcutPinState = GameShortcutPinState.UNSUPPORTED,
+                        shortcutPinRequestPending = false,
+                        onPinShortcut = {},
                     )
                 }
             }

--- a/app/src/androidTest/java/com/papi/nova/ui/NovaPolarisSyncSheetComposeTest.kt
+++ b/app/src/androidTest/java/com/papi/nova/ui/NovaPolarisSyncSheetComposeTest.kt
@@ -166,7 +166,6 @@ class NovaPolarisSyncSheetComposeTest {
             onSendNova = {},
             onUsePolaris = {},
             onClearProfile = {},
-            onAutoQuality = {},
             onKeepInStep = {},
         ),
     )

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt
@@ -1439,6 +1439,12 @@ class NovaGameDetailActivity : NovaActivity() {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
                 setContent {
             NovaComposeTheme {
+                val launchPreferences = PreferenceConfiguration.readPreferences(this@NovaGameDetailActivity)
+                val launchPreview = optimizationState.withLaunchProfileSummary(
+                    launchOptimization(),
+                    clientAskedFps = (effectiveFpsPin(chosenFps, profilePreference, launchPreferences.fps)
+                        ?: launchPreferences.fps.toInt()).toDouble(),
+                )
                 NovaGameDetailContent(
                     uiState = uiState,
                     launchIntro = buildLaunchIntro(uiState),
@@ -1463,7 +1469,7 @@ class NovaGameDetailActivity : NovaActivity() {
                     steamLaunchLabel = getString(R.string.nova_steam_launch_detail_label),
                     steamLaunchModeLabel = steamLaunchModeLabel(uiState.steamLaunchMode),
                     steamLaunchCaption = steamLaunchCaption(uiState),
-                    optimizationState = optimizationState,
+                    optimizationState = launchPreview,
                     playSetupRows = buildPlaySetupRows(),
                     explainedPlaySetupRow = explainedRow,
                     playSetupScope = playSetupScope,
@@ -1540,8 +1546,8 @@ class NovaGameDetailActivity : NovaActivity() {
                     } else if (optimizationState.reviewRequired) {
                         getString(R.string.nova_library_review_and_launch)
                     } else {
-                        // Pin-aware in the summary itself now, so the button just reads it.
-                        optimizationState.profileSummary
+                        // Describe the same composed choices attemptLaunch() will send.
+                        launchPreview.profileSummary
                             ?.primaryLaunchLabel
                             ?.takeIf { it.isNotBlank() }
                             ?: primaryPlayLabel(uiState)

--- a/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaGameDetailOverview.kt
@@ -446,7 +446,6 @@ private fun NovaGameDetailActions(
             onClick = if (activeSession != null) onResumeSession else onPrimaryLaunch,
             enabled = uiState.playEnabled || activeSession != null,
             primary = activeSession?.watchOnly != true,
-            glyph = stringResource(R.string.nova_controller_hint_a),
             modifier = actionModifier
                 .focusRequester(playFocusRequester)
                 .testTag("nova-game-detail-primary"),
@@ -810,8 +809,8 @@ private fun Modifier.novaFadeToGround(ground: Color): Modifier = drawWithContent
 }
 
 /**
- * One action in the lane. The primary carries the button it is bound to and an accent
- * gradient; the rest are quiet, hairline-bordered and marked. Focus is a ring and a
+ * One action in the lane. The primary uses an accent gradient; the rest are quiet,
+ * hairline-bordered and marked. Focus is a contrasting ring and a brighter fill,
  * tint — never a scale or an offset, which is the contract the poster cards settled on.
  */
 @Composable
@@ -821,7 +820,6 @@ private fun NovaGameDetailAction(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     primary: Boolean = false,
-    glyph: String? = null,
     mark: String? = null,
     iconRes: Int? = null,
     iconOnly: Boolean = false,
@@ -834,14 +832,18 @@ private fun NovaGameDetailAction(
 
     val background = if (primary && enabled) {
         Brush.linearGradient(
-            listOf(
+            if (focused) listOf(
+                lerp(colors.accent, Color.White, 0.48f),
+                lerp(colors.accent, Color.White, 0.68f),
+                lerp(colors.accent, Color.White, 0.82f),
+            ) else listOf(
                 colors.accent,
                 lerp(colors.accent, Color.White, 0.28f),
                 lerp(colors.accent, Color.White, 0.62f),
             ),
         )
     } else {
-        SolidColor(surfaces.control.copy(alpha = 1f))
+        SolidColor((if (focused) surfaces.selectedControl else surfaces.control).copy(alpha = 1f))
     }
     val label = when {
         primary && enabled -> colors.onAccent
@@ -867,8 +869,12 @@ private fun NovaGameDetailAction(
             .clip(shape)
             .background(background, shape)
             .border(
-                width = if (focused) 2.dp else 1.dp,
-                color = if (focused) colors.accent else surfaces.tileBorder,
+                width = if (focused) 3.dp else 1.dp,
+                color = when {
+                    focused && primary && enabled -> colors.onAccent
+                    focused -> colors.accent
+                    else -> surfaces.tileBorder
+                },
                 shape = shape,
             )
             .onFocusChanged { focused = it.isFocused }
@@ -884,22 +890,6 @@ private fun NovaGameDetailAction(
                 vertical = 10.dp,
             ),
     ) {
-        if (glyph != null) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(20.dp)
-                    .clip(RoundedCornerShape(percent = 50))
-                    .background(colors.window.copy(alpha = 0.88f)),
-            ) {
-                Text(
-                    text = glyph,
-                    color = colors.textPrimary,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-        }
         if (mark != null) {
             Text(text = mark, color = label.copy(alpha = 0.62f), fontSize = 13.sp)
         }

--- a/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLaunchProfileSummary.kt
@@ -12,6 +12,14 @@ enum class NovaLaunchProfileNoticeTone {
 
 private const val HEALTHY_PROFILE_TARGET_TOLERANCE_FPS = 0.5
 
+/** Refresh presentation after a local choice without changing host preflight authority. */
+internal fun NovaGameDetailOptimizationState.withLaunchProfileSummary(
+    launchOptimization: JSONObject?,
+    clientAskedFps: Double,
+): NovaGameDetailOptimizationState = copy(
+    profileSummary = buildNovaLaunchProfileSummary(launchOptimization, clientAskedFps = clientAskedFps),
+)
+
 data class NovaLaunchProfileSummary(
     val primaryLaunchLabel: String,
     val requestedLine: String,

--- a/app/src/test/java/com/papi/nova/ui/NovaLaunchStreamOverrideTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLaunchStreamOverrideTest.kt
@@ -57,6 +57,47 @@ class NovaLaunchStreamOverrideTest {
     }
 
     @Test
+    fun launchSummaryFollowsFrameRateChoiceAndReturningToAuto() {
+        val raw = deterministicBlob()
+        val state = NovaGameDetailOptimizationState(
+            rawOptimization = raw,
+            profileSummary = buildNovaLaunchProfileSummary(raw),
+            preflightFailed = true,
+            reviewRequired = true,
+        )
+        for (fps in listOf(120, 90, 60, null)) {
+            val composed = NovaLaunchStreamOverride.compose(raw, null, fps, 1920, 1080, 60)
+            val preview = state.withLaunchProfileSummary(composed, (fps ?: 60).toDouble())
+            val summary = requireNotNull(preview.profileSummary)
+            val expected = fps ?: 60
+            assertEquals("Launch Quality profile · $expected FPS", summary.primaryLaunchLabel)
+            assertTrue(summary.selectedLine.contains("1920×1080 @ $expected FPS"))
+            assertTrue(preview.preflightFailed)
+            assertTrue(preview.reviewRequired)
+            assertSame(raw, preview.rawOptimization)
+        }
+        assertEquals(60, raw.getJSONObject("resolved_profile").getJSONObject("fields")
+            .getJSONObject("target_fps").getInt("value"))
+    }
+
+    @Test
+    fun launchSummaryUsesExplicitRateOverHighFpsAndCurrentResolution() {
+        val raw = deterministicBlob()
+        val chosenFps = effectiveFpsPin(60, "high_fps", 120f)
+        val composed = NovaLaunchStreamOverride.compose(raw, choice("1280x720x120"), chosenFps, 1920, 1080, 120)
+        val summary = requireNotNull(NovaGameDetailOptimizationState(rawOptimization = raw)
+            .withLaunchProfileSummary(composed, 60.0).profileSummary)
+        assertEquals("Launch Quality profile · 60 FPS", summary.primaryLaunchLabel)
+        assertTrue(summary.selectedLine.contains("1280×720 @ 60 FPS"))
+    }
+
+    @Test
+    fun absentLaunchPlanDoesNotRetainAnOldFrameRatePromise() {
+        val state = NovaGameDetailOptimizationState(profileSummary = buildNovaLaunchProfileSummary(deterministicBlob()))
+        assertNull(state.withLaunchProfileSummary(null, 120.0).profileSummary)
+    }
+
+    @Test
     fun resolutionPickPreservesOnlyTypedDeterministicFields() {
         val composed = NovaLaunchStreamOverride.compose(
             deterministicBlob(), choice("1440x810x60"), null, 1920, 1080, 120


### PR DESCRIPTION
## Summary

The Launch button on a game's page read the cached host plan while launch itself composed the frame rate chosen in Play Setup, so choosing 120 FPS showed "Launch Auto · 60 FPS" and then streamed at 120. The button now previews the same composed launch profile that launch sends and goes back to the host plan on Auto. The redundant A badge is gone from the primary button, and the focused primary button draws a thicker contrasting ring with a brighter fill so controller focus stays obvious.

Second commit repairs two instrumentation tests that had fallen behind their composables (missing shortcut pin parameters, a removed `onAutoQuality` action) so `assembleNonRoot_gameDebugAndroidTest` builds again; CI never compiles androidTest.

## Exact candidate

Branch `fix/launch-label-follows-frame-rate` on master `fa4c3c02`. Head SHA in the PR timeline.

## Verification

- `testNonRoot_gameDebugUnitTest` for NovaLaunchStreamOverrideTest, NovaLaunchProfileSummaryTest, NovaFrameRateOverridesTest, NovaMenuBlurOwnershipTest, NovaQuickMenuUiStateTest: 103 tests, 0 failures (three new cases cover the frame-rate follow, the explicit-rate-over-High-FPS case, and the absent-plan case).
- `assembleNonRoot_gameDebugAndroidTest`: builds.
- `assembleNonRoot_gameRelease` for arm64-v8a, armeabi-v7a, x86_64: builds.
- On a Retroid Pocket 6 against a Polaris host on Bazzite (Nova Validation build of this branch): the Frame Rate row cycles 30, 60, 90, 120 and Auto; the detail page reads "Launch Auto · 120 FPS" at 120 and "Launch Auto · 60 FPS" on Auto; no A badge; the focused button shows the ring and fill.
