### PR TITLE
release: prepare Nova 1.4.5 with the Command Center wash fix and the library button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@
 
 Matched client for Polaris 1.4.5: Live Tuning that follows the host, a Launch button that says what it will do, a library card whose focus you cannot miss, and a Steam Deck shell that reads real hosts and hands games to Moonlight-Qt.
 
-- Live Tuning is one host setting now. Command Center and NovaHUD show the state the host confirmed, tell the requested bitrate from the applied one, and say Saving while a change is on its way instead of guessing. (#293)
+- Live Tuning is one host setting now. Command Center and NovaHUD show the state the host confirmed, tell the requested bitrate from the applied one, and say Saving while a change is on its way instead of guessing. The row stays under your controller cursor while it saves; disabling it mid-press used to wash the whole screen until the menu closed. (#293, #296)
 - The Launch button on a game's page now reads the frame rate you chose in Play Setup, so a 120 FPS choice says 120 FPS before you press it. The A badge is gone from that button, and the focused button gets a clearer ring and fill so the controller highlight is easy to see.
 - The library's Review & Launch button drops its A badge and lights up clearly when focused, the same treatment the game page's Launch button got.
 - Launching on a Sunshine host works again. Since 1.4.0 the launch gate identified the host by probing a Polaris-only route and treating anything it could not read as a reason to refuse with "Update Polaris before launching". Sunshine answers an unknown route with a malformed reply that Android reads as a protocol error, so every Sunshine host was blocked. Nova now reads the host family from GameStream serverinfo, the route every host answers the same way, and launches a stock host with local settings. Polaris hosts are identified exactly as before. (#291)
 - Steam Deck shell (Linux, experimental): reads your paired hosts and the Polaris library through Moonlight's own pairing, hands the highlighted game to Moonlight-Qt from the launch card, ships as a Flatpak that registers itself with Steam for Game Mode, forwards the display it is on when launching from inside the sandbox, probes hosts concurrently, and keeps an authenticated fallback when a probe fails. (#287, #288, #289, #290, #294)
-- Heads up: toggling Live Tuning with the controller in the Command Center can wash the whole screen until the menu closes; tap beside the panel or press B to clear it. Tracked as #296.
 
 ## 1.4.4 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## Unreleased
 
+## 1.4.5 - 2026-09-10
+
+Matched client for Polaris 1.4.5: Live Tuning that follows the host, a Launch button that says what it will do, a library card whose focus you cannot miss, and a Steam Deck shell that reads real hosts and hands games to Moonlight-Qt.
+
+- Live Tuning is one host setting now. Command Center and NovaHUD show the state the host confirmed, tell the requested bitrate from the applied one, and say Saving while a change is on its way instead of guessing. (#293)
 - The Launch button on a game's page now reads the frame rate you chose in Play Setup, so a 120 FPS choice says 120 FPS before you press it. The A badge is gone from that button, and the focused button gets a clearer ring and fill so the controller highlight is easy to see.
+- The library's Review & Launch button drops its A badge and lights up clearly when focused, the same treatment the game page's Launch button got.
 - Launching on a Sunshine host works again. Since 1.4.0 the launch gate identified the host by probing a Polaris-only route and treating anything it could not read as a reason to refuse with "Update Polaris before launching". Sunshine answers an unknown route with a malformed reply that Android reads as a protocol error, so every Sunshine host was blocked. Nova now reads the host family from GameStream serverinfo, the route every host answers the same way, and launches a stock host with local settings. Polaris hosts are identified exactly as before. (#291)
+- Steam Deck shell (Linux, experimental): reads your paired hosts and the Polaris library through Moonlight's own pairing, hands the highlighted game to Moonlight-Qt from the launch card, ships as a Flatpak that registers itself with Steam for Game Mode, forwards the display it is on when launching from inside the sandbox, probes hosts concurrently, and keeps an authenticated fallback when a probe fails. (#287, #288, #289, #290, #294)
+- Heads up: toggling Live Tuning with the controller in the Command Center can wash the whole screen until the menu closes; tap beside the panel or press B to clear it. Tracked as #296.
 
 ## 1.4.4 - 2026-09-06
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.4.4"
-        versionCode = 46
+        versionName "1.4.5"
+        versionCode = 47
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed as gridItemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.ui.res.stringResource
@@ -53,6 +52,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalDensity
@@ -683,8 +683,14 @@ private fun NovaStageHeroAction(
     val surfaces = LocalNovaLibrarySurfaces.current
     val opacityScale = LocalNovaMenuOpacityScale.current
     val shape = RoundedCornerShape(NovaRadius.hero)
-    val focusedScale = if (focused) 1.02f else 1f
-    val baseColor = if (emphasized) colors.accent else surfaces.focusedArtworkScrim
+    val focusedScale = if (focused) 1.06f else 1f
+    // Focus is a scale and a brighter fill, never an outline: the emphasized CTA lifts its
+    // accent toward white so the selected state reads from across the room.
+    val baseColor = when {
+        emphasized && focused -> lerp(colors.accent, Color.White, 0.42f)
+        emphasized -> colors.accent
+        else -> surfaces.focusedArtworkScrim
+    }
     // The hero's primary action is not menu chrome. Folding the menu-opacity preference
     // (64% by default) into its fill composited the accent down against the backdrop until
     // the on-accent label sat at 2:1 against it, which is below the large-text floor.
@@ -713,17 +719,9 @@ private fun NovaStageHeroAction(
         else -> 16.sp
     }
 
-    // The glyph is dropped at large font scales so the label keeps the width it needs.
-    val showGlyph = emphasized && !largeText
     Box(
         modifier = modifier
-            .width(
-                when {
-                    largeText -> 140.dp
-                    showGlyph -> 138.dp
-                    else -> 116.dp
-                },
-            )
+            .width(if (largeText) 140.dp else 116.dp)
             .height(if (largeText) 42.dp else 40.dp)
             .onFocusChanged { focusState ->
                 focused = focusState.isFocused || focusState.hasFocus
@@ -736,13 +734,7 @@ private fun NovaStageHeroAction(
     ) {
         Box(
             modifier = Modifier
-                .width(
-                    when {
-                        largeText -> 132.dp
-                        showGlyph -> 130.dp
-                        else -> 108.dp
-                    },
-                )
+                .width(if (largeText) 132.dp else 108.dp)
                 .height(if (largeText) 34.dp else 28.dp)
                 .graphicsLayer {
                     scaleX = focusedScale
@@ -757,25 +749,6 @@ private fun NovaStageHeroAction(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                if (showGlyph) {
-                    Box(
-                        modifier = Modifier
-                            .size(16.dp)
-                            .clip(CircleShape)
-                            .background(emphasizedLabelColor.copy(alpha = 0.86f))
-                            .testTag("${testTag}-glyph"),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.nova_controller_hint_a),
-                            color = baseColor,
-                            fontSize = 9.sp,
-                            lineHeight = 10.sp,
-                            fontWeight = FontWeight.Black,
-                            maxLines = 1,
-                        )
-                    }
-                }
                 Text(
                     text = label,
                     color = if (emphasized) emphasizedLabelColor else colors.textPrimary,

--- a/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaQuickMenuUiState.kt
@@ -435,7 +435,10 @@ data class NovaQuickMenuUiState(
                     caption = if (liveTuningPending) "Saving…" else if (hostStateUnavailable) "Reconnecting — state not confirmed" else
                         "${autoQuality.label}. Host setting. ${autoQuality.detail}",
                     chip = NovaQuickMenuChip(if (hostStateUnavailable || status == null || (status.liveTuningPresent && status.liveTuning == null)) "Unknown" else if (autoQuality.enabled) "On" else "Off", if (autoQuality.enabled) NovaQuickMenuTone.ACTIVE else NovaQuickMenuTone.INACTIVE),
-                    enabled = !liveTuningPending && !hostStateUnavailable && canAdjustHostTuning &&
+                    // The row stays enabled while a save is pending: the caption already says
+                    // Saving, onLiveTuning ignores a second press, and disabling the row under a
+                    // controller cursor drops focus mid-press.
+                    enabled = !hostStateUnavailable && canAdjustHostTuning &&
                         (status?.liveTuning != null || (status?.liveTuningPresent != true && adaptiveSupported))
                 ),
                 title = context.getString(R.string.nova_quick_menu_command_center_title),

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,13 +81,13 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/46.txt"
+            "fastlane/metadata/android/en-US/changelogs/47.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.4.4\""))
-        assertTrue(build.contains("versionCode = 46"))
-        assertTrue(changelog.contains("## 1.4.4 - 2026-09-06"))
+        assertTrue(build.contains("versionName \"1.4.5\""))
+        assertTrue(build.contains("versionCode = 47"))
+        assertTrue(changelog.contains("## 1.4.5 - 2026-09-10"))
         assertTrue(changelog.contains("Steam Input remains manual and read-only."))
         assertTrue(changelog.contains("Polaris owns encoder probing, fallback, and launch policy"))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
@@ -108,7 +108,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.4.4"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.4.5"))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryStageSourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryStageSourceTest.kt
@@ -630,19 +630,19 @@ class NovaLibraryStageSourceTest {
         assertTrue(start >= 0 && end > start)
         val action = stage.substring(start, end)
 
-        // The accessible target keeps its size; the emphasized variant widens only to seat
-        // the controller glyph, and the visible surface always stays inside the target.
-        assertTrue(action.contains("largeText -> 140.dp"))
-        assertTrue(action.contains("showGlyph -> 138.dp"))
-        assertTrue(action.contains("else -> 116.dp"))
+        // The accessible target keeps its size, the visible surface always stays inside
+        // it, and the CTA carries only its label: the controller glyph is gone for good.
+        assertTrue(action.contains(".width(if (largeText) 140.dp else 116.dp)"))
         assertTrue(action.contains(".height(if (largeText) 42.dp else 40.dp)"))
-        assertTrue(action.contains("largeText -> 132.dp"))
-        assertTrue(action.contains("showGlyph -> 130.dp"))
-        assertTrue(action.contains("else -> 108.dp"))
+        assertTrue(action.contains(".width(if (largeText) 132.dp else 108.dp)"))
+        assertFalse("Stage CTA must not seat a controller glyph", action.contains("nova_controller_hint_a"))
+        assertFalse(action.contains("showGlyph"))
         assertTrue(action.contains(".height(if (largeText) 34.dp else 28.dp)"))
         assertTrue(action.contains(".testTag(\"${'$'}{testTag}-surface\")"))
         assertTrue(action.contains(".testTag(\"${'$'}{testTag}-label\")"))
-        assertTrue(action.contains("val focusedScale = if (focused) 1.02f else 1f"))
+        // Focus reads as a scale and a brighter accent fill, never an outline.
+        assertTrue(action.contains("val focusedScale = if (focused) 1.06f else 1f"))
+        assertTrue(action.contains("emphasized && focused -> lerp(colors.accent, Color.White, 0.42f)"))
         assertTrue(action.contains("colors.accent"))
         assertTrue(action.contains("maxLines = 1"))
         assertTrue(action.contains("overflow = TextOverflow.Ellipsis"))

--- a/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaQuickMenuUiStateTest.kt
@@ -952,9 +952,21 @@ class NovaQuickMenuUiStateTest {
         assertEquals(NovaMenuPreferences.OPACITY_PRESETS, state.menuOpacity.presets)
     }
 
+    @Test
+    fun pendingLiveTuningSaveKeepsTheRowUnderTheCursor() {
+        // Disabling the row while its save was pending dropped controller focus mid-press,
+        // and the Command Center washed white until it closed (#296). The caption says
+        // Saving and onLiveTuning ignores a second press; the row itself stays enabled.
+        val state = quickState(status = status(), liveTuningPending = true)
+
+        assertEquals("Saving…", state.liveTuningAction.caption)
+        assertTrue(state.liveTuningAction.enabled)
+    }
+
     private fun quickState(
         status: PolarisSessionStatus?,
         apiAvailable: Boolean = true,
+        liveTuningPending: Boolean = false,
         adaptiveSupported: Boolean = true,
         aiSupported: Boolean = true,
         adaptiveEnabled: Boolean = false,
@@ -975,6 +987,7 @@ class NovaQuickMenuUiStateTest {
         context = context,
         status = status,
         apiAvailable = apiAvailable,
+        liveTuningPending = liveTuningPending,
         adaptiveSupported = adaptiveSupported,
         aiSupported = aiSupported,
         adaptiveEnabled = adaptiveEnabled,

--- a/fastlane/metadata/android/en-US/changelogs/47.txt
+++ b/fastlane/metadata/android/en-US/changelogs/47.txt
@@ -1,0 +1,2 @@
+Nova 1.4.5
+Live Tuning follows the host: Command Center and NovaHUD show the confirmed state, requested versus applied bitrate, and Saving while a change lands. The Launch button reads the frame rate you chose in Play Setup, the library's Review & Launch button loses its A badge and lights up when focused, and launching on a Sunshine host works again. Experimental Steam Deck shell with Moonlight pairing and Moonlight-Qt hand-off. Matched client for Polaris 1.4.5.


### PR DESCRIPTION
## Summary

Release prep for Nova 1.4.5, matched with Polaris 1.4.5, plus the two client fixes that came out of today's Bazzite acceptance on the Retroid Pocket 6:

- `fix(library)`: the Review & Launch button drops its A glyph and gets a clear focus treatment (scale 1.06, accent fill lifted toward white, no outline), the same intent as the game page's button in #295.
- `fix(command-center)`: toggling Live Tuning with the controller washed the whole Command Center white until it closed (#296). The row disabled itself while its save was pending, which dropped Compose focus mid-press. It now stays enabled while pending; the caption already says Saving and the handler already ignores a second press.
- `release`: version 1.4.5, code 47, dated changelog section covering everything since 1.4.4 (Live Tuning sync #293, the launch label #295, the library button, the Sunshine launch fix #291, the Steam Deck shell #287 to #290 and #294), store notes under 500 characters, metadata test re-pinned.

## Exact candidate

Branch `nova-145-ui` on master `ac3aecbe`. Head SHA in the PR timeline.

## Verification

- Unit: NovaQuickMenuUiStateTest 38 (new pin `pendingLiveTuningSaveKeepsTheRowUnderTheCursor`), NovaLibraryStageSourceTest 25 (re-pinned: no glyph, new focus rule), NovaReleaseMetadataTest 3.
- `assembleNonRoot_gameDebugAndroidTest` builds.
- Device: the wash recipe (Back, D-pad Down, Center) on the RP6 against a Polaris host: unfixed build frame brightness 169 to 181, fixed build 39 to 42 across three toggles; host accepted every toggle.
- The library button was built into the same validation APK and installed on the RP6.
