### PR TITLE
Stream natively on the Deck through moonlight-common-c

### DIFF
--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(nova_deck_core STATIC
     src/polaris_game_fixture.cpp
     src/backend/deck_backend_interfaces.cpp
     src/stream/deck_stream_core.cpp
+    src/stream/deck_gamestream_launch.cpp
     src/stream/deck_stream_media_adapters.cpp
     src/stream/deck_moonlight_handoff_preflight.cpp
     src/identity/deck_moonlight_identity.cpp
@@ -95,6 +96,12 @@ if(BUILD_TESTING)
     )
     target_link_libraries(nova_deck_stream_core_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_stream_core_test COMMAND nova_deck_stream_core_test)
+
+    add_executable(nova_deck_gamestream_launch_test
+        tests/deck_gamestream_launch_test.cpp
+    )
+    target_link_libraries(nova_deck_gamestream_launch_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_gamestream_launch_test COMMAND nova_deck_gamestream_launch_test)
 
     add_executable(nova_deck_stream_media_adapters_test
         tests/deck_stream_media_adapters_test.cpp

--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(nova_deck_core STATIC
     src/backend/deck_backend_interfaces.cpp
     src/stream/deck_stream_core.cpp
     src/stream/deck_gamestream_launch.cpp
+    src/stream/deck_gamestream_session_builder.cpp
     src/stream/deck_stream_media_adapters.cpp
     src/stream/deck_moonlight_handoff_preflight.cpp
     src/identity/deck_moonlight_identity.cpp
@@ -102,6 +103,12 @@ if(BUILD_TESTING)
     )
     target_link_libraries(nova_deck_gamestream_launch_test PRIVATE nova_deck_core)
     add_test(NAME nova_deck_gamestream_launch_test COMMAND nova_deck_gamestream_launch_test)
+
+    add_executable(nova_deck_gamestream_session_builder_test
+        tests/deck_gamestream_session_builder_test.cpp
+    )
+    target_link_libraries(nova_deck_gamestream_session_builder_test PRIVATE nova_deck_core)
+    add_test(NAME nova_deck_gamestream_session_builder_test COMMAND nova_deck_gamestream_session_builder_test)
 
     add_executable(nova_deck_stream_media_adapters_test
         tests/deck_stream_media_adapters_test.cpp

--- a/clients/deck/src/main.cpp
+++ b/clients/deck/src/main.cpp
@@ -5,6 +5,7 @@
 #include "backend/deck_live_read_only_state.h"
 #include "runtime/deck_moonlight_launcher.h"
 #include "runtime/deck_steam_shortcuts.h"
+#include "stream/deck_gamestream_session_builder.h"
 #include "stream/deck_stream_media_adapters.h"
 
 #include <QClipboard>
@@ -637,11 +638,6 @@ public:
         return updateLastReport(lifecycleGate_.stop());
     }
 
-signals:
-    void lastReportChanged();
-    void operatorAuthorizationChanged();
-
-private:
     static QString lifecycleStateLabel(const nova::deck::stream::DeckStreamSessionState state) {
         using nova::deck::stream::DeckStreamSessionState;
         switch (state) {
@@ -665,6 +661,11 @@ private:
         return QStringLiteral("unknown");
     }
 
+signals:
+    void lastReportChanged();
+    void operatorAuthorizationChanged();
+
+private:
     static QString requestSummaryForReport(const nova::deck::stream::DeckGuardedPreviewLifecycleReport& report) {
         if (report.hostId.empty() && report.gameId.empty()) {
             return QStringLiteral("No selected request has been armed yet.");
@@ -1201,6 +1202,244 @@ void writeExpandedDiagnosticsFrameSmokeArtifact(QObject* rootObject, const QStri
 
     qInfo().noquote() << "Nova Deck expanded-diagnostics-frame-smoke artifact" << artifactPath;
 }
+
+struct NativeLaunchOptions {
+    QString title;
+    int appIdOverride = 0;
+    int waitMs = 15000;
+    int bitrateKbps = 20000;
+    int width = 1280;
+    int height = 800;
+    int fps = 60;
+    bool modeValid = true;
+};
+
+NativeLaunchOptions parseNativeLaunchOptions(const QStringList& arguments) {
+    NativeLaunchOptions options;
+    options.title = stringArgumentAfter(arguments, QStringLiteral("--native-launch"));
+    options.appIdOverride = intArgumentAfter(arguments, QStringLiteral("--native-app-id"), 0);
+    options.waitMs = intArgumentAfter(arguments, QStringLiteral("--native-wait-ms"), 15000);
+    options.bitrateKbps = intArgumentAfter(arguments, QStringLiteral("--native-bitrate-kbps"), 20000);
+    const QString mode = stringArgumentAfter(arguments, QStringLiteral("--native-mode"));
+    if (!mode.isEmpty()) {
+        const QStringList parts = mode.split(QLatin1Char('x'));
+        bool wOk = false;
+        bool hOk = false;
+        bool fOk = false;
+        if (parts.size() == 3) {
+            options.width = parts[0].toInt(&wOk);
+            options.height = parts[1].toInt(&hOk);
+            options.fps = parts[2].toInt(&fOk);
+        }
+        options.modeValid = wOk && hOk && fOk && options.width > 0 && options.height > 0 && options.fps > 0;
+    }
+    return options;
+}
+
+std::string nativeStateLabel(const nova::deck::stream::DeckStreamSessionState state) {
+    return QtPreviewLifecycleBridge::lifecycleStateLabel(state).toStdString();
+}
+
+void printNativeReportLine(const char* phase, const nova::deck::stream::DeckGuardedPreviewLifecycleReport& report) {
+    std::cout << "nova-deck native: " << phase
+              << " statusCode=" << report.statusCode
+              << " state=" << nativeStateLabel(report.state)
+              << " networkStarted=" << (report.networkStarted ? "true" : "false")
+              << " reason=\"" << report.reason << "\"" << std::endl;
+}
+
+/**
+ * --native-launch "<title>" is the headless proof of the Deck's own stream
+ * path: ask the selected live host to start the title, open the
+ * moonlight-common-c session through the guarded gate with an operator start
+ * authorization, count decoded hardware frames for a while, then stop the
+ * stream and ask the host to end the app. One line per phase, then a summary.
+ * Nothing here names the host address or the session material; the
+ * transition reasons and counters are the whole story.
+ * Exit codes: 0 streamed and decoded at least one hardware frame; 2 could not
+ * ask (no identity, no selected host, unknown title, host unreachable);
+ * 3 the host refused the launch; 4 the connection failed or ended early;
+ * 5 the stream ran but no hardware frame was decoded.
+ */
+int nativeLaunchCommand(
+    const QStringList& arguments,
+    const std::optional<nova::deck::identity::DeckMoonlightIdentity>& identity,
+    const std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot>& snapshot,
+    nova::deck::stream::DeckGuardedPreviewLifecycleGate& gate) {
+    using nova::deck::stream::DeckStreamSessionState;
+    const NativeLaunchOptions options = parseNativeLaunchOptions(arguments);
+    if (!options.modeValid) {
+        std::cout << "nova-deck native: --native-mode must look like 1280x800x60" << std::endl;
+        return 2;
+    }
+    if (!identity || !snapshot || snapshot->selectedHostId.empty()) {
+        std::cout << "nova-deck native: no live host selected; Moonlight identity or a reachable Polaris host is missing" << std::endl;
+        return 2;
+    }
+    const auto* host = identity->hostById(snapshot->selectedHostId);
+    if (host == nullptr || !host->hasServerCertificate()) {
+        std::cout << "nova-deck native: the selected host has no pinned server certificate in Moonlight's identity" << std::endl;
+        return 2;
+    }
+    int httpsPort = 0;
+    for (const auto& probe : snapshot->probes) {
+        if (probe.hostId == host->stableId()) {
+            httpsPort = probe.resolvedHttpsPort;
+        }
+    }
+    if (httpsPort <= 0) {
+        httpsPort = nova::deck::identity::polarisHttpsPortForMoonlightHttpPort(host->preferredHttpPort());
+    }
+    const auto client = nova::deck::backend::polarisClientForHost(*identity, *host, httpsPort, std::chrono::milliseconds(4000));
+
+    // Resolve the title against the live library first, then Moonlight's cached
+    // app list, unless an app id was given outright.
+    int appId = options.appIdOverride;
+    std::string resolvedTitle = options.title.toStdString();
+    std::string gameId;
+    if (appId == 0) {
+        const auto games = client.fetchAllGames();
+        if (games.ok()) {
+            for (const auto& game : *games.value) {
+                if (QString::fromStdString(game.name).compare(options.title, Qt::CaseInsensitive) == 0) {
+                    appId = game.appId;
+                    resolvedTitle = game.name;
+                    gameId = game.id;
+                    break;
+                }
+            }
+        }
+        if (appId == 0) {
+            for (const auto& app : host->apps) {
+                if (QString::fromStdString(app.name).compare(options.title, Qt::CaseInsensitive) == 0) {
+                    appId = app.id;
+                    resolvedTitle = app.name;
+                    break;
+                }
+            }
+        }
+        if (appId == 0) {
+            std::cout << "nova-deck native: title \"" << options.title.toStdString() << "\" was not found in the live library"
+                      << " (polaris " << (games.ok() ? std::to_string(games.value->size()) : std::string("unavailable"))
+                      << ", cached " << host->apps.size() << ")" << std::endl;
+            return 2;
+        }
+    }
+    if (gameId.empty()) {
+        gameId = "app-" + std::to_string(appId);
+    }
+    std::cout << "nova-deck native: host=\"" << host->displayName() << "\" [" << host->stableId() << "]"
+              << " title=\"" << resolvedTitle << "\" appId=" << appId
+              << " mode=" << options.width << "x" << options.height << "x" << options.fps
+              << " bitrateKbps=" << options.bitrateKbps << " waitMs=" << options.waitMs << std::endl;
+
+    // One request feeds both the launch and the session, so the host encodes
+    // exactly what the client prepared to decode.
+    const nova::deck::stream::DeckStreamRequest request{
+        .hostId = host->stableId(),
+        .gameId = gameId,
+        .width = options.width,
+        .height = options.height,
+        .fps = options.fps,
+        .bitrateKbps = options.bitrateKbps,
+    };
+    const auto launch = nova::deck::stream::launchRequestForStream(request, appId);
+    const auto keys = nova::deck::stream::generateStreamKeys();
+    const auto fetcher = nova::deck::stream::fetcherOverPolarisClient(client);
+    std::cout << "nova-deck native: session keys generated; asking the host to start the title" << std::endl;
+    const auto build = nova::deck::stream::buildStreamConnection(fetcher, host->preferredAddress(), launch, keys);
+    if (!build.ok) {
+        std::cout << "nova-deck native: host session not assembled: " << build.error
+                  << " (launchRefused=" << (build.launchRefused ? "true" : "false")
+                  << " hostStatus=" << build.launchStatusCode
+                  << (build.launchStatusMessage.empty() ? std::string{} : " \"" + build.launchStatusMessage + "\"") << ")" << std::endl;
+        return build.launchRefused ? 3 : 2;
+    }
+    std::cout << "nova-deck native: host session assembled: rtsp url received, hostToken="
+              << (build.connectionInfo.hostSessionToken.empty() ? "none" : "received")
+              << " codecModeSupport=" << build.connectionInfo.serverCodecModeSupport << std::endl;
+
+    nova::deck::stream::DeckOperatorStartAuthorizationPolicy operatorPolicy;
+    operatorPolicy.authorizeStart("deck-cli-native-launch-operator-approved");
+    const auto started = gate.startAuthorizedHostSession(operatorPolicy.snapshot(), request, build.connectionInfo, fetcher);
+    printNativeReportLine("start", started);
+
+    bool connectionEndedEarly = false;
+    if (started.statusCode == "host-network-started") {
+        QElapsedTimer deadline;
+        deadline.start();
+        qint64 nextProgressMs = 2000;
+        // The connection's own threads deliver frames; this loop only watches.
+        // The timed processEvents overload never waits, so sleep between passes.
+        while (deadline.elapsed() < options.waitMs) {
+            QCoreApplication::processEvents();
+            QThread::msleep(100);
+            if (gate.sessionState() != DeckStreamSessionState::Active) {
+                connectionEndedEarly = true;
+                std::cout << "nova-deck native: the session left the active state after " << deadline.elapsed() << " ms" << std::endl;
+                break;
+            }
+            if (deadline.elapsed() >= nextProgressMs) {
+                const auto renderer = gate.rendererLifecycle();
+                const auto audio = gate.audioLifecycle();
+                std::cout << "nova-deck native: t=" << deadline.elapsed() << "ms"
+                          << " decodedHardwareFrames=" << renderer.decodedHardwareFrames
+                          << " submitCalls=" << renderer.submitCalls
+                          << " audioSampleCalls=" << audio.sampleCalls << std::endl;
+                nextProgressMs += 2000;
+            }
+        }
+    }
+
+    const auto stopped = gate.stop();
+    printNativeReportLine("stop", stopped);
+
+    const auto renderer = gate.rendererLifecycle();
+    const auto audio = gate.audioLifecycle();
+    const auto moonlight = gate.connectionStatus();
+    const auto transitions = gate.transitions();
+    std::cout << "nova-deck native summary: statusCode=" << stopped.statusCode
+              << " state=" << nativeStateLabel(stopped.state)
+              << " startStatusCode=" << started.statusCode
+              << " hostConnectionTornDown=" << (stopped.hostConnectionTornDown ? "true" : "false")
+              << " transitions=" << transitions.size() << std::endl;
+    for (const auto& transition : transitions) {
+        std::cout << "  - " << nativeStateLabel(transition.state) << ": " << transition.reason << std::endl;
+    }
+    std::cout << "nova-deck native renderer: setupCalls=" << renderer.setupCalls
+              << " startCalls=" << renderer.startCalls
+              << " submitCalls=" << renderer.submitCalls
+              << " decodedHardwareFrames=" << renderer.decodedHardwareFrames
+              << " presentedHardwareFrames=" << renderer.presentedHardwareFrames
+              << " stopCalls=" << renderer.stopCalls
+              << " cleanupCalls=" << renderer.cleanupCalls
+              << " videoFormat=" << renderer.videoFormat
+              << " size=" << renderer.width << "x" << renderer.height << "@" << renderer.redrawRate
+              << " runtimeStatus=\"" << renderer.runtimeStatus << "\""
+              << " lastRuntimeError=\"" << renderer.lastRuntimeError << "\"" << std::endl;
+    std::cout << "nova-deck native audio: initCalls=" << audio.initCalls
+              << " sampleCalls=" << audio.sampleCalls
+              << " lastSampleLength=" << audio.lastSampleLength
+              << " audioConfiguration=" << audio.audioConfiguration << std::endl;
+    std::cout << "nova-deck native moonlight: connectionStarted=" << (moonlight.connectionStarted ? "true" : "false")
+              << " terminated=" << (moonlight.terminated ? "true" : "false")
+              << " terminationErrorCode=" << moonlight.terminationErrorCode
+              << " lastStage=" << moonlight.lastStage
+              << " failedStage=" << moonlight.failedStage
+              << " failedStageErrorCode=" << moonlight.failedStageErrorCode << std::endl;
+    std::cout << "nova-deck native host cancel: requested=" << (stopped.hostCancelRequested ? "true" : "false")
+              << " cancelled=" << (stopped.hostCancelled ? "true" : "false")
+              << " summary=\"" << stopped.hostCancelSummary << "\"" << std::endl;
+
+    int exitCode = 0;
+    if (started.statusCode != "host-network-started" || connectionEndedEarly) {
+        exitCode = 4;
+    } else if (renderer.decodedHardwareFrames == 0) {
+        exitCode = 5;
+    }
+    std::cout << "nova-deck native: exit=" << exitCode << std::endl;
+    return exitCode;
+}
 } // namespace
 
 /**
@@ -1271,9 +1510,10 @@ int main(int argc, char *argv[]) {
     // keep proving the shell without a host.
     const bool liveRoute = appArguments.contains(QStringLiteral("--live")) || qEnvironmentVariableIntValue("NOVA_DECK_LIVE") == 1;
     const bool printLiveState = appArguments.contains(QStringLiteral("--print-live-state"));
+    const bool nativeLaunch = appArguments.contains(QStringLiteral("--native-launch"));
     std::optional<nova::deck::backend::DeckLiveHostLibrarySnapshot> liveSnapshot;
     std::optional<nova::deck::identity::DeckMoonlightIdentity> liveIdentity;
-    if (liveRoute || printLiveState) {
+    if (liveRoute || printLiveState || nativeLaunch) {
         liveIdentity = nova::deck::identity::loadDefaultMoonlightIdentity();
         liveSnapshot = nova::deck::backend::buildLiveSnapshotFromDefaultIdentity(std::chrono::milliseconds(4000));
         // Plain stdout on purpose: Qt routes qInfo to journald when stderr is
@@ -1361,6 +1601,11 @@ int main(int argc, char *argv[]) {
     DeckGuardedPreviewLifecycleGate productPreviewLifecycleGate(productPreviewProducer);
     productPreviewLifecycleGate.attachProductPreviewPipeline(productPreviewPipeline);
     QtPreviewLifecycleBridge previewLifecycle(productPreviewLifecycleGate);
+    // --native-launch runs the headless stream proof through the same gate the
+    // shell uses and exits before any window exists.
+    if (nativeLaunch) {
+        return nativeLaunchCommand(appArguments, liveIdentity, liveSnapshot, productPreviewLifecycleGate);
+    }
     const auto mediaProbe = nova::deck::stream::DeckLinuxMediaProbe::detect();
     const auto presenterReadiness = nova::deck::stream::DeckVaapiEglImagePresenter::readinessReportForPlan(
         nova::deck::stream::DeckQrhiVaapiImportPlan{

--- a/clients/deck/src/stream/deck_gamestream_launch.cpp
+++ b/clients/deck/src/stream/deck_gamestream_launch.cpp
@@ -80,6 +80,7 @@ std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStream
     appendParam(out, first, "remoteControllersBitmap", std::to_string(request.gamepadMask));
     appendParam(out, first, "gcmap", std::to_string(request.gamepadMask));
     appendParam(out, first, "gcpersist", request.persistGamepads ? "1" : "0");
+    out += request.extraQuery;
     return out;
 }
 

--- a/clients/deck/src/stream/deck_gamestream_launch.cpp
+++ b/clients/deck/src/stream/deck_gamestream_launch.cpp
@@ -1,0 +1,120 @@
+#include "stream/deck_gamestream_launch.h"
+
+#include <QXmlStreamReader>
+
+#include <array>
+#include <cstdint>
+#include <random>
+#include <string>
+
+namespace nova::deck::stream {
+
+namespace {
+
+// Write the id big-endian into the first four IV bytes, zero the rest. This is
+// the same layout the Android client builds with ByteBuffer.putInt.
+void writeIvFromKeyId(std::array<std::uint8_t, 16>& iv, std::int32_t rikeyId) {
+    iv.fill(0);
+    const auto id = static_cast<std::uint32_t>(rikeyId);
+    iv[0] = static_cast<std::uint8_t>((id >> 24) & 0xFF);
+    iv[1] = static_cast<std::uint8_t>((id >> 16) & 0xFF);
+    iv[2] = static_cast<std::uint8_t>((id >> 8) & 0xFF);
+    iv[3] = static_cast<std::uint8_t>(id & 0xFF);
+}
+
+void appendParam(std::string& out, bool& first, std::string_view key, const std::string& value) {
+    out += first ? '?' : '&';
+    first = false;
+    out += key;
+    out += '=';
+    out += value;
+}
+
+}  // namespace
+
+DeckStreamKeys buildStreamKeys(const std::array<std::uint8_t, 16>& aesKey, std::int32_t rikeyId) {
+    DeckStreamKeys keys;
+    keys.aesKey = aesKey;
+    keys.rikeyId = rikeyId;
+    writeIvFromKeyId(keys.aesIv, rikeyId);
+    return keys;
+}
+
+DeckStreamKeys generateStreamKeys() {
+    std::random_device source;
+    std::array<std::uint8_t, 16> key{};
+    for (auto& byte : key) {
+        byte = static_cast<std::uint8_t>(source() & 0xFF);
+    }
+    const auto rikeyId = static_cast<std::int32_t>(source());
+    return buildStreamKeys(key, rikeyId);
+}
+
+std::string toHexLower(const std::array<std::uint8_t, 16>& bytes) {
+    static constexpr char kDigits[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (const auto byte : bytes) {
+        out.push_back(kDigits[(byte >> 4) & 0xF]);
+        out.push_back(kDigits[byte & 0xF]);
+    }
+    return out;
+}
+
+std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStreamKeys& keys) {
+    std::string out = request.resume ? "/resume" : "/launch";
+    bool first = true;
+    appendParam(out, first, "appid", std::to_string(request.appId));
+    if (!request.appUuid.empty()) {
+        appendParam(out, first, "appuuid", request.appUuid);
+    }
+    appendParam(out, first, "mode",
+                std::to_string(request.width) + "x" + std::to_string(request.height) + "x" +
+                    std::to_string(request.fps));
+    appendParam(out, first, "additionalStates", "1");
+    appendParam(out, first, "sops", request.sops ? "1" : "0");
+    appendParam(out, first, "rikey", toHexLower(keys.aesKey));
+    appendParam(out, first, "rikeyid", std::to_string(keys.rikeyId));
+    appendParam(out, first, "localAudioPlayMode", request.playLocalAudio ? "1" : "0");
+    appendParam(out, first, "surroundAudioInfo", std::to_string(request.surroundAudioInfo));
+    appendParam(out, first, "remoteControllersBitmap", std::to_string(request.gamepadMask));
+    appendParam(out, first, "gcmap", std::to_string(request.gamepadMask));
+    appendParam(out, first, "gcpersist", request.persistGamepads ? "1" : "0");
+    return out;
+}
+
+DeckLaunchResult parseLaunchResponse(bool resume, std::string_view xml) {
+    DeckLaunchResult result;
+    QXmlStreamReader reader(QByteArray(xml.data(), static_cast<int>(xml.size())));
+    QString current;
+    const QString startedTag = resume ? QStringLiteral("resume") : QStringLiteral("gamesession");
+    while (!reader.atEnd()) {
+        const auto token = reader.readNext();
+        if (token == QXmlStreamReader::StartElement) {
+            current = reader.name().toString();
+            if (current == QStringLiteral("root")) {
+                const auto status = reader.attributes().value(QStringLiteral("status_code"));
+                if (!status.isEmpty()) {
+                    result.statusCode = status.toInt();
+                }
+            }
+        } else if (token == QXmlStreamReader::Characters && !reader.isWhitespace()) {
+            const QString text = reader.text().toString();
+            if (current == startedTag) {
+                result.started = text.trimmed() != QStringLiteral("0") && !text.trimmed().isEmpty();
+            } else if (current == QStringLiteral("sessionUrl0")) {
+                result.rtspSessionUrl = text.trimmed().toStdString();
+            } else if (current == QStringLiteral("sessionToken")) {
+                result.sessionToken = text.trimmed().toStdString();
+            }
+        } else if (token == QXmlStreamReader::EndElement) {
+            current.clear();
+        }
+    }
+    if (reader.hasError()) {
+        return DeckLaunchResult{};
+    }
+    return result;
+}
+
+}  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_launch.cpp
+++ b/clients/deck/src/stream/deck_gamestream_launch.cpp
@@ -1,5 +1,6 @@
 #include "stream/deck_gamestream_launch.h"
 
+#include <QUrl>
 #include <QXmlStreamReader>
 
 #include <array>
@@ -28,6 +29,46 @@ void appendParam(std::string& out, bool& first, std::string_view key, const std:
     out += key;
     out += '=';
     out += value;
+}
+
+// Percent-encode one query key or value so it stays a single parameter.
+std::string percentEncoded(std::string_view value) {
+    return QUrl::toPercentEncoding(QString::fromUtf8(value.data(), static_cast<qsizetype>(value.size()))).toStdString();
+}
+
+// Re-emit a caller-supplied "&k=v&k2=v2" tail with every key and value
+// encoded. Empty pieces are dropped; a piece without '=' is kept as a bare key.
+void appendEncodedExtraQuery(std::string& out, std::string_view extraQuery) {
+    std::size_t position = 0;
+    while (position <= extraQuery.size()) {
+        const std::size_t next = extraQuery.find('&', position);
+        const std::string_view piece = extraQuery.substr(position, next == std::string_view::npos ? std::string_view::npos : next - position);
+        if (!piece.empty()) {
+            const std::size_t equals = piece.find('=');
+            out += '&';
+            out += percentEncoded(piece.substr(0, equals));
+            if (equals != std::string_view::npos) {
+                out += '=';
+                out += percentEncoded(piece.substr(equals + 1));
+            }
+        }
+        if (next == std::string_view::npos) {
+            break;
+        }
+        position = next + 1;
+    }
+}
+
+// Read the root element's status attributes; shared by every host answer.
+void readRootStatus(const QXmlStreamReader& reader, int& statusCode, std::string& statusMessage) {
+    const auto status = reader.attributes().value(QStringLiteral("status_code"));
+    if (!status.isEmpty()) {
+        statusCode = status.toInt();
+    }
+    const auto message = reader.attributes().value(QStringLiteral("status_message"));
+    if (!message.isEmpty()) {
+        statusMessage = message.toString().toStdString();
+    }
 }
 
 }  // namespace
@@ -72,7 +113,7 @@ std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStream
     bool first = true;
     appendParam(out, first, "appid", std::to_string(request.appId));
     if (!request.appUuid.empty()) {
-        appendParam(out, first, "appuuid", request.appUuid);
+        appendParam(out, first, "appuuid", percentEncoded(request.appUuid));
     }
     appendParam(out, first, "mode",
                 std::to_string(request.width) + "x" + std::to_string(request.height) + "x" +
@@ -86,7 +127,7 @@ std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStream
     appendParam(out, first, "remoteControllersBitmap", std::to_string(request.gamepadMask));
     appendParam(out, first, "gcmap", std::to_string(request.gamepadMask));
     appendParam(out, first, "gcpersist", request.persistGamepads ? "1" : "0");
-    out += request.extraQuery;
+    appendEncodedExtraQuery(out, request.extraQuery);
     return out;
 }
 
@@ -100,10 +141,7 @@ DeckLaunchResult parseLaunchResponse(bool resume, std::string_view xml) {
         if (token == QXmlStreamReader::StartElement) {
             current = reader.name().toString();
             if (current == QStringLiteral("root")) {
-                const auto status = reader.attributes().value(QStringLiteral("status_code"));
-                if (!status.isEmpty()) {
-                    result.statusCode = status.toInt();
-                }
+                readRootStatus(reader, result.statusCode, result.statusMessage);
             }
         } else if (token == QXmlStreamReader::Characters && !reader.isWhitespace()) {
             const QString text = reader.text().toString();
@@ -120,6 +158,41 @@ DeckLaunchResult parseLaunchResponse(bool resume, std::string_view xml) {
     }
     if (reader.hasError()) {
         return DeckLaunchResult{};
+    }
+    return result;
+}
+
+std::string buildCancelTarget(std::string_view sessionToken) {
+    std::string out = "/cancel";
+    if (!sessionToken.empty()) {
+        out += "?sessiontoken=";
+        out += percentEncoded(sessionToken);
+    }
+    return out;
+}
+
+DeckCancelResult parseCancelResponse(std::string_view xml) {
+    DeckCancelResult result;
+    QXmlStreamReader reader(QByteArray(xml.data(), static_cast<int>(xml.size())));
+    QString current;
+    while (!reader.atEnd()) {
+        const auto token = reader.readNext();
+        if (token == QXmlStreamReader::StartElement) {
+            current = reader.name().toString();
+            if (current == QStringLiteral("root")) {
+                readRootStatus(reader, result.statusCode, result.statusMessage);
+            }
+        } else if (token == QXmlStreamReader::Characters && !reader.isWhitespace()) {
+            if (current == QStringLiteral("cancel")) {
+                const QString text = reader.text().toString().trimmed();
+                result.cancelled = !text.isEmpty() && text != QStringLiteral("0");
+            }
+        } else if (token == QXmlStreamReader::EndElement) {
+            current.clear();
+        }
+    }
+    if (reader.hasError()) {
+        return DeckCancelResult{};
     }
     return result;
 }

--- a/clients/deck/src/stream/deck_gamestream_launch.cpp
+++ b/clients/deck/src/stream/deck_gamestream_launch.cpp
@@ -41,10 +41,16 @@ DeckStreamKeys buildStreamKeys(const std::array<std::uint8_t, 16>& aesKey, std::
 }
 
 DeckStreamKeys generateStreamKeys() {
+    // On Linux, std::random_device is backed by the kernel CSPRNG (/dev/urandom),
+    // which is what the Deck runs. Use every bit of each 32-bit draw for the key.
     std::random_device source;
     std::array<std::uint8_t, 16> key{};
-    for (auto& byte : key) {
-        byte = static_cast<std::uint8_t>(source() & 0xFF);
+    for (std::size_t i = 0; i < key.size(); i += 4) {
+        const std::uint32_t word = source();
+        key[i] = static_cast<std::uint8_t>(word & 0xFF);
+        key[i + 1] = static_cast<std::uint8_t>((word >> 8) & 0xFF);
+        key[i + 2] = static_cast<std::uint8_t>((word >> 16) & 0xFF);
+        key[i + 3] = static_cast<std::uint8_t>((word >> 24) & 0xFF);
     }
     const auto rikeyId = static_cast<std::int32_t>(source());
     return buildStreamKeys(key, rikeyId);

--- a/clients/deck/src/stream/deck_gamestream_launch.h
+++ b/clients/deck/src/stream/deck_gamestream_launch.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+// GameStream launch protocol for the Deck's own streaming session. A live
+// stream needs three things this file produces, all before any socket is
+// opened: the AES stream keys the host and client share, the launch/resume
+// request the host answers with an RTSP session, and the parse of that answer.
+// Nothing here touches moonlight-common-c or the network; it is pure protocol
+// so it can be unit-tested on any host. deck_stream_core owns the moonlight
+// structs and the connection call; this only prepares what they need.
+namespace nova::deck::stream {
+
+/// The AES stream keys a GameStream launch negotiates.
+///
+/// `rikeyId` is a signed 32-bit id that rides the launch URL as a decimal int.
+/// The IV is 16 bytes with `rikeyId` in big-endian order in the first four and
+/// zero after, which is what moonlight-common-c expects in
+/// `STREAM_CONFIGURATION.remoteInputAesIv`; `aesKey` is `remoteInputAesKey`.
+struct DeckStreamKeys {
+    std::array<std::uint8_t, 16> aesKey{};
+    std::int32_t rikeyId = 0;
+    std::array<std::uint8_t, 16> aesIv{};
+};
+
+/// Build the keys from a fixed 16-byte key and id. The IV is derived from the
+/// id; the key is copied through. Pure, so tests can pin exact bytes.
+DeckStreamKeys buildStreamKeys(const std::array<std::uint8_t, 16>& aesKey, std::int32_t rikeyId);
+
+/// Generate fresh keys from the system's cryptographic random source.
+DeckStreamKeys generateStreamKeys();
+
+/// Lowercase hex of 16 bytes, as the launch URL's `rikey` value.
+std::string toHexLower(const std::array<std::uint8_t, 16>& bytes);
+
+/// The parameters Nova sends to start or resume a session.
+struct DeckLaunchRequest {
+    int appId = 0;
+    std::string appUuid;          ///< optional; omitted from the URL when empty
+    int width = 1280;
+    int height = 800;
+    int fps = 60;
+    bool sops = true;             ///< host-side optimal settings
+    bool playLocalAudio = false;
+    int surroundAudioInfo = 0;    ///< channel-count/mask the audio config reports
+    int gamepadMask = 0;          ///< remoteControllersBitmap and gcmap
+    bool persistGamepads = false; ///< gcpersist
+    bool resume = false;          ///< false = /launch, true = /resume
+};
+
+/// Build the request target (path plus query) for the launch or resume GET.
+/// The host is never named here; the caller sends it over its own connection.
+std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStreamKeys& keys);
+
+/// The outcome of a launch or resume response.
+struct DeckLaunchResult {
+    bool started = false;         ///< gamesession (launch) or resume element was non-zero
+    int statusCode = 0;           ///< the root element's status_code attribute
+    std::string rtspSessionUrl;   ///< sessionUrl0, the RTSP URL for the session
+    std::string sessionToken;     ///< sessionToken, when the host returns one
+};
+
+/// Parse a launch or resume XML response. `resume` selects which element proves
+/// the session started. Pure; a malformed body yields a not-started result.
+DeckLaunchResult parseLaunchResponse(bool resume, std::string_view xml);
+
+}  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_launch.h
+++ b/clients/deck/src/stream/deck_gamestream_launch.h
@@ -49,6 +49,11 @@ struct DeckLaunchRequest {
     int gamepadMask = 0;          ///< remoteControllersBitmap and gcmap
     bool persistGamepads = false; ///< gcpersist
     bool resume = false;          ///< false = /launch, true = /resume
+    /// Extra query the host wants appended verbatim (it already begins with `&`).
+    /// Production passes moonlight-common-c's LiGetLaunchUrlQueryParameters(),
+    /// which enables extended Sunshine handshake features; kept as a caller
+    /// string so this module needs no moonlight dependency.
+    std::string extraQuery;
 };
 
 /// Build the request target (path plus query) for the launch or resume GET.

--- a/clients/deck/src/stream/deck_gamestream_launch.h
+++ b/clients/deck/src/stream/deck_gamestream_launch.h
@@ -58,12 +58,15 @@ struct DeckLaunchRequest {
 
 /// Build the request target (path plus query) for the launch or resume GET.
 /// The host is never named here; the caller sends it over its own connection.
+/// Caller-supplied values (the app uuid, the extra query's keys and values) are
+/// percent-encoded so they cannot smuggle extra parameters into the query.
 std::string buildLaunchTarget(const DeckLaunchRequest& request, const DeckStreamKeys& keys);
 
 /// The outcome of a launch or resume response.
 struct DeckLaunchResult {
     bool started = false;         ///< gamesession (launch) or resume element was non-zero
     int statusCode = 0;           ///< the root element's status_code attribute
+    std::string statusMessage;    ///< the root element's status_message attribute, when present
     std::string rtspSessionUrl;   ///< sessionUrl0, the RTSP URL for the session
     std::string sessionToken;     ///< sessionToken, when the host returns one
 };
@@ -71,5 +74,21 @@ struct DeckLaunchResult {
 /// Parse a launch or resume XML response. `resume` selects which element proves
 /// the session started. Pure; a malformed body yields a not-started result.
 DeckLaunchResult parseLaunchResponse(bool resume, std::string_view xml);
+
+/// Build the request target that asks the host to end the app this client
+/// started. The session token the launch returned rides along when known, so a
+/// host that tracks sessions by token can match it; the paired identity is
+/// what authorizes the request either way.
+std::string buildCancelTarget(std::string_view sessionToken);
+
+/// The outcome of a cancel response.
+struct DeckCancelResult {
+    bool cancelled = false;       ///< the cancel element was non-zero
+    int statusCode = 0;           ///< the root element's status_code attribute
+    std::string statusMessage;    ///< the root element's status_message attribute, when present
+};
+
+/// Parse a cancel XML response. Pure; a malformed body yields a not-cancelled result.
+DeckCancelResult parseCancelResponse(std::string_view xml);
 
 }  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_session_builder.cpp
+++ b/clients/deck/src/stream/deck_gamestream_session_builder.cpp
@@ -57,7 +57,9 @@ RawServerInfo readServerInfo(std::string_view xml) {
 
 std::optional<DeckServerInfo> parseServerInfo(std::string_view xml) {
     const RawServerInfo raw = readServerInfo(xml);
-    if (!raw.rootOk || !raw.sawAppVersion || raw.appVersion.isEmpty()) {
+    // The GameStream root carries its own status_code; an authorization or
+    // pairing error can still include an appversion, so gate on it too.
+    if (!raw.rootOk || raw.statusCode != 200 || !raw.sawAppVersion || raw.appVersion.isEmpty()) {
         return std::nullopt;
     }
     DeckServerInfo info;
@@ -92,6 +94,10 @@ DeckSessionBuildResult buildStreamConnection(
     const DeckHttpResponse launchReply = fetch(buildLaunchTarget(request, keys));
     if (!launchReply.transportOk) {
         result.error = "could not reach the host to start the session";
+        return result;
+    }
+    if (launchReply.status != 200) {
+        result.error = "host launch returned an unexpected status";
         return result;
     }
     const DeckLaunchResult launch = parseLaunchResponse(request.resume, launchReply.body);

--- a/clients/deck/src/stream/deck_gamestream_session_builder.cpp
+++ b/clients/deck/src/stream/deck_gamestream_session_builder.cpp
@@ -4,6 +4,9 @@
 #include <QString>
 #include <QXmlStreamReader>
 
+#include <chrono>
+#include <thread>
+
 namespace nova::deck::stream {
 
 namespace {
@@ -69,6 +72,28 @@ std::optional<DeckServerInfo> parseServerInfo(std::string_view xml) {
     return info;
 }
 
+DeckHttpFetcher fetcherOverPolarisClient(const polaris::DeckPolarisClient& client) {
+    return [&client](const std::string& target) -> DeckHttpResponse {
+        const auto reply = client.get(target);
+        DeckHttpResponse response;
+        switch (reply.status) {
+        case polaris::DeckPolarisRequestStatus::Unreachable:
+        case polaris::DeckPolarisRequestStatus::Timeout:
+        case polaris::DeckPolarisRequestStatus::InvalidIdentity:
+            response.transportOk = false;
+            break;
+        default:
+            response.transportOk = true;
+            break;
+        }
+        response.status = reply.httpStatus;
+        if (reply.value) {
+            response.body = *reply.value;
+        }
+        return response;
+    };
+}
+
 DeckSessionBuildResult buildStreamConnection(
     const DeckHttpFetcher& fetch,
     const std::string& serverAddress,
@@ -97,15 +122,21 @@ DeckSessionBuildResult buildStreamConnection(
         return result;
     }
     if (launchReply.status != 200) {
+        result.launchRefused = true;
+        result.launchStatusCode = launchReply.status;
         result.error = "host launch returned an unexpected status";
         return result;
     }
     const DeckLaunchResult launch = parseLaunchResponse(request.resume, launchReply.body);
+    result.launchStatusCode = launch.statusCode;
+    result.launchStatusMessage = launch.statusMessage;
     if (!launch.started) {
+        result.launchRefused = true;
         result.error = "the host did not start the session";
         return result;
     }
     if (launch.rtspSessionUrl.empty()) {
+        result.launchRefused = true;
         result.error = "the host started the session without an RTSP url";
         return result;
     }
@@ -117,7 +148,47 @@ DeckSessionBuildResult buildStreamConnection(
     result.connectionInfo.rtspSessionUrl = launch.rtspSessionUrl;
     result.connectionInfo.serverCodecModeSupport = serverInfo->serverCodecModeSupport;
     result.connectionInfo.keys = keys;
+    result.connectionInfo.hostSessionToken = launch.sessionToken;
     return result;
+}
+
+DeckHostCancelOutcome requestHostSessionCancel(const DeckHttpFetcher& fetch, const std::string& sessionToken) {
+    DeckHostCancelOutcome outcome;
+    if (!fetch) {
+        outcome.summary = "host cancel not requested: no host fetcher";
+        return outcome;
+    }
+    const std::string target = buildCancelTarget(sessionToken);
+    // The host refuses (409) while it still counts a session as attached; the
+    // RTSP teardown lands a moment after LiStopConnection returns.
+    constexpr int kAttempts = 4;
+    for (int attempt = 1; attempt <= kAttempts; ++attempt) {
+        const DeckHttpResponse reply = fetch(target);
+        outcome.requested = true;
+        outcome.transportOk = reply.transportOk;
+        outcome.httpStatus = reply.status;
+        if (!reply.transportOk) {
+            outcome.summary = "host cancel requested but the host could not be reached";
+            return outcome;
+        }
+        const DeckCancelResult parsed = parseCancelResponse(reply.body);
+        outcome.cancelled = reply.status == 200 && parsed.cancelled;
+        outcome.hostStatusCode = parsed.statusCode;
+        outcome.hostStatusMessage = parsed.statusMessage;
+        if (outcome.cancelled) {
+            outcome.summary = "host confirmed the app ended (attempt " + std::to_string(attempt) + ")";
+            return outcome;
+        }
+        const bool retryable = reply.status == 200 && parsed.statusCode == 409 && attempt < kAttempts;
+        if (!retryable) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    outcome.summary = "host did not confirm the app ended (http " + std::to_string(outcome.httpStatus) +
+        ", host status " + std::to_string(outcome.hostStatusCode) +
+        (outcome.hostStatusMessage.empty() ? std::string{} : ": " + outcome.hostStatusMessage) + ")";
+    return outcome;
 }
 
 }  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_session_builder.cpp
+++ b/clients/deck/src/stream/deck_gamestream_session_builder.cpp
@@ -1,0 +1,117 @@
+#include "stream/deck_gamestream_session_builder.h"
+
+#include <QByteArray>
+#include <QString>
+#include <QXmlStreamReader>
+
+namespace nova::deck::stream {
+
+namespace {
+
+// Read the flat GameStream serverinfo elements this needs in one pass.
+struct RawServerInfo {
+    bool rootOk = false;
+    int statusCode = 0;
+    QString appVersion;
+    QString gfeVersion;
+    QString codecModeSupport;
+    bool sawAppVersion = false;
+};
+
+RawServerInfo readServerInfo(std::string_view xml) {
+    RawServerInfo out;
+    QXmlStreamReader reader(QByteArray(xml.data(), static_cast<int>(xml.size())));
+    QString current;
+    while (!reader.atEnd()) {
+        const auto token = reader.readNext();
+        if (token == QXmlStreamReader::StartElement) {
+            current = reader.name().toString();
+            if (current == QStringLiteral("root")) {
+                out.rootOk = true;
+                const auto status = reader.attributes().value(QStringLiteral("status_code"));
+                if (!status.isEmpty()) {
+                    out.statusCode = status.toInt();
+                }
+            }
+        } else if (token == QXmlStreamReader::Characters && !reader.isWhitespace()) {
+            const QString text = reader.text().toString().trimmed();
+            if (current == QStringLiteral("appversion")) {
+                out.appVersion = text;
+                out.sawAppVersion = true;
+            } else if (current == QStringLiteral("GfeVersion")) {
+                out.gfeVersion = text;
+            } else if (current == QStringLiteral("ServerCodecModeSupport")) {
+                out.codecModeSupport = text;
+            }
+        } else if (token == QXmlStreamReader::EndElement) {
+            current.clear();
+        }
+    }
+    if (reader.hasError()) {
+        out.rootOk = false;
+    }
+    return out;
+}
+
+}  // namespace
+
+std::optional<DeckServerInfo> parseServerInfo(std::string_view xml) {
+    const RawServerInfo raw = readServerInfo(xml);
+    if (!raw.rootOk || !raw.sawAppVersion || raw.appVersion.isEmpty()) {
+        return std::nullopt;
+    }
+    DeckServerInfo info;
+    info.appVersion = raw.appVersion.toStdString();
+    info.gfeVersion = raw.gfeVersion.toStdString();
+    info.serverCodecModeSupport = raw.codecModeSupport.isEmpty() ? 0 : raw.codecModeSupport.toInt();
+    return info;
+}
+
+DeckSessionBuildResult buildStreamConnection(
+    const DeckHttpFetcher& fetch,
+    const std::string& serverAddress,
+    const DeckLaunchRequest& request,
+    const DeckStreamKeys& keys) {
+    DeckSessionBuildResult result;
+
+    const DeckHttpResponse serverInfoReply = fetch("/serverinfo");
+    if (!serverInfoReply.transportOk) {
+        result.error = "could not reach the host for serverinfo";
+        return result;
+    }
+    if (serverInfoReply.status != 200) {
+        result.error = "host serverinfo returned an unexpected status";
+        return result;
+    }
+    const auto serverInfo = parseServerInfo(serverInfoReply.body);
+    if (!serverInfo) {
+        result.error = "host serverinfo was unreadable";
+        return result;
+    }
+
+    const DeckHttpResponse launchReply = fetch(buildLaunchTarget(request, keys));
+    if (!launchReply.transportOk) {
+        result.error = "could not reach the host to start the session";
+        return result;
+    }
+    const DeckLaunchResult launch = parseLaunchResponse(request.resume, launchReply.body);
+    if (!launch.started) {
+        result.error = "the host did not start the session";
+        return result;
+    }
+    if (launch.rtspSessionUrl.empty()) {
+        result.error = "the host started the session without an RTSP url";
+        return result;
+    }
+
+    result.ok = true;
+    result.connectionInfo.serverAddress = serverAddress;
+    result.connectionInfo.appVersion = serverInfo->appVersion;
+    result.connectionInfo.gfeVersion = serverInfo->gfeVersion;
+    result.connectionInfo.rtspSessionUrl = launch.rtspSessionUrl;
+    result.connectionInfo.serverCodecModeSupport = serverInfo->serverCodecModeSupport;
+    result.connectionInfo.keys = keys;
+    return result;
+}
+
+}  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_session_builder.h
+++ b/clients/deck/src/stream/deck_gamestream_session_builder.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "stream/deck_gamestream_launch.h"
+#include "stream/deck_stream_core.h"
+
+// Assembles a DeckStreamConnectionInfo from a host: read its serverinfo for the
+// versions and codec support, issue the launch to get an RTSP session, and pair
+// that with the AES keys. The host is reached through an injected fetcher, so the
+// assembly is testable without a network; production wires the fetcher to the
+// pinned-certificate GET the Polaris client already performs.
+namespace nova::deck::stream {
+
+/// The fields a launch needs from the host's GameStream serverinfo.
+struct DeckServerInfo {
+    std::string appVersion;            ///< appversion tag
+    std::string gfeVersion;            ///< GfeVersion tag, empty when absent
+    int serverCodecModeSupport = 0;    ///< ServerCodecModeSupport tag
+};
+
+/// Parse the serverinfo fields a launch needs. Pure; nullopt on a bad root or a
+/// missing appversion.
+std::optional<DeckServerInfo> parseServerInfo(std::string_view xml);
+
+/// One host request: the fetcher is given a request target ("/path" or
+/// "/path?query") and returns the HTTP status, the body, and whether the
+/// transport reached the host at all.
+struct DeckHttpResponse {
+    bool transportOk = false;
+    int status = 0;
+    std::string body;
+};
+using DeckHttpFetcher = std::function<DeckHttpResponse(const std::string& target)>;
+
+/// The outcome of assembling a connection descriptor.
+struct DeckSessionBuildResult {
+    bool ok = false;
+    std::string error;   ///< public-safe reason when not ok; never carries the address
+    DeckStreamConnectionInfo connectionInfo;
+};
+
+/// Read serverinfo and issue the launch through `fetch`, then assemble the
+/// connection descriptor. `keys` are supplied so a test can pin them; production
+/// passes generateStreamKeys(). The host address is not requested here, only
+/// carried into the result, so the fetcher owns how the host is reached.
+DeckSessionBuildResult buildStreamConnection(
+    const DeckHttpFetcher& fetch,
+    const std::string& serverAddress,
+    const DeckLaunchRequest& request,
+    const DeckStreamKeys& keys);
+
+}  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_gamestream_session_builder.h
+++ b/clients/deck/src/stream/deck_gamestream_session_builder.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 
+#include "polaris/deck_polaris_client.h"
 #include "stream/deck_gamestream_launch.h"
 #include "stream/deck_stream_core.h"
 
@@ -36,11 +37,24 @@ struct DeckHttpResponse {
 };
 using DeckHttpFetcher = std::function<DeckHttpResponse(const std::string& target)>;
 
+/// A fetcher over the pinned-certificate Polaris client, so the GameStream
+/// requests ride the same mTLS identity the library read uses. `client` must
+/// outlive the fetcher. A host that could not be reached at all (no answer,
+/// timeout, unusable identity) is a transport failure; every other outcome is
+/// an answer and carries the HTTP status, with the body only when it was 2xx.
+DeckHttpFetcher fetcherOverPolarisClient(const polaris::DeckPolarisClient& client);
+
 /// The outcome of assembling a connection descriptor.
 struct DeckSessionBuildResult {
     bool ok = false;
     std::string error;   ///< public-safe reason when not ok; never carries the address
-    DeckStreamConnectionInfo connectionInfo;
+    /// The host answered the launch and did not start the session (an HTTP
+    /// error, a busy host, a refusal). False when the host was never reached
+    /// or serverinfo already failed.
+    bool launchRefused = false;
+    int launchStatusCode = 0;        ///< the launch answer's root status_code, when parsed
+    std::string launchStatusMessage; ///< the launch answer's status_message, when present
+    DeckStreamConnectionInfo connectionInfo;  ///< carries the host session token when the host returned one
 };
 
 /// Read serverinfo and issue the launch through `fetch`, then assemble the
@@ -52,5 +66,22 @@ DeckSessionBuildResult buildStreamConnection(
     const std::string& serverAddress,
     const DeckLaunchRequest& request,
     const DeckStreamKeys& keys);
+
+/// The outcome of asking the host to end the app after the stream is down.
+struct DeckHostCancelOutcome {
+    bool requested = false;      ///< a cancel request was sent
+    bool transportOk = false;    ///< the host was reached
+    int httpStatus = 0;
+    bool cancelled = false;      ///< the host confirmed the app ended
+    int hostStatusCode = 0;      ///< the answer's root status_code
+    std::string hostStatusMessage;
+    std::string summary;         ///< one public-safe line for a report
+};
+
+/// Ask the host to end the app this client launched. Best effort: the outcome
+/// is reported, never thrown. The host refuses while a stream session is still
+/// attached, so callers tear the connection down first; a refusal on that
+/// ground is retried a few times with a short pause.
+DeckHostCancelOutcome requestHostSessionCancel(const DeckHttpFetcher& fetch, const std::string& sessionToken);
 
 }  // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_stream_core.cpp
+++ b/clients/deck/src/stream/deck_stream_core.cpp
@@ -1,6 +1,18 @@
 #include "stream/deck_stream_core.h"
 
+#include <cstring>
+
 namespace nova::deck::stream {
+
+void applyConnectionStreamConfig(STREAM_CONFIGURATION& config, const DeckStreamConnectionInfo& info) {
+    static_assert(sizeof(config.remoteInputAesKey) == 16, "remoteInputAesKey is 16 bytes");
+    static_assert(sizeof(config.remoteInputAesIv) == 16, "remoteInputAesIv is 16 bytes");
+    std::memcpy(config.remoteInputAesKey, info.keys.aesKey.data(), info.keys.aesKey.size());
+    std::memcpy(config.remoteInputAesIv, info.keys.aesIv.data(), info.keys.aesIv.size());
+    config.encryptionFlags = info.encryptionFlags;
+    config.colorSpace = info.colorSpace;
+    config.colorRange = info.colorRange;
+}
 
 namespace {
 
@@ -827,9 +839,54 @@ DeckStreamTransition DeckStreamSession::startNoNetwork() {
     return transitionTo(DeckStreamSessionState::Active, "active skeleton session; no sockets or host connection opened");
 }
 
+DeckStreamTransition DeckStreamSession::startNetwork(const DeckStreamConnectionInfo& info) {
+    if (state_ != DeckStreamSessionState::Preparing) {
+        return fail("network start requested before prepare");
+    }
+    if (info.serverAddress.empty() || info.rtspSessionUrl.empty()) {
+        return fail("network start requires a host address and an RTSP session URL");
+    }
+
+    // Own the strings the host session points into for its lifetime.
+    serverAddress_ = info.serverAddress;
+    serverAppVersion_ = info.appVersion;
+    serverGfeVersion_ = info.gfeVersion;
+    rtspSessionUrl_ = info.rtspSessionUrl;
+    applyConnectionStreamConfig(streamConfig_, info);
+    moonlightBoundary_.networkStartAllowed = true;
+
+    SERVER_INFORMATION serverInfo{};
+    serverInfo.address = serverAddress_.c_str();
+    serverInfo.serverInfoAppVersion = serverAppVersion_.c_str();
+    serverInfo.serverInfoGfeVersion = serverGfeVersion_.empty() ? nullptr : serverGfeVersion_.c_str();
+    serverInfo.rtspSessionUrl = rtspSessionUrl_.c_str();
+    serverInfo.serverCodecModeSupport = info.serverCodecModeSupport;
+
+    transitionTo(DeckStreamSessionState::Starting, "starting host session via moonlight-common-c");
+    const int rc = LiStartConnection(&serverInfo, &streamConfig_, &listenerCallbacks_, &videoCallbacks_,
+                                     &audioCallbacks_, callbackContext_, 0, callbackContext_, 0);
+    if (rc != 0) {
+        moonlightBoundary_.networkStartAllowed = false;
+        clearCallbackOwner(*this);
+        return fail("LiStartConnection did not establish the host session");
+    }
+    networkStarted_ = true;
+    return transitionTo(DeckStreamSessionState::Active, "active host session streaming via moonlight-common-c", true);
+}
+
 DeckStreamTransition DeckStreamSession::stop() {
     if (state_ != DeckStreamSessionState::Starting && state_ != DeckStreamSessionState::Active) {
         return fail("stop requested before active stream");
+    }
+
+    if (networkStarted_) {
+        transitionTo(DeckStreamSessionState::Stopping, "stopping host session; calling LiStopConnection");
+        LiStopConnection();
+        networkStarted_ = false;
+        moonlightBoundary_.networkStartAllowed = false;
+        auto stopped = transitionTo(DeckStreamSessionState::Stopped, "stopped host session");
+        clearCallbackOwner(*this);
+        return stopped;
     }
 
     transitionTo(DeckStreamSessionState::Stopping, "stopping skeleton session; LiStopConnection not called because network never started");

--- a/clients/deck/src/stream/deck_stream_core.cpp
+++ b/clients/deck/src/stream/deck_stream_core.cpp
@@ -793,6 +793,13 @@ DeckStreamSession::DeckStreamSession(
 }
 
 DeckStreamSession::~DeckStreamSession() {
+    // moonlight-common-c has one global connection; a live one must be torn down
+    // or the next LiStartConnection fails. stop() does it on the normal path;
+    // this covers a session dropped while still streaming.
+    if (networkStarted_) {
+        LiStopConnection();
+        networkStarted_ = false;
+    }
     clearCallbackOwner(*this);
     releaseCallbackSlot(callbackSlot_);
     callbackSlot_ = kInvalidCallbackSlot;
@@ -896,7 +903,14 @@ DeckStreamTransition DeckStreamSession::stop() {
 }
 
 DeckStreamTransition DeckStreamSession::cancel(const std::string_view reason) {
-    auto cancelled = transitionTo(DeckStreamSessionState::Cancelled, reason.empty() ? "cancelled before network start" : reason);
+    // cancel() has no state guard, so it can arrive on a network-active session;
+    // tear the host connection down before leaving it.
+    if (networkStarted_) {
+        LiStopConnection();
+        networkStarted_ = false;
+        moonlightBoundary_.networkStartAllowed = false;
+    }
+    auto cancelled = transitionTo(DeckStreamSessionState::Cancelled, reason.empty() ? "cancelled" : reason);
     clearCallbackOwner(*this);
     return cancelled;
 }

--- a/clients/deck/src/stream/deck_stream_core.cpp
+++ b/clients/deck/src/stream/deck_stream_core.cpp
@@ -1,8 +1,21 @@
 #include "stream/deck_stream_core.h"
 
 #include <cstring>
+#include <string>
 
 namespace nova::deck::stream {
+
+DeckLaunchRequest launchRequestForStream(const DeckStreamRequest& request, const int appId, std::string appUuid) {
+    DeckLaunchRequest launch;
+    launch.appId = appId;
+    launch.appUuid = std::move(appUuid);
+    launch.width = request.width;
+    launch.height = request.height;
+    launch.fps = request.fps;
+    launch.surroundAudioInfo = SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(request.audioConfiguration);
+    launch.extraQuery = LiGetLaunchUrlQueryParameters();
+    return launch;
+}
 
 void applyConnectionStreamConfig(STREAM_CONFIGURATION& config, const DeckStreamConnectionInfo& info) {
     static_assert(sizeof(config.remoteInputAesKey) == 16, "remoteInputAesKey is 16 bytes");
@@ -47,10 +60,34 @@ void* nextOpaqueCallbackContext() {
 }
 
 bool isValidStreamRequest(const DeckStreamRequest& request) {
-    return request.width > 0 && request.height > 0 && request.fps > 0 && request.bitrateKbps > 0;
+    return request.width > 0 && request.height > 0 && request.fps > 0 && request.bitrateKbps > 0 &&
+        request.audioConfiguration != 0;
 }
 
+class DefaultMoonlightConnectionDriver final : public DeckMoonlightConnectionDriver {
+public:
+    int start(
+        SERVER_INFORMATION& serverInfo,
+        STREAM_CONFIGURATION& streamConfig,
+        CONNECTION_LISTENER_CALLBACKS& listenerCallbacks,
+        DECODER_RENDERER_CALLBACKS& videoCallbacks,
+        AUDIO_RENDERER_CALLBACKS& audioCallbacks,
+        void* callbackContext) override {
+        return LiStartConnection(&serverInfo, &streamConfig, &listenerCallbacks, &videoCallbacks,
+                                 &audioCallbacks, callbackContext, 0, callbackContext, 0);
+    }
+
+    void stop() override {
+        LiStopConnection();
+    }
+};
+
 } // namespace
+
+DeckMoonlightConnectionDriver& defaultMoonlightConnectionDriver() {
+    static DefaultMoonlightConnectionDriver driver;
+    return driver;
+}
 
 DeckStreamSession* DeckStreamSession::ownerFromContext(void* context) {
     if (context == nullptr) {
@@ -125,11 +162,63 @@ void DeckStreamSession::audioStopForSlot(const std::size_t slot) { if (auto* own
 void DeckStreamSession::audioCleanupForSlot(const std::size_t slot) { if (auto* owner = ownerForSlot(slot)) { owner->audio_.cleanup(); } }
 void DeckStreamSession::audioDecodeAndPlaySampleForSlot(const std::size_t slot, char* sampleData, const int sampleLength) { if (auto* owner = ownerForSlot(slot)) { owner->audio_.decodeAndPlaySample(sampleData, sampleLength); } }
 
-void DeckStreamSession::listenerStageStartingForSlot(const std::size_t slot, const int stage) { (void)stage; if (auto* owner = ownerForSlot(slot)) { owner->noteSessionEvent("moonlight stage starting"); } }
-void DeckStreamSession::listenerStageCompleteForSlot(const std::size_t slot, const int stage) { (void)stage; if (auto* owner = ownerForSlot(slot)) { owner->noteSessionEvent("moonlight stage complete"); } }
-void DeckStreamSession::listenerStageFailedForSlot(const std::size_t slot, const int stage, const int errorCode) { (void)stage; (void)errorCode; if (auto* owner = ownerForSlot(slot)) { owner->noteSessionEvent("moonlight stage failed"); } }
-void DeckStreamSession::listenerConnectionStartedForSlot(const std::size_t slot) { if (auto* owner = ownerForSlot(slot)) { owner->noteSessionEvent("moonlight connection started callback received in no-network adapter"); } }
-void DeckStreamSession::listenerConnectionTerminatedForSlot(const std::size_t slot, const int errorCode) { (void)errorCode; if (auto* owner = ownerForSlot(slot)) { owner->noteSessionEvent("moonlight connection terminated callback received in no-network adapter"); } }
+void DeckStreamSession::listenerStageStartingForSlot(const std::size_t slot, const int stage) {
+    if (auto* owner = ownerForSlot(slot)) {
+        owner->lastStage_ = stage;
+        owner->noteSessionEvent("moonlight stage starting: " + std::string(LiGetStageName(stage)));
+    }
+}
+
+void DeckStreamSession::listenerStageCompleteForSlot(const std::size_t slot, const int stage) {
+    if (auto* owner = ownerForSlot(slot)) {
+        owner->lastStage_ = stage;
+        owner->noteSessionEvent("moonlight stage complete: " + std::string(LiGetStageName(stage)));
+    }
+}
+
+void DeckStreamSession::listenerStageFailedForSlot(const std::size_t slot, const int stage, const int errorCode) {
+    if (auto* owner = ownerForSlot(slot)) {
+        owner->failedStage_ = stage;
+        owner->failedStageErrorCode_ = errorCode;
+        owner->noteSessionEvent("moonlight stage failed: " + std::string(LiGetStageName(stage)) + " (error " + std::to_string(errorCode) + ")");
+    }
+}
+
+void DeckStreamSession::listenerConnectionStartedForSlot(const std::size_t slot) {
+    if (auto* owner = ownerForSlot(slot)) {
+        owner->connectionStartedSeen_ = true;
+        owner->noteSessionEvent("moonlight connection started");
+    }
+}
+
+// Runs on moonlight-common-c's termination thread, once per connection, only
+// when the host or the network ended it (a stop this side requested never
+// reaches here). The connection is gone, so the session leaves Active; the
+// driver's stop is still owed and stays owed, because moonlight-common-c
+// releases its threads only in that call, and calling it from this thread
+// would deadlock on the very thread it joins. stop() settles it later.
+void DeckStreamSession::listenerConnectionTerminatedForSlot(const std::size_t slot, const int errorCode) {
+    auto* owner = ownerForSlot(slot);
+    if (owner == nullptr) {
+        return;
+    }
+    owner->connectionTerminatedSeen_ = true;
+    owner->terminationErrorCode_ = errorCode;
+    owner->networkStarted_ = false;
+    if (!owner->stopConnectionOwed_.load()) {
+        // No host connection is live (a synthetic call, or one that raced a
+        // finished teardown); there is nothing to leave.
+        owner->noteSessionEvent("moonlight connection terminated callback received without a live host connection (error " + std::to_string(errorCode) + ")");
+        return;
+    }
+    if (errorCode == ML_ERROR_GRACEFUL_TERMINATION) {
+        owner->transitionTo(DeckStreamSessionState::Stopped, "moonlight connection terminated gracefully by the host");
+        return;
+    }
+    owner->transitionTo(
+        DeckStreamSessionState::Failed,
+        "moonlight connection terminated (error " + std::to_string(errorCode) + ")");
+}
 void DeckStreamSession::listenerRumbleForSlot(const std::size_t slot, const unsigned short controllerNumber, const unsigned short lowFreqMotor, const unsigned short highFreqMotor) { if (auto* owner = ownerForSlot(slot)) { owner->input_.rumble(controllerNumber, lowFreqMotor, highFreqMotor); } }
 void DeckStreamSession::listenerSetMotionEventStateForSlot(const std::size_t slot, const uint16_t controllerNumber, const uint8_t motionType, const uint16_t reportRateHz) { if (auto* owner = ownerForSlot(slot)) { owner->input_.setMotionEventState(controllerNumber, motionType, reportRateHz); } }
 void DeckStreamSession::listenerSetControllerLedForSlot(const std::size_t slot, const uint16_t controllerNumber, const uint8_t r, const uint8_t g, const uint8_t b) { if (auto* owner = ownerForSlot(slot)) { owner->input_.setControllerLed(controllerNumber, r, g, b); } }
@@ -764,10 +853,19 @@ DeckStreamSession::DeckStreamSession(
     DeckStreamAudio& audio,
     DeckStreamInput& input,
     DeckStreamSessionEvents& events)
+    : DeckStreamSession(renderer, audio, input, events, defaultMoonlightConnectionDriver()) {}
+
+DeckStreamSession::DeckStreamSession(
+    DeckStreamRenderer& renderer,
+    DeckStreamAudio& audio,
+    DeckStreamInput& input,
+    DeckStreamSessionEvents& events,
+    DeckMoonlightConnectionDriver& driver)
     : renderer_(renderer)
     , audio_(audio)
     , input_(input)
-    , events_(events) {
+    , events_(events)
+    , driver_(driver) {
     LiInitializeStreamConfiguration(&streamConfig_);
     LiInitializeConnectionCallbacks(&listenerCallbacks_);
     LiInitializeVideoCallbacks(&videoCallbacks_);
@@ -796,25 +894,34 @@ DeckStreamSession::~DeckStreamSession() {
     // moonlight-common-c has one global connection; a live one must be torn down
     // or the next LiStartConnection fails. stop() does it on the normal path;
     // this covers a session dropped while still streaming.
-    if (networkStarted_) {
-        LiStopConnection();
-        networkStarted_ = false;
-    }
+    teardownHostConnection();
     clearCallbackOwner(*this);
     releaseCallbackSlot(callbackSlot_);
     callbackSlot_ = kInvalidCallbackSlot;
 }
 
 DeckStreamSessionState DeckStreamSession::state() const {
-    return state_;
+    return state_.load();
 }
 
 const DeckMoonlightBoundary& DeckStreamSession::moonlightBoundary() const {
     return moonlightBoundary_;
 }
 
+DeckMoonlightConnectionStatus DeckStreamSession::connectionStatus() const {
+    return DeckMoonlightConnectionStatus{
+        .connectionStarted = connectionStartedSeen_.load(),
+        .terminated = connectionTerminatedSeen_.load(),
+        .terminationErrorCode = terminationErrorCode_.load(),
+        .lastStage = lastStage_.load(),
+        .failedStage = failedStage_.load(),
+        .failedStageErrorCode = failedStageErrorCode_.load(),
+    };
+}
+
 DeckStreamTransition DeckStreamSession::prepare(const DeckStreamRequest& request) {
-    if (state_ != DeckStreamSessionState::Idle && state_ != DeckStreamSessionState::Stopped) {
+    const auto state = state_.load();
+    if (state != DeckStreamSessionState::Idle && state != DeckStreamSessionState::Stopped) {
         return fail("prepare requested while stream session is not idle");
     }
     if (!isValidStreamRequest(request)) {
@@ -833,12 +940,19 @@ DeckStreamTransition DeckStreamSession::prepare(const DeckStreamRequest& request
     streamConfig_.height = request.height;
     streamConfig_.fps = request.fps;
     streamConfig_.bitrate = request.bitrateKbps;
+    streamConfig_.audioConfiguration = request.audioConfiguration;
     streamConfig_.packetSize = 1024;
+    connectionStartedSeen_ = false;
+    connectionTerminatedSeen_ = false;
+    terminationErrorCode_ = 0;
+    lastStage_ = -1;
+    failedStage_ = -1;
+    failedStageErrorCode_ = 0;
     return transitionTo(DeckStreamSessionState::Preparing, "prepared no-network moonlight-common-c boundary");
 }
 
 DeckStreamTransition DeckStreamSession::startNoNetwork() {
-    if (state_ != DeckStreamSessionState::Preparing) {
+    if (state_.load() != DeckStreamSessionState::Preparing) {
         return fail("start requested before prepare");
     }
 
@@ -847,7 +961,7 @@ DeckStreamTransition DeckStreamSession::startNoNetwork() {
 }
 
 DeckStreamTransition DeckStreamSession::startNetwork(const DeckStreamConnectionInfo& info) {
-    if (state_ != DeckStreamSessionState::Preparing) {
+    if (state_.load() != DeckStreamSessionState::Preparing) {
         return fail("network start requested before prepare");
     }
     if (info.serverAddress.empty() || info.rtspSessionUrl.empty()) {
@@ -870,28 +984,48 @@ DeckStreamTransition DeckStreamSession::startNetwork(const DeckStreamConnectionI
     serverInfo.serverCodecModeSupport = info.serverCodecModeSupport;
 
     transitionTo(DeckStreamSessionState::Starting, "starting host session via moonlight-common-c");
-    const int rc = LiStartConnection(&serverInfo, &streamConfig_, &listenerCallbacks_, &videoCallbacks_,
-                                     &audioCallbacks_, callbackContext_, 0, callbackContext_, 0);
+    const int rc = driver_.start(serverInfo, streamConfig_, listenerCallbacks_, videoCallbacks_, audioCallbacks_, callbackContext_);
     if (rc != 0) {
+        // A failed LiStartConnection already unwound its own stages, and a
+        // second stop is a no-op there because every unwind step is guarded by
+        // the stage counter. Calling it anyway keeps one rule for the seam:
+        // exactly one stop follows every start, whoever the driver is.
+        driver_.stop();
         moonlightBoundary_.networkStartAllowed = false;
+        clearHostStrings();
+        const auto status = connectionStatus();
+        std::string reason = "LiStartConnection did not establish the host session (result " + std::to_string(rc);
+        if (status.failedStage >= 0) {
+            reason += ", failed stage " + std::string(LiGetStageName(status.failedStage)) + " error " + std::to_string(status.failedStageErrorCode);
+        }
+        reason += ")";
+        auto failed = transitionTo(DeckStreamSessionState::Failed, reason);
+        failed.hostConnectionTornDown = true;
         clearCallbackOwner(*this);
-        return fail("LiStartConnection did not establish the host session");
+        return failed;
     }
     networkStarted_ = true;
+    stopConnectionOwed_ = true;
     return transitionTo(DeckStreamSessionState::Active, "active host session streaming via moonlight-common-c", true);
 }
 
 DeckStreamTransition DeckStreamSession::stop() {
-    if (state_ != DeckStreamSessionState::Starting && state_ != DeckStreamSessionState::Active) {
+    const auto state = state_.load();
+    const bool hostConnectionOwed = stopConnectionOwed_.load();
+    if (!hostConnectionOwed && state != DeckStreamSessionState::Starting && state != DeckStreamSessionState::Active) {
         return fail("stop requested before active stream");
     }
 
-    if (networkStarted_) {
-        transitionTo(DeckStreamSessionState::Stopping, "stopping host session; calling LiStopConnection");
-        LiStopConnection();
-        networkStarted_ = false;
-        moonlightBoundary_.networkStartAllowed = false;
-        auto stopped = transitionTo(DeckStreamSessionState::Stopped, "stopped host session");
+    if (hostConnectionOwed) {
+        const bool hostEndedIt = connectionTerminatedSeen_.load();
+        transitionTo(DeckStreamSessionState::Stopping, hostEndedIt
+            ? "stopping host session after the host ended the connection; calling LiStopConnection to release moonlight-common-c"
+            : "stopping host session; calling LiStopConnection");
+        teardownHostConnection();
+        auto stopped = transitionTo(DeckStreamSessionState::Stopped, hostEndedIt
+            ? "stopped host session after moonlight termination (error " + std::to_string(terminationErrorCode_.load()) + ")"
+            : "stopped host session");
+        stopped.hostConnectionTornDown = true;
         clearCallbackOwner(*this);
         return stopped;
     }
@@ -905,24 +1039,43 @@ DeckStreamTransition DeckStreamSession::stop() {
 DeckStreamTransition DeckStreamSession::cancel(const std::string_view reason) {
     // cancel() has no state guard, so it can arrive on a network-active session;
     // tear the host connection down before leaving it.
-    if (networkStarted_) {
-        LiStopConnection();
-        networkStarted_ = false;
-        moonlightBoundary_.networkStartAllowed = false;
-    }
+    const bool tornDown = teardownHostConnection();
     auto cancelled = transitionTo(DeckStreamSessionState::Cancelled, reason.empty() ? "cancelled" : reason);
+    cancelled.hostConnectionTornDown = tornDown;
     clearCallbackOwner(*this);
     return cancelled;
 }
 
 DeckStreamTransition DeckStreamSession::fail(const std::string_view reason) {
+    // A failure on a session with a live host connection must not leave the
+    // connection running underneath a Failed state.
+    const bool tornDown = teardownHostConnection();
     auto failed = transitionTo(DeckStreamSessionState::Failed, reason.empty() ? "stream skeleton failed before network start" : reason);
+    failed.hostConnectionTornDown = tornDown;
     clearCallbackOwner(*this);
     return failed;
 }
 
+bool DeckStreamSession::teardownHostConnection() {
+    if (!stopConnectionOwed_.exchange(false)) {
+        return false;
+    }
+    driver_.stop();
+    networkStarted_ = false;
+    moonlightBoundary_.networkStartAllowed = false;
+    clearHostStrings();
+    return true;
+}
+
+void DeckStreamSession::clearHostStrings() {
+    serverAddress_.clear();
+    serverAppVersion_.clear();
+    serverGfeVersion_.clear();
+    rtspSessionUrl_.clear();
+}
+
 void DeckStreamSession::noteSessionEvent(const std::string_view reason) {
-    events_.onSessionEvent(state_, reason);
+    events_.onSessionEvent(state_.load(), reason);
 }
 
 DeckStreamTransition DeckStreamSession::transitionTo(
@@ -930,9 +1083,9 @@ DeckStreamTransition DeckStreamSession::transitionTo(
     const std::string_view reason,
     const bool networkStarted) {
     state_ = state;
-    events_.onSessionEvent(state_, reason);
+    events_.onSessionEvent(state, reason);
     return DeckStreamTransition{
-        .state = state_,
+        .state = state,
         .reason = std::string(reason),
         .networkStarted = networkStarted,
     };

--- a/clients/deck/src/stream/deck_stream_core.h
+++ b/clients/deck/src/stream/deck_stream_core.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <string_view>
 
+#include "stream/deck_gamestream_launch.h"
+
 namespace nova::deck::stream {
 
 enum class DeckStreamSessionState {
@@ -34,6 +36,27 @@ struct DeckStreamTransition {
     std::string reason;
     bool networkStarted = false;
 };
+
+/// Everything a real connection needs beyond the request: the host address, the
+/// version strings and codec support the host reports in serverinfo, the RTSP
+/// session URL the launch handshake returned, and the AES stream keys. The
+/// caller assembles this from deck_gamestream_launch plus a serverinfo read.
+struct DeckStreamConnectionInfo {
+    std::string serverAddress;
+    std::string appVersion;
+    std::string gfeVersion;          ///< empty when the host omits it
+    std::string rtspSessionUrl;
+    int serverCodecModeSupport = 0;
+    DeckStreamKeys keys;
+    int encryptionFlags = ENCFLG_AUDIO;   ///< the launch negotiates the rest
+    int colorSpace = COLORSPACE_REC_709;
+    int colorRange = COLOR_RANGE_LIMITED;
+};
+
+/// Copy the AES key and IV and the encryption and color choices from a
+/// connection descriptor into a stream configuration. Pure, so tests can pin
+/// the exact bytes without opening a connection.
+void applyConnectionStreamConfig(STREAM_CONFIGURATION& config, const DeckStreamConnectionInfo& info);
 
 struct DeckMoonlightBoundary {
     const CONNECTION_LISTENER_CALLBACKS* listenerCallbacks = nullptr;
@@ -99,6 +122,10 @@ public:
 
     DeckStreamTransition prepare(const DeckStreamRequest& request);
     DeckStreamTransition startNoNetwork();
+    /// Open the real host session: fill SERVER_INFORMATION and the AES fields
+    /// from `info`, authorize this session's boundary, and call LiStartConnection.
+    /// Only reachable after prepare(); a failure fails the session closed.
+    DeckStreamTransition startNetwork(const DeckStreamConnectionInfo& info);
     DeckStreamTransition stop();
     DeckStreamTransition cancel(std::string_view reason);
     DeckStreamTransition fail(std::string_view reason);
@@ -437,6 +464,13 @@ private:
     DECODER_RENDERER_CALLBACKS videoCallbacks_{};
     AUDIO_RENDERER_CALLBACKS audioCallbacks_{};
     DeckMoonlightBoundary moonlightBoundary_{};
+    // SERVER_INFORMATION holds raw pointers, so the session owns the backing
+    // strings for the connection's lifetime.
+    std::string serverAddress_;
+    std::string serverAppVersion_;
+    std::string serverGfeVersion_;
+    std::string rtspSessionUrl_;
+    bool networkStarted_ = false;
 };
 
 } // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_stream_core.h
+++ b/clients/deck/src/stream/deck_stream_core.h
@@ -48,7 +48,10 @@ struct DeckStreamConnectionInfo {
     std::string rtspSessionUrl;
     int serverCodecModeSupport = 0;
     DeckStreamKeys keys;
-    int encryptionFlags = ENCFLG_AUDIO;   ///< the launch negotiates the rest
+    // Encrypt everything the host supports. moonlight-common-c recommends
+    // ENCFLG_ALL and negotiates down to what the host offers; the Android client
+    // uses it whenever the platform has fast AES, which the Deck's AMD APU does.
+    int encryptionFlags = ENCFLG_ALL;
     int colorSpace = COLORSPACE_REC_709;
     int colorRange = COLOR_RANGE_LIMITED;
 };

--- a/clients/deck/src/stream/deck_stream_core.h
+++ b/clients/deck/src/stream/deck_stream_core.h
@@ -2,6 +2,7 @@
 
 #include <Limelight.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstddef>
 #include <string>
@@ -29,13 +30,24 @@ struct DeckStreamRequest {
     int height = 800;
     int fps = 60;
     int bitrateKbps = 20000;
+    /// The moonlight audio layout the session decodes; the launch tells the
+    /// host the same layout, so both sides are derived from this one value.
+    int audioConfiguration = AUDIO_CONFIGURATION_STEREO;
 };
 
 struct DeckStreamTransition {
     DeckStreamSessionState state = DeckStreamSessionState::Idle;
     std::string reason;
     bool networkStarted = false;
+    /// True when this transition tore down a live host connection.
+    bool hostConnectionTornDown = false;
 };
+
+/// The host launch parameters for a stream request: the same size, rate and
+/// audio layout the session is prepared with, taken from the one request so the
+/// host's encoder and the client's decoder cannot drift apart. The extra query
+/// is what moonlight-common-c wants appended for this protocol version.
+DeckLaunchRequest launchRequestForStream(const DeckStreamRequest& request, int appId, std::string appUuid = {});
 
 /// Everything a real connection needs beyond the request: the host address, the
 /// version strings and codec support the host reports in serverinfo, the RTSP
@@ -46,6 +58,9 @@ struct DeckStreamConnectionInfo {
     std::string appVersion;
     std::string gfeVersion;          ///< empty when the host omits it
     std::string rtspSessionUrl;
+    /// The host's token for this session, when it returns one; rides the
+    /// cancel request so the host can match the session it started for us.
+    std::string hostSessionToken;
     int serverCodecModeSupport = 0;
     DeckStreamKeys keys;
     // Encrypt everything the host supports. moonlight-common-c recommends
@@ -69,6 +84,36 @@ struct DeckMoonlightBoundary {
     void* callbackContext = nullptr;
     bool networkStartAllowed = false;
 };
+
+/// What moonlight-common-c reported about the connection, gathered from the
+/// listener callbacks. Readable from any thread after the fact.
+struct DeckMoonlightConnectionStatus {
+    bool connectionStarted = false;   ///< the connectionStarted callback fired
+    bool terminated = false;          ///< the connectionTerminated callback fired
+    int terminationErrorCode = 0;     ///< its ML_ERROR_* code; 0 is graceful
+    int lastStage = -1;               ///< the last STAGE_* reported, -1 when none
+    int failedStage = -1;             ///< the STAGE_* that failed, -1 when none
+    int failedStageErrorCode = 0;     ///< the error code that stage reported
+};
+
+/// The two moonlight-common-c calls that open and close its single global
+/// connection, behind a seam so the session's teardown paths can be exercised
+/// without a host. Production uses the built-in driver; tests inject a fake.
+class DeckMoonlightConnectionDriver {
+public:
+    virtual ~DeckMoonlightConnectionDriver() = default;
+    virtual int start(
+        SERVER_INFORMATION& serverInfo,
+        STREAM_CONFIGURATION& streamConfig,
+        CONNECTION_LISTENER_CALLBACKS& listenerCallbacks,
+        DECODER_RENDERER_CALLBACKS& videoCallbacks,
+        AUDIO_RENDERER_CALLBACKS& audioCallbacks,
+        void* callbackContext) = 0;
+    virtual void stop() = 0;
+};
+
+/// The driver that calls moonlight-common-c for real.
+DeckMoonlightConnectionDriver& defaultMoonlightConnectionDriver();
 
 class DeckStreamRenderer {
 public:
@@ -114,6 +159,13 @@ public:
         DeckStreamAudio& audio,
         DeckStreamInput& input,
         DeckStreamSessionEvents& events);
+    /// As above, with the connection driver injected. `driver` must outlive the session.
+    DeckStreamSession(
+        DeckStreamRenderer& renderer,
+        DeckStreamAudio& audio,
+        DeckStreamInput& input,
+        DeckStreamSessionEvents& events,
+        DeckMoonlightConnectionDriver& driver);
     ~DeckStreamSession();
     DeckStreamSession(const DeckStreamSession&) = delete;
     DeckStreamSession& operator=(const DeckStreamSession&) = delete;
@@ -122,13 +174,19 @@ public:
 
     DeckStreamSessionState state() const;
     const DeckMoonlightBoundary& moonlightBoundary() const;
+    /// A copy of what the listener callbacks reported so far.
+    DeckMoonlightConnectionStatus connectionStatus() const;
 
     DeckStreamTransition prepare(const DeckStreamRequest& request);
     DeckStreamTransition startNoNetwork();
     /// Open the real host session: fill SERVER_INFORMATION and the AES fields
     /// from `info`, authorize this session's boundary, and call LiStartConnection.
-    /// Only reachable after prepare(); a failure fails the session closed.
+    /// Only reachable after prepare(); a failure tears the attempt down and
+    /// fails the session closed.
     DeckStreamTransition startNetwork(const DeckStreamConnectionInfo& info);
+    /// End the session. A live host connection is torn down with
+    /// LiStopConnection; that also holds after the host ended the connection,
+    /// because moonlight-common-c still owes a stop call for its threads.
     DeckStreamTransition stop();
     DeckStreamTransition cancel(std::string_view reason);
     DeckStreamTransition fail(std::string_view reason);
@@ -163,6 +221,9 @@ private:
     void installCallbackThunks();
     bool hasCallbackSlot() const;
     void noteSessionEvent(std::string_view reason);
+    /// Call the driver's stop when a start is still owed one; true when it was.
+    bool teardownHostConnection();
+    void clearHostStrings();
 
     static int videoSetup0(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags);
     static void videoStart0();
@@ -458,7 +519,9 @@ private:
     DeckStreamAudio& audio_;
     DeckStreamInput& input_;
     DeckStreamSessionEvents& events_;
-    DeckStreamSessionState state_ = DeckStreamSessionState::Idle;
+    DeckMoonlightConnectionDriver& driver_;
+    // Written by the moonlight callback threads as well as the caller's thread.
+    std::atomic<DeckStreamSessionState> state_ = DeckStreamSessionState::Idle;
     DeckStreamRequest request_;
     std::size_t callbackSlot_ = kInvalidCallbackSlot;
     void* callbackContext_ = nullptr;
@@ -473,7 +536,18 @@ private:
     std::string serverAppVersion_;
     std::string serverGfeVersion_;
     std::string rtspSessionUrl_;
-    bool networkStarted_ = false;
+    /// The host connection is live: the start succeeded and the host has not ended it.
+    std::atomic<bool> networkStarted_ = false;
+    /// The driver's stop call is owed: a start succeeded and no stop has run
+    /// since. Stays true after the host ends the connection, because
+    /// moonlight-common-c still needs the stop to release its threads.
+    std::atomic<bool> stopConnectionOwed_ = false;
+    std::atomic<bool> connectionStartedSeen_ = false;
+    std::atomic<bool> connectionTerminatedSeen_ = false;
+    std::atomic<int> terminationErrorCode_ = 0;
+    std::atomic<int> lastStage_ = -1;
+    std::atomic<int> failedStage_ = -1;
+    std::atomic<int> failedStageErrorCode_ = 0;
 };
 
 } // namespace nova::deck::stream

--- a/clients/deck/src/stream/deck_stream_media_adapters.cpp
+++ b/clients/deck/src/stream/deck_stream_media_adapters.cpp
@@ -1453,6 +1453,7 @@ int DeckVaapiFfmpegRenderer::setup(
     const int drFlags) {
     (void)context;
     (void)drFlags;
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.setupCalls;
     lifecycle_.videoFormat = videoFormat;
     lifecycle_.width = width;
@@ -1527,19 +1528,23 @@ int DeckVaapiFfmpegRenderer::setup(
 }
 
 void DeckVaapiFfmpegRenderer::start() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.startCalls;
 }
 
 void DeckVaapiFfmpegRenderer::stop() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.stopCalls;
 }
 
 void DeckVaapiFfmpegRenderer::cleanup() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.cleanupCalls;
     resetDecoder();
 }
 
 int DeckVaapiFfmpegRenderer::submitDecodeUnit(PDECODE_UNIT decodeUnit) {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.submitCalls;
     lifecycle_.lastFrameWasHardwareBacked = false;
     if (!ready_ || decodeUnit == nullptr) {
@@ -1607,7 +1612,8 @@ int DeckVaapiFfmpegRenderer::submitDecodeUnit(PDECODE_UNIT decodeUnit) {
     return DR_NEED_IDR;
 }
 
-const DeckRendererLifecycle& DeckVaapiFfmpegRenderer::lifecycle() const {
+DeckRendererLifecycle DeckVaapiFfmpegRenderer::lifecycle() const {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     return lifecycle_;
 }
 
@@ -1656,6 +1662,7 @@ int DeckPipeWireAudio::init(
     const int arFlags) {
     (void)context;
     (void)arFlags;
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.initCalls;
     lifecycle_.audioConfiguration = audioConfiguration;
     lifecycle_.samplesPerFrame = opusConfig == nullptr ? 0 : opusConfig->samplesPerFrame;
@@ -1667,19 +1674,23 @@ int DeckPipeWireAudio::init(
 }
 
 void DeckPipeWireAudio::start() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.startCalls;
 }
 
 void DeckPipeWireAudio::stop() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.stopCalls;
 }
 
 void DeckPipeWireAudio::cleanup() {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     ++lifecycle_.cleanupCalls;
     ready_ = false;
 }
 
 void DeckPipeWireAudio::decodeAndPlaySample(char* sampleData, const int sampleLength) {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     if (!ready_ || sampleData == nullptr || sampleLength <= 0) {
         return;
     }
@@ -1687,12 +1698,16 @@ void DeckPipeWireAudio::decodeAndPlaySample(char* sampleData, const int sampleLe
     lifecycle_.lastSampleLength = sampleLength;
 }
 
-const DeckAudioLifecycle& DeckPipeWireAudio::lifecycle() const {
+DeckAudioLifecycle DeckPipeWireAudio::lifecycle() const {
+    const std::lock_guard<std::mutex> lock(lifecycleMutex_);
     return lifecycle_;
 }
 
 DeckGuardedStreamSessionPreviewProducer::DeckGuardedStreamSessionPreviewProducer()
     : session_(renderer_, audio_, input_, *this) {}
+
+DeckGuardedStreamSessionPreviewProducer::DeckGuardedStreamSessionPreviewProducer(DeckMoonlightConnectionDriver& driver)
+    : session_(renderer_, audio_, input_, *this, driver) {}
 
 DeckGuardedStreamSessionPreviewProducer::~DeckGuardedStreamSessionPreviewProducer() = default;
 
@@ -1716,6 +1731,10 @@ DeckStreamTransition DeckGuardedStreamSessionPreviewProducer::stop() {
     return session_.stop();
 }
 
+DeckStreamTransition DeckGuardedStreamSessionPreviewProducer::cancel(const std::string_view reason) {
+    return session_.cancel(reason);
+}
+
 const DeckMoonlightBoundary& DeckGuardedStreamSessionPreviewProducer::moonlightBoundary() const {
     return session_.moonlightBoundary();
 }
@@ -1724,11 +1743,24 @@ DeckVaapiFfmpegRenderer& DeckGuardedStreamSessionPreviewProducer::decodedFramePr
     return renderer_;
 }
 
-const DeckRendererLifecycle& DeckGuardedStreamSessionPreviewProducer::rendererLifecycle() const {
+DeckStreamSessionState DeckGuardedStreamSessionPreviewProducer::sessionState() const {
+    return session_.state();
+}
+
+DeckMoonlightConnectionStatus DeckGuardedStreamSessionPreviewProducer::connectionStatus() const {
+    return session_.connectionStatus();
+}
+
+DeckRendererLifecycle DeckGuardedStreamSessionPreviewProducer::rendererLifecycle() const {
     return renderer_.lifecycle();
 }
 
-const std::vector<DeckStreamTransition>& DeckGuardedStreamSessionPreviewProducer::transitions() const {
+DeckAudioLifecycle DeckGuardedStreamSessionPreviewProducer::audioLifecycle() const {
+    return audio_.lifecycle();
+}
+
+std::vector<DeckStreamTransition> DeckGuardedStreamSessionPreviewProducer::transitions() const {
+    const std::lock_guard<std::mutex> lock(transitionsMutex_);
     return transitions_;
 }
 
@@ -1768,6 +1800,8 @@ void DeckGuardedStreamSessionPreviewProducer::NoopInput::setControllerLed(
 void DeckGuardedStreamSessionPreviewProducer::onSessionEvent(
     const DeckStreamSessionState state,
     const std::string_view reason) {
+    // Called from the session on whichever thread moonlight reports on.
+    const std::lock_guard<std::mutex> lock(transitionsMutex_);
     transitions_.push_back(DeckStreamTransition{
         .state = state,
         .reason = std::string(reason),
@@ -1970,7 +2004,8 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::requestOperat
 DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::startAuthorizedHostSession(
     const DeckOperatorStartAuthorizationSnapshot& authorization,
     const DeckStreamRequest& request,
-    const DeckStreamConnectionInfo& connection) {
+    const DeckStreamConnectionInfo& connection,
+    DeckHttpFetcher hostFetcher) {
     lastReport_.hostId = request.hostId;
     lastReport_.gameId = request.gameId;
     lastReport_.width = request.width;
@@ -1996,10 +2031,18 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::startAuthoriz
         return lastReport_;
     }
 
+    // From here on the host has an app running for this session (the launch is
+    // what produced the RTSP url), so it is owed a cancel when this ends,
+    // whether or not the stream comes up.
+    hostFetcher_ = std::move(hostFetcher);
+    hostSessionToken_ = connection.hostSessionToken;
+    hostSessionPending_ = true;
+
     const auto prepared = producer_.prepareNoNetwork(request);
     if (prepared.state != DeckStreamSessionState::Preparing) {
         lastReport_ = reportForTransition(prepared, "host-start-prepare-denied", false, false, &request);
         lastReport_.operatorAuthorizationState = operatorAuthorizationStateLabel(authorization.mode);
+        settleHostSession(lastReport_);
         return lastReport_;
     }
 
@@ -2016,7 +2059,7 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::startAuthoriz
 }
 
 DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::stop() {
-    if (lastReport_.state == DeckStreamSessionState::Stopped) {
+    if (lastReport_.state == DeckStreamSessionState::Stopped && !hostSessionPending_) {
         lastReport_.statusCode = "already-stopped-no-network";
         lastReport_.reason = "guarded product preview is already stopped; duplicate stop request stayed local and idempotent";
         lastReport_.prepared = false;
@@ -2029,20 +2072,67 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::stop() {
     }
 
     const auto stopped = producer_.stop();
+    std::string statusCode;
+    if (stopped.state == DeckStreamSessionState::Stopped) {
+        statusCode = stopped.hostConnectionTornDown ? "stopped-host-session" : "stopped-no-network";
+    } else if (hostSessionPending_) {
+        // The stream never came up or had already failed; only the host app was left to end.
+        statusCode = "stop-settled-host-session";
+    } else {
+        statusCode = "stop-denied-no-network";
+    }
+    lastReport_ = reportForTransition(stopped, std::move(statusCode), false, false);
+    settleHostSession(lastReport_);
+    return lastReport_;
+}
+
+DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::cancel(std::string reason) {
+    const auto cancelled = producer_.cancel(reason);
     lastReport_ = reportForTransition(
-        stopped,
-        stopped.state == DeckStreamSessionState::Stopped ? "stopped-no-network" : "stop-denied-no-network",
+        cancelled,
+        cancelled.hostConnectionTornDown ? "cancelled-host-session" : "cancelled-no-network",
         false,
         false);
+    settleHostSession(lastReport_);
     return lastReport_;
+}
+
+void DeckGuardedPreviewLifecycleGate::settleHostSession(DeckGuardedPreviewLifecycleReport& report) {
+    if (!hostSessionPending_) {
+        report.hostCancelSummary = "no host session to end";
+        return;
+    }
+    const DeckHostCancelOutcome outcome = requestHostSessionCancel(hostFetcher_, hostSessionToken_);
+    report.hostCancelRequested = outcome.requested;
+    report.hostCancelled = outcome.cancelled;
+    report.hostCancelSummary = outcome.summary;
+    hostSessionPending_ = false;
+    hostFetcher_ = {};
+    hostSessionToken_.clear();
 }
 
 const DeckGuardedPreviewLifecycleReport& DeckGuardedPreviewLifecycleGate::lastReport() const {
     return lastReport_;
 }
 
-const std::vector<DeckStreamTransition>& DeckGuardedPreviewLifecycleGate::transitions() const {
+std::vector<DeckStreamTransition> DeckGuardedPreviewLifecycleGate::transitions() const {
     return producer_.transitions();
+}
+
+DeckStreamSessionState DeckGuardedPreviewLifecycleGate::sessionState() const {
+    return producer_.sessionState();
+}
+
+DeckMoonlightConnectionStatus DeckGuardedPreviewLifecycleGate::connectionStatus() const {
+    return producer_.connectionStatus();
+}
+
+DeckRendererLifecycle DeckGuardedPreviewLifecycleGate::rendererLifecycle() const {
+    return producer_.rendererLifecycle();
+}
+
+DeckAudioLifecycle DeckGuardedPreviewLifecycleGate::audioLifecycle() const {
+    return producer_.audioLifecycle();
 }
 
 DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::reportForTransition(
@@ -2077,6 +2167,7 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::reportForTran
         .operatorAuthorizationState = lastReport_.operatorAuthorizationState,
         .networkStartAllowed = producer_.moonlightBoundary().networkStartAllowed,
         .networkStarted = transition.networkStarted,
+        .hostConnectionTornDown = transition.hostConnectionTornDown,
         .transitionCount = producer_.transitions().size(),
     };
 }

--- a/clients/deck/src/stream/deck_stream_media_adapters.cpp
+++ b/clients/deck/src/stream/deck_stream_media_adapters.cpp
@@ -1708,6 +1708,10 @@ DeckStreamTransition DeckGuardedStreamSessionPreviewProducer::startNoNetwork() {
     return session_.startNoNetwork();
 }
 
+DeckStreamTransition DeckGuardedStreamSessionPreviewProducer::startNetwork(const DeckStreamConnectionInfo& info) {
+    return session_.startNetwork(info);
+}
+
 DeckStreamTransition DeckGuardedStreamSessionPreviewProducer::stop() {
     return session_.stop();
 }
@@ -1960,6 +1964,54 @@ DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::requestOperat
 
     lastReport_.statusCode = "operator-start-not-ready";
     lastReport_.reason = "operator start contract is approved, but external host readiness is not available and the Deck product route keeps network disabled; no network start was attempted";
+    return lastReport_;
+}
+
+DeckGuardedPreviewLifecycleReport DeckGuardedPreviewLifecycleGate::startAuthorizedHostSession(
+    const DeckOperatorStartAuthorizationSnapshot& authorization,
+    const DeckStreamRequest& request,
+    const DeckStreamConnectionInfo& connection) {
+    lastReport_.hostId = request.hostId;
+    lastReport_.gameId = request.gameId;
+    lastReport_.width = request.width;
+    lastReport_.height = request.height;
+    lastReport_.fps = request.fps;
+    lastReport_.bitrateKbps = request.bitrateKbps;
+    lastReport_.dryRunPreflightRequested = false;
+    lastReport_.hostStartBoundaryExplicit = true;
+    lastReport_.hostStartContractAuthorized = authorization.startAuthorized;
+    lastReport_.operatorAuthorizationState = operatorAuthorizationStateLabel(authorization.mode);
+    lastReport_.networkStartAllowed = false;
+    lastReport_.networkStarted = false;
+    lastReport_.transitionCount = producer_.transitions().size();
+
+    if (!authorization.startAuthorized) {
+        lastReport_.statusCode = "host-network-start-blocked";
+        lastReport_.reason = "operator start contract is blocked; no host session was started";
+        return lastReport_;
+    }
+    if (connection.serverAddress.empty() || connection.rtspSessionUrl.empty()) {
+        lastReport_.statusCode = "operator-start-not-ready";
+        lastReport_.reason = "operator start contract is approved but no host readiness was assembled; no host session was started";
+        return lastReport_;
+    }
+
+    const auto prepared = producer_.prepareNoNetwork(request);
+    if (prepared.state != DeckStreamSessionState::Preparing) {
+        lastReport_ = reportForTransition(prepared, "host-start-prepare-denied", false, false, &request);
+        lastReport_.operatorAuthorizationState = operatorAuthorizationStateLabel(authorization.mode);
+        return lastReport_;
+    }
+
+    const auto started = producer_.startNetwork(connection);
+    lastReport_ = reportForTransition(
+        started,
+        started.networkStarted ? "host-network-started" : "host-network-start-failed",
+        true,
+        started.networkStarted,
+        &request);
+    lastReport_.hostStartContractAuthorized = true;
+    lastReport_.operatorAuthorizationState = operatorAuthorizationStateLabel(authorization.mode);
     return lastReport_;
 }
 

--- a/clients/deck/src/stream/deck_stream_media_adapters.h
+++ b/clients/deck/src/stream/deck_stream_media_adapters.h
@@ -434,6 +434,9 @@ public:
     void attachProductPreviewPipeline(DeckProductPreviewPipeline& pipeline);
     DeckStreamTransition prepareNoNetwork(const DeckStreamRequest& request);
     DeckStreamTransition startNoNetwork();
+    /// Open the real host session. Only the guarded gate's authorized lane calls
+    /// this; it forwards to the stream session, which owns the connection call.
+    DeckStreamTransition startNetwork(const DeckStreamConnectionInfo& info);
     DeckStreamTransition stop();
 
     const DeckMoonlightBoundary& moonlightBoundary() const;
@@ -522,6 +525,14 @@ public:
         const DeckStreamRequest& request);
     DeckGuardedPreviewLifecycleReport requestOperatorAuthorizedHostNetworkStart(
         const DeckOperatorStartAuthorizationSnapshot& authorization);
+    /// The approved real-start lane: with an operator start authorization and an
+    /// assembled host connection, prepare the session and open the host stream.
+    /// Without either, it stays report-only, so a real start is reachable only
+    /// through this lane with both in hand.
+    DeckGuardedPreviewLifecycleReport startAuthorizedHostSession(
+        const DeckOperatorStartAuthorizationSnapshot& authorization,
+        const DeckStreamRequest& request,
+        const DeckStreamConnectionInfo& connection);
     DeckGuardedPreviewLifecycleReport stop();
 
     const DeckGuardedPreviewLifecycleReport& lastReport() const;

--- a/clients/deck/src/stream/deck_stream_media_adapters.h
+++ b/clients/deck/src/stream/deck_stream_media_adapters.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "stream/deck_gamestream_session_builder.h"
 #include "stream/deck_stream_core.h"
 
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -369,13 +371,17 @@ public:
     void cleanup() override;
     int submitDecodeUnit(PDECODE_UNIT decodeUnit) override;
 
-    const DeckRendererLifecycle& lifecycle() const;
+    /// A snapshot of the counters. The callbacks above run on moonlight's
+    /// decoder thread while a caller reads from its own, so this copies under
+    /// the lock instead of handing out a reference.
+    DeckRendererLifecycle lifecycle() const;
     DeckQrhiVaapiPresentationHandoff& presentationHandoff();
     const DeckQrhiVaapiPresentationHandoff& presentationHandoff() const;
 
 private:
     void resetDecoder();
 
+    mutable std::mutex lifecycleMutex_;
     DeckRendererLifecycle lifecycle_{};
     bool ready_ = false;
     AVBufferRef* hardwareDevice_ = nullptr;
@@ -415,9 +421,11 @@ public:
     void cleanup() override;
     void decodeAndPlaySample(char* sampleData, int sampleLength) override;
 
-    const DeckAudioLifecycle& lifecycle() const;
+    /// A snapshot of the counters; see DeckVaapiFfmpegRenderer::lifecycle.
+    DeckAudioLifecycle lifecycle() const;
 
 private:
+    mutable std::mutex lifecycleMutex_;
     DeckAudioLifecycle lifecycle_{};
     bool ready_ = false;
 };
@@ -425,6 +433,8 @@ private:
 class DeckGuardedStreamSessionPreviewProducer final : private DeckStreamSessionEvents {
 public:
     DeckGuardedStreamSessionPreviewProducer();
+    /// As above, with the connection driver injected; `driver` must outlive the producer.
+    explicit DeckGuardedStreamSessionPreviewProducer(DeckMoonlightConnectionDriver& driver);
     ~DeckGuardedStreamSessionPreviewProducer() override;
     DeckGuardedStreamSessionPreviewProducer(const DeckGuardedStreamSessionPreviewProducer&) = delete;
     DeckGuardedStreamSessionPreviewProducer& operator=(const DeckGuardedStreamSessionPreviewProducer&) = delete;
@@ -438,11 +448,16 @@ public:
     /// this; it forwards to the stream session, which owns the connection call.
     DeckStreamTransition startNetwork(const DeckStreamConnectionInfo& info);
     DeckStreamTransition stop();
+    DeckStreamTransition cancel(std::string_view reason);
 
     const DeckMoonlightBoundary& moonlightBoundary() const;
     DeckVaapiFfmpegRenderer& decodedFrameProducer();
-    const DeckRendererLifecycle& rendererLifecycle() const;
-    const std::vector<DeckStreamTransition>& transitions() const;
+    DeckStreamSessionState sessionState() const;
+    DeckMoonlightConnectionStatus connectionStatus() const;
+    DeckRendererLifecycle rendererLifecycle() const;
+    DeckAudioLifecycle audioLifecycle() const;
+    /// A copy: the session reports events from moonlight's threads too.
+    std::vector<DeckStreamTransition> transitions() const;
 
 private:
     class NoopInput final : public DeckStreamInput {
@@ -459,6 +474,7 @@ private:
     DeckPipeWireAudio audio_{};
     NoopInput input_{};
     DeckStreamSession session_;
+    mutable std::mutex transitionsMutex_;
     std::vector<DeckStreamTransition> transitions_{};
 };
 
@@ -480,6 +496,12 @@ struct DeckGuardedPreviewLifecycleReport {
     std::string operatorAuthorizationState = "blocked";
     bool networkStartAllowed = false;
     bool networkStarted = false;
+    /// The report's transition tore down a live host connection.
+    bool hostConnectionTornDown = false;
+    /// The host was asked to end the app after the stream came down.
+    bool hostCancelRequested = false;
+    bool hostCancelled = false;
+    std::string hostCancelSummary;
     std::size_t transitionCount = 0;
 };
 
@@ -528,15 +550,23 @@ public:
     /// The approved real-start lane: with an operator start authorization and an
     /// assembled host connection, prepare the session and open the host stream.
     /// Without either, it stays report-only, so a real start is reachable only
-    /// through this lane with both in hand.
+    /// through this lane with both in hand. `hostFetcher` is the connection the
+    /// launch went through; the gate keeps it to ask the host to end the app
+    /// when the session stops or is cancelled, whatever the stream did.
     DeckGuardedPreviewLifecycleReport startAuthorizedHostSession(
         const DeckOperatorStartAuthorizationSnapshot& authorization,
         const DeckStreamRequest& request,
-        const DeckStreamConnectionInfo& connection);
+        const DeckStreamConnectionInfo& connection,
+        DeckHttpFetcher hostFetcher = {});
     DeckGuardedPreviewLifecycleReport stop();
+    DeckGuardedPreviewLifecycleReport cancel(std::string reason);
 
     const DeckGuardedPreviewLifecycleReport& lastReport() const;
-    const std::vector<DeckStreamTransition>& transitions() const;
+    std::vector<DeckStreamTransition> transitions() const;
+    DeckStreamSessionState sessionState() const;
+    DeckMoonlightConnectionStatus connectionStatus() const;
+    DeckRendererLifecycle rendererLifecycle() const;
+    DeckAudioLifecycle audioLifecycle() const;
 
 private:
     DeckGuardedPreviewLifecycleReport reportForTransition(
@@ -545,9 +575,15 @@ private:
         bool prepared,
         bool armed,
         const DeckStreamRequest* request = nullptr) const;
+    /// After the stream is down: ask the host to end the app it launched for
+    /// this session, once, and record the outcome in `report`.
+    void settleHostSession(DeckGuardedPreviewLifecycleReport& report);
 
     DeckGuardedStreamSessionPreviewProducer& producer_;
     DeckGuardedPreviewLifecycleReport lastReport_{};
+    DeckHttpFetcher hostFetcher_{};
+    std::string hostSessionToken_;
+    bool hostSessionPending_ = false;
 };
 
 } // namespace nova::deck::stream

--- a/clients/deck/tests/deck_gamestream_launch_test.cpp
+++ b/clients/deck/tests/deck_gamestream_launch_test.cpp
@@ -89,6 +89,36 @@ void testLaunchTarget() {
         "&localAudioPlayMode=0&surroundAudioInfo=131075"
         "&remoteControllersBitmap=0&gcmap=0&gcpersist=0";
     assert(buildLaunchTarget(request, keys) == expectedResume);
+
+    // Caller-supplied values are percent-encoded so they stay one parameter:
+    // an app uuid with a space, an ampersand and an equals sign, and an extra
+    // query whose values carry spaces. The extra query's own separators survive.
+    DeckLaunchRequest escaped = request;
+    escaped.resume = false;
+    escaped.appUuid = "a b&c=d";
+    escaped.extraQuery = "&x=1 2&flag&y=%";
+    const std::string escapedTarget = buildLaunchTarget(escaped, keys);
+    assert(escapedTarget.find("&appuuid=a%20b%26c%3Dd&") != std::string::npos);
+    assert(escapedTarget.find("&x=1%202&flag&y=%25") != std::string::npos);
+    assert(escapedTarget.find("a b") == std::string::npos);
+}
+
+void testCancelProtocol() {
+    assert(buildCancelTarget("") == "/cancel");
+    assert(buildCancelTarget("tok-abc") == "/cancel?sessiontoken=tok-abc");
+    assert(buildCancelTarget("tok/1 2") == "/cancel?sessiontoken=tok%2F1%202");
+
+    const auto ok = parseCancelResponse("<root status_code=\"200\"><cancel>1</cancel></root>");
+    assert(ok.cancelled && ok.statusCode == 200 && ok.statusMessage.empty());
+
+    const auto busy = parseCancelResponse(
+        "<root status_code=\"409\" status_message=\"The active session changed or is already stopping\"><cancel>0</cancel></root>");
+    assert(!busy.cancelled && busy.statusCode == 409);
+    assert(busy.statusMessage == "The active session changed or is already stopping");
+
+    assert(!parseCancelResponse("<root status_code=\"200\"></root>").cancelled);
+    assert(!parseCancelResponse("not xml <<<").cancelled);
+    assert(!parseCancelResponse("").cancelled);
 }
 
 void testParseResponses() {
@@ -105,7 +135,13 @@ void testParseResponses() {
     const std::string launchBusy =
         "<root status_code=\"200\"><gamesession>0</gamesession></root>";
     auto busy = parseLaunchResponse(false, launchBusy);
-    assert(!busy.started && busy.statusCode == 200);
+    assert(!busy.started && busy.statusCode == 200 && busy.statusMessage.empty());
+
+    // A refusal carries the host's status message alongside its code.
+    const std::string launchRefused =
+        "<root status_code=\"503\" status_message=\"The host is busy\"><gamesession>0</gamesession></root>";
+    auto refused = parseLaunchResponse(false, launchRefused);
+    assert(!refused.started && refused.statusCode == 503 && refused.statusMessage == "The host is busy");
 
     const std::string resumeOk =
         "<root status_code=\"200\"><resume>1</resume>"
@@ -130,6 +166,7 @@ int main(int argc, char** argv) {
     testKeyDerivation();
     testGeneratedKeys();
     testLaunchTarget();
+    testCancelProtocol();
     testParseResponses();
     return 0;
 }

--- a/clients/deck/tests/deck_gamestream_launch_test.cpp
+++ b/clients/deck/tests/deck_gamestream_launch_test.cpp
@@ -1,0 +1,129 @@
+// Tests for the GameStream launch protocol: key derivation, the launch/resume
+// request URL, and parsing the host's answer. All pure; no network.
+#include "stream/deck_gamestream_launch.h"
+
+#include <QCoreApplication>
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <string>
+
+using namespace nova::deck::stream;
+
+namespace {
+
+void testKeyDerivation() {
+    std::array<std::uint8_t, 16> key{};
+    for (std::size_t i = 0; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i);
+    }
+    const auto keys = buildStreamKeys(key, 0x01020304);
+    assert(keys.aesKey == key);
+    assert(keys.rikeyId == 0x01020304);
+    // IV: id big-endian in the first four bytes, zero after.
+    assert(keys.aesIv[0] == 0x01 && keys.aesIv[1] == 0x02 && keys.aesIv[2] == 0x03 && keys.aesIv[3] == 0x04);
+    for (std::size_t i = 4; i < keys.aesIv.size(); ++i) {
+        assert(keys.aesIv[i] == 0x00);
+    }
+
+    // A negative id is two's-complement big-endian.
+    const auto negative = buildStreamKeys(key, -1);
+    assert(negative.aesIv[0] == 0xFF && negative.aesIv[1] == 0xFF && negative.aesIv[2] == 0xFF && negative.aesIv[3] == 0xFF);
+    assert(negative.aesIv[4] == 0x00);
+
+    assert(toHexLower(key) == "000102030405060708090a0b0c0d0e0f");
+}
+
+void testGeneratedKeys() {
+    const auto a = generateStreamKeys();
+    const auto b = generateStreamKeys();
+    // Distinct across calls, and the IV always agrees with its own id.
+    assert(a.aesKey != b.aesKey || a.rikeyId != b.rikeyId);
+    assert(buildStreamKeys(a.aesKey, a.rikeyId).aesIv == a.aesIv);
+    bool anyNonZero = false;
+    for (const auto byte : a.aesKey) {
+        anyNonZero = anyNonZero || byte != 0;
+    }
+    assert(anyNonZero && "a generated key is not all zero");
+}
+
+void testLaunchTarget() {
+    std::array<std::uint8_t, 16> key{};
+    for (std::size_t i = 0; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i);
+    }
+    const auto keys = buildStreamKeys(key, 16909060);  // 0x01020304
+
+    DeckLaunchRequest request;
+    request.appId = 42;
+    request.width = 1280;
+    request.height = 800;
+    request.fps = 60;
+    request.sops = true;
+    request.playLocalAudio = false;
+    request.surroundAudioInfo = 131075;  // stereo: (2 << 16) | 0x3
+    request.gamepadMask = 0;
+    request.persistGamepads = false;
+
+    const std::string expected =
+        "/launch?appid=42&mode=1280x800x60&additionalStates=1&sops=1"
+        "&rikey=000102030405060708090a0b0c0d0e0f&rikeyid=16909060"
+        "&localAudioPlayMode=0&surroundAudioInfo=131075"
+        "&remoteControllersBitmap=0&gcmap=0&gcpersist=0";
+    assert(buildLaunchTarget(request, keys) == expected);
+
+    // With an app uuid and resume verb.
+    request.appUuid = "e720-6600";
+    request.resume = true;
+    request.sops = false;
+    const std::string expectedResume =
+        "/resume?appid=42&appuuid=e720-6600&mode=1280x800x60&additionalStates=1&sops=0"
+        "&rikey=000102030405060708090a0b0c0d0e0f&rikeyid=16909060"
+        "&localAudioPlayMode=0&surroundAudioInfo=131075"
+        "&remoteControllersBitmap=0&gcmap=0&gcpersist=0";
+    assert(buildLaunchTarget(request, keys) == expectedResume);
+}
+
+void testParseResponses() {
+    const std::string launchOk =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<root status_code=\"200\"><gamesession>1</gamesession>"
+        "<sessionUrl0>rtsp://192.0.2.10:48010</sessionUrl0>"
+        "<sessionToken>tok-abc</sessionToken></root>";
+    auto ok = parseLaunchResponse(false, launchOk);
+    assert(ok.started && ok.statusCode == 200);
+    assert(ok.rtspSessionUrl == "rtsp://192.0.2.10:48010");
+    assert(ok.sessionToken == "tok-abc");
+
+    const std::string launchBusy =
+        "<root status_code=\"200\"><gamesession>0</gamesession></root>";
+    auto busy = parseLaunchResponse(false, launchBusy);
+    assert(!busy.started && busy.statusCode == 200);
+
+    const std::string resumeOk =
+        "<root status_code=\"200\"><resume>1</resume>"
+        "<sessionUrl0>rtsp://192.0.2.10:48010</sessionUrl0></root>";
+    auto resumed = parseLaunchResponse(true, resumeOk);
+    assert(resumed.started && resumed.rtspSessionUrl == "rtsp://192.0.2.10:48010");
+    // The same body judged as a launch has no gamesession element, so not started.
+    assert(!parseLaunchResponse(false, resumeOk).started);
+
+    const std::string denied = "<root status_code=\"401\"></root>";
+    auto d = parseLaunchResponse(false, denied);
+    assert(!d.started && d.statusCode == 401);
+
+    assert(!parseLaunchResponse(false, "not xml at all <<<").started);
+    assert(!parseLaunchResponse(false, "").started);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    testKeyDerivation();
+    testGeneratedKeys();
+    testLaunchTarget();
+    testParseResponses();
+    return 0;
+}

--- a/clients/deck/tests/deck_gamestream_launch_test.cpp
+++ b/clients/deck/tests/deck_gamestream_launch_test.cpp
@@ -73,6 +73,12 @@ void testLaunchTarget() {
         "&remoteControllersBitmap=0&gcmap=0&gcpersist=0";
     assert(buildLaunchTarget(request, keys) == expected);
 
+    // A host extra query is appended verbatim after the built parameters.
+    DeckLaunchRequest withExtra = request;
+    withExtra.extraQuery = "&corever=5&somefeature=1";
+    const std::string built = buildLaunchTarget(withExtra, keys);
+    assert(built == expected + "&corever=5&somefeature=1");
+
     // With an app uuid and resume verb.
     request.appUuid = "e720-6600";
     request.resume = true;

--- a/clients/deck/tests/deck_gamestream_session_builder_test.cpp
+++ b/clients/deck/tests/deck_gamestream_session_builder_test.cpp
@@ -23,7 +23,12 @@ const std::string kServerInfo =
 
 const std::string kLaunchOk =
     "<root status_code=\"200\"><gamesession>1</gamesession>"
-    "<sessionUrl0>rtsp://192.0.2.10:48010</sessionUrl0></root>";
+    "<sessionUrl0>rtsp://192.0.2.10:48010</sessionUrl0>"
+    "<sessionToken>tok-abc</sessionToken></root>";
+
+const std::string kCancelOk = "<root status_code=\"200\"><cancel>1</cancel></root>";
+const std::string kCancelBusy =
+    "<root status_code=\"409\" status_message=\"The active session changed or is already stopping\"><cancel>0</cancel></root>";
 
 DeckStreamKeys fixedKeys() {
     std::array<std::uint8_t, 16> key{};
@@ -96,6 +101,9 @@ void testBuildOk() {
     assert(info.rtspSessionUrl == "rtsp://192.0.2.10:48010");
     assert(info.serverCodecModeSupport == 65793);
     assert(info.keys.aesKey == keys.aesKey && info.keys.rikeyId == keys.rikeyId);
+    // The host's session token is carried so the cancel can name the session.
+    assert(info.hostSessionToken == "tok-abc");
+    assert(!result.launchRefused && result.launchStatusCode == 200);
 
     // serverinfo first, then the launch carrying this session's rikey.
     assert(host.seen.size() == 2 && host.seen[0] == "/serverinfo");
@@ -106,11 +114,12 @@ void testBuildOk() {
 void testBuildFailures() {
     const auto keys = fixedKeys();
 
-    // serverinfo transport failure.
+    // serverinfo transport failure: the host never answered a launch.
     {
         FakeHost host;
         const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
         assert(!r.ok && r.error == "could not reach the host for serverinfo");
+        assert(!r.launchRefused);
     }
     // serverinfo non-200.
     {
@@ -126,14 +135,17 @@ void testBuildFailures() {
         host.table["/launch"] = DeckHttpResponse{true, 500, "server error"};
         const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
         assert(!r.ok && r.error == "host launch returned an unexpected status");
+        assert(r.launchRefused && r.launchStatusCode == 500);
     }
-    // launch not started (host busy).
+    // launch not started (host busy): a refusal, with the host's own status.
     {
         FakeHost host;
         host.table["/serverinfo"] = DeckHttpResponse{true, 200, kServerInfo};
-        host.table["/launch"] = DeckHttpResponse{true, 200, "<root status_code=\"200\"><gamesession>0</gamesession></root>"};
+        host.table["/launch"] = DeckHttpResponse{true, 200,
+            "<root status_code=\"503\" status_message=\"The host is busy\"><gamesession>0</gamesession></root>"};
         const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
         assert(!r.ok && r.error == "the host did not start the session");
+        assert(r.launchRefused && r.launchStatusCode == 503 && r.launchStatusMessage == "The host is busy");
     }
     // launch started but no RTSP url.
     {
@@ -145,6 +157,70 @@ void testBuildFailures() {
     }
 }
 
+void testHostCancel() {
+    // The cancel names the session the launch returned and is confirmed by the host.
+    {
+        FakeHost host;
+        host.table["/cancel"] = DeckHttpResponse{true, 200, kCancelOk};
+        const auto outcome = requestHostSessionCancel(host.fetcher(), "tok-abc");
+        assert(outcome.requested && outcome.transportOk && outcome.cancelled);
+        assert(outcome.httpStatus == 200 && outcome.hostStatusCode == 200);
+        assert(host.seen.size() == 1 && host.seen[0] == "/cancel?sessiontoken=tok-abc");
+        assert(outcome.summary.find("confirmed") != std::string::npos);
+    }
+    // Without a token the request is bare.
+    {
+        FakeHost host;
+        host.table["/cancel"] = DeckHttpResponse{true, 200, kCancelOk};
+        const auto outcome = requestHostSessionCancel(host.fetcher(), "");
+        assert(outcome.cancelled && host.seen.size() == 1 && host.seen[0] == "/cancel");
+    }
+    // A host still counting the session (409) is retried and then confirms.
+    {
+        int calls = 0;
+        const DeckHttpFetcher fetcher = [&calls](const std::string& target) {
+            ++calls;
+            assert(target.rfind("/cancel", 0) == 0);
+            return calls == 1 ? DeckHttpResponse{true, 200, kCancelBusy} : DeckHttpResponse{true, 200, kCancelOk};
+        };
+        const auto outcome = requestHostSessionCancel(fetcher, "tok-abc");
+        assert(outcome.cancelled && calls == 2);
+        assert(outcome.summary.find("attempt 2") != std::string::npos);
+    }
+    // A refusal on other grounds is reported once, with the host's message.
+    {
+        FakeHost host;
+        host.table["/cancel"] = DeckHttpResponse{true, 200,
+            "<root status_code=\"470\" status_message=\"The current session belongs to another client\"><cancel>0</cancel></root>"};
+        const auto outcome = requestHostSessionCancel(host.fetcher(), "tok-abc");
+        assert(outcome.requested && !outcome.cancelled && outcome.hostStatusCode == 470);
+        assert(host.seen.size() == 1);
+        assert(outcome.summary.find("belongs to another client") != std::string::npos);
+    }
+    // Transport failure and a missing fetcher are reported, never thrown.
+    {
+        FakeHost host;
+        const auto outcome = requestHostSessionCancel(host.fetcher(), "tok-abc");
+        assert(outcome.requested && !outcome.transportOk && !outcome.cancelled);
+        const auto none = requestHostSessionCancel(DeckHttpFetcher{}, "tok-abc");
+        assert(!none.requested && !none.cancelled);
+        assert(none.summary.find("no host fetcher") != std::string::npos);
+    }
+}
+
+void testFetcherOverPolarisClient() {
+    // An unusable identity never reaches the network and is a transport failure,
+    // not an answer, so the builder reports the host as unreachable.
+    const nova::deck::polaris::DeckPolarisClient client(
+        nova::deck::polaris::DeckPolarisEndpoint{.address = "192.0.2.10", .httpsPort = 47984},
+        nova::deck::polaris::DeckPolarisTlsIdentity{});
+    const DeckHttpFetcher fetcher = fetcherOverPolarisClient(client);
+    const auto reply = fetcher("/serverinfo");
+    assert(!reply.transportOk && reply.status == 0 && reply.body.empty());
+    const auto r = buildStreamConnection(fetcher, "192.0.2.10", sampleRequest(), fixedKeys());
+    assert(!r.ok && r.error == "could not reach the host for serverinfo");
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -152,5 +228,7 @@ int main(int argc, char** argv) {
     testServerInfoParse();
     testBuildOk();
     testBuildFailures();
+    testHostCancel();
+    testFetcherOverPolarisClient();
     return 0;
 }

--- a/clients/deck/tests/deck_gamestream_session_builder_test.cpp
+++ b/clients/deck/tests/deck_gamestream_session_builder_test.cpp
@@ -1,0 +1,146 @@
+// Tests for assembling a connection descriptor from serverinfo plus a launch,
+// through an injected fetcher. No network.
+#include "stream/deck_gamestream_session_builder.h"
+
+#include <QCoreApplication>
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace nova::deck::stream;
+
+namespace {
+
+const std::string kServerInfo =
+    "<?xml version=\"1.0\"?><root status_code=\"200\">"
+    "<hostname>pc-papi</hostname><appversion>7.1.431.-1</appversion>"
+    "<GfeVersion>3.23.0.74</GfeVersion><ServerCodecModeSupport>65793</ServerCodecModeSupport>"
+    "<state>POLARIS_SERVER_FREE</state></root>";
+
+const std::string kLaunchOk =
+    "<root status_code=\"200\"><gamesession>1</gamesession>"
+    "<sessionUrl0>rtsp://192.0.2.10:48010</sessionUrl0></root>";
+
+DeckStreamKeys fixedKeys() {
+    std::array<std::uint8_t, 16> key{};
+    for (std::size_t i = 0; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i + 1);
+    }
+    return buildStreamKeys(key, 7);
+}
+
+DeckLaunchRequest sampleRequest() {
+    DeckLaunchRequest request;
+    request.appId = 881448767;
+    request.width = 1280;
+    request.height = 800;
+    request.fps = 60;
+    return request;
+}
+
+// A fetcher that answers from a fixed table, records the targets it saw, and can
+// force a transport failure for one target.
+struct FakeHost {
+    std::map<std::string, DeckHttpResponse> table;
+    std::vector<std::string> seen;
+
+    DeckHttpFetcher fetcher() {
+        return [this](const std::string& target) -> DeckHttpResponse {
+            seen.push_back(target);
+            // Match /launch and /resume by prefix, everything else exactly.
+            for (const auto& [key, value] : table) {
+                if (target == key || (key.size() < target.size() && target.compare(0, key.size(), key) == 0)) {
+                    return value;
+                }
+            }
+            return DeckHttpResponse{false, 0, ""};
+        };
+    }
+};
+
+void testServerInfoParse() {
+    const auto info = parseServerInfo(kServerInfo);
+    assert(info.has_value());
+    assert(info->appVersion == "7.1.431.-1");
+    assert(info->gfeVersion == "3.23.0.74");
+    assert(info->serverCodecModeSupport == 65793);
+
+    // Missing appversion, an error root, and garbage all fail to parse.
+    assert(!parseServerInfo("<root status_code=\"200\"><state>x</state></root>").has_value());
+    assert(!parseServerInfo("<root status_code=\"401\"></root>").has_value());
+    assert(!parseServerInfo("not xml").has_value());
+
+    // GfeVersion and codec support are optional; codec defaults to zero.
+    const auto minimal = parseServerInfo("<root status_code=\"200\"><appversion>7.1</appversion></root>");
+    assert(minimal.has_value() && minimal->gfeVersion.empty() && minimal->serverCodecModeSupport == 0);
+}
+
+void testBuildOk() {
+    FakeHost host;
+    host.table["/serverinfo"] = DeckHttpResponse{true, 200, kServerInfo};
+    host.table["/launch"] = DeckHttpResponse{true, 200, kLaunchOk};
+
+    const auto keys = fixedKeys();
+    const auto result = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+    assert(result.ok);
+    const auto& info = result.connectionInfo;
+    assert(info.serverAddress == "192.0.2.10");
+    assert(info.appVersion == "7.1.431.-1");
+    assert(info.gfeVersion == "3.23.0.74");
+    assert(info.rtspSessionUrl == "rtsp://192.0.2.10:48010");
+    assert(info.serverCodecModeSupport == 65793);
+    assert(info.keys.aesKey == keys.aesKey && info.keys.rikeyId == keys.rikeyId);
+
+    // serverinfo first, then the launch carrying this session's rikey.
+    assert(host.seen.size() == 2 && host.seen[0] == "/serverinfo");
+    assert(host.seen[1].rfind("/launch?appid=881448767", 0) == 0);
+    assert(host.seen[1].find("rikeyid=7") != std::string::npos);
+}
+
+void testBuildFailures() {
+    const auto keys = fixedKeys();
+
+    // serverinfo transport failure.
+    {
+        FakeHost host;
+        const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+        assert(!r.ok && r.error == "could not reach the host for serverinfo");
+    }
+    // serverinfo non-200.
+    {
+        FakeHost host;
+        host.table["/serverinfo"] = DeckHttpResponse{true, 401, "<root status_code=\"401\"/>"};
+        const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+        assert(!r.ok && r.error == "host serverinfo returned an unexpected status");
+    }
+    // launch not started (host busy).
+    {
+        FakeHost host;
+        host.table["/serverinfo"] = DeckHttpResponse{true, 200, kServerInfo};
+        host.table["/launch"] = DeckHttpResponse{true, 200, "<root status_code=\"200\"><gamesession>0</gamesession></root>"};
+        const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+        assert(!r.ok && r.error == "the host did not start the session");
+    }
+    // launch started but no RTSP url.
+    {
+        FakeHost host;
+        host.table["/serverinfo"] = DeckHttpResponse{true, 200, kServerInfo};
+        host.table["/launch"] = DeckHttpResponse{true, 200, "<root status_code=\"200\"><gamesession>1</gamesession></root>"};
+        const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+        assert(!r.ok && r.error == "the host started the session without an RTSP url");
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    testServerInfoParse();
+    testBuildOk();
+    testBuildFailures();
+    return 0;
+}

--- a/clients/deck/tests/deck_gamestream_session_builder_test.cpp
+++ b/clients/deck/tests/deck_gamestream_session_builder_test.cpp
@@ -73,6 +73,8 @@ void testServerInfoParse() {
     assert(!parseServerInfo("<root status_code=\"200\"><state>x</state></root>").has_value());
     assert(!parseServerInfo("<root status_code=\"401\"></root>").has_value());
     assert(!parseServerInfo("not xml").has_value());
+    // An error root that still carries an appversion is rejected on its status.
+    assert(!parseServerInfo("<root status_code=\"401\"><appversion>7.1</appversion></root>").has_value());
 
     // GfeVersion and codec support are optional; codec defaults to zero.
     const auto minimal = parseServerInfo("<root status_code=\"200\"><appversion>7.1</appversion></root>");
@@ -116,6 +118,14 @@ void testBuildFailures() {
         host.table["/serverinfo"] = DeckHttpResponse{true, 401, "<root status_code=\"401\"/>"};
         const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
         assert(!r.ok && r.error == "host serverinfo returned an unexpected status");
+    }
+    // launch HTTP error (wrong endpoint / server error) is surfaced distinctly.
+    {
+        FakeHost host;
+        host.table["/serverinfo"] = DeckHttpResponse{true, 200, kServerInfo};
+        host.table["/launch"] = DeckHttpResponse{true, 500, "server error"};
+        const auto r = buildStreamConnection(host.fetcher(), "192.0.2.10", sampleRequest(), keys);
+        assert(!r.ok && r.error == "host launch returned an unexpected status");
     }
     // launch not started (host busy).
     {

--- a/clients/deck/tests/deck_media_assert_guard_test.py
+++ b/clients/deck/tests/deck_media_assert_guard_test.py
@@ -105,10 +105,16 @@ class DeckMediaAssertGuardTest(unittest.TestCase):
             "Deck shell must not submit decode units directly; decoded frames arrive through the guarded stream-session producer",
         )
 
-    def test_guarded_preview_lifecycle_gate_keeps_network_start_source_unreachable(self):
+    def test_network_start_is_reachable_only_through_the_operator_authorized_lane(self):
+        # A real host start is reachable through exactly one lane,
+        # startAuthorizedHostSession, and only with an operator start
+        # authorization and an assembled host connection in hand. The connection
+        # call itself and the raw networkStartAllowed=true stay out of this file;
+        # they live in the stream core the producer forwards to.
         header = (DECK_ROOT / "src" / "stream" / "deck_stream_media_adapters.h").read_text(encoding="utf-8")
         source = MEDIA_ADAPTER_SOURCE.read_text(encoding="utf-8")
 
+        self.assertIn("startAuthorizedHostSession", header)
         self.assertIn("struct DeckGuardedPreviewLifecycleReport", header)
         self.assertIn("struct DeckOperatorStartAuthorizationSnapshot", header)
         self.assertIn("class DeckOperatorStartAuthorizationPolicy", header)

--- a/clients/deck/tests/deck_media_assert_guard_test.py
+++ b/clients/deck/tests/deck_media_assert_guard_test.py
@@ -380,11 +380,18 @@ class DeckMediaAssertGuardTest(unittest.TestCase):
         self.assertIn("assertDiagnosticsAndPreflightCopyArePrivate", test)
         self.assertIn("copy.find(forbiddenToken) == std::string::npos", test)
 
-    def test_raw_start_symbols_are_source_allowlisted_away_from_ui_and_stream_core(self):
+    def test_raw_start_symbols_stay_in_the_stream_backend_seam(self):
+        # The real host connection lives in the stream backend seam that owns the
+        # moonlight-common-c structs (deck_stream_core) and the backend interfaces,
+        # with their tests. It stays out of the UI, the shell (main.cpp), the media
+        # adapters, and the preflight, which is what the other cases here enforce.
         allowed_paths = {
             BACKEND_HEADER,
             BACKEND_SOURCE,
             BACKEND_TEST,
+            DECK_ROOT / "src" / "stream" / "deck_stream_core.h",
+            DECK_ROOT / "src" / "stream" / "deck_stream_core.cpp",
+            DECK_ROOT / "tests" / "deck_stream_core_test.cpp",
             pathlib.Path(__file__).resolve(),
         }
         forbidden_symbols = (
@@ -406,7 +413,9 @@ class DeckMediaAssertGuardTest(unittest.TestCase):
         self.assertEqual(
             offenders,
             [],
-            "raw backend/start symbols must stay in backend seams or backend test seams only:\n" + "\n".join(offenders),
+            "raw backend/start symbols must stay in the stream backend seam "
+            "(deck_stream_core, deck_backend_interfaces) and their tests, never in the "
+            "UI, shell, media adapters, or preflight:\n" + "\n".join(offenders),
         )
 
 

--- a/clients/deck/tests/deck_stream_core_test.cpp
+++ b/clients/deck/tests/deck_stream_core_test.cpp
@@ -15,11 +15,13 @@ namespace {
 
 using nova::deck::stream::applyConnectionStreamConfig;
 using nova::deck::stream::buildStreamKeys;
+using nova::deck::stream::DeckMoonlightConnectionDriver;
 using nova::deck::stream::DeckStreamConnectionInfo;
 using nova::deck::stream::DeckStreamRequest;
 using nova::deck::stream::DeckStreamSession;
 using nova::deck::stream::DeckStreamSessionState;
 using nova::deck::stream::generateStreamKeys;
+using nova::deck::stream::launchRequestForStream;
 
 struct RendererCall {
     int videoFormat = 0;
@@ -136,6 +138,57 @@ public:
     std::vector<InputCall> leds;
 };
 
+// Stands in for moonlight-common-c's start and stop: records what it was
+// handed, answers with a fixed result, and can report a failed stage the way
+// the real start does before returning non-zero.
+class FakeDriver final : public DeckMoonlightConnectionDriver {
+public:
+    int start(
+        SERVER_INFORMATION& serverInfo,
+        STREAM_CONFIGURATION& streamConfig,
+        CONNECTION_LISTENER_CALLBACKS& listenerCallbacks,
+        DECODER_RENDERER_CALLBACKS& videoCallbacks,
+        AUDIO_RENDERER_CALLBACKS& audioCallbacks,
+        void* callbackContext) override {
+        (void)videoCallbacks;
+        (void)audioCallbacks;
+        ++startCalls;
+        lastAddress = serverInfo.address == nullptr ? "" : serverInfo.address;
+        lastRtspUrl = serverInfo.rtspSessionUrl == nullptr ? "" : serverInfo.rtspSessionUrl;
+        lastConfig = streamConfig;
+        lastContext = callbackContext;
+        listener = &listenerCallbacks;
+        if (startResult != 0 && failStage >= 0) {
+            listenerCallbacks.stageStarting(failStage);
+            listenerCallbacks.stageFailed(failStage, failStageErrorCode);
+        }
+        return startResult;
+    }
+
+    void stop() override { ++stopCalls; }
+
+    int startResult = 0;
+    int failStage = -1;
+    int failStageErrorCode = 0;
+    int startCalls = 0;
+    int stopCalls = 0;
+    std::string lastAddress;
+    std::string lastRtspUrl;
+    STREAM_CONFIGURATION lastConfig{};
+    void* lastContext = nullptr;
+    CONNECTION_LISTENER_CALLBACKS* listener = nullptr;
+};
+
+DeckStreamConnectionInfo validConnection() {
+    DeckStreamConnectionInfo info;
+    info.serverAddress = "192.0.2.10";
+    info.appVersion = "7.1.431.-1";
+    info.rtspSessionUrl = "rtsp://192.0.2.10:48010";
+    info.serverCodecModeSupport = 65793;
+    info.keys = generateStreamKeys();
+    return info;
+}
+
 DeckStreamRequest validRequest(std::string gameId = "game-123") {
     return DeckStreamRequest{
         .hostId = "host-gaming-pc",
@@ -249,6 +302,14 @@ int main() {
     sessionListenerCallbacks->setMotionEventState(0, 1, 120);
     sessionListenerCallbacks->setControllerLED(0, 8, 16, 32);
     sessionListenerCallbacks->connectionTerminated(ML_ERROR_GRACEFUL_TERMINATION);
+    // Without a live host connection the callbacks are only noted, and the
+    // notes describe what happened rather than a no-network adapter.
+    assert(session.state() == DeckStreamSessionState::Preparing);
+    for (const auto& reason : events.reasons) {
+        assert(reason.find("no-network adapter") == std::string::npos);
+    }
+    assert(events.reasons.back() == "moonlight connection terminated callback received without a live host connection (error 0)");
+    assert(session.connectionStatus().terminated);
     assert((input.rumbles == std::vector<InputCall>{InputCall{0, 100, 200, 0}}));
     assert((input.motionStates == std::vector<InputCall>{InputCall{0, 1, 120, 0}}));
     assert((input.leds == std::vector<InputCall>{InputCall{0, 8, 16, 32}}));
@@ -445,7 +506,8 @@ int main() {
         StubAudio a;
         StubInput in;
         RecordingEvents ev;
-        DeckStreamSession s(r, a, in, ev);
+        FakeDriver driver;
+        DeckStreamSession s(r, a, in, ev, driver);
         s.prepare(validRequest("game-net-guard"));
         DeckStreamConnectionInfo missingUrl;
         missingUrl.serverAddress = "192.0.2.10";
@@ -454,6 +516,177 @@ int main() {
         assert(refusedUrl.state == DeckStreamSessionState::Failed);
         assert(refusedUrl.reason == "network start requires a host address and an RTSP session URL");
         assert(!s.moonlightBoundary().networkStartAllowed);
+        assert(driver.startCalls == 0 && driver.stopCalls == 0);
+    }
+
+    // The launch parameters and the session's stream configuration come from
+    // the one request, so the host encodes what the client prepared to decode.
+    {
+        DeckStreamRequest request = validRequest("game-one-request");
+        request.width = 1920;
+        request.height = 1080;
+        request.fps = 90;
+        request.audioConfiguration = AUDIO_CONFIGURATION_51_SURROUND;
+        const auto launch = launchRequestForStream(request, 4242, "uuid-1");
+        assert(launch.appId == 4242 && launch.appUuid == "uuid-1");
+        assert(launch.width == 1920 && launch.height == 1080 && launch.fps == 90);
+        assert(launch.surroundAudioInfo == SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(AUDIO_CONFIGURATION_51_SURROUND));
+        assert(!launch.extraQuery.empty() && launch.extraQuery.front() == '&');
+        const auto stereo = launchRequestForStream(validRequest(), 1);
+        assert(stereo.surroundAudioInfo == SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(AUDIO_CONFIGURATION_STEREO));
+        // The wire value the host reads: the channel mask sits in the high 16
+        // bits and the channel count in the low ones, so stereo is 0x3 << 16 | 2.
+        // Polaris uses the same 196610 as its own default.
+        assert(stereo.surroundAudioInfo == 196610);
+
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        DeckStreamSession s(r, a, in, ev);
+        assert(s.prepare(request).state == DeckStreamSessionState::Preparing);
+        const auto* config = s.moonlightBoundary().streamConfig;
+        assert(config->width == 1920 && config->height == 1080 && config->fps == 90);
+        assert(config->audioConfiguration == AUDIO_CONFIGURATION_51_SURROUND);
+        s.cancel("one-request probe complete");
+    }
+
+    // A real start hands the driver the connection descriptor, and when the
+    // host ends the connection the session leaves Active with the error code,
+    // while the stop the driver is owed still happens on stop().
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        DeckStreamSession s(r, a, in, ev, driver);
+        s.prepare(validRequest("game-terminated"));
+        const auto info = validConnection();
+        const auto started = s.startNetwork(info);
+        assert(started.state == DeckStreamSessionState::Active && started.networkStarted);
+        assert(s.moonlightBoundary().networkStartAllowed);
+        assert(driver.startCalls == 1 && driver.stopCalls == 0);
+        assert(driver.lastAddress == info.serverAddress && driver.lastRtspUrl == info.rtspSessionUrl);
+        assert(driver.lastContext == s.moonlightBoundary().callbackContext);
+        assert(std::memcmp(driver.lastConfig.remoteInputAesKey, info.keys.aesKey.data(), info.keys.aesKey.size()) == 0);
+        assert(driver.lastConfig.width == 1280 && driver.lastConfig.fps == 60);
+
+        driver.listener->connectionStarted();
+        assert(s.connectionStatus().connectionStarted);
+        driver.listener->connectionTerminated(-100);
+        assert(s.state() == DeckStreamSessionState::Failed);
+        assert(ev.states.back() == DeckStreamSessionState::Failed);
+        assert(ev.reasons.back() == "moonlight connection terminated (error -100)");
+        const auto status = s.connectionStatus();
+        assert(status.terminated && status.terminationErrorCode == -100);
+        // The callback never calls the driver's stop; that would deadlock on
+        // moonlight's own thread. It stays owed until stop().
+        assert(driver.stopCalls == 0);
+
+        const auto stopped = s.stop();
+        assert(stopped.state == DeckStreamSessionState::Stopped);
+        assert(stopped.hostConnectionTornDown);
+        assert(stopped.reason == "stopped host session after moonlight termination (error -100)");
+        assert(driver.stopCalls == 1);
+        assert(!s.moonlightBoundary().networkStartAllowed);
+        // Nothing is owed any more: a second stop is the usual guard failure.
+        assert(s.stop().state == DeckStreamSessionState::Failed);
+        assert(driver.stopCalls == 1);
+    }
+
+    // A graceful end by the host lands in Stopped, and stop() still settles the driver.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        DeckStreamSession s(r, a, in, ev, driver);
+        s.prepare(validRequest("game-graceful"));
+        assert(s.startNetwork(validConnection()).networkStarted);
+        driver.listener->connectionTerminated(ML_ERROR_GRACEFUL_TERMINATION);
+        assert(s.state() == DeckStreamSessionState::Stopped);
+        assert(ev.reasons.back() == "moonlight connection terminated gracefully by the host");
+        const auto stopped = s.stop();
+        assert(stopped.state == DeckStreamSessionState::Stopped && stopped.hostConnectionTornDown);
+        assert(driver.stopCalls == 1);
+    }
+
+    // fail() and cancel() on a live host connection tear it down first.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        DeckStreamSession s(r, a, in, ev, driver);
+        s.prepare(validRequest("game-fail"));
+        assert(s.startNetwork(validConnection()).networkStarted);
+        const auto failed = s.fail("renderer adapter died mid-stream");
+        assert(failed.state == DeckStreamSessionState::Failed && failed.hostConnectionTornDown);
+        assert(failed.reason == "renderer adapter died mid-stream");
+        assert(driver.stopCalls == 1);
+        assert(!s.moonlightBoundary().networkStartAllowed);
+        assert(!s.fail("again").hostConnectionTornDown);
+        assert(driver.stopCalls == 1);
+    }
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        DeckStreamSession s(r, a, in, ev, driver);
+        s.prepare(validRequest("game-cancel"));
+        assert(s.startNetwork(validConnection()).networkStarted);
+        const auto cancelled = s.cancel("operator backed out");
+        assert(cancelled.state == DeckStreamSessionState::Cancelled && cancelled.hostConnectionTornDown);
+        assert(driver.stopCalls == 1);
+        assert(!s.moonlightBoundary().networkStartAllowed);
+    }
+
+    // A failed start is followed by the driver's stop so moonlight-common-c
+    // unwinds the stages that came up, and the reason names the failed stage.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        driver.startResult = -1;
+        driver.failStage = STAGE_RTSP_HANDSHAKE;
+        driver.failStageErrorCode = -5;
+        DeckStreamSession s(r, a, in, ev, driver);
+        s.prepare(validRequest("game-start-failed"));
+        const auto failed = s.startNetwork(validConnection());
+        assert(failed.state == DeckStreamSessionState::Failed);
+        assert(!failed.networkStarted && failed.hostConnectionTornDown);
+        assert(failed.reason.find("result -1") != std::string::npos);
+        assert(failed.reason.find("failed stage") != std::string::npos);
+        assert(failed.reason.find("error -5") != std::string::npos);
+        assert(driver.startCalls == 1 && driver.stopCalls == 1);
+        assert(!s.moonlightBoundary().networkStartAllowed);
+        const auto status = s.connectionStatus();
+        assert(status.failedStage == STAGE_RTSP_HANDSHAKE && status.failedStageErrorCode == -5);
+        // No stop is owed after the failed start settled itself.
+        assert(s.stop().state == DeckStreamSessionState::Failed);
+        assert(driver.stopCalls == 1);
+    }
+
+    // A session dropped while streaming still tears the connection down.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        FakeDriver driver;
+        {
+            DeckStreamSession s(r, a, in, ev, driver);
+            s.prepare(validRequest("game-dropped"));
+            assert(s.startNetwork(validConnection()).networkStarted);
+        }
+        assert(driver.stopCalls == 1);
     }
 
     return 0;

--- a/clients/deck/tests/deck_stream_core_test.cpp
+++ b/clients/deck/tests/deck_stream_core_test.cpp
@@ -2,8 +2,10 @@
 
 #include <Limelight.h>
 
+#include <array>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -11,9 +13,13 @@
 
 namespace {
 
+using nova::deck::stream::applyConnectionStreamConfig;
+using nova::deck::stream::buildStreamKeys;
+using nova::deck::stream::DeckStreamConnectionInfo;
 using nova::deck::stream::DeckStreamRequest;
 using nova::deck::stream::DeckStreamSession;
 using nova::deck::stream::DeckStreamSessionState;
+using nova::deck::stream::generateStreamKeys;
 
 struct RendererCall {
     int videoFormat = 0;
@@ -386,6 +392,68 @@ int main() {
         const auto preparedSequential = sequential.prepare(validRequest("game-sequential-" + std::to_string(i)));
         assert(preparedSequential.state == DeckStreamSessionState::Preparing);
         sequential.cancel("sequential owner release");
+    }
+
+    // The connection config helper copies the AES material and the encryption
+    // and color choices into a stream configuration, byte for byte.
+    {
+        STREAM_CONFIGURATION cfg;
+        LiInitializeStreamConfiguration(&cfg);
+        std::array<std::uint8_t, 16> key{};
+        for (std::size_t i = 0; i < key.size(); ++i) {
+            key[i] = static_cast<std::uint8_t>(0xA0 + i);
+        }
+        DeckStreamConnectionInfo info;
+        info.keys = buildStreamKeys(key, 0x0A0B0C0D);
+        info.encryptionFlags = ENCFLG_AUDIO;
+        info.colorSpace = COLORSPACE_REC_709;
+        info.colorRange = COLOR_RANGE_LIMITED;
+        applyConnectionStreamConfig(cfg, info);
+        assert(std::memcmp(cfg.remoteInputAesKey, key.data(), key.size()) == 0);
+        assert(static_cast<unsigned char>(cfg.remoteInputAesIv[0]) == 0x0A);
+        assert(static_cast<unsigned char>(cfg.remoteInputAesIv[1]) == 0x0B);
+        assert(static_cast<unsigned char>(cfg.remoteInputAesIv[2]) == 0x0C);
+        assert(static_cast<unsigned char>(cfg.remoteInputAesIv[3]) == 0x0D);
+        assert(cfg.remoteInputAesIv[4] == 0);
+        assert(cfg.encryptionFlags == ENCFLG_AUDIO);
+        assert(cfg.colorSpace == COLORSPACE_REC_709);
+        assert(cfg.colorRange == COLOR_RANGE_LIMITED);
+    }
+
+    // startNetwork before prepare fails closed and never authorizes the boundary,
+    // so no connection is attempted.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        DeckStreamSession s(r, a, in, ev);
+        DeckStreamConnectionInfo info;
+        info.serverAddress = "192.0.2.10";
+        info.rtspSessionUrl = "rtsp://192.0.2.10:48010";
+        info.keys = generateStreamKeys();
+        const auto beforePrepare = s.startNetwork(info);
+        assert(beforePrepare.state == DeckStreamSessionState::Failed);
+        assert(beforePrepare.reason == "network start requested before prepare");
+        assert(!s.moonlightBoundary().networkStartAllowed);
+    }
+
+    // A prepared session still refuses to start without an address or RTSP URL,
+    // before LiStartConnection is ever reached.
+    {
+        StubRenderer r;
+        StubAudio a;
+        StubInput in;
+        RecordingEvents ev;
+        DeckStreamSession s(r, a, in, ev);
+        s.prepare(validRequest("game-net-guard"));
+        DeckStreamConnectionInfo missingUrl;
+        missingUrl.serverAddress = "192.0.2.10";
+        missingUrl.keys = generateStreamKeys();
+        const auto refusedUrl = s.startNetwork(missingUrl);
+        assert(refusedUrl.state == DeckStreamSessionState::Failed);
+        assert(refusedUrl.reason == "network start requires a host address and an RTSP session URL");
+        assert(!s.moonlightBoundary().networkStartAllowed);
     }
 
     return 0;

--- a/clients/deck/tests/deck_stream_media_adapters_test.cpp
+++ b/clients/deck/tests/deck_stream_media_adapters_test.cpp
@@ -259,6 +259,7 @@ int main(int argc, char** argv) {
     using nova::deck::stream::DeckGuardedStreamSessionPreviewProducer;
     using nova::deck::stream::DeckOperatorStartAuthorizationMode;
     using nova::deck::stream::DeckOperatorStartAuthorizationPolicy;
+    using nova::deck::stream::DeckStreamConnectionInfo;
     using nova::deck::stream::DeckStreamRequest;
     using nova::deck::stream::DeckStreamSession;
     using nova::deck::stream::DeckStreamSessionState;
@@ -669,6 +670,49 @@ int main(int argc, char** argv) {
     NOVA_TEST_REQUIRE(!lifecycleStopped.dryRunPreflightRequested);
     NOVA_TEST_REQUIRE(!lifecycleStopped.networkStarted);
     NOVA_TEST_REQUIRE(guardedLifecycleGate.transitions().size() >= 4);
+
+    // The approved real-start lane refuses without authorization or without an
+    // assembled connection, and never reaches the connection call in those cases.
+    {
+        DeckGuardedStreamSessionPreviewProducer realStartProducer;
+        DeckGuardedPreviewLifecycleGate realStartGate(realStartProducer);
+        const DeckStreamRequest realStartRequest{
+            .hostId = "host-real-start",
+            .gameId = "game-real-start",
+            .width = 1280,
+            .height = 800,
+            .fps = 60,
+            .bitrateKbps = 20000,
+        };
+
+        DeckOperatorStartAuthorizationPolicy blockedPolicy;
+        const auto blockedStart = realStartGate.startAuthorizedHostSession(
+            blockedPolicy.snapshot(), realStartRequest, DeckStreamConnectionInfo{});
+        NOVA_TEST_REQUIRE(blockedStart.statusCode == std::string("host-network-start-blocked"));
+        NOVA_TEST_REQUIRE(!blockedStart.networkStartAllowed);
+        NOVA_TEST_REQUIRE(!blockedStart.networkStarted);
+        NOVA_TEST_REQUIRE(realStartProducer.rendererLifecycle().setupCalls == 0);
+
+        DeckOperatorStartAuthorizationPolicy approvedPolicy;
+        approvedPolicy.authorizeStart("local-real-start-ok");
+        const auto notReady = realStartGate.startAuthorizedHostSession(
+            approvedPolicy.snapshot(), realStartRequest, DeckStreamConnectionInfo{});
+        NOVA_TEST_REQUIRE(notReady.statusCode == std::string("operator-start-not-ready"));
+        NOVA_TEST_REQUIRE(notReady.hostStartContractAuthorized);
+        NOVA_TEST_REQUIRE(!notReady.networkStartAllowed);
+        NOVA_TEST_REQUIRE(!notReady.networkStarted);
+
+        // An address without an RTSP url is still not ready, and stops before the
+        // session's own connection call is reached.
+        DeckStreamConnectionInfo addressWithoutRtsp;
+        addressWithoutRtsp.serverAddress = "192.0.2.10";
+        const auto stillNotReady = realStartGate.startAuthorizedHostSession(
+            approvedPolicy.snapshot(), realStartRequest, addressWithoutRtsp);
+        NOVA_TEST_REQUIRE(stillNotReady.statusCode == std::string("operator-start-not-ready"));
+        NOVA_TEST_REQUIRE(!stillNotReady.networkStartAllowed);
+        NOVA_TEST_REQUIRE(!stillNotReady.networkStarted);
+        NOVA_TEST_REQUIRE(realStartProducer.rendererLifecycle().setupCalls == 0);
+    }
 
     DeckGuardedStreamSessionPreviewProducer idempotentLifecycleProducer;
     DeckGuardedPreviewLifecycleGate idempotentLifecycleGate(idempotentLifecycleProducer);

--- a/clients/deck/tests/deck_stream_media_adapters_test.cpp
+++ b/clients/deck/tests/deck_stream_media_adapters_test.cpp
@@ -257,6 +257,9 @@ int main(int argc, char** argv) {
     using nova::deck::stream::DeckProductPreviewPipeline;
     using nova::deck::stream::DeckGuardedPreviewLifecycleGate;
     using nova::deck::stream::DeckGuardedStreamSessionPreviewProducer;
+    using nova::deck::stream::DeckHttpFetcher;
+    using nova::deck::stream::DeckHttpResponse;
+    using nova::deck::stream::DeckMoonlightConnectionDriver;
     using nova::deck::stream::DeckOperatorStartAuthorizationMode;
     using nova::deck::stream::DeckOperatorStartAuthorizationPolicy;
     using nova::deck::stream::DeckStreamConnectionInfo;
@@ -749,6 +752,181 @@ int main(int argc, char** argv) {
     NOVA_TEST_REQUIRE(!idempotentSecondStop.armed);
     NOVA_TEST_REQUIRE(!idempotentSecondStop.networkStarted);
     NOVA_TEST_REQUIRE(idempotentLifecycleGate.transitions().size() == idempotentTransitionCountAfterStop);
+
+    // The real-start lane with a fake connection driver and a recording host
+    // fetcher: stop and cancel tear the connection down and then ask the host
+    // to end the app, naming the session the launch returned.
+    {
+        class FakeDriver final : public DeckMoonlightConnectionDriver {
+        public:
+            int start(
+                SERVER_INFORMATION& serverInfo,
+                STREAM_CONFIGURATION& streamConfig,
+                CONNECTION_LISTENER_CALLBACKS& listenerCallbacks,
+                DECODER_RENDERER_CALLBACKS& videoCallbacks,
+                AUDIO_RENDERER_CALLBACKS& audioCallbacks,
+                void* callbackContext) override {
+                (void)serverInfo;
+                (void)listenerCallbacks;
+                (void)videoCallbacks;
+                (void)audioCallbacks;
+                (void)callbackContext;
+                ++startCalls;
+                lastConfig = streamConfig;
+                return startResult;
+            }
+            void stop() override { ++stopCalls; }
+            int startResult = 0;
+            int startCalls = 0;
+            int stopCalls = 0;
+            STREAM_CONFIGURATION lastConfig{};
+        };
+        FakeDriver driver;
+        std::vector<std::string> hostTargets;
+        const DeckHttpFetcher hostFetcher = [&hostTargets](const std::string& target) {
+            hostTargets.push_back(target);
+            return DeckHttpResponse{true, 200, "<root status_code=\"200\"><cancel>1</cancel></root>"};
+        };
+        DeckGuardedStreamSessionPreviewProducer realProducer(driver);
+        DeckGuardedPreviewLifecycleGate realGate(realProducer);
+        DeckOperatorStartAuthorizationPolicy approvedPolicy;
+        approvedPolicy.authorizeStart("local-real-start-ok");
+        const DeckStreamRequest realRequest{
+            .hostId = "host-real",
+            .gameId = "game-real",
+            .width = 1920,
+            .height = 1080,
+            .fps = 90,
+            .bitrateKbps = 30000,
+            .audioConfiguration = AUDIO_CONFIGURATION_51_SURROUND,
+        };
+        DeckStreamConnectionInfo connection;
+        connection.serverAddress = "192.0.2.10";
+        connection.appVersion = "7.1.431.-1";
+        connection.rtspSessionUrl = "rtsp://192.0.2.10:48010";
+        connection.hostSessionToken = "tok-1";
+        connection.keys = nova::deck::stream::generateStreamKeys();
+
+        const auto started = realGate.startAuthorizedHostSession(approvedPolicy.snapshot(), realRequest, connection, hostFetcher);
+        NOVA_TEST_REQUIRE(started.statusCode == std::string("host-network-started"));
+        NOVA_TEST_REQUIRE(started.state == DeckStreamSessionState::Active);
+        NOVA_TEST_REQUIRE(started.networkStarted);
+        NOVA_TEST_REQUIRE(started.networkStartAllowed);
+        NOVA_TEST_REQUIRE(started.hostStartContractAuthorized);
+        NOVA_TEST_REQUIRE(driver.startCalls == 1 && driver.stopCalls == 0);
+        NOVA_TEST_REQUIRE(hostTargets.empty());
+        NOVA_TEST_REQUIRE(realGate.sessionState() == DeckStreamSessionState::Active);
+        // The stream configuration the driver saw is the request the gate got,
+        // and the launch built from that request says the same thing.
+        NOVA_TEST_REQUIRE(driver.lastConfig.width == 1920 && driver.lastConfig.height == 1080 && driver.lastConfig.fps == 90);
+        NOVA_TEST_REQUIRE(driver.lastConfig.bitrate == 30000);
+        NOVA_TEST_REQUIRE(driver.lastConfig.audioConfiguration == AUDIO_CONFIGURATION_51_SURROUND);
+        const auto launchFromRequest = nova::deck::stream::launchRequestForStream(realRequest, 7);
+        NOVA_TEST_REQUIRE(launchFromRequest.width == driver.lastConfig.width);
+        NOVA_TEST_REQUIRE(launchFromRequest.height == driver.lastConfig.height);
+        NOVA_TEST_REQUIRE(launchFromRequest.fps == driver.lastConfig.fps);
+        NOVA_TEST_REQUIRE(launchFromRequest.surroundAudioInfo == SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(driver.lastConfig.audioConfiguration));
+
+        const auto stopped = realGate.stop();
+        NOVA_TEST_REQUIRE(stopped.statusCode == std::string("stopped-host-session"));
+        NOVA_TEST_REQUIRE(stopped.state == DeckStreamSessionState::Stopped);
+        NOVA_TEST_REQUIRE(stopped.hostConnectionTornDown);
+        NOVA_TEST_REQUIRE(!stopped.networkStartAllowed);
+        NOVA_TEST_REQUIRE(driver.stopCalls == 1);
+        NOVA_TEST_REQUIRE(stopped.hostCancelRequested && stopped.hostCancelled);
+        NOVA_TEST_REQUIRE(hostTargets.size() == 1);
+        NOVA_TEST_REQUIRE(hostTargets[0] == std::string("/cancel?sessiontoken=tok-1"));
+        NOVA_TEST_REQUIRE(stopped.hostCancelSummary.find("confirmed") != std::string::npos);
+        const auto stoppedAgain = realGate.stop();
+        NOVA_TEST_REQUIRE(stoppedAgain.statusCode == std::string("already-stopped-no-network"));
+        NOVA_TEST_REQUIRE(hostTargets.size() == 1 && driver.stopCalls == 1);
+
+        // cancel forwards through the gate and the producer, tears the
+        // connection down and ends the host app the same way.
+        const auto startedAgain = realGate.startAuthorizedHostSession(approvedPolicy.snapshot(), realRequest, connection, hostFetcher);
+        NOVA_TEST_REQUIRE(startedAgain.statusCode == std::string("host-network-started"));
+        NOVA_TEST_REQUIRE(driver.startCalls == 2);
+        const auto cancelled = realGate.cancel("operator backed out");
+        NOVA_TEST_REQUIRE(cancelled.statusCode == std::string("cancelled-host-session"));
+        NOVA_TEST_REQUIRE(cancelled.state == DeckStreamSessionState::Cancelled);
+        NOVA_TEST_REQUIRE(cancelled.reason == std::string("operator backed out"));
+        NOVA_TEST_REQUIRE(cancelled.hostConnectionTornDown);
+        NOVA_TEST_REQUIRE(driver.stopCalls == 2);
+        NOVA_TEST_REQUIRE(cancelled.hostCancelRequested && cancelled.hostCancelled);
+        NOVA_TEST_REQUIRE(hostTargets.size() == 2 && hostTargets[1] == std::string("/cancel?sessiontoken=tok-1"));
+        NOVA_TEST_REQUIRE(realGate.transitions().size() >= 6);
+        // The transitions log carries the real-session reasons, not the
+        // no-network wording.
+        bool sawHostStop = false;
+        for (const auto& transition : realGate.transitions()) {
+            if (transition.reason == std::string("stopped host session")) {
+                sawHostStop = true;
+            }
+        }
+        NOVA_TEST_REQUIRE(sawHostStop);
+    }
+
+    // When the connection itself fails to come up the host app was still
+    // launched, so stop() settles it with the host even though there is no
+    // stream to stop.
+    {
+        class FailingDriver final : public DeckMoonlightConnectionDriver {
+        public:
+            int start(SERVER_INFORMATION&, STREAM_CONFIGURATION&, CONNECTION_LISTENER_CALLBACKS&,
+                      DECODER_RENDERER_CALLBACKS&, AUDIO_RENDERER_CALLBACKS&, void*) override {
+                ++startCalls;
+                return -1;
+            }
+            void stop() override { ++stopCalls; }
+            int startCalls = 0;
+            int stopCalls = 0;
+        };
+        FailingDriver driver;
+        std::vector<std::string> hostTargets;
+        const DeckHttpFetcher hostFetcher = [&hostTargets](const std::string& target) {
+            hostTargets.push_back(target);
+            return DeckHttpResponse{true, 200, "<root status_code=\"200\"><cancel>1</cancel></root>"};
+        };
+        DeckGuardedStreamSessionPreviewProducer failingProducer(driver);
+        DeckGuardedPreviewLifecycleGate failingGate(failingProducer);
+        DeckOperatorStartAuthorizationPolicy approvedPolicy;
+        approvedPolicy.authorizeStart("local-real-start-ok");
+        DeckStreamConnectionInfo connection;
+        connection.serverAddress = "192.0.2.10";
+        connection.rtspSessionUrl = "rtsp://192.0.2.10:48010";
+        connection.keys = nova::deck::stream::generateStreamKeys();
+        const auto failed = failingGate.startAuthorizedHostSession(
+            approvedPolicy.snapshot(),
+            DeckStreamRequest{.hostId = "host-real", .gameId = "game-real"},
+            connection,
+            hostFetcher);
+        NOVA_TEST_REQUIRE(failed.statusCode == std::string("host-network-start-failed"));
+        NOVA_TEST_REQUIRE(failed.state == DeckStreamSessionState::Failed);
+        NOVA_TEST_REQUIRE(!failed.networkStarted && !failed.networkStartAllowed);
+        NOVA_TEST_REQUIRE(failed.hostConnectionTornDown);
+        NOVA_TEST_REQUIRE(driver.startCalls == 1 && driver.stopCalls == 1);
+        NOVA_TEST_REQUIRE(hostTargets.empty());
+        const auto settled = failingGate.stop();
+        NOVA_TEST_REQUIRE(settled.statusCode == std::string("stop-settled-host-session"));
+        NOVA_TEST_REQUIRE(settled.hostCancelRequested && settled.hostCancelled);
+        NOVA_TEST_REQUIRE(hostTargets.size() == 1 && hostTargets[0] == std::string("/cancel"));
+        NOVA_TEST_REQUIRE(driver.stopCalls == 1);
+    }
+
+    // cancel on a no-network preview stays local: no driver, no host request.
+    {
+        DeckGuardedStreamSessionPreviewProducer localProducer;
+        DeckGuardedPreviewLifecycleGate localGate(localProducer);
+        const auto armed = localGate.armNoNetwork(DeckStreamRequest{.hostId = "offline-host", .gameId = "offline-game"});
+        NOVA_TEST_REQUIRE(armed.statusCode == std::string("active-no-network"));
+        const auto cancelled = localGate.cancel("preview dismissed");
+        NOVA_TEST_REQUIRE(cancelled.statusCode == std::string("cancelled-no-network"));
+        NOVA_TEST_REQUIRE(cancelled.state == DeckStreamSessionState::Cancelled);
+        NOVA_TEST_REQUIRE(!cancelled.hostConnectionTornDown);
+        NOVA_TEST_REQUIRE(!cancelled.hostCancelRequested && !cancelled.hostCancelled);
+        NOVA_TEST_REQUIRE(cancelled.hostCancelSummary == std::string("no host session to end"));
+        NOVA_TEST_REQUIRE(localGate.sessionState() == DeckStreamSessionState::Cancelled);
+    }
 
     AVFrame* fakeVaapiFrame = av_frame_alloc();
     if (!require(fakeVaapiFrame != nullptr, "expected test VAAPI frame allocation")) {


### PR DESCRIPTION
## Summary

Nova's Deck client streams from Polaris on its own, through
moonlight-common-c, rather than handing off to Moonlight-Qt. Proven on the
real Steam Deck against a live 1.4.5 host.

The branch already had the protocol and the guarded lane. What it did not have
was a caller: nothing in the shell or the command line could reach
`startAuthorizedHostSession`, so the native path had never run against a host.
It also had three ways to leave a connection behind.

1. The session's state and its connection are now the same story. The
   terminated callback used to record a note and leave the session Active with
   its network flag set, so the next prepare was refused. A failure left a live
   connection running underneath a Failed state. The session now tracks
   separately whether the connection is live and whether moonlight-common-c is
   still owed its stop, because the library releases its threads only in that
   call and calling it from the termination thread would deadlock on the thread
   it joins. Every teardown path goes through one guarded call that cannot stop
   twice, and the listener callbacks write atomics because they run on the
   library's own threads.
2. The launch path carries the session token the host returns and says whether
   a host answered and refused or was never reached, and it asks the host to end
   the app once the stream is down, retrying briefly because the host still
   counts the session as attached for a moment after teardown. Query values are
   percent encoded, so a value carrying an ampersand cannot smuggle a parameter.
3. `--native-launch "<title>"` runs the whole thing headless: resolve the title
   against the live library, assemble the session through the pinned certificate
   client, open the connection through the same gate the shell uses, watch the
   decoder, then stop and cancel. One line per phase, a summary of the counters,
   and an exit code that says which part failed.

The launch parameters and the stream configuration now come from one request,
so the mode and audio layout the host encodes cannot drift from what the client
decodes.

## Exact candidate

`c4a5892` on `feat/deck-native-streaming`.

## Verification

On the Steam Deck (SteamOS 3.8.16, Game Mode) against pc-papi's Polaris 1.4.5,
launching the Synthetic Frame Counter: all twelve moonlight stages completed,
720 hardware VAAPI frames decoded in 12 seconds at the requested 1280x800x60,
clean stop, the host confirmed the app ended on the first cancel attempt, and
the host returned to free. Exit 0. A second run at 8 seconds decoded 480 frames
with the same outcome. Logs are on pc-papi under the worktree's `proof/`.
`presentedHardwareFrames` is zero by design in the headless lane, which has no
QML surface.

On Fedora 44 with Qt 6.11: the Deck client builds and all 20 CTest cases pass,
including the media assert guard, and each of the three commits builds on its
own.

Two things the review caught rather than the tests. A new test asserted stereo
surround audio as 131075 with the channel mask and count swapped; the wire
value is 196610, which is also Polaris's own default. And a comment claimed
moonlight-common-c wants a stop call after a failed start, when the library
already unwinds itself and the extra call is a no-op.

## Still open

The shell button still reaches the report only lane, so the UI does not yet
start a real stream. `LiStartConnection` is synchronous on its caller's thread,
which is fine headless and would need moving off the GUI thread before the
button is wired. Audio decodes nothing yet; it counts.
