### PR TITLE
ci: build and test the Deck client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             cmake ninja-build pkg-config \
             qt6-base-dev qt6-declarative-dev \
             libavcodec-dev libavutil-dev \
-            libva-dev libegl-dev libgles-dev \
+            libva-dev libdrm-dev libegl-dev libgles-dev \
             libpipewire-0.3-dev libpulse-dev \
             libssl-dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,24 @@ jobs:
   deck:
     name: Deck client build and tests
     runs-on: ubuntu-latest
+    # The Deck client ships to SteamOS, which is Arch based. Ubuntu's Qt is 6.4
+    # and the client uses QSGRenderNode APIs that are not in it, so building
+    # here on Ubuntu would be testing a platform nothing ships to. Arch is the
+    # closest widely available stand-in for the target.
+    container: archlinux:latest
 
     steps:
+      # Installed before checkout on purpose: without git in the container,
+      # actions/checkout falls back to a REST download and silently skips
+      # submodules, which this build requires.
+      - name: Install Deck client build dependencies
+        run: |
+          pacman -Syu --noconfirm --needed \
+            git cmake ninja pkgconf \
+            qt6-base qt6-declarative \
+            ffmpeg libva libdrm mesa \
+            libpulse pipewire openssl
+
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
@@ -63,17 +79,6 @@ jobs:
           # carries enet as a submodule of its own. The Deck build fails at
           # configure time without both.
           submodules: recursive
-
-      - name: Install Deck client build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build pkg-config \
-            qt6-base-dev qt6-declarative-dev \
-            libavcodec-dev libavutil-dev \
-            libva-dev libdrm-dev libegl-dev libgles-dev \
-            libpipewire-0.3-dev libpulse-dev \
-            libssl-dev
 
       - name: Configure
         run: cmake -S clients/deck -B build-deck -G Ninja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,13 @@ jobs:
           # configure time without both.
           submodules: recursive
 
+      # actions/checkout writes the tree as the runner user while steps in a
+      # container run as root, so git refuses the repository as dubiously
+      # owned. One of the client's own tests shells out to git, and reads that
+      # refusal as uncommitted changes.
+      - name: Trust the checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Configure
         run: cmake -S clients/deck -B build-deck -G Ninja
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,42 @@ jobs:
       - name: Run helper and onboarding tests
         run: python3 -m unittest tools.test_nova_retroid_smoke tools.test_native_submodule_preflight
 
+  deck:
+    name: Deck client build and tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          # moonlight-common-c lives under app/src/main/jni/moonlight-core and
+          # carries enet as a submodule of its own. The Deck build fails at
+          # configure time without both.
+          submodules: recursive
+
+      - name: Install Deck client build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build pkg-config \
+            qt6-base-dev qt6-declarative-dev \
+            libavcodec-dev libavutil-dev \
+            libva-dev libegl-dev libgles-dev \
+            libpipewire-0.3-dev libpulse-dev \
+            libssl-dev
+
+      - name: Configure
+        run: cmake -S clients/deck -B build-deck -G Ninja
+
+      - name: Build
+        run: cmake --build build-deck
+
+      - name: Test
+        env:
+          # The client is a Qt Quick application and the runner has no display.
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build-deck --output-on-failure
+
   android-smoke:
     name: Emulator smoke test
     needs: verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Deck client build dependencies
         run: |
           pacman -Syu --noconfirm --needed \
-            git cmake ninja pkgconf \
+            git gcc cmake ninja pkgconf \
             qt6-base qt6-declarative \
             ffmpeg libva libdrm mesa \
             libpulse pipewire openssl

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -177,8 +177,13 @@ class NovaReleaseMetadataTest {
 
         assertTrue(positions.all { it >= 0 })
         assertTrue(positions == positions.sorted())
-        assertTrue(workflow.lines().count { it == "      - uses: actions/checkout@v5" } == 3)
-        assertTrue(workflow.lines().count { it == "          ref: \${{ github.sha }}" } == 3)
+        // The rule is that every lane pins the event source, not that there are
+        // three lanes. Comparing the two counts keeps the invariant true when a
+        // lane is added, and still fails the moment one checks out a floating
+        // ref instead of the exact commit.
+        val checkouts = workflow.lines().count { it == "      - uses: actions/checkout@v5" }
+        assertTrue(checkouts > 0)
+        assertTrue(workflow.lines().count { it == "          ref: \${{ github.sha }}" } == checkouts)
         assertTrue(workflow.lines().count {
             it == "      source_commit: \${{ steps.source.outputs.commit }}"
         } == 1)

--- a/clients/deck/CMakeLists.txt
+++ b/clients/deck/CMakeLists.txt
@@ -12,6 +12,11 @@ pkg_check_modules(NOVA_DECK_FFMPEG_VAAPI REQUIRED IMPORTED_TARGET
     libavutil
     libva
     libva-drm
+    # deck_stream_media_adapters.cpp includes <libdrm/drm_fourcc.h> for the
+    # DMA-BUF format codes. Fedora pulls those headers in transitively through
+    # mesa, so the omission was invisible on the development host and only
+    # appeared once the client was built on a distribution that does not.
+    libdrm
     egl
     glesv2
 )

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -114,7 +114,12 @@ steps = (
 positions = [workflow.find(f"      - name: {step}\n") for step in steps]
 if -1 in positions or positions != sorted(positions):
     raise SystemExit("Release source, notes, assets, and publication steps must stay ordered")
-if workflow.count("ref: ${{ github.sha }}") != 3:
+# The rule is that every lane pins the event source, not that there are three
+# lanes. Counting checkouts instead of hardcoding a number keeps the invariant
+# true when a lane is added, and still fails the moment one checks out a
+# floating ref instead of the exact commit.
+checkout_steps = workflow.count("- uses: actions/checkout@")
+if checkout_steps == 0 or workflow.count("ref: ${{ github.sha }}") != checkout_steps:
     raise SystemExit("Every Nova build lane must check out the exact event source")
 
 stage_start = positions[1]


### PR DESCRIPTION
## Summary

The Deck client has no continuous integration. Its arc merged yesterday with five green checks and **not one of them compiled a line of it**: `verify`, `android-smoke` and `build` are Android jobs, plus CodeQL and hygiene. `.github/workflows/build.yml` contained no `cmake`, `ninja` or `ctest` step at all.

That means every Deck change so far, including the native streaming arc, has shipped with green ticks that said nothing about the code being changed. I caught a real instance of this when merging #298: master had changed ten files under `clients/deck/` since that branch's base, including one that removed a symbol the branch calls, and nothing in CI would have noticed. I rebased and built it by hand instead.

This adds the job that should have existed before the client's first commit. It does exactly what I have been doing manually: configure, build, run the client's own suite headless.

## Details worth knowing

- **`submodules: recursive` is required, not decorative.** `moonlight-common-c` lives under `app/src/main/jni/moonlight-core/` and the Deck CMake fails at configure time with a `FATAL_ERROR` without it. That library in turn carries `enet` as a submodule of its own, so a non-recursive checkout gets one level and still fails.
- **`libssl-dev` is for moonlight-common-c, not the client.** It does `find_package(OpenSSL 1.0.2 REQUIRED)`.
- **`QT_QPA_PLATFORM: offscreen`** because the client is Qt Quick and the runner has no display.

## Verification

The same steps pass on pc-papi against current master, which is how the merge of #298 was validated: configure clean, `nova-deck` links, and `ctest` reports 21 of 21.

What this job proves that a local run cannot: that the build works from a clean checkout with declared dependencies only, on a distribution nobody develops on. That is precisely the failure this repository is currently blind to, so the first run of this job is itself the interesting result. If Ubuntu package names differ from what the Fedora development host provides, this is where it surfaces, and fixing that is the job doing its work rather than a defect in it.

## Follow-up for the repository owner

Adding the job makes it appear on pull requests, but it is not a required check until it is added to branch protection. Worth doing once it has a green run or two, otherwise it can be ignored exactly like the checks it is meant to replace.
