### PR TITLE
feat(library): give the landscape showcase its screen back

### DIFF
--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -101,6 +102,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -1338,48 +1340,50 @@ class NovaLibraryActivity : NovaActivity() {
                             modifier = Modifier.fillMaxSize(),
                             reserveControllerHintSpace = true,
                         ) {
-                            NovaLibraryLandscapeToolbar(
-                                serverName = serverName,
-                                serverHost = serverHost,
-                                model = model,
-                                clientSettings = clientSettings,
-                                onOpenOptions = onOpenOptions,
-                                onOpenSystemMenu = onOpenSystemMenu
+                            val showContinue = NovaLibraryUiStateMapper.showStandaloneHomeHero(
+                                layoutMode = model.optionsState.layoutMode,
+                                hasActiveSession = activeSession != null,
                             )
-                            if (
-                                NovaLibraryUiStateMapper.showStandaloneHomeHero(
-                                    layoutMode = model.optionsState.layoutMode,
-                                    hasActiveSession = activeSession != null,
-                                )
-                            ) {
-                                NovaLibraryHomeHero(
-                                    hero = model.hero,
-                                    compact = true,
-                                    apiClient = apiClient,
-                                    onPrimaryAction = {
-                                        when (model.hero.primaryAction) {
-                                            NovaLibraryHeroPrimaryAction.RESUME,
-                                            NovaLibraryHeroPrimaryAction.WATCH -> activeSession?.let(onResumeSession)
-                                            NovaLibraryHeroPrimaryAction.OPEN_DETAIL -> model.hero.game?.let(onOpenDetail)
-                                            NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
-                                            NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
-                                        }
-                                    },
-                                    onSecondaryAction = {
-                                        when (model.hero.secondaryAction) {
-                                            NovaLibraryHeroSecondaryAction.END_SESSION -> activeSession?.let(onEndSession)
-                                            null -> Unit
-                                        }
-                                    },
-                                    onOpenDetail = model.hero.game?.let { game -> { onOpenDetail(game) } },
-                                    onGameFocused = onGameFocused
-                                )
-                            }
+                            NovaLibraryLandscapeShowcaseStripContent(
+                                hostLabel = serverName?.takeIf { it.isNotBlank() } ?: serverHost,
+                                resultCount = model.resultCount,
+                                layoutLabel = layoutModeLabel(model.optionsState.layoutMode),
+                                polarisReady = clientSettings != null,
+                                onOpenOptions = onOpenOptions,
+                                onOpenSystemMenu = onOpenSystemMenu,
+                                continueSlot = if (showContinue) {
+                                    {
+                                        NovaLibraryShowcaseContinue(
+                                            hero = model.hero,
+                                            apiClient = apiClient,
+                                            onPrimaryAction = {
+                                                when (model.hero.primaryAction) {
+                                                    NovaLibraryHeroPrimaryAction.RESUME,
+                                                    NovaLibraryHeroPrimaryAction.WATCH ->
+                                                        activeSession?.let(onResumeSession)
+                                                    NovaLibraryHeroPrimaryAction.OPEN_DETAIL ->
+                                                        model.hero.game?.let(onOpenDetail)
+                                                    NovaLibraryHeroPrimaryAction.MANAGE_LIBRARY -> onManageServer()
+                                                    NovaLibraryHeroPrimaryAction.CLEAR_FILTERS -> onClearFilters()
+                                                }
+                                            },
+                                            onSecondaryAction = when (model.hero.secondaryAction) {
+                                                NovaLibraryHeroSecondaryAction.END_SESSION ->
+                                                    { { activeSession?.let(onEndSession) } }
+                                                null -> null
+                                            },
+                                        )
+                                    }
+                                } else {
+                                    null
+                                },
+                            )
                             NovaLibraryContent(
                                 modifier = Modifier.weight(1f),
                                 model = model,
                                 filterState = filterState,
                                 columns = columns,
+                                windowClass = layoutSpec.windowClass,
                                 isLandscape = true,
                                 isInitialLoading = isInitialLoading,
                                 isRefreshing = isRefreshing,
@@ -1469,6 +1473,7 @@ class NovaLibraryActivity : NovaActivity() {
                                 model = model,
                                 filterState = filterState,
                                 columns = columns,
+                                windowClass = layoutSpec.windowClass,
                                 isLandscape = false,
                                 isInitialLoading = isInitialLoading,
                                 isRefreshing = isRefreshing,
@@ -1900,6 +1905,103 @@ class NovaLibraryActivity : NovaActivity() {
         )
     }
 
+    /**
+     * The continue action as it appears inside the landscape strip: cover, what
+     * it is, and the verb. The old standalone card carried an eyebrow, a title,
+     * a subtitle, a caption and badges across a full-width panel whose right half
+     * was empty; at strip height only the first three earn their place.
+     */
+    @Composable
+    private fun RowScope.NovaLibraryShowcaseContinue(
+        hero: NovaLibraryHeroState,
+        apiClient: PolarisApiClient,
+        onPrimaryAction: () -> Unit,
+        onSecondaryAction: (() -> Unit)?,
+    ) {
+        val colors = LocalNovaComposeColors.current
+        val surfaces = LocalNovaLibrarySurfaces.current
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .padding(start = 4.dp)
+                .testTag("nova-library-showcase-continue"),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp),
+        ) {
+            val game = hero.game
+            if (game != null) {
+                val shape = RoundedCornerShape(NovaRadius.chip)
+                Box(
+                    modifier = Modifier
+                        .aspectRatio(1f)
+                        .fillMaxHeight()
+                        .clip(shape)
+                        .background(surfaces.mediaPlaceholder)
+                        .border(
+                            1.dp,
+                            surfaces.tileBorder.copy(alpha = 0.74f * LocalNovaMenuOpacityScale.current),
+                            shape,
+                        ),
+                ) {
+                    key(PolarisApiClient.artworkPresentationKey(game, PolarisGame.ARTWORK_KIND_POSTER)) {
+                        AndroidView(
+                            modifier = Modifier.fillMaxSize(),
+                            factory = { context ->
+                                ImageView(context).apply {
+                                    scaleType = ImageView.ScaleType.CENTER_CROP
+                                    setBackgroundColor(surfaces.mediaPlaceholder.toArgb())
+                                    contentDescription = context.getString(R.string.nova_a11y_game_cover)
+                                    apiClient.loadCoverInto(this, game)
+                                }
+                            },
+                            update = { apiClient.loadCoverInto(it, game) },
+                        )
+                    }
+                }
+            }
+            Column(
+                modifier = Modifier.weight(1f, fill = false),
+                verticalArrangement = Arrangement.spacedBy(1.dp),
+            ) {
+                Text(
+                    text = hero.eyebrow.uppercase(),
+                    style = NovaChromeType.label(fontSize = 8.sp),
+                    color = colors.accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = hero.title,
+                    color = colors.textPrimary,
+                    fontSize = 14.sp,
+                    lineHeight = 16.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            NovaActionButton(
+                text = hero.actionLabel,
+                onClick = onPrimaryAction,
+                modifier = Modifier.widthIn(min = 88.dp),
+                minHeight = 30.dp,
+                fontSize = 10.sp,
+            )
+            val secondaryLabel = hero.secondaryActionLabel
+            if (secondaryLabel != null && onSecondaryAction != null) {
+                NovaActionButton(
+                    text = secondaryLabel,
+                    onClick = onSecondaryAction,
+                    modifier = Modifier.widthIn(min = 72.dp),
+                    primary = false,
+                    minHeight = 30.dp,
+                    fontSize = 10.sp,
+                )
+            }
+        }
+    }
+
     @Composable
     private fun NovaLibraryTopHeader(
         serverName: String?,
@@ -2321,6 +2423,7 @@ class NovaLibraryActivity : NovaActivity() {
         model: NovaLibraryUiModel,
         filterState: NovaLibraryFilterState,
         columns: Int,
+        windowClass: NovaLibraryWindowClass,
         isLandscape: Boolean,
         isInitialLoading: Boolean,
         isRefreshing: Boolean,
@@ -2338,7 +2441,6 @@ class NovaLibraryActivity : NovaActivity() {
         onOpenDetail: (PolarisGame) -> Unit
     ) {
         val layoutMode = model.optionsState.layoutMode
-        val gridColumns = columns
         val stablePosterLoader = remember(apiClient) {
             { view: ImageView, targetGame: PolarisGame -> apiClient.loadCoverInto(view, targetGame) }
         }
@@ -2461,18 +2563,35 @@ class NovaLibraryActivity : NovaActivity() {
                             posterLoader = stablePosterLoader
                         )
                     } else {
-                        Box(modifier = Modifier.fillMaxSize()) {
+                        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                        // Measure the grid's real viewport and pick the columns that fit
+                        // whole rows in it. Taking a fixed column count and letting the
+                        // remainder fall where it may is how the second row came to land
+                        // a few dp short and read as clipped rather than as more below.
+                        val gridPaddingDp = NovaLibraryUiStateMapper.gridContentPaddingDp()
+                        val viewportSpec = NovaLibraryUiStateMapper.gridViewportSpec(
+                            contentWidthDp = (maxWidth.value.toInt() - gridPaddingDp * 2)
+                                .coerceAtLeast(1),
+                            viewportHeightDp = (maxHeight.value.toInt() - gridPaddingDp)
+                                .coerceAtLeast(1),
+                            layoutMode = layoutMode,
+                            windowClass = windowClass,
+                        )
                         LazyVerticalGrid(
-                            columns = GridCells.Fixed(gridColumns),
+                            columns = GridCells.Fixed(viewportSpec.columns),
                             modifier = Modifier.fillMaxSize(),
                             contentPadding = PaddingValues(
-                                start = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
-                                top = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
-                                end = NovaLibraryUiStateMapper.gridContentPaddingDp().dp,
+                                start = gridPaddingDp.dp,
+                                top = gridPaddingDp.dp,
+                                end = gridPaddingDp.dp,
                                 bottom = NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape).dp
                             ),
-                            verticalArrangement = Arrangement.spacedBy(10.dp),
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            verticalArrangement = Arrangement.spacedBy(
+                                NovaLibraryUiStateMapper.gridItemSpacingDp().dp,
+                            ),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                NovaLibraryUiStateMapper.gridItemSpacingDp().dp,
+                            ),
                         ) {
                             items(
                                 model.filteredGames,
@@ -2505,9 +2624,10 @@ class NovaLibraryActivity : NovaActivity() {
                                 .height(NovaLibraryGridScrollFadeHeight)
                                 .background(
                                     Brush.verticalGradient(
-                                        colors = listOf(
-                                            androidx.compose.ui.graphics.Color.Transparent,
-                                            LocalNovaComposeColors.current.window.copy(alpha = 0.85f),
+                                        colorStops = arrayOf(
+                                            0.0f to androidx.compose.ui.graphics.Color.Transparent,
+                                            0.45f to LocalNovaComposeColors.current.window.copy(alpha = 0.62f),
+                                            1.0f to LocalNovaComposeColors.current.window.copy(alpha = 0.95f),
                                         ),
                                     ),
                                 ),
@@ -3797,8 +3917,15 @@ class NovaLibraryActivity : NovaActivity() {
          *  as atmosphere behind it rather than competing with twenty covers. */
         private const val NovaLibraryGridBackdropStrength = 0.45f
 
-        /** Height of the fade at the foot of the scrolling poster grid. */
-        private val NovaLibraryGridScrollFadeHeight = 44.dp
+        /**
+         * Height of the fade at the foot of the scrolling poster grid. It reads as
+         * more content below, and since the hint bar is drawn over the grid rather
+         * than on a slab of its own, it is also the ground those hints are read
+         * against. It has to clear the bar with room to ramp, or the wash ends in a
+         * line and the seam becomes the most visible edge on the screen.
+         */
+        private val NovaLibraryGridScrollFadeHeight =
+            (NovaLibraryUiStateMapper.controllerHintBarMinHeightDp() + 38).dp
 
         private val LARGE_TEXT_HINT_INDICES = setOf(0, 1, 3)
         private val PRIMARY_HINT_INDICES = setOf(0, 1, 2)

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryStage.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -231,6 +232,82 @@ internal fun NovaLibraryPortraitToolbarContent(
                 onClick = onOpenSystemMenu,
             )
         }
+    }
+}
+
+/**
+ * Landscape draws identity, the continue action, the result count and the two
+ * menu buttons in one row.
+ *
+ * A toolbar stacked above a continue card spent the width twice. The toolbar
+ * carried an empty gap almost two thirds of the screen wide between the host
+ * name and the count, and the card stopped at the halfway mark, so two
+ * full-width strips were each about half empty and the poster grid was left with
+ * one row. The continue slot sits in the gap the toolbar already had.
+ *
+ * When there is nothing to continue the slot is absent rather than blank, and
+ * identity and metadata reflow across the space instead of holding it open.
+ */
+@Composable
+internal fun NovaLibraryLandscapeShowcaseStripContent(
+    hostLabel: String,
+    resultCount: Int,
+    layoutLabel: String,
+    polarisReady: Boolean,
+    onOpenOptions: () -> Unit,
+    onOpenSystemMenu: () -> Unit,
+    continueSlot: (@Composable RowScope.() -> Unit)? = null,
+) {
+    val surfaces = LocalNovaLibrarySurfaces.current
+    val largeText = LocalDensity.current.fontScale >= 1.5f
+    val shape = RoundedCornerShape(NovaRadius.row)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(NovaLibraryUiStateMapper.landscapeShowcaseStripHeightDp(largeText).dp)
+            .clip(shape)
+            .background(surfaces.panel.copy(alpha = 0.34f * LocalNovaMenuOpacityScale.current))
+            .border(1.dp, surfaces.tileBorder, shape)
+            .padding(horizontal = 10.dp, vertical = 5.5.dp)
+            .testTag("nova-library-landscape-toolbar"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        NovaLibraryToolbarIdentity(
+            hostLabel = hostLabel,
+            cinematic = true,
+            modifier = Modifier.widthIn(min = 104.dp, max = 168.dp),
+            statusContent = {
+                if (polarisReady) {
+                    Text(
+                        text = stringResource(R.string.nova_system_menu_status_polaris_ready),
+                        color = LocalNovaComposeColors.current.textSecondary,
+                        fontSize = 10.sp,
+                        lineHeight = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            },
+        )
+        if (continueSlot != null) {
+            continueSlot()
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+        NovaLibraryResultAndLayoutMeta(
+            resultCount = resultCount,
+            layoutLabel = layoutLabel,
+            cinematic = true,
+        )
+        NovaLibraryToolbarOptionsAction(
+            largeText = largeText,
+            primary = false,
+            onClick = onOpenOptions,
+        )
+        NovaLibraryToolbarSystemAction(
+            onClick = onOpenSystemMenu,
+        )
     }
 }
 

--- a/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
+++ b/app/src/main/java/com/papi/nova/ui/NovaLibraryUiState.kt
@@ -47,6 +47,20 @@ internal data class NovaPortraitPosterSize(
     val heightDp: Int,
 )
 
+/**
+ * What the poster grid resolves to once its real viewport is known: how many
+ * columns, the exact 2:3 poster those columns give, and how much of the next row
+ * is left showing.
+ */
+data class NovaLibraryGridViewportSpec(
+    val columns: Int,
+    val posterWidthDp: Int,
+    val posterHeightDp: Int,
+    val rowPitchDp: Int,
+    val fullRows: Int,
+    val peekDp: Int,
+)
+
 internal data class NovaPosterPresentationSpec(
     val focusedScale: Float,
     val unfocusedAlpha: Float,
@@ -267,7 +281,19 @@ object NovaLibraryUiStateMapper {
     private const val RECENT_RAIL_HORIZONTAL_PADDING_DP = 24
     private const val GAME_CARD_GAP_DP = 10
     private const val GRID_CONTENT_PADDING_DP = 10
-    private const val LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP = 24
+    private const val GRID_ITEM_SPACING_DP = 6
+    private const val MIN_GRID_POSTER_WIDTH_DP = 72
+    private const val MAX_EXTRA_GRID_COLUMNS = 3
+    private const val MIN_GRID_PEEK_DP = 16
+
+    /**
+     * Clearance for the overlaid hint bar at the end of a scroll. The bar used to
+     * be paid for twice: once as a shell slab the grid could never draw into, and
+     * again here. Only this one is needed, because a row sliding under a scrim
+     * mid-scroll reads as more content, not as a clipped row.
+     */
+    private const val LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP = 44
+    private const val CONTROLLER_HINT_BAR_MIN_HEIGHT_DP = 34
     private const val MIN_RECENT_RAIL_CARD_WIDTH_DP = 72
     private const val RAIL_SCROLL_BOTTOM_PADDING_DP = 96
     private const val RAIL_VERTICAL_SPACING_DP = 4
@@ -281,7 +307,13 @@ object NovaLibraryUiStateMapper {
     private const val LANDSCAPE_SCREEN_PADDING_DP = 8
     private const val PORTRAIT_SCREEN_PADDING_DP = 8
     private const val LANDSCAPE_CONTENT_SPACING_DP = 6
-    private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 48
+
+    /**
+     * Zero because the landscape hint bar is an overlay. Its clearance lives in
+     * LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP instead, so the 48dp this used to
+     * hold back is returned to the poster grid.
+     */
+    private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 0
 
     /**
      * The cinematic stage reserves less than the grid/compact shells. Those lay poster
@@ -900,20 +932,10 @@ object NovaLibraryUiStateMapper {
             widthDp >= 1280 -> NovaLibraryWindowClass.TV_LANDSCAPE
             else -> NovaLibraryWindowClass.HANDHELD_LANDSCAPE
         }
-        val gridColumns = when (windowClass) {
-            NovaLibraryWindowClass.PHONE_PORTRAIT -> when (layoutMode) {
-                NovaLibraryLayoutMode.COMPACT -> 4
-                else -> 3
-            }
-            NovaLibraryWindowClass.HANDHELD_LANDSCAPE -> when (layoutMode) {
-                NovaLibraryLayoutMode.COMPACT -> 6
-                else -> 5
-            }
-            NovaLibraryWindowClass.TV_LANDSCAPE -> when (layoutMode) {
-                NovaLibraryLayoutMode.COMPACT -> 9
-                else -> 7
-            }
-        }
+        // One ladder. This file already carried a second, unused one in
+        // gridColumnsForScreen, and the grid's viewport solver needs the same
+        // starting point, so the count lives in baseGridColumns and nowhere else.
+        val gridColumns = baseGridColumns(layoutMode, windowClass)
         val gameCardHeightDp = when (windowClass) {
             NovaLibraryWindowClass.PHONE_PORTRAIT -> if (layoutMode == NovaLibraryLayoutMode.COMPACT) 104 else 168
             NovaLibraryWindowClass.HANDHELD_LANDSCAPE -> if (layoutMode == NovaLibraryLayoutMode.COMPACT) 88 else 112
@@ -1086,6 +1108,102 @@ object NovaLibraryUiStateMapper {
 
     fun gridContentPaddingDp(): Int = GRID_CONTENT_PADDING_DP
 
+    /**
+     * Space between posters. The old 10dp sat on top of each card's own focus
+     * gutter, so neighbouring artwork was 22dp apart against a 112dp poster,
+     * about a fifth of the poster itself. The gutter keeps its job of giving the
+     * focus scale somewhere to grow; this is the part that was simply wide.
+     */
+    fun gridItemSpacingDp(): Int = GRID_ITEM_SPACING_DP
+
+    /**
+     * The grid's own viewport in landscape: what is left after the screen padding
+     * and the one strip above it. GRID and COMPACT had no viewport arithmetic at
+     * all, they took fixed dp and let Modifier.weight absorb the rest, which is
+     * why the second row landed a few dp short and read as clipped.
+     */
+    fun landscapeGridViewportHeightDp(
+        screenHeightDp: Int,
+        safeVerticalInsetsDp: Int,
+        largeText: Boolean = false,
+    ): Int = (
+        screenHeightDp -
+            safeVerticalInsetsDp.coerceAtLeast(0) -
+            screenPaddingDp(isLandscape = true) * 2 -
+            landscapeShowcaseStripHeightDp(largeText) -
+            landscapeContentSpacingDp()
+        ).coerceAtLeast(0)
+
+    /**
+     * Choose the column count that shows the rows a mode is meant to show.
+     *
+     * COMPACT calls itself "a materially denser readable browser for fast
+     * controller sweeps" but only ever added one column, so it showed the same
+     * single row GRID did. It earns the name here by fitting two whole rows.
+     * GRID keeps the larger artwork and takes a deliberate peek of the next row
+     * instead, which is what tells you the grid scrolls.
+     */
+    fun gridViewportSpec(
+        contentWidthDp: Int,
+        viewportHeightDp: Int,
+        layoutMode: NovaLibraryLayoutMode,
+        windowClass: NovaLibraryWindowClass,
+    ): NovaLibraryGridViewportSpec {
+        val spacing = gridItemSpacingDp()
+        val gutter = posterPresentationSpec(layoutMode).focusGutterDp
+        val baseColumns = baseGridColumns(layoutMode, windowClass)
+        val targetRows = if (layoutMode == NovaLibraryLayoutMode.COMPACT) 2 else 1
+
+        var fallback: NovaLibraryGridViewportSpec? = null
+        var rowsOnly: NovaLibraryGridViewportSpec? = null
+        for (columns in baseColumns..(baseColumns + MAX_EXTRA_GRID_COLUMNS)) {
+            val cellWidthDp = (contentWidthDp - spacing * (columns - 1)) / columns
+            val posterWidthDp = cellWidthDp - gutter * 2
+            if (posterWidthDp < MIN_GRID_POSTER_WIDTH_DP) break
+            val poster = portraitPosterSizeForWidth(posterWidthDp)
+            val rowPitchDp = poster.heightDp + spacing
+            val fullRows = if (rowPitchDp <= 0) {
+                0
+            } else {
+                ((viewportHeightDp + spacing) / rowPitchDp).coerceAtLeast(0)
+            }
+            val candidate = NovaLibraryGridViewportSpec(
+                columns = columns,
+                posterWidthDp = poster.widthDp,
+                posterHeightDp = poster.heightDp,
+                rowPitchDp = rowPitchDp,
+                fullRows = fullRows,
+                peekDp = (viewportHeightDp - (fullRows * rowPitchDp - spacing)).coerceAtLeast(0),
+            )
+            if (fallback == null) fallback = candidate
+            if (fullRows >= targetRows) {
+                // A row count that exactly fills the viewport leaves nothing showing
+                // of the next one, and a grid with no peek does not look like it
+                // scrolls. Prefer the first candidate that fits the rows and still
+                // shows a sliver; fall back to rows alone if none does.
+                if (candidate.peekDp >= MIN_GRID_PEEK_DP) return candidate
+                if (rowsOnly == null) rowsOnly = candidate
+            }
+        }
+        return rowsOnly ?: fallback ?: NovaLibraryGridViewportSpec(
+            columns = baseColumns,
+            posterWidthDp = MIN_GRID_POSTER_WIDTH_DP,
+            posterHeightDp = MIN_GRID_POSTER_WIDTH_DP * 3 / 2,
+            rowPitchDp = MIN_GRID_POSTER_WIDTH_DP * 3 / 2 + spacing,
+            fullRows = 0,
+            peekDp = viewportHeightDp.coerceAtLeast(0),
+        )
+    }
+
+    private fun baseGridColumns(
+        layoutMode: NovaLibraryLayoutMode,
+        windowClass: NovaLibraryWindowClass,
+    ): Int = when (windowClass) {
+        NovaLibraryWindowClass.PHONE_PORTRAIT -> if (layoutMode == NovaLibraryLayoutMode.COMPACT) 4 else 3
+        NovaLibraryWindowClass.HANDHELD_LANDSCAPE -> if (layoutMode == NovaLibraryLayoutMode.COMPACT) 6 else 5
+        NovaLibraryWindowClass.TV_LANDSCAPE -> if (layoutMode == NovaLibraryLayoutMode.COMPACT) 9 else 7
+    }
+
     fun gridBottomContentPaddingDp(isLandscape: Boolean): Int {
         return if (isLandscape) LANDSCAPE_GRID_BOTTOM_CONTENT_PADDING_DP else GRID_CONTENT_PADDING_DP
     }
@@ -1116,6 +1234,28 @@ object NovaLibraryUiStateMapper {
     fun landscapeContentSpacingDp(): Int = LANDSCAPE_CONTENT_SPACING_DP
 
     fun landscapeToolbarHeightDp(largeText: Boolean = false): Int = if (largeText) 74 else 60
+
+    /**
+     * Landscape draws identity, the continue action, the result count and the two
+     * menu buttons in one strip. Stacking a toolbar above a continue card spent
+     * the width twice: the toolbar carried a gap almost two thirds of the screen
+     * wide between the host name and the count, and the card stopped at the
+     * halfway mark. The height is the toolbar's, because the floor is two 48dp
+     * touch targets rather than anything the text needs.
+     */
+    fun landscapeShowcaseStripHeightDp(largeText: Boolean = false): Int =
+        landscapeToolbarHeightDp(largeText)
+
+    fun controllerHintBarMinHeightDp(): Int = CONTROLLER_HINT_BAR_MIN_HEIGHT_DP
+
+    /**
+     * What a poster row actually clears at the end of a scroll. The shell no
+     * longer reserves a slab, so this is the one number that keeps rows out from
+     * under the hint bar, and it is what the contract test should hold.
+     */
+    fun landscapeHintClearanceDp(): Int =
+        controllerHintBarBottomPaddingDp(isLandscape = true) +
+            gridBottomContentPaddingDp(isLandscape = true)
 
     fun stageRailVerticalContentPaddingDp(): Int = 4
 

--- a/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaComposeSourceGuardTest.kt
@@ -273,9 +273,8 @@ class NovaComposeSourceGuardTest {
                 portraitHeader.contains("NovaLibraryPrimaryFilter.entries.forEach")
         )
         assertTrue(
-            "landscape should keep the compact hero + full-width grid stack after the slim toolbar",
-            screen.contains("NovaLibraryLandscapeToolbar(") &&
-                screen.contains("NovaLibraryHomeHero(") &&
+            "landscape should keep one showcase strip above a full-width grid. The toolbar and the continue card used to be two strips, and the grid was left with a single poster row because of it.",
+            screen.contains("NovaLibraryLandscapeShowcaseStripContent(") &&
                 screen.contains("NovaLibraryContent(")
         )
     }
@@ -569,8 +568,10 @@ class NovaComposeSourceGuardTest {
         val landscape = screen.blockStartingAt("if (isLandscape) {")
 
         assertTrue(
-            "landscape library should promote the hero before grid content so the picker remains visible on Retroid",
-            landscape.indexOf("NovaLibraryHomeHero(") in 0 until landscape.indexOf("NovaLibraryContent(")
+            "landscape library should promote the continue action before grid content so the picker remains visible on Retroid. It is a slot inside the one showcase strip rather than a card of its own, because two stacked full-width strips were each about half empty.",
+            landscape.indexOf("NovaLibraryLandscapeShowcaseStripContent(") in
+                0 until landscape.indexOf("NovaLibraryContent(") &&
+                landscape.contains("NovaLibraryShowcaseContinue(")
         )
         assertTrue(
             "landscape library should restore the recent rail after picker/grid content, not between hero and picker",
@@ -696,14 +697,15 @@ class NovaComposeSourceGuardTest {
         )
 
         assertTrue(
-            "landscape shell should reserve a mapper-owned footer gutter for the overlaid controller hints instead of letting poster rows render under the bar",
+            "landscape should keep a mapper-owned clearance for the overlaid controller hints instead of letting poster rows settle under the bar. The shell used to hold that back as a slab the grid could never draw into, and the grid paid for it a second time in its own inset; the inset alone buys the clearance now, so the mapper has to own the rule that says so.",
             screen.contains("NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape).dp") &&
-                mapper.contains("private const val LANDSCAPE_CONTROLLER_HINT_BOTTOM_PADDING_DP = 48")
+                mapper.contains("fun landscapeHintClearanceDp(): Int") &&
+                mapper.contains("fun controllerHintBarMinHeightDp(): Int")
         )
         assertTrue(
             "game grid should use mapper-owned inner padding with extra bottom scroll room so the final poster row can settle above the footer",
             content.contains("contentPadding = PaddingValues(") &&
-                content.contains("NovaLibraryUiStateMapper.gridContentPaddingDp().dp") &&
+                content.contains("NovaLibraryUiStateMapper.gridContentPaddingDp()") &&
                 content.contains("bottom = NovaLibraryUiStateMapper.gridBottomContentPaddingDp(isLandscape).dp") &&
                 mapper.contains("fun gridBottomContentPaddingDp(isLandscape: Boolean): Int")
         )
@@ -1859,7 +1861,7 @@ class NovaComposeSourceGuardTest {
                 libraryScreen.contains("val controllerHintBarBottomPadding = NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape).dp") &&
                 libraryScreen.contains("val showLandscapeControlRail = NovaLibraryUiStateMapper.showLandscapeControlRail()") &&
                 libraryScreen.contains("if (isLandscape) {") &&
-                libraryScreen.contains("NovaLibraryLandscapeToolbar(") &&
+                libraryScreen.contains("NovaLibraryLandscapeShowcaseStripContent(") &&
                 libraryScreen.contains(".padding(bottom = controllerHintBarBottomPadding)") &&
                 libraryScreen.contains("NovaLibraryCinematicControllerHints(") &&
                 libraryScreen.contains("hints = visibleControllerHints") &&
@@ -3082,7 +3084,11 @@ class NovaComposeSourceGuardTest {
         assertTrue(focusLookup >= 0 && focusedItem > focusLookup)
         assertTrue(focusedItem < heroFallback && heroFallback < filteredFallback && filteredFallback < recentFallback)
         assertTrue(backdropCall >= 0 && backdropCall < particles && backdropCall < windowContent)
-        assertTrue(activity.windowed("onGameFocused = onGameFocused".length).count { it == "onGameFocused = onGameFocused" } >= 7)
+        assertTrue(
+            "every surface that can focus a game has to report it so the backdrop follows. The count dropped by one when the standalone continue card became a slot in the showcase strip, which has a button rather than a focusable card.",
+            activity.windowed("onGameFocused = onGameFocused".length)
+                .count { it == "onGameFocused = onGameFocused" } >= 6,
+        )
     }
 
     private fun readNovaLibraryActivity(): String =

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryActivitySourceTest.kt
@@ -22,14 +22,14 @@ class NovaLibraryActivitySourceTest {
         val source = readLibraryActivitySource()
 
         assertTrue(source.contains("val showLandscapeControlRail = NovaLibraryUiStateMapper.showLandscapeControlRail()"))
-        assertTrue(source.contains("NovaLibraryLandscapeToolbar("))
+        assertTrue(source.contains("NovaLibraryLandscapeShowcaseStripContent("))
         assertFalse(source.contains("controllerHintBarLandscapeStartPadding"))
         assertTrue(source.contains("NovaLibraryCinematicControllerHints("))
         val landscapeBranch = source.substring(
             source.indexOf("if (isLandscape) {"),
             source.indexOf("} else {", source.indexOf("if (isLandscape) {"))
         )
-        assertTrue(landscapeBranch.contains("NovaLibraryLandscapeToolbar("))
+        assertTrue(landscapeBranch.contains("NovaLibraryLandscapeShowcaseStripContent("))
     }
 
     @Test

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryLayoutV2Test.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryLayoutV2Test.kt
@@ -279,10 +279,15 @@ class NovaLibraryLayoutV2Test {
         // The stage reserves less than the grid/compact shells: those lay poster rows out
         // beneath an overlaid hint bar, while the stage anchors one rail above a light
         // three-hint footer.
+        //
+        // The grid shells now clear that bar through their own bottom content padding
+        // rather than a shell slab the grid could never draw into, so the comparison is
+        // against the clearance a poster row actually gets. Reading the shell padding
+        // alone stopped meaning anything the moment it became zero.
         assertTrue(NovaLibraryUiStateMapper.stageControllerHintFooterHeightDp() in 36..44)
         assertTrue(
             NovaLibraryUiStateMapper.stageControllerHintFooterHeightDp() <
-                NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true),
+                NovaLibraryUiStateMapper.landscapeHintClearanceDp(),
         )
         assertEquals(
             540 - 16 - NovaLibraryUiStateMapper.screenPaddingDp(true) * 2 -
@@ -421,4 +426,73 @@ class NovaLibraryLayoutV2Test {
             }
         }
     }
+
+    /**
+     * The showcase used to spend 212dp of the RP6's 390 on chrome and leave the
+     * grid 178dp, which is one 168dp poster row and a 9dp sliver of the next. Six
+     * covers from a 24 game library, with the second row reading as clipped.
+     */
+    @Test
+    fun rp6LandscapeGivesTheGridItsScreenBackAndFitsWholeRows() {
+        val viewportDp = NovaLibraryUiStateMapper.landscapeGridViewportHeightDp(
+            screenHeightDp = 390,
+            safeVerticalInsetsDp = 0,
+            largeText = false,
+        )
+        assertEquals(308, viewportDp)
+
+        val chromeDp = 390 - viewportDp
+        assertTrue(
+            "one strip plus padding should cost well under a third of the screen, was $chromeDp",
+            chromeDp <= 120,
+        )
+
+        val gridPadding = NovaLibraryUiStateMapper.gridContentPaddingDp()
+        val contentWidthDp = 833 - NovaLibraryUiStateMapper.screenPaddingDp(isLandscape = true) * 2 -
+            gridPadding * 2
+        val rowsHeightDp = viewportDp - gridPadding
+
+        val compact = NovaLibraryUiStateMapper.gridViewportSpec(
+            contentWidthDp = contentWidthDp,
+            viewportHeightDp = rowsHeightDp,
+            layoutMode = NovaLibraryLayoutMode.COMPACT,
+            windowClass = NovaLibraryWindowClass.HANDHELD_LANDSCAPE,
+        )
+        assertTrue(
+            "compact calls itself materially denser, so it has to show more than one row",
+            compact.fullRows >= 2,
+        )
+        assertTrue("compact should still look scrollable", compact.peekDp >= 16)
+        assertEquals(compact.posterWidthDp * 3, compact.posterHeightDp * 2)
+        assertTrue(
+            "compact covers visible went from 6, was ${compact.columns * compact.fullRows}",
+            compact.columns * compact.fullRows >= 14,
+        )
+
+        val grid = NovaLibraryUiStateMapper.gridViewportSpec(
+            contentWidthDp = contentWidthDp,
+            viewportHeightDp = rowsHeightDp,
+            layoutMode = NovaLibraryLayoutMode.GRID,
+            windowClass = NovaLibraryWindowClass.HANDHELD_LANDSCAPE,
+        )
+        assertTrue("grid keeps the larger artwork", grid.posterWidthDp > compact.posterWidthDp)
+        assertTrue("grid shows a real peek of the next row, not a sliver", grid.peekDp >= 48)
+        assertEquals(grid.posterWidthDp * 3, grid.posterHeightDp * 2)
+    }
+
+    /**
+     * The hint bar is drawn over the grid now, so the shell reserves nothing for
+     * it. The guarantee that a poster row never ends up under the bar moved into
+     * the grid's own bottom content padding, and that is what has to hold.
+     */
+    @Test
+    fun overlaidHintBarStillClearsTheLastPosterRow() {
+        assertEquals(0, NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true))
+        assertTrue(
+            "clearance must still cover the bar plus breathing room",
+            NovaLibraryUiStateMapper.landscapeHintClearanceDp() >=
+                NovaLibraryUiStateMapper.controllerHintBarMinHeightDp() + 8,
+        )
+    }
+
 }

--- a/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
+++ b/app/src/test/java/com/papi/nova/ui/NovaLibraryUiStateTest.kt
@@ -740,10 +740,14 @@ class NovaLibraryUiStateTest {
 
     @Test
     fun compactRetroidLandscapeChromeBudgetLeavesGameWallPrimaryAboveFooter() {
+        // Everything the shell spends before the grid gets a single dp. The toolbar
+        // was missing from this sum, which let the largest single item in it grow
+        // while the guard kept passing. Landscape now draws one strip instead of a
+        // toolbar above a hero, so the strip is counted and the hero is not.
         val persistentChromeBudget =
             (NovaLibraryUiStateMapper.screenPaddingDp(isLandscape = true) * 2) +
-                (NovaLibraryUiStateMapper.landscapeContentSpacingDp() * 2) +
-                NovaLibraryUiStateMapper.heroHeightDp(compact = true) +
+                NovaLibraryUiStateMapper.landscapeContentSpacingDp() +
+                NovaLibraryUiStateMapper.landscapeShowcaseStripHeightDp() +
                 NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true)
 
         assertTrue(
@@ -755,8 +759,9 @@ class NovaLibraryUiStateTest {
             NovaLibraryUiStateMapper.landscapeContentSpacingDp() <= 6
         )
         assertTrue(
-            "Retroid landscape footer reserve should clear the full controller hint bar plus breathing room so poster rows do not sit underneath it",
-            NovaLibraryUiStateMapper.controllerHintBarBottomPaddingDp(isLandscape = true) in 44..52
+            "Retroid landscape must still clear the full controller hint bar plus breathing room so poster rows do not sit underneath it, but it buys that clearance from the grid's own bottom inset instead of a shell slab the grid could never draw into",
+            NovaLibraryUiStateMapper.landscapeHintClearanceDp() >=
+                NovaLibraryUiStateMapper.controllerHintBarMinHeightDp() + 8
         )
         assertEquals(
             "portrait footer reserve should stay unchanged while the compact landscape shell is tightened",
@@ -780,7 +785,19 @@ class NovaLibraryUiStateTest {
         )
         assertTrue(
             "compact landscape persistent chrome should leave the game grid as the visual primary surface",
-            persistentChromeBudget <= 156
+            persistentChromeBudget <= 96
+        )
+        // The point of all of the above, stated once in the terms a person would use:
+        // on the RP6 the wall of games gets most of the screen. It used to get 178dp
+        // of 390, which is one poster row and a sliver of the next.
+        val gridSharePercent =
+            NovaLibraryUiStateMapper.landscapeGridViewportHeightDp(
+                screenHeightDp = 390,
+                safeVerticalInsetsDp = 0,
+            ) * 100 / 390
+        assertTrue(
+            "the game wall should be the majority of the screen, had ${'$'}gridSharePercent%",
+            gridSharePercent >= 70
         )
     }
 


### PR DESCRIPTION
## Summary

The RP6 reports 833x390dp in landscape and **212dp of that 390 was chrome**. The poster grid got 178dp, which is one 168dp row and a 9dp sliver of the next, so a 24 game library showed six covers and the second row read as clipped rather than as more below.

Measured off the screenshot rather than judged by eye. Three regions, each mostly empty:

| Region | Height | Waste |
|---|---|---|
| Toolbar | 73dp | one gap **1236px wide, 64% of the screen**, between the host name and the count |
| Continue card | 73dp | **49% empty**, all content stopping halfway across |
| Hint bar | 64dp | **82% empty**, 336px of ink in a full-width strip |

No single element was too big. Two stacked full-width strips that were each about half empty was the bug, and the projects this was compared against name the same thing in their own source: *"the page used to stack them, a spotlight band across the top and the list beneath it, that spent the width twice over"*.

**One strip.** Identity, the continue action, the count and the two menu buttons share the row the toolbar already had, and the continue slot sits in the gap. With nothing to continue the slot is absent rather than blank and the rest reflows, instead of holding a space open.

**The hint bar was paid for twice**, once as a shell slab the grid could never draw into and again in the grid's own bottom inset. The inset alone buys the same clearance, so the slab is gone and the bar is drawn over the grid, with the scroll fade grown into the ground its hints are read against.

**The grid budgets against its real viewport**, which GRID and COMPACT never did: they took fixed dp and let `Modifier.weight` absorb whatever was left, which is precisely how the second row came to land a few dp short. It now measures and picks the column count that fits whole rows, reusing the exact 2:3 integer solver already in the mapper serving the stage rail.

COMPACT earns its name doing it. It calls itself "a materially denser readable browser for fast controller sweeps" and only ever added one column, showing the same single row GRID did.

## Verification

Measured on a Retroid Pocket 6, same build and same mode either side. The baseline was built from master rather than taken from the installed release, so the two differ only by this change.

| | before | after |
|---|---|---|
| Chrome | 212dp of 390 (54%) | **82dp (21%)** |
| Grid viewport | 178dp | 308dp |
| Covers visible, Compact | **6** | **14**, plus a third row peeking |
| Grid mode | 1 row + 9dp sliver | 5 columns, larger art, real second-row peek |

- [x] 1628 unit tests pass, including a new one pinning that the grid fits whole rows and keeps a peek at both modes, and that the overlaid bar still clears the last row.
- [x] `assembleNonRoot_gameDebugAndroidTest` compiles. Worth stating because the emulator job only runs on manual `workflow_dispatch`, so CI never compiles it.
- [x] `lintNonRoot_gameDebug` clean.
- [x] Both modes confirmed on the device, not just Compact.

## On the six source guards

All six were re-pinned, none deleted. Each still holds what it held: that a poster row never sits under the hint bar, that the continue action comes before the grid, that the library keeps its own hint renderer. They read the mechanism that provides those guarantees now instead of the one that used to. One needed a new composable moved out of the slice it inspects, which was the honest fix rather than loosening an assertion.

Two gaps closed while in there: the chrome budget guard now counts the toolbar, which is the largest single item in it and was silently omitted, and the column ladder that existed twice is now in one place.

## Not included

Moving the `A` glyph onto the focused poster so it can leave the hint bar. Dropping `A Select` without that would remove the affordance rather than relocate it, so it wants doing properly.

Portrait is untouched and remains its own path.

## Exact candidate

`Commit: 7c80d5326ee0c14fffb5a1a8fe78af1f303a7273`
`Tree: c317903026f43ceb142a23e2f2e71aecaae2aaa8`
`Parent: 81fbeac19e69961a9df8e7eb516488c27b7879ea`
