### PR TITLE
release: prepare 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 1.4.7 - 2026-09-12
+
+Matched client for Polaris 1.4.7: the landscape library gives its screen back to the games.
+
+- The library in landscape was spending more than half its height on chrome, and the wall of games got one row and a sliver of the next. The host name, the game you were last playing and the menu buttons now share one strip instead of two stacked bars that were each about half empty, and the controller hints are drawn over the grid rather than on a slab of their own.
+- The grid measures the space it actually has and picks a column count that fits whole rows in it, instead of taking a fixed number and letting the leftover fall where it may. Compact shows two full rows and a peek of the third where it used to show one row; Grid keeps larger artwork and takes a real peek instead. On a Retroid Pocket 6 that is fourteen covers where there were six. (#300)
+- Compact means something now. It described itself as a materially denser browser while only ever adding a single column, so it showed the same one row Grid did.
+
 ## 1.4.5 - 2026-09-10
 
 Matched client for Polaris 1.4.5: Live Tuning that follows the host, a Launch button that says what it will do, a library card whose focus you cannot miss, and a Steam Deck shell that reads real hosts and hands games to Moonlight-Qt.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,8 @@ android {
         minSdk 21
         targetSdk 36
 
-        versionName "1.4.5"
-        versionCode = 47
+        versionName "1.4.7"
+        versionCode = 48
 
         buildConfigField "boolean", "FDROID_BUILD", fdroidBuild.toString()
 

--- a/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
+++ b/app/src/test/java/com/papi/nova/NovaReleaseMetadataTest.kt
@@ -81,13 +81,13 @@ class NovaReleaseMetadataTest {
         val releaseWorkflow = File(root, ".github/workflows/build.yml").readText()
         val storeNotes = File(
             root,
-            "fastlane/metadata/android/en-US/changelogs/47.txt"
+            "fastlane/metadata/android/en-US/changelogs/48.txt"
         )
         val storeNotesBody = if (storeNotes.isFile) storeNotes.readText().trimEnd() else ""
 
-        assertTrue(build.contains("versionName \"1.4.5\""))
-        assertTrue(build.contains("versionCode = 47"))
-        assertTrue(changelog.contains("## 1.4.5 - 2026-09-10"))
+        assertTrue(build.contains("versionName \"1.4.7\""))
+        assertTrue(build.contains("versionCode = 48"))
+        assertTrue(changelog.contains("## 1.4.7 - 2026-09-12"))
         assertTrue(changelog.contains("Steam Input remains manual and read-only."))
         assertTrue(changelog.contains("Polaris owns encoder probing, fallback, and launch policy"))
         assertTrue(releaseWorkflow.contains("python3 scripts/extract_release_notes.py"))
@@ -108,7 +108,7 @@ class NovaReleaseMetadataTest {
             "Google Play release notes must be at most 500 Unicode characters",
             storeNotesBody.codePointCount(0, storeNotesBody.length) <= 500,
         )
-        assertTrue(storeNotesBody.startsWith("Nova 1.4.5"))
+        assertTrue(storeNotesBody.startsWith("Nova 1.4.7"))
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -1,0 +1,5 @@
+Nova 1.4.7
+
+The landscape library gives its screen back to the games. The host name, your last played game and the menu buttons share one strip instead of two half-empty bars, and the controller hints sit over the grid.
+
+The grid measures the space it has and fits whole rows into it. Compact shows two full rows where it showed one, which on a handheld is fourteen covers instead of six. Grid keeps the larger artwork and shows a real peek of the next row.


### PR DESCRIPTION
## Summary

Release prep for Nova 1.4.7, the matched client for Polaris 1.4.7, carrying the landscape library rework from #300.

**Nova goes 1.4.5 to 1.4.7, skipping 1.4.6.** That number was deliberately a Polaris-only release: Nova master was identical to its own tag at the time, so a matched release would have been an empty version bump. Taking 1.4.6 now would leave two different releases carrying the same number. Skipping it keeps the pair meaning one thing. `versionCode` follows its own sequence, 47 to 48.

## Pins moved

| Pin | To |
|---|---|
| `app/build.gradle` versionName | 1.4.7 |
| `app/build.gradle` versionCode | 48 |
| `CHANGELOG.md` | `## 1.4.7 - 2026-09-12`, one dated heading |
| `fastlane/.../changelogs/48.txt` | opens `Nova 1.4.7`, 458 of the 500 code points allowed |
| `NovaReleaseMetadataTest.kt` | all four of the above |

## Verification

- [x] `NovaReleaseMetadataTest` passes, including the checks that publication stays bound to one verified source and that the release script tags only the exact protected master head.
- [x] `scripts/check-public-docs.sh` clean.

## What the release says

The landscape library was spending more than half its height on chrome and the wall of games got one row and a sliver of the next. One strip instead of two half-empty bars, hints drawn over the grid, and a grid that measures the space it has and fits whole rows into it. On a Retroid Pocket 6 that is fourteen covers where there were six, and Compact finally means something: it described itself as a materially denser browser while only ever adding a single column.
